### PR TITLE
Add GitHub Actions CI/CD pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,90 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+env:
+  CARGO_TERM_COLOR: always
+  RUSTFLAGS: "-Dwarnings"
+
+jobs:
+  build:
+    name: Build (${{ matrix.toolchain }})
+    runs-on: macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        toolchain: [stable, nightly]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust ${{ matrix.toolchain }}
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.toolchain }}
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          key: ${{ matrix.toolchain }}
+
+      - name: Build workspace
+        run: cargo build --workspace
+
+  test:
+    name: Test
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Run tests
+        run: cargo test --workspace
+
+  clippy:
+    name: Clippy
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Run clippy
+        run: cargo clippy --workspace -- -D warnings
+
+  fmt:
+    name: Format
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Rust stable
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+
+      - name: Check formatting
+        run: cargo fmt --all -- --check
+
+  audit:
+    name: Security Audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install cargo-audit
+        uses: taiki-e/install-action@cargo-audit
+
+      - name: Run audit
+        run: cargo audit

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # agentd
 
+[![CI](https://github.com/geoffjay/agentd/actions/workflows/ci.yml/badge.svg)](https://github.com/geoffjay/agentd/actions/workflows/ci.yml)
+
 A modular daemon system for managing notifications, interactive questions, and system monitoring on macOS.
 
 ## Overview


### PR DESCRIPTION
## Summary

- Added `.github/workflows/ci.yml` with five CI jobs triggered on push/PR to `main`
- Added CI status badge to `README.md`

## CI Jobs

| Job | Runner | Description |
|-----|--------|-------------|
| **Build** | macOS (stable + nightly) | `cargo build --workspace` |
| **Test** | macOS | `cargo test --workspace` |
| **Clippy** | macOS | `cargo clippy --workspace -- -D warnings` |
| **Format** | Ubuntu | `cargo fmt --all -- --check` |
| **Audit** | Ubuntu | `cargo audit` for known vulnerabilities |

All jobs use `Swatinem/rust-cache` for faster builds and `dtolnay/rust-toolchain` for Rust installation.

## Notes

There are pre-existing clippy warnings (`wildcard_in_or_patterns` in `wrap`, `should_implement_trait` in `baml`) and minor formatting diffs in `orchestrator/src/api.rs` that will cause the clippy and fmt jobs to fail on current `main`. These should be addressed in a follow-up PR to get the pipeline fully green.

## Test plan

- [x] Workflow YAML is valid syntax
- [x] All five required jobs are present
- [x] Triggers on push and PR to `main`
- [x] README badge points to correct workflow URL
- [ ] Pipeline runs on GitHub (will verify after merge)

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)