### PR TITLE
Add test coverage for baml and cli crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -285,6 +285,7 @@ name = "baml"
 version = "0.2.0"
 dependencies = [
  "anyhow",
+ "mockito",
  "reqwest",
  "serde",
  "serde_json",

--- a/crates/baml/Cargo.toml
+++ b/crates/baml/Cargo.toml
@@ -26,3 +26,4 @@ tracing = { workspace = true }
 [dev-dependencies]
 tokio = { workspace = true, features = ["rt-multi-thread", "macros"] }
 tracing-subscriber = "0.3"
+mockito = "1.2"

--- a/crates/baml/src/client.rs
+++ b/crates/baml/src/client.rs
@@ -683,3 +683,304 @@ impl BamlClient {
             .await
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::error::BamlError;
+    use mockito::Server;
+
+    fn client_with_url(url: &str) -> BamlClient {
+        let config = BamlClientConfig::new(url).with_timeout(5).with_max_retries(0);
+        BamlClient::new(config)
+    }
+
+    fn client_with_retries(url: &str, retries: u32) -> BamlClient {
+        let config = BamlClientConfig::new(url).with_timeout(5).with_max_retries(retries);
+        BamlClient::new(config)
+    }
+
+    // -- Config tests --
+
+    #[test]
+    fn test_default_config() {
+        let config = BamlClientConfig::default();
+        assert_eq!(config.base_url, "http://localhost:2024");
+        assert_eq!(config.timeout_secs, 30);
+        assert_eq!(config.max_retries, 2);
+    }
+
+    #[test]
+    fn test_config_builder() {
+        let config = BamlClientConfig::new("http://example.com")
+            .with_timeout(10)
+            .with_max_retries(5);
+        assert_eq!(config.base_url, "http://example.com");
+        assert_eq!(config.timeout_secs, 10);
+        assert_eq!(config.max_retries, 5);
+    }
+
+    #[test]
+    fn test_default_client() {
+        let _client = BamlClient::default();
+    }
+
+    // -- call_function success --
+
+    #[tokio::test]
+    async fn test_call_function_success() {
+        let mut server = Server::new_async().await;
+        let mock = server
+            .mock("POST", "/call/CategorizeNotification")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{
+                "category": "error",
+                "priority": "high",
+                "suggested_lifetime": "persistent",
+                "reasoning": "Database error detected",
+                "suggested_action": "Check database connectivity"
+            }"#)
+            .create_async()
+            .await;
+
+        let client = client_with_url(&server.url());
+        let result = client
+            .categorize_notification("DB Error", "Connection lost", "production")
+            .await;
+
+        assert!(result.is_ok());
+        let category = result.unwrap();
+        assert_eq!(category.category, "error");
+        assert_eq!(category.priority, "high");
+        mock.assert_async().await;
+    }
+
+    // -- Error handling --
+
+    #[tokio::test]
+    async fn test_function_not_found() {
+        let mut server = Server::new_async().await;
+        let mock = server
+            .mock("POST", "/call/NonExistentFunction")
+            .with_status(404)
+            .create_async()
+            .await;
+
+        let client = client_with_url(&server.url());
+        let result: Result<String> = client.call_function("NonExistentFunction", &"{}").await;
+
+        assert!(result.is_err());
+        assert!(matches!(result.unwrap_err(), BamlError::FunctionNotFound { .. }));
+        mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn test_server_error_500() {
+        let mut server = Server::new_async().await;
+        let mock = server
+            .mock("POST", "/call/TestFunc")
+            .with_status(500)
+            .with_body("Internal server error")
+            .create_async()
+            .await;
+
+        let client = client_with_url(&server.url());
+        let result: Result<String> = client.call_function("TestFunc", &"{}").await;
+
+        assert!(result.is_err());
+        assert!(matches!(result.unwrap_err(), BamlError::ServerError { status: 500, .. }));
+        mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn test_invalid_json_response() {
+        let mut server = Server::new_async().await;
+        let mock = server
+            .mock("POST", "/call/CategorizeNotification")
+            .with_status(200)
+            .with_body("not valid json")
+            .create_async()
+            .await;
+
+        let client = client_with_url(&server.url());
+        let result = client
+            .categorize_notification("Test", "Test", "test")
+            .await;
+
+        assert!(result.is_err());
+        assert!(matches!(result.unwrap_err(), BamlError::InvalidResponse(_)));
+        mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn test_server_unreachable() {
+        let client = client_with_url("http://127.0.0.1:19999");
+        let result = client
+            .categorize_notification("Test", "Test", "test")
+            .await;
+
+        assert!(result.is_err());
+    }
+
+    // -- Retry logic --
+
+    #[tokio::test]
+    async fn test_retry_on_server_error() {
+        let mut server = Server::new_async().await;
+
+        // First call returns 500, second returns 200
+        let fail_mock = server
+            .mock("POST", "/call/TestFunc")
+            .with_status(500)
+            .with_body("temporary error")
+            .expect(1)
+            .create_async()
+            .await;
+
+        let success_mock = server
+            .mock("POST", "/call/TestFunc")
+            .with_status(200)
+            .with_body("\"success\"")
+            .expect(1)
+            .create_async()
+            .await;
+
+        let client = client_with_retries(&server.url(), 1);
+        let result: Result<String> = client.call_function("TestFunc", &"{}").await;
+
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap(), "success");
+        fail_mock.assert_async().await;
+        success_mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn test_no_retry_on_404() {
+        let mut server = Server::new_async().await;
+
+        let mock = server
+            .mock("POST", "/call/Missing")
+            .with_status(404)
+            .expect(1)
+            .create_async()
+            .await;
+
+        let client = client_with_retries(&server.url(), 2);
+        let result: Result<String> = client.call_function("Missing", &"{}").await;
+
+        assert!(result.is_err());
+        assert!(matches!(result.unwrap_err(), BamlError::FunctionNotFound { .. }));
+        mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn test_exhausts_retries() {
+        let mut server = Server::new_async().await;
+
+        let mock = server
+            .mock("POST", "/call/TestFunc")
+            .with_status(500)
+            .with_body("persistent error")
+            .expect(3) // initial + 2 retries
+            .create_async()
+            .await;
+
+        let client = client_with_retries(&server.url(), 2);
+        let result: Result<String> = client.call_function("TestFunc", &"{}").await;
+
+        assert!(result.is_err());
+        assert!(matches!(result.unwrap_err(), BamlError::ServerError { .. }));
+        mock.assert_async().await;
+    }
+
+    // -- Domain method tests --
+
+    #[tokio::test]
+    async fn test_summarize_notifications() {
+        let mut server = Server::new_async().await;
+        let mock = server
+            .mock("POST", "/call/SummarizeNotifications")
+            .with_status(200)
+            .with_body(r#"{
+                "summary": "5 notifications in the last hour",
+                "key_actions": ["Review database alerts"],
+                "urgent_count": 1,
+                "high_count": 2,
+                "normal_count": 1,
+                "low_count": 1,
+                "categories": {"error": 3, "info": 2},
+                "trends": "Increasing error rate",
+                "recommendations": ["Check database"]
+            }"#)
+            .create_async()
+            .await;
+
+        let client = client_with_url(&server.url());
+        let notifications = vec!["Alert 1".to_string(), "Alert 2".to_string()];
+        let result = client.summarize_notifications(&notifications, "last hour").await;
+
+        assert!(result.is_ok());
+        let digest = result.unwrap();
+        assert_eq!(digest.urgent_count, 1);
+        assert_eq!(digest.high_count, 2);
+        mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn test_analyze_answer() {
+        let mut server = Server::new_async().await;
+        let mock = server
+            .mock("POST", "/call/AnalyzeAnswer")
+            .with_status(200)
+            .with_body(r#"{
+                "interpretation": "User agrees",
+                "confidence": 0.95,
+                "suggested_action": "proceed",
+                "needs_followup": false,
+                "followup_question": null
+            }"#)
+            .create_async()
+            .await;
+
+        let client = client_with_url(&server.url());
+        let result = client.analyze_answer("Start tmux?", "yes", "yes_no").await;
+
+        assert!(result.is_ok());
+        let analysis = result.unwrap();
+        assert_eq!(analysis.confidence, 0.95);
+        assert!(!analysis.needs_followup);
+        mock.assert_async().await;
+    }
+
+    #[tokio::test]
+    async fn test_analyze_shell_event() {
+        let mut server = Server::new_async().await;
+        let mock = server
+            .mock("POST", "/call/AnalyzeShellEvent")
+            .with_status(200)
+            .with_body(r#"{
+                "should_notify": true,
+                "notification_title": "Build Failed",
+                "notification_message": "cargo build exited with code 1",
+                "priority": "high",
+                "reasoning": "Build failure detected",
+                "metadata": {},
+                "indicates_problem": true,
+                "suggested_actions": ["Fix compilation errors"]
+            }"#)
+            .create_async()
+            .await;
+
+        let client = client_with_url(&server.url());
+        let result = client
+            .analyze_shell_event("cargo build", 1, "error[E0308]", 5000, "development")
+            .await;
+
+        assert!(result.is_ok());
+        let action = result.unwrap();
+        assert!(action.should_notify);
+        assert!(action.indicates_problem);
+        mock.assert_async().await;
+    }
+}

--- a/crates/baml/src/types.rs
+++ b/crates/baml/src/types.rs
@@ -291,3 +291,166 @@ pub struct CommandInsight {
     /// Whether user typically cares about this command's completion
     pub user_cares_about_completion: bool,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_notification_category_serde() {
+        let category = NotificationCategory {
+            category: "error".to_string(),
+            priority: "high".to_string(),
+            suggested_lifetime: "persistent".to_string(),
+            reasoning: "Critical issue".to_string(),
+            suggested_action: Some("Investigate".to_string()),
+        };
+
+        let json = serde_json::to_string(&category).unwrap();
+        let deserialized: NotificationCategory = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.category, "error");
+        assert_eq!(deserialized.priority, "high");
+        assert_eq!(deserialized.suggested_action, Some("Investigate".to_string()));
+    }
+
+    #[test]
+    fn test_notification_category_optional_field() {
+        let json = r#"{
+            "category": "info",
+            "priority": "low",
+            "suggested_lifetime": "ephemeral",
+            "reasoning": "FYI",
+            "suggested_action": null
+        }"#;
+        let category: NotificationCategory = serde_json::from_str(json).unwrap();
+        assert!(category.suggested_action.is_none());
+    }
+
+    #[test]
+    fn test_notification_digest_serde() {
+        let digest = NotificationDigest {
+            summary: "5 alerts".to_string(),
+            key_actions: vec!["Review".to_string()],
+            urgent_count: 1,
+            high_count: 2,
+            normal_count: 1,
+            low_count: 1,
+            categories: HashMap::from([("error".to_string(), 3)]),
+            trends: "Increasing".to_string(),
+            recommendations: vec!["Check logs".to_string()],
+        };
+
+        let json = serde_json::to_string(&digest).unwrap();
+        let deserialized: NotificationDigest = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.urgent_count, 1);
+        assert_eq!(deserialized.categories.get("error"), Some(&3));
+    }
+
+    #[test]
+    fn test_system_question_serde() {
+        let question = SystemQuestion {
+            question_text: "Start tmux?".to_string(),
+            suggested_responses: vec!["yes".to_string(), "no".to_string()],
+            reasoning: "No sessions running".to_string(),
+            urgency: "normal".to_string(),
+            follow_up_actions: HashMap::from([("yes".to_string(), "start session".to_string())]),
+            help_text: None,
+        };
+
+        let json = serde_json::to_string(&question).unwrap();
+        let deserialized: SystemQuestion = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.question_text, "Start tmux?");
+        assert_eq!(deserialized.suggested_responses.len(), 2);
+    }
+
+    #[test]
+    fn test_answer_analysis_serde() {
+        let analysis = AnswerAnalysis {
+            interpretation: "User agrees".to_string(),
+            confidence: 0.95,
+            suggested_action: "proceed".to_string(),
+            needs_followup: false,
+            followup_question: None,
+        };
+
+        let json = serde_json::to_string(&analysis).unwrap();
+        let deserialized: AnswerAnalysis = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.confidence, 0.95);
+        assert!(!deserialized.needs_followup);
+    }
+
+    #[test]
+    fn test_log_analysis_serde() {
+        let analysis = LogAnalysis {
+            has_errors: true,
+            error_summary: "Connection timeouts".to_string(),
+            affected_services: vec!["db".to_string()],
+            suggested_actions: vec!["Restart".to_string()],
+            severity: "error".to_string(),
+            root_cause: "Network".to_string(),
+            requires_immediate_attention: true,
+            impact_assessment: "High".to_string(),
+        };
+
+        let json = serde_json::to_string(&analysis).unwrap();
+        let deserialized: LogAnalysis = serde_json::from_str(&json).unwrap();
+        assert!(deserialized.has_errors);
+        assert!(deserialized.requires_immediate_attention);
+    }
+
+    #[test]
+    fn test_command_intent_serde() {
+        let intent = CommandIntent {
+            action: "list".to_string(),
+            parameters: HashMap::from([("status".to_string(), "pending".to_string())]),
+            confidence: 0.9,
+            requires_confirmation: false,
+            execution_summary: "List pending items".to_string(),
+            warnings: None,
+        };
+
+        let json = serde_json::to_string(&intent).unwrap();
+        let deserialized: CommandIntent = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.action, "list");
+        assert_eq!(deserialized.confidence, 0.9);
+    }
+
+    #[test]
+    fn test_hook_action_serde() {
+        let action = HookAction {
+            should_notify: true,
+            notification_title: "Build Failed".to_string(),
+            notification_message: "Error in main.rs".to_string(),
+            priority: "high".to_string(),
+            reasoning: "Build failure".to_string(),
+            metadata: HashMap::new(),
+            indicates_problem: true,
+            suggested_actions: Some(vec!["Fix errors".to_string()]),
+        };
+
+        let json = serde_json::to_string(&action).unwrap();
+        let deserialized: HookAction = serde_json::from_str(&json).unwrap();
+        assert!(deserialized.should_notify);
+        assert!(deserialized.indicates_problem);
+    }
+
+    #[test]
+    fn test_baml_error_display() {
+        use crate::error::BamlError;
+
+        let err = BamlError::FunctionNotFound { function_name: "TestFunc".to_string() };
+        assert!(err.to_string().contains("TestFunc"));
+
+        let err = BamlError::ServerError { status: 500, message: "fail".to_string() };
+        assert!(err.to_string().contains("500"));
+
+        let err = BamlError::Timeout { timeout_secs: 30 };
+        assert!(err.to_string().contains("30"));
+
+        let err = BamlError::InvalidResponse("bad json".to_string());
+        assert!(err.to_string().contains("bad json"));
+
+        let err = BamlError::ConfigError("bad config".to_string());
+        assert!(err.to_string().contains("bad config"));
+    }
+}

