### PR TITLE
Fix port number inconsistencies across all documentation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,5 +41,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CLI skeleton
 - Project documentation
 
-[Unreleased]: https://github.com/yourusername/agentd/compare/v0.1.0...HEAD
-[0.1.0]: https://github.com/yourusername/agentd/releases/tag/v0.1.0
+[Unreleased]: https://github.com/geoffjay/agentd/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/geoffjay/agentd/releases/tag/v0.1.0

--- a/README.md
+++ b/README.md
@@ -13,12 +13,13 @@ A modular daemon system for managing notifications, interactive questions, and s
 - **agentd-ask** - Interactive question service with tmux integration
 - **agentd-hook** - Shell hook integration service
 - **agentd-monitor** - System monitoring service
+- **agentd-orchestrator** - Agent lifecycle and workflow orchestration service
 
 ## Quick Start
 
 ```bash
 # Clone the repository
-git clone https://github.com/yourusername/agentd.git
+git clone https://github.com/geoffjay/agentd.git
 cd agentd
 
 # Install (creates Agent.app bundle)
@@ -101,17 +102,17 @@ agent ask answer <UUID> "yes"  # Answer a question
 
 ### REST API
 
-**Notify Service (port 3000):**
+**Notify Service (default port 17004):**
 
 ```bash
 # Health check
-curl http://localhost:3000/health
+curl http://localhost:17004/health
 
 # List notifications
-curl http://localhost:3000/notifications
+curl http://localhost:17004/notifications
 
 # Create notification
-curl -X POST http://localhost:3000/notifications \
+curl -X POST http://localhost:17004/notifications \
   -H "Content-Type: application/json" \
   -d '{
     "source": {"type": "system"},
@@ -123,17 +124,17 @@ curl -X POST http://localhost:3000/notifications \
   }'
 ```
 
-**Ask Service (port 3001):**
+**Ask Service (default port 17001):**
 
 ```bash
 # Health check
-curl http://localhost:3001/health
+curl http://localhost:17001/health
 
 # Trigger checks
-curl -X POST http://localhost:3001/trigger
+curl -X POST http://localhost:17001/trigger
 
 # Answer question
-curl -X POST http://localhost:3001/answer \
+curl -X POST http://localhost:17001/answer \
   -H "Content-Type: application/json" \
   -d '{
     "question_id": "UUID",
@@ -149,11 +150,13 @@ curl -X POST http://localhost:3001/answer \
 ├── Contents/
 │   ├── Info.plist
 │   ├── MacOS/
-│   │   ├── cli                # CLI (symlinked from /usr/local/bin/agent)
-│   │   ├── agentd-notify      # Notification service
-│   │   ├── agentd-ask         # Ask service
-│   │   ├── agentd-hook        # Hook service
-│   │   └── agentd-monitor     # Monitor service
+│   │   ├── cli                    # CLI (symlinked from /usr/local/bin/agent)
+│   │   ├── agentd-notify          # Notification service
+│   │   ├── agentd-ask             # Ask service
+│   │   ├── agentd-hook            # Hook service
+│   │   ├── agentd-monitor         # Monitor service
+│   │   ├── agentd-wrap            # Wrap service
+│   │   └── agentd-orchestrator    # Orchestrator service
 │   └── Resources/
 │
 /usr/local/bin/agent -> /Applications/Agent.app/Contents/MacOS/cli
@@ -162,9 +165,12 @@ curl -X POST http://localhost:3001/answer \
 
 ### Service Communication
 Services communicate via REST APIs:
-- agentd-notify: http://localhost:3000
-- agentd-ask: http://localhost:3001
-```
+- agentd-ask: http://localhost:17001
+- agentd-hook: http://localhost:17002
+- agentd-monitor: http://localhost:17003
+- agentd-notify: http://localhost:17004
+- agentd-wrap: http://localhost:17005
+- agentd-orchestrator: http://localhost:17006
 
 ## Development
 
@@ -175,9 +181,9 @@ Services communicate via REST APIs:
 cargo build --release
 
 # Build specific crate
-cargo build -p agentd-cli --release
-cargo build -p agentd-notify --release
-cargo build -p agentd-ask --release
+cargo build -p cli --release
+cargo build -p notify --release
+cargo build -p ask --release
 ```
 
 ### Testing
@@ -187,8 +193,8 @@ cargo build -p agentd-ask --release
 cargo test
 
 # Run tests for specific crate
-cargo test -p agentd-cli
-cargo test -p agentd-ask
+cargo test -p cli
+cargo test -p ask
 
 # Run with output
 cargo test -- --nocapture
@@ -202,14 +208,14 @@ cargo test -- --nocapture
 ### Running Services Locally
 
 ```bash
-# Terminal 1: Notify service
+# Terminal 1: Notify service (port 17004)
 cargo run -p agentd-notify
 
-# Terminal 2: Ask service
+# Terminal 2: Ask service (port 17001)
 cargo run -p agentd-ask
 
 # Terminal 3: CLI
-cargo run -p agentd-cli -- notify list
+cargo run -p cli -- notify list
 ```
 
 ### Code Quality
@@ -250,10 +256,20 @@ launchctl list | grep agentd
 
 ## Configuration
 
-### Service Ports
+### Port Configuration
 
