### PR TITLE
Remove duplicate request types in notify crate

### DIFF
--- a/crates/notify/src/api.rs
+++ b/crates/notify/src/api.rs
@@ -549,65 +549,6 @@ struct ListParams {
     status: Option<String>,
 }
 
-/// Request body for creating a notification.
-///
-/// All fields are required when creating a new notification via the
-/// `POST /notifications` endpoint.
-///
-/// # Examples
-///
-/// ```json
-/// {
-///   "source": "System",
-///   "lifetime": "Persistent",
-///   "priority": "High",
-///   "title": "Update Available",
-///   "message": "Version 2.0 is ready to install",
-///   "requires_response": false
-/// }
-/// ```
-#[derive(Debug, Deserialize)]
-pub struct CreateNotificationRequest {
-    /// Source of the notification
-    pub source: NotificationSource,
-    /// Lifetime behavior (Persistent or Ephemeral)
-    pub lifetime: NotificationLifetime,
-    /// Priority level (Low, Normal, High, Urgent)
-    pub priority: NotificationPriority,
-    /// Notification title
-    pub title: String,
-    /// Notification message body
-    pub message: String,
-    /// Whether a response is required from the user
-    pub requires_response: bool,
-}
-
-/// Request body for updating a notification.
-///
-/// Both fields are optional. Used by the `PUT /notifications/{id}` endpoint
-/// to modify an existing notification's status and/or response.
-///
-/// # Examples
-///
-/// ```json
-/// {
-///   "status": "Dismissed"
-/// }
-/// ```
-///
-/// ```json
-/// {
-///   "response": "Approved"
-/// }
-/// ```
-#[derive(Debug, Deserialize)]
-pub struct UpdateNotificationRequest {
-    /// New status for the notification
-    pub status: Option<NotificationStatus>,
-    /// User's response text
-    pub response: Option<String>,
-}
-
 // === Error Handling ===
 
 /// API error types that can be returned from handlers.


### PR DESCRIPTION
## Summary

- Removed duplicate `CreateNotificationRequest` and `UpdateNotificationRequest` definitions from `api.rs`
- The `api.rs` module already imports `use crate::types::*`, so the canonical `types.rs` definitions are used automatically
- Eliminates the `dead_code` compiler warnings for these structs

## Details

The `types.rs` versions are the correct canonical definitions because they:
- Include `Clone` and `Serialize` derives (needed by downstream crates)
- Have `#[serde(skip_serializing_if)]` on optional fields in `UpdateNotificationRequest`
- Are part of the public library API used by `ask` and `cli` crates

The `api.rs` versions only had `Debug, Deserialize` and were shadowing the `types::*` import within the API module.

## Test plan

- [x] `cargo build -p notify` compiles with no warnings
- [x] `cargo build -p ask -p cli` compiles successfully (no downstream breakage)
- [x] `cargo test -p notify -p cli` — all tests pass
- [x] No `dead_code` warnings for `CreateNotificationRequest` or `UpdateNotificationRequest`

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)