--- a/crates/cli/src/commands/ask.rs
+++ b/crates/cli/src/commands/ask.rs
@@ -197,3 +197,54 @@ async fn answer_question(
 
     Ok(())
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ask::types::{AnswerResponse, TriggerResponse};
+
+    #[test]
+    fn test_trigger_response_json_deserialization() {
+        let json = r#"{
+            "checks_run": ["tmux_sessions"],
+            "notifications_sent": [],
+            "results": {
+                "tmux_sessions": {
+                    "running": true,
+                    "session_count": 2
+                }
+            }
+        }"#;
+
+        let response: TriggerResponse = serde_json::from_str(json).unwrap();
+        assert_eq!(response.checks_run, vec!["tmux_sessions"]);
+        assert!(response.notifications_sent.is_empty());
+        assert!(response.results.tmux_sessions.running);
+        assert_eq!(response.results.tmux_sessions.session_count, 2);
+    }
+
+    #[test]
+    fn test_answer_request_serialization() {
+        let request = AnswerRequest {
+            question_id: Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap(),
+            answer: "yes".to_string(),
+        };
+
+        let json = serde_json::to_string(&request).unwrap();
+        assert!(json.contains("550e8400"));
+        assert!(json.contains("yes"));
+    }
+
+    #[test]
+    fn test_answer_response_deserialization() {
+        let json = r#"{
+            "success": true,
+            "message": "Answer recorded",
+            "question_id": "550e8400-e29b-41d4-a716-446655440000"
+        }"#;
+
+        let response: AnswerResponse = serde_json::from_str(json).unwrap();
+        assert!(response.success);
+        assert_eq!(response.message, "Answer recorded");
+    }
+}


### PR DESCRIPTION
## Summary

Adds 26 new tests across the baml and cli crates, which previously had zero (baml) or minimal (cli ask commands) test coverage.

## New Tests

### baml crate — 23 tests

**Config & client creation (3):**
- `test_default_config` — verifies default BamlClientConfig values
- `test_config_builder` — verifies builder pattern (with_timeout, with_max_retries)
- `test_default_client` — BamlClient::default() doesn't panic

**call_function error handling (4):**
- `test_call_function_success` — mock 200 with valid JSON → parses NotificationCategory
- `test_function_not_found` — mock 404 → BamlError::FunctionNotFound
- `test_server_error_500` — mock 500 → BamlError::ServerError
- `test_invalid_json_response` — mock 200 with bad body → BamlError::InvalidResponse
- `test_server_unreachable` — connection refused → error

**Retry logic (3):**
- `test_retry_on_server_error` — 500 then 200 → succeeds on retry (verifies both mocks hit exactly once)
- `test_no_retry_on_404` — 404 returns immediately without retry (mock expects exactly 1 call)
- `test_exhausts_retries` — 3x 500 → final ServerError (mock expects exactly 3 calls)

**Domain methods with mocked responses (3):**
- `test_summarize_notifications` — verifies NotificationDigest parsing
- `test_analyze_answer` — verifies AnswerAnalysis parsing with confidence scores
- `test_analyze_shell_event` — verifies HookAction parsing

**Type serialization (8):**
- Round-trip serde tests for: NotificationCategory, NotificationDigest, SystemQuestion, AnswerAnalysis, LogAnalysis, CommandIntent, HookAction
- Optional field handling (null → None)

**Error display (1):**
- `test_baml_error_display` — all BamlError variants produce meaningful messages

### cli crate — 3 tests

- `test_trigger_response_json_deserialization` — TriggerResponse with check results
- `test_answer_request_serialization` — AnswerRequest with UUID and answer
- `test_answer_response_deserialization` — AnswerResponse success case

## Dependencies Added

- `mockito = "1.2"` added to baml dev-dependencies

## Test Results

```
baml:  23 passed
cli:   19 binary + 31 integration + 3 lib + 9 doc = 62 tests (was 59)
```

All existing tests continue to pass.

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)