-- **agentd-notify**: Port 3000 (configurable via environment)
-- **agentd-ask**: Port 3001 (configurable via `ASK_PORT`)
+Each service uses a **development port** (17xxx) by default when started with `cargo run`, and a **production port** (7xxx) when running as a LaunchAgent. All ports are configurable via the `PORT` environment variable.
+
+| Service | Dev Port | Prod Port | Description |
+|---------|----------|-----------|-------------|
+| agentd-ask | 17001 | 7001 | Interactive question service |
+| agentd-hook | 17002 | 7002 | Shell hook integration |
+| agentd-monitor | 17003 | 7003 | System monitoring |
+| agentd-notify | 17004 | 7004 | Notification service |
+| agentd-wrap | 17005 | 7005 | Tmux session management |
+| agentd-orchestrator | 17006 | 7006 | Agent orchestration |
+
+Production ports are set in the LaunchAgent plist files under `contrib/plists/`.
 
 ### Log Files
 
@@ -262,6 +278,8 @@ Logs are written to `/usr/local/var/log/`:
 - `agentd-ask.log` / `agentd-ask.err`
 - `agentd-hook.log` / `agentd-hook.err`
 - `agentd-monitor.log` / `agentd-monitor.err`
+- `agentd-wrap.log` / `agentd-wrap.err`
+- `agentd-orchestrator.log` / `agentd-orchestrator.err`
 
 ### Database
 
@@ -287,7 +305,7 @@ rm -f ~/Library/LaunchAgents/com.geoffjay.agentd-*.plist
 
 1. Check logs: `tail -f /usr/local/var/log/agentd-*.err`
 2. Check status: `cargo xtask service-status`
-3. Verify ports: `lsof -i :3000` and `lsof -i :3001`
+3. Verify ports: `lsof -i :17004` and `lsof -i :17001`
 
 ### Permission errors
 
@@ -301,9 +319,9 @@ sudo chown -R $(whoami) /usr/local/var
 ### Cannot connect to service
 
 ```bash
-# Test health endpoints
-curl http://localhost:3000/health
-curl http://localhost:3001/health
+# Test health endpoints (dev ports)
+curl http://localhost:17004/health
+curl http://localhost:17001/health
 
 # Restart services
 cargo xtask stop-services

--- a/contrib/README.md
+++ b/contrib/README.md
@@ -39,11 +39,13 @@ cargo xtask install-user
 
 **Service Configuration:**
 
-Each service is configured with:
-- **notify** - Port 3000
-- **ask** - Port 3001 (configurable via `ASK_PORT`)
-- **hook** - TBD
-- **monitor** - TBD
+Each service is configured with a production port (set via `PORT` env var in the plist):
+- **ask** - Port 7001
+- **hook** - Port 7002
+- **monitor** - Port 7003
+- **notify** - Port 7004
+- **wrap** - Port 7005
+- **orchestrator** - Port 7006
 
 ### scripts/
 

--- a/crates/ask/src/api.rs
+++ b/crates/ask/src/api.rs
@@ -23,21 +23,21 @@
 //! ## Health Check
 //!
 //! ```bash
-//! curl http://localhost:3001/health
+//! curl http://localhost:17001/health
 //! # Returns: {"status":"ok","service":"agentd-ask","version":"0.1.0",...}
 //! ```
 //!
 //! ## Trigger Checks
 //!
 //! ```bash
-//! curl -X POST http://localhost:3001/trigger
+//! curl -X POST http://localhost:17001/trigger
 //! # Returns: {"checks_run":["tmux_sessions"],"notifications_sent":[...],...}
 //! ```
 //!
 //! ## Submit Answer
 //!
 //! ```bash
-//! curl -X POST http://localhost:3001/answer \
+//! curl -X POST http://localhost:17001/answer \
 //!   -H "Content-Type: application/json" \
 //!   -d '{"question_id":"550e8400-e29b-41d4-a716-446655440000","answer":"yes"}'
 //! # Returns: {"success":true,"message":"Answer recorded...","question_id":"..."}
@@ -82,8 +82,8 @@ use uuid::Uuid;
 ///
 /// let api_state = ApiState {
 ///     app_state: AppState::new(),
-///     notification_client: NotificationClient::new("http://localhost:3000".to_string()),
-///     notification_service_url: "http://localhost:3000".to_string(),
+///     notification_client: NotificationClient::new("http://localhost:17004".to_string()),
+///     notification_service_url: "http://localhost:17004".to_string(),
 /// };
 /// ```
 #[derive(Clone)]
