### PR TITLE
Standardize axum version across all service crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,3 +31,5 @@ clap = { version = "4.5", features = ["derive"] }
 reqwest = { version = "0.12", default-features = false, features = [
     "rustls-tls",
 ] }
+axum = "0.8"
+tower-http = { version = "0.6", features = ["trace"] }

--- a/crates/ask/Cargo.toml
+++ b/crates/ask/Cargo.toml
@@ -18,8 +18,8 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 thiserror = { workspace = true }
 
-axum = "0.7"
-tower-http = { version = "0.6", features = ["trace"] }
+axum = { workspace = true }
+tower-http = { workspace = true }
 reqwest = { version = "0.12", features = ["json"] }
 uuid = { version = "1.0", features = ["serde", "v4"] }
 chrono = { version = "0.4", features = ["serde"] }

--- a/crates/notify/Cargo.toml
+++ b/crates/notify/Cargo.toml
@@ -19,9 +19,9 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 
 # HTTP API server
-axum = "0.8.6"
+axum = { workspace = true }
 tower = "0.5"
-tower-http = { version = "0.6", features = ["cors", "trace"] }
+tower-http = { workspace = true, features = ["cors"] }
 
 # HTTP client
 reqwest = { version = "0.12", features = ["json"] }

--- a/crates/orchestrator/Cargo.toml
+++ b/crates/orchestrator/Cargo.toml
@@ -19,9 +19,9 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 
 # HTTP API server + WebSocket
-axum = { version = "0.8", features = ["ws"] }
+axum = { workspace = true, features = ["ws"] }
 tower = "0.5"
-tower-http = { version = "0.6", features = ["cors", "trace"] }
+tower-http = { workspace = true, features = ["cors"] }
 
 # Database
 sqlx = { version = "0.8", features = [

--- a/crates/wrap/Cargo.toml
+++ b/crates/wrap/Cargo.toml
@@ -18,8 +18,8 @@ thiserror = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 
-axum = "0.8"
-tower-http = { version = "0.6", features = ["trace"] }
+axum = { workspace = true }
+tower-http = { workspace = true }
 chrono = "0.4"
 uuid = { version = "1.11", features = ["v4", "serde"] }
 reqwest = { version = "0.12", features = ["json"] }


### PR DESCRIPTION
## Summary
- Added `axum = "0.8"` and `tower-http = { version = "0.6", features = ["trace"] }` to `[workspace.dependencies]` in root `Cargo.toml`
- Updated all service crates (`ask`, `notify`, `orchestrator`, `wrap`) to use `axum.workspace = true` and `tower-http.workspace = true`
- Migrated `ask` crate from axum 0.7 to 0.8 (no source changes needed — the APIs used are compatible)

## Test plan
- [x] `cargo check` passes for all workspace members
- [x] All 68 unit tests pass
- [x] All 17 doc tests pass

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)