@@ -114,8 +114,8 @@ pub struct ApiState {
 /// # async fn example() {
 /// let api_state = ApiState {
 ///     app_state: AppState::new(),
-///     notification_client: NotificationClient::new("http://localhost:3000".to_string()),
-///     notification_service_url: "http://localhost:3000".to_string(),
+///     notification_client: NotificationClient::new("http://localhost:17004".to_string()),
+///     notification_service_url: "http://localhost:17004".to_string(),
 /// };
 ///
 /// let router = create_router(api_state);
@@ -150,7 +150,7 @@ pub fn create_router(state: ApiState) -> Router {
 /// # Examples
 ///
 /// ```bash
-/// curl http://localhost:3001/health
+/// curl http://localhost:17001/health
 /// ```
 ///
 /// Response:
@@ -159,7 +159,7 @@ pub fn create_router(state: ApiState) -> Router {
 ///   "status": "ok",
 ///   "service": "agentd-ask",
 ///   "version": "0.1.0",
-///   "notification_service_url": "http://localhost:3000"
+///   "notification_service_url": "http://localhost:17004"
 /// }
 /// ```
 async fn health_check(State(state): State<ApiState>) -> impl IntoResponse {
@@ -206,7 +206,7 @@ async fn health_check(State(state): State<ApiState>) -> impl IntoResponse {
 /// # Examples
 ///
 /// ```bash
-/// curl -X POST http://localhost:3001/trigger
+/// curl -X POST http://localhost:17001/trigger
 /// ```
 ///
 /// Response when notification is sent:
@@ -360,7 +360,7 @@ async fn trigger_checks(State(state): State<ApiState>) -> Result<Json<TriggerRes
 /// # Examples
 ///
 /// ```bash
-/// curl -X POST http://localhost:3001/answer \
+/// curl -X POST http://localhost:17001/answer \
 ///   -H "Content-Type: application/json" \
 ///   -d '{
 ///     "question_id": "550e8400-e29b-41d4-a716-446655440000",
@@ -477,8 +477,8 @@ async fn answer_question(
 /// # async fn example() {
 /// let api_state = ApiState {
 ///     app_state: AppState::new(),
-///     notification_client: NotificationClient::new("http://localhost:3000".to_string()),
-///     notification_service_url: "http://localhost:3000".to_string(),
+///     notification_client: NotificationClient::new("http://localhost:17004".to_string()),
+///     notification_service_url: "http://localhost:17004".to_string(),
 /// };
 ///
 /// let router = create_router_with_tracing(api_state);
@@ -502,14 +502,14 @@ mod tests {
     #[test]
     fn test_api_state_creation() {
         let app_state = AppState::new();
-        let notification_client = NotificationClient::new("http://localhost:3000".to_string());
+        let notification_client = NotificationClient::new("http://localhost:17004".to_string());
         let api_state = ApiState {
             app_state,
             notification_client,
-            notification_service_url: "http://localhost:3000".to_string(),
+            notification_service_url: "http://localhost:17004".to_string(),
         };
 
-        assert_eq!(api_state.notification_service_url, "http://localhost:3000");
+        assert_eq!(api_state.notification_service_url, "http://localhost:17004");
     }
 
     // More comprehensive tests would require mocking or integration testing

--- a/crates/ask/src/lib.rs
+++ b/crates/ask/src/lib.rs
@@ -31,7 +31,7 @@
 //! Health check endpoint that returns service status and configuration.
 //!
 //! ```bash
-//! curl http://localhost:3001/health
+//! curl http://localhost:17001/health
 //! ```
 //!
 //! ## POST /trigger
@@ -41,7 +41,7 @@
 //! to start one if none are running.
 //!
 //! ```bash
-//! curl -X POST http://localhost:3001/trigger
+//! curl -X POST http://localhost:17001/trigger
 //! ```
 //!
 //! ## POST /answer
@@ -49,15 +49,15 @@
 //! Submits an answer to a pending question.
 //!
 //! ```bash
-//! curl -X POST http://localhost:3001/answer \
+//! curl -X POST http://localhost:17001/answer \
 //!   -H "Content-Type: application/json" \
 //!   -d '{"question_id": "uuid-here", "answer": "yes"}'
 //! ```
 //!
 //! # Environment Variables
 //!
-//! - `ASK_PORT` - Port to listen on (default: 3001)
-//! - `NOTIFY_SERVICE_URL` - URL of notification service (default: http://localhost:3000)
+//! - `PORT` - Port to listen on (default: 17001 dev, 7001 production)
+//! - `NOTIFY_SERVICE_URL` - URL of notification service (default: http://localhost:17004)
 //! - `RUST_LOG` - Logging level (default: info)
 //!
 //! # Examples
@@ -74,14 +74,14 @@
 //!
 //!     // Create notification client
 //!     let notification_client = NotificationClient::new(
-//!         "http://localhost:3000".to_string()
+//!         "http://localhost:17004".to_string()
 //!     );
 //!
 //!     // Create API state
 //!     let api_state = ApiState {
 //!         app_state,
 //!         notification_client,
-//!         notification_service_url: "http://localhost:3000".to_string(),
+//!         notification_service_url: "http://localhost:17004".to_string(),
 //!     };
 //!
 //!     // Create router and serve...

--- a/crates/ask/src/main.rs
+++ b/crates/ask/src/main.rs
@@ -8,7 +8,7 @@
 //! The following environment variables configure the service:
 //!
 //! - `PORT` - The port to bind to (default: 17001 dev, 7001 production)
-//! - `NOTIFY_SERVICE_URL` - Base URL of the notification service (default: http://localhost:3000)
+//! - `NOTIFY_SERVICE_URL` - Base URL of the notification service (default: http://localhost:17004)
 //! - `RUST_LOG` - Logging configuration (default: info)
 //!
 //! # Service Lifecycle
@@ -26,7 +26,7 @@
 //!
 //! ```bash
 //! cargo run
-//! # Starts on port 3001, connects to notification service at http://localhost:3000
+//! # Starts on port 17001, connects to notification service at http://localhost:17004
 //! ```
 //!
 //! ## Running with custom configuration

--- a/crates/ask/src/notification_client.rs
+++ b/crates/ask/src/notification_client.rs
@@ -28,7 +28,7 @@
 //! use ask::notification_client::NotificationClient;
 //!
 //! # async fn example() -> Result<(), Box<dyn std::error::Error>> {
-//! let client = NotificationClient::new("http://localhost:3000".to_string());
+//! let client = NotificationClient::new("http://localhost:17004".to_string());
 //!
 //! match client.health_check().await {
 //!     Ok(true) => println!("Notification service is healthy"),
@@ -46,7 +46,7 @@
 //! use uuid::Uuid;
 //!
 //! # async fn example() -> Result<(), Box<dyn std::error::Error>> {
-//! let client = NotificationClient::new("http://localhost:3000".to_string());
+//! let client = NotificationClient::new("http://localhost:17004".to_string());
 //! let question_id = Uuid::new_v4();
 //!
 //! let notification = client.create_tmux_session_question(question_id).await?;
@@ -80,7 +80,7 @@ use uuid::Uuid;
 /// ```no_run
 /// use ask::notification_client::NotificationClient;
 ///
-/// let client = NotificationClient::new("http://localhost:3000".to_string());
+/// let client = NotificationClient::new("http://localhost:17004".to_string());
 /// let client_clone = client.clone(); // Cheap clone
 /// ```
 #[derive(Clone)]
@@ -94,7 +94,7 @@ impl NotificationClient {
     ///
     /// # Arguments
     ///
-    /// - `base_url` - The base URL of the notification service (e.g., "http://localhost:3000")
+    /// - `base_url` - The base URL of the notification service (e.g., "http://localhost:17004")
     ///
     /// # Returns
     ///
@@ -105,7 +105,7 @@ impl NotificationClient {
     /// ```
     /// use ask::notification_client::NotificationClient;
     ///
-    /// let client = NotificationClient::new("http://localhost:3000".to_string());
+    /// let client = NotificationClient::new("http://localhost:17004".to_string());
     /// ```
     pub fn new(base_url: String) -> Self {
         Self { client: Client::new(), base_url }
@@ -142,7 +142,7 @@ impl NotificationClient {
     /// use uuid::Uuid;
     ///
     /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
-    /// let client = NotificationClient::new("http://localhost:3000".to_string());
+    /// let client = NotificationClient::new("http://localhost:17004".to_string());
     ///
     /// let request = CreateNotificationRequest {
     ///     source: NotificationSource::AskService { request_id: Uuid::new_v4() },
@@ -218,7 +218,7 @@ impl NotificationClient {
     /// use uuid::Uuid;
     ///
     /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
-    /// let client = NotificationClient::new("http://localhost:3000".to_string());
+    /// let client = NotificationClient::new("http://localhost:17004".to_string());
     /// let notification_id = Uuid::new_v4();
     ///
     /// let request = UpdateNotificationRequest {
@@ -313,7 +313,7 @@ impl NotificationClient {
     /// use ask::notification_client::NotificationClient;
     ///
     /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
-    /// let client = NotificationClient::new("http://localhost:3000".to_string());
+    /// let client = NotificationClient::new("http://localhost:17004".to_string());
     ///
     /// match client.health_check().await {
     ///     Ok(true) => println!("Service is healthy"),
@@ -361,7 +361,7 @@ impl NotificationClient {
     /// use uuid::Uuid;
     ///
     /// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
-    /// let client = NotificationClient::new("http://localhost:3000".to_string());
+    /// let client = NotificationClient::new("http://localhost:17004".to_string());
     /// let question_id = Uuid::new_v4();
     ///
     /// let notification = client.create_tmux_session_question(question_id).await?;
@@ -394,8 +394,8 @@ mod tests {
 
     #[test]
     fn test_notification_client_new() {
-        let client = NotificationClient::new("http://localhost:3000".to_string());
-        assert_eq!(client.base_url, "http://localhost:3000");
+        let client = NotificationClient::new("http://localhost:17004".to_string());
+        assert_eq!(client.base_url, "http://localhost:17004");
     }
 
     // Integration tests with mockito

--- a/crates/ask/tests/api_test.rs
+++ b/crates/ask/tests/api_test.rs
@@ -26,11 +26,11 @@ async fn parse_response_body(body: Body) -> Value {
 #[tokio::test]
 async fn test_health_endpoint() {
     let app_state = AppState::new();
-    let notification_client = NotificationClient::new("http://localhost:3000".to_string());
+    let notification_client = NotificationClient::new("http://localhost:17004".to_string());
     let api_state = ApiState {
         app_state,
         notification_client,
-        notification_service_url: "http://localhost:3000".to_string(),
+        notification_service_url: "http://localhost:17004".to_string(),
     };
 
     let app = create_router(api_state);
@@ -233,11 +233,11 @@ async fn test_answer_valid_question() {
 #[tokio::test]
 async fn test_answer_nonexistent_question() {
     let app_state = AppState::new();
-    let notification_client = NotificationClient::new("http://localhost:3000".to_string());
+    let notification_client = NotificationClient::new("http://localhost:17004".to_string());
     let api_state = ApiState {
         app_state,
         notification_client,
-        notification_service_url: "http://localhost:3000".to_string(),
+        notification_service_url: "http://localhost:17004".to_string(),
     };
 
     let app = create_router(api_state);
@@ -279,11 +279,11 @@ async fn test_answer_already_answered_question() {
     };
     app_state.add_question(question).await;
 
-    let notification_client = NotificationClient::new("http://localhost:3000".to_string());
+    let notification_client = NotificationClient::new("http://localhost:17004".to_string());
     let api_state = ApiState {
         app_state,
         notification_client,
-        notification_service_url: "http://localhost:3000".to_string(),
+        notification_service_url: "http://localhost:17004".to_string(),
     };
 
     let app = create_router(api_state);
@@ -370,11 +370,11 @@ async fn test_answer_notification_update_fails_but_answer_succeeds() {
 #[tokio::test]
 async fn test_concurrent_trigger_requests() {
     let app_state = AppState::with_cooldown(Duration::milliseconds(100));
-    let notification_client = NotificationClient::new("http://localhost:3000".to_string());
+    let notification_client = NotificationClient::new("http://localhost:17004".to_string());
     let api_state = ApiState {
         app_state,
         notification_client,
-        notification_service_url: "http://localhost:3000".to_string(),
+        notification_service_url: "http://localhost:17004".to_string(),
     };
 
     let app = create_router(api_state);
@@ -438,11 +438,11 @@ async fn test_health_response_structure() {
 #[tokio::test]
 async fn test_trigger_response_structure() {
     let app_state = AppState::new();
-    let notification_client = NotificationClient::new("http://localhost:3000".to_string());
+    let notification_client = NotificationClient::new("http://localhost:17004".to_string());
     let api_state = ApiState {
         app_state,
         notification_client,
-        notification_service_url: "http://localhost:3000".to_string(),
+        notification_service_url: "http://localhost:17004".to_string(),
     };
 
     let app = create_router(api_state);
@@ -469,11 +469,11 @@ async fn test_trigger_response_structure() {
 #[tokio::test]
 async fn test_answer_with_invalid_json() {
     let app_state = AppState::new();
-    let notification_client = NotificationClient::new("http://localhost:3000".to_string());
+    let notification_client = NotificationClient::new("http://localhost:17004".to_string());
     let api_state = ApiState {
         app_state,
         notification_client,
-        notification_service_url: "http://localhost:3000".to_string(),
+        notification_service_url: "http://localhost:17004".to_string(),
     };
 
     let app = create_router(api_state);
@@ -498,11 +498,11 @@ async fn test_answer_with_invalid_json() {
 #[tokio::test]
 async fn test_wrong_http_method() {
     let app_state = AppState::new();
-    let notification_client = NotificationClient::new("http://localhost:3000".to_string());
+    let notification_client = NotificationClient::new("http://localhost:17004".to_string());
     let api_state = ApiState {
         app_state,
         notification_client,
-        notification_service_url: "http://localhost:3000".to_string(),
+        notification_service_url: "http://localhost:17004".to_string(),
     };
 
     let app = create_router(api_state);
@@ -520,11 +520,11 @@ async fn test_wrong_http_method() {
 #[tokio::test]
 async fn test_nonexistent_endpoint() {
     let app_state = AppState::new();
-    let notification_client = NotificationClient::new("http://localhost:3000".to_string());
+    let notification_client = NotificationClient::new("http://localhost:17004".to_string());
     let api_state = ApiState {
         app_state,
         notification_client,
-        notification_service_url: "http://localhost:3000".to_string(),
+        notification_service_url: "http://localhost:17004".to_string(),
     };
 
     let app = create_router(api_state);

--- a/crates/cli/src/commands/ask.rs
+++ b/crates/cli/src/commands/ask.rs
@@ -43,7 +43,7 @@ use uuid::Uuid;
 /// Ask service subcommands.
 ///
 /// Each variant corresponds to a specific operation on the ask service.
-/// All commands communicate with the ask service REST API on port 3001.
+/// All commands communicate with the ask service REST API on port 7001.
 #[derive(Subcommand)]
 pub enum AskCommand {
     /// Trigger all checks in the ask service.

--- a/crates/cli/src/commands/notify.rs
+++ b/crates/cli/src/commands/notify.rs
@@ -55,7 +55,7 @@ use uuid::Uuid;
 /// Notification management subcommands.
 ///
 /// Each variant corresponds to a specific operation on notifications. All commands
-/// communicate with the notification service REST API on port 3000.
+/// communicate with the notification service REST API on port 7004.
 #[derive(Subcommand)]
 pub enum NotifyCommand {
     /// Create a new notification via the REST API.

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1,8 +1,10 @@
 //! Command-line interface for the agentd service ecosystem.
 //!
 //! The `agent` CLI provides a unified interface for interacting with multiple services:
-//! - **Notification Service** (port 3000): Manage notifications from various sources
-//! - **Ask Service** (port 3001): Trigger checks and answer questions
+//! - **Notification Service** (port 17004): Manage notifications from various sources
+//! - **Ask Service** (port 17001): Trigger checks and answer questions
+//! - **Orchestrator Service** (port 17006): Manage agents and workflows
+//! - **Wrap Service** (port 17005): Launch agents in tmux sessions
 //! - **Hook Daemon**: Git and system hooks integration (coming soon)
 //! - **Monitor Daemon**: System monitoring and alerts (coming soon)
 //!
@@ -58,9 +60,11 @@
 //!
 //! # Service URLs
 //!
-//! The CLI connects to services running on localhost:
-//! - Notification service: `http://localhost:3000`
-//! - Ask service: `http://localhost:3001`
+//! The CLI connects to services running on localhost (default dev ports):
+//! - Notification service: `http://localhost:7004` (override with `NOTIFY_SERVICE_URL`)
+//! - Ask service: `http://localhost:7001` (override with `ASK_SERVICE_URL`)
+//! - Wrap service: `http://localhost:7005` (override with `WRAP_SERVICE_URL`)
+//! - Orchestrator service: `http://localhost:7006` (override with `ORCHESTRATOR_SERVICE_URL`)
 //!
 //! # Architecture
 //!
@@ -107,7 +111,7 @@ enum Commands {
     ///
     /// Manage notifications from various sources including agent hooks, ask service,
     /// monitor service, and system notifications. The notification service runs on
-    /// port 3000 by default.
+    /// port 7004 by default.
     Notify {
         #[command(subcommand)]
         command: NotifyCommand,
@@ -115,7 +119,7 @@ enum Commands {
     /// Interact with the ask service
     ///
     /// Trigger periodic checks and answer questions from the ask service. The ask
-    /// service runs on port 3001 by default and can create notifications when checks
+    /// service runs on port 7001 by default and can create notifications when checks
     /// require user attention.
     Ask {
         #[command(subcommand)]
@@ -158,8 +162,10 @@ enum Commands {
 ///
 /// # Service Connections
 ///
-/// - Notify commands connect to `http://localhost:3000`
-/// - Ask commands connect to `http://localhost:3001`
+/// - Notify commands connect to `http://localhost:7004`
+/// - Ask commands connect to `http://localhost:7001`
+/// - Wrap commands connect to `http://localhost:7005`
+/// - Orchestrator commands connect to `http://localhost:7006`
 ///
 /// # Error Handling
 ///

--- a/crates/notify/src/api.rs
+++ b/crates/notify/src/api.rs
@@ -33,7 +33,7 @@
 //!     let router = create_router(state);
 //!
 //!     // Bind and serve
-//!     let listener = tokio::net::TcpListener::bind("127.0.0.1:3030").await?;
+//!     let listener = tokio::net::TcpListener::bind("127.0.0.1:17004").await?;
 //!     axum::serve(listener, router).await?;
 //!     Ok(())
 //! }
@@ -43,10 +43,10 @@
 //!
 //! ```bash
 //! # Health check
-//! curl http://localhost:3030/health
+//! curl http://localhost:17004/health
 //!
 //! # Create notification
-//! curl -X POST http://localhost:3030/notifications \
+//! curl -X POST http://localhost:17004/notifications \
 //!   -H "Content-Type: application/json" \
 //!   -d '{
 //!     "source": "System",
@@ -58,13 +58,13 @@
 //!   }'
 //!
 //! # List notifications
-//! curl http://localhost:3030/notifications
+//! curl http://localhost:17004/notifications
 //!
 //! # Filter by status
-//! curl "http://localhost:3030/notifications?status=pending"
+//! curl "http://localhost:17004/notifications?status=pending"
 //!
 //! # Get actionable notifications
-//! curl http://localhost:3030/notifications/actionable
+//! curl http://localhost:17004/notifications/actionable
 //! ```
 
 use crate::{storage::NotificationStorage, types::*};
@@ -134,7 +134,7 @@ pub struct ApiState {
 ///     };
 ///     let router = create_router(state);
 ///
-///     let listener = tokio::net::TcpListener::bind("127.0.0.1:3030").await?;
+///     let listener = tokio::net::TcpListener::bind("127.0.0.1:17004").await?;
 ///     axum::serve(listener, router).await?;
 ///     Ok(())
 /// }
@@ -181,7 +181,7 @@ pub fn create_router(state: ApiState) -> Router {
 /// # Examples
 ///
 /// ```bash
-/// curl http://localhost:3030/health
+/// curl http://localhost:17004/health
 /// ```
 async fn health_check() -> impl IntoResponse {
     Json(serde_json::json!({
@@ -218,10 +218,10 @@ async fn health_check() -> impl IntoResponse {
 ///
 /// ```bash
 /// # Get all notifications
-/// curl http://localhost:3030/notifications
+/// curl http://localhost:17004/notifications
 ///
 /// # Get only pending notifications
-/// curl "http://localhost:3030/notifications?status=pending"
+/// curl "http://localhost:17004/notifications?status=pending"
 /// ```
 async fn list_notifications(
     State(state): State<ApiState>,
@@ -256,7 +256,7 @@ async fn list_notifications(
 /// # Examples
 ///
 /// ```bash
-/// curl http://localhost:3030/notifications/actionable
+/// curl http://localhost:17004/notifications/actionable
 /// ```
 async fn list_actionable(
     State(state): State<ApiState>,
@@ -285,7 +285,7 @@ async fn list_actionable(
 /// # Examples
 ///
 /// ```bash
-/// curl http://localhost:3030/notifications/history
+/// curl http://localhost:17004/notifications/history
 /// ```
 async fn list_history(State(state): State<ApiState>) -> Result<Json<Vec<Notification>>, ApiError> {
     let notifications = state.storage.list_history().await?;
@@ -310,7 +310,7 @@ async fn list_history(State(state): State<ApiState>) -> Result<Json<Vec<Notifica
 /// # Example
 ///
 /// ```bash
-/// curl http://localhost:3030/notifications/count
+/// curl http://localhost:17004/notifications/count
 /// ```
 ///
 /// Response:
@@ -370,7 +370,7 @@ async fn count_notifications(
 /// # Examples
 ///
 /// ```bash
-/// curl -X POST http://localhost:3030/notifications \
+/// curl -X POST http://localhost:17004/notifications \
 ///   -H "Content-Type: application/json" \
 ///   -d '{
 ///     "source": "System",
@@ -423,7 +423,7 @@ async fn create_notification(
 /// # Examples
 ///
 /// ```bash
-/// curl http://localhost:3030/notifications/550e8400-e29b-41d4-a716-446655440000
+/// curl http://localhost:17004/notifications/550e8400-e29b-41d4-a716-446655440000
 /// ```
 async fn get_notification(
     State(state): State<ApiState>,
@@ -471,12 +471,12 @@ async fn get_notification(
 ///
 /// ```bash
 /// # Dismiss a notification
-/// curl -X PUT http://localhost:3030/notifications/550e8400-e29b-41d4-a716-446655440000 \
+/// curl -X PUT http://localhost:17004/notifications/550e8400-e29b-41d4-a716-446655440000 \
 ///   -H "Content-Type: application/json" \
 ///   -d '{"status": "Dismissed"}'
 ///
 /// # Respond to a notification
-/// curl -X PUT http://localhost:3030/notifications/550e8400-e29b-41d4-a716-446655440000 \
+/// curl -X PUT http://localhost:17004/notifications/550e8400-e29b-41d4-a716-446655440000 \
 ///   -H "Content-Type: application/json" \
 ///   -d '{"response": "Approved"}'
 /// ```
@@ -528,7 +528,7 @@ async fn update_notification(
 /// # Examples
 ///
 /// ```bash
-/// curl -X DELETE http://localhost:3030/notifications/550e8400-e29b-41d4-a716-446655440000
+/// curl -X DELETE http://localhost:17004/notifications/550e8400-e29b-41d4-a716-446655440000
 /// ```
 async fn delete_notification(
     State(state): State<ApiState>,

--- a/crates/notify/src/lib.rs
+++ b/crates/notify/src/lib.rs
@@ -76,7 +76,7 @@
 //!
 //! ## Configuration
 //!
-//! The service listens on port 3000 by default and stores data in:
+//! The service listens on port 17004 by default (dev) or 7004 (production) and stores data in:
 //! `~/.local/share/agentd/notifications.db`
 
 pub mod api;

--- a/crates/notify/src/main.rs
+++ b/crates/notify/src/main.rs
@@ -7,7 +7,7 @@
 //! # Features
 //!
 //! - SQLite-based persistent notification storage
-//! - REST API on `http://127.0.0.1:3000`
+//! - REST API on `http://127.0.0.1:17004` (dev default)
 //! - Automatic cleanup of expired notifications every 5 minutes
 //! - Structured logging with tracing
 //! - Graceful shutdown support
@@ -57,7 +57,7 @@
 //! cargo run -p agentd-notify
 //!
 //! # In another terminal, test the API
-//! curl http://localhost:3000/health
+//! curl http://localhost:17004/health
 //! ```
 
 mod api;
@@ -79,7 +79,7 @@ use tracing::{info, warn};
 /// 2. Initializes the SQLite storage backend
 /// 3. Spawns a background task for cleaning up expired notifications
 /// 4. Creates and configures the Axum HTTP router
-/// 5. Starts the HTTP server on `127.0.0.1:3000`
+/// 5. Starts the HTTP server on `127.0.0.1:17004` (dev default)
 ///
 /// # Returns
 ///

--- a/docs/public/install.md
+++ b/docs/public/install.md
@@ -7,8 +7,8 @@ This guide covers installation of the agentd system on macOS.
 The agentd system consists of:
 
 - **agent** - Command-line interface for interacting with services
-- **agentd-notify** - Notification service (REST API on port 3000)
-- **agentd-ask** - Ask service for interactive questions (REST API on port 3001)
+- **agentd-notify** - Notification service (REST API on port 17004 dev / 7004 prod)
+- **agentd-ask** - Ask service for interactive questions (REST API on port 17001 dev / 7001 prod)
 - **agentd-hook** - Hook service for shell integration
 - **agentd-monitor** - Monitoring service
 
@@ -31,7 +31,7 @@ Choose one of two installation methods:
 
 ```bash
 # Clone the repository
-git clone https://github.com/yourusername/agentd.git
+git clone https://github.com/geoffjay/agentd.git
 cd agentd
 
 # Fix /usr/local permissions (one-time setup)
@@ -203,11 +203,19 @@ launchctl list com.geoffjay.agentd-notify
 
 ### Service Ports
 
-Default ports for services:
-- **agentd-notify**: 3000
-- **agentd-ask**: 3001
+Each service uses a development port (17xxx) by default when started with `cargo run`,
+and a production port (7xxx) when running as a LaunchAgent:
 
-Ports can be configured via environment variables in the plist files.
+| Service | Dev Port | Prod Port |
+|---------|----------|-----------|
+| agentd-ask | 17001 | 7001 |
+| agentd-hook | 17002 | 7002 |
+| agentd-monitor | 17003 | 7003 |
+| agentd-notify | 17004 | 7004 |
+| agentd-wrap | 17005 | 7005 |
+| agentd-orchestrator | 17006 | 7006 |
+
+All ports are configurable via the `PORT` environment variable.
 
 ### Custom Installation Location
 
@@ -281,8 +289,8 @@ export PATH="$HOME/.local/bin:$PATH"
 
 4. Verify port availability:
    ```bash
-   lsof -i :3000
-   lsof -i :3001
+   lsof -i :17004
+   lsof -i :17001
    ```
 
 ### Service Keeps Restarting
@@ -306,8 +314,8 @@ Common issues:
 
 2. Check if port is listening:
    ```bash
-   curl http://localhost:3000/health
-   curl http://localhost:3001/health
+   curl http://localhost:17004/health
+   curl http://localhost:17001/health
    ```
 
 3. Restart services:
@@ -375,8 +383,8 @@ After installation:
 
 2. Check service health:
    ```bash
-   curl http://localhost:3000/health
-   curl http://localhost:3001/health
+   curl http://localhost:17004/health
+   curl http://localhost:17001/health
    ```
 
 3. View logs to ensure services are running:

--- a/docs/public/services/notify.md
+++ b/docs/public/services/notify.md
@@ -5,7 +5,7 @@ The notify service is a pure API daemon that manages notifications. It exposes a
 ## Base URL
 
 ```
-http://127.0.0.1:3030
+http://127.0.0.1:17004
 ```
 
 ## Endpoints
@@ -245,7 +245,7 @@ Notifications are stored in SQLite at:
 ### Create a system notification
 
 ```bash
-curl -X POST http://127.0.0.1:3030/notifications \
+curl -X POST http://127.0.0.1:17004/notifications \
   -H "Content-Type: application/json" \
   -d '{
     "source": "System",
@@ -260,7 +260,7 @@ curl -X POST http://127.0.0.1:3030/notifications \
 ### Create an ephemeral notification from agent hook
 
 ```bash
-curl -X POST http://127.0.0.1:3030/notifications \
+curl -X POST http://127.0.0.1:17004/notifications \
   -H "Content-Type: application/json" \
   -d '{
     "source": {"AgentHook": {"agent_id": "git-agent", "hook_type": "pre-commit"}},
@@ -275,13 +275,13 @@ curl -X POST http://127.0.0.1:3030/notifications \
 ### Get actionable notifications
 
 ```bash
-curl http://127.0.0.1:3030/notifications/actionable
+curl http://127.0.0.1:17004/notifications/actionable
 ```
 
 ### Mark notification as viewed
 
 ```bash
-curl -X PUT http://127.0.0.1:3030/notifications/{id} \
+curl -X PUT http://127.0.0.1:17004/notifications/{id} \
   -H "Content-Type: application/json" \
   -d '{"status": "Viewed"}'
 ```
@@ -289,7 +289,7 @@ curl -X PUT http://127.0.0.1:3030/notifications/{id} \
 ### Respond to a notification
 
 ```bash
-curl -X PUT http://127.0.0.1:3030/notifications/{id} \
+curl -X PUT http://127.0.0.1:17004/notifications/{id} \
   -H "Content-Type: application/json" \
   -d '{"status": "Responded", "response": "User approved the request"}'
 ```
@@ -300,4 +300,4 @@ curl -X PUT http://127.0.0.1:3030/notifications/{id} \
 cargo run -p agentd-notify
 ```
 
-The service will start on `http://127.0.0.1:3030`
+The service will start on `http://127.0.0.1:17004`


### PR DESCRIPTION
## Summary

- Fixed all port number references across 16 files to use the correct canonical mapping
- Added a Port Configuration table to README explaining dev vs prod ports
- Fixed git clone URL (`yourusername` -> `geoffjay`) in README, install docs, and CHANGELOG
- Fixed incorrect env var name (`ASK_PORT` -> `PORT`) in ask crate docs

## Canonical Port Mapping

| Service | Dev Port | Prod Port |
|---------|----------|-----------|
| ask | 17001 | 7001 |
| hook | 17002 | 7002 |
| monitor | 17003 | 7003 |
| notify | 17004 | 7004 |
| wrap | 17005 | 7005 |
| orchestrator | 17006 | 7006 |

## Files Changed (16)

**Documentation:**
- `README.md` — ports, clone URL, added port config section, added orchestrator/wrap to architecture
- `docs/public/install.md` — ports, clone URL, added port table
- `docs/public/services/notify.md` — base URL 3030 -> 17004
- `contrib/README.md` — port listing with all 6 services
- `CHANGELOG.md` — GitHub URLs

**Rust doc comments:**
- `crates/notify/src/api.rs` — all 3030 references -> 17004
- `crates/notify/src/lib.rs` — port 3000 -> 17004
- `crates/notify/src/main.rs` — port 3000 -> 17004
- `crates/ask/src/lib.rs` — ports, env var name fix
- `crates/ask/src/api.rs` — all 3001/3000 references
- `crates/ask/src/main.rs` — ports
- `crates/ask/src/notification_client.rs` — doc comment ports
- `crates/cli/src/main.rs` — doc comment ports, added new services
- `crates/cli/src/commands/ask.rs` — port in doc comment
- `crates/cli/src/commands/notify.rs` — port in doc comment

**Tests:**
- `crates/ask/tests/api_test.rs` — test fixture URLs for consistency

## Test plan

- [x] `cargo build --workspace` passes
- [x] `cargo test -p cli -p notify` — all tests pass
- [x] `cargo test -p ask` — 64 pass, 4 pre-existing failures (unrelated to port changes)
- [x] No remaining references to ports 3000, 3001, or 3030 in .rs or .md files

Closes #21

🤖 Generated with [Claude Code](https://claude.com/claude-code)