### PR TITLE
Add health/status commands to CLI for all services

### DIFF
--- a/crates/cli/src/commands/ask.rs
+++ b/crates/cli/src/commands/ask.rs
@@ -59,6 +59,15 @@ pub enum AskCommand {
     /// ```
     Trigger,
 
+    /// Check the health of the ask service.
+    ///
+    /// # Examples
+    ///
+    /// ```bash
+    /// agent ask health
+    /// ```
+    Health,
+
     /// Answer a specific question from the ask service.
     ///
     /// Questions are identified by UUID and typically correspond to
@@ -91,6 +100,7 @@ impl AskCommand {
     /// Returns `Ok(())` on success, or an error if the command fails.
     pub async fn execute(&self, client: &AskClient, json: bool) -> Result<()> {
         match self {
+            AskCommand::Health => health(client, json).await,
             AskCommand::Trigger => trigger_checks(client, json).await,
             AskCommand::Answer { question_id, answer } => {
                 answer_question(client, question_id, answer, json).await
@@ -193,6 +203,22 @@ async fn answer_question(
         println!("{}", "✓ Answer submitted successfully!".green().bold());
         println!();
         println!("{}: {}", "Message".bold(), response.message);
+    }
+
+    Ok(())
+}
+
+/// Check the health of the ask service.
+async fn health(client: &AskClient, json: bool) -> Result<()> {
+    let response = client
+        .health()
+        .await
+        .context("Failed to reach ask service. Is it running?")?;
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&response)?);
+    } else {
+        println!("{} {}", "ask:".bold(), "ok".green().bold());
     }
 
     Ok(())

--- a/crates/cli/src/commands/notify.rs
+++ b/crates/cli/src/commands/notify.rs
@@ -58,6 +58,15 @@ use uuid::Uuid;
 /// communicate with the notification service REST API on port 7004.
 #[derive(Subcommand)]
 pub enum NotifyCommand {
+    /// Check the health of the notification service.
+    ///
+    /// # Examples
+    ///
+    /// ```bash
+    /// agent notify health
+    /// ```
+    Health,
+
     /// Create a new notification via the REST API.
     ///
     /// # Examples
@@ -197,6 +206,7 @@ impl NotifyCommand {
     /// Returns `Ok(())` on success, or an error if the command fails.
     pub async fn execute(&self, client: &NotifyClient, json: bool) -> Result<()> {
         match self {
+            NotifyCommand::Health => notify_health(client, json).await,
             NotifyCommand::Create {
                 source,
                 lifetime,
@@ -582,6 +592,25 @@ async fn respond_to_notification(
         println!("{}", "Response submitted successfully!".green().bold());
         println!();
         display_notification(&notification);
+    }
+
+    Ok(())
+}
+
+/// Check the health of the notification service.
+async fn notify_health(client: &NotifyClient, json: bool) -> Result<()> {
+    client
+        .health()
+        .await
+        .context("Failed to reach notification service. Is it running?")?;
+
+    if json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&serde_json::json!({"status": "ok"}))?
+        );
+    } else {
+        println!("{} {}", "notify:".bold(), "ok".green().bold());
     }
 
     Ok(())

--- a/crates/cli/src/commands/orchestrator.rs
+++ b/crates/cli/src/commands/orchestrator.rs
@@ -72,6 +72,17 @@ struct PaginatedResponse<T> {
 /// All commands communicate with the orchestrator service REST API.
 #[derive(Subcommand)]
 pub enum OrchestratorCommand {
+    /// Check the health of the orchestrator service.
+    ///
+    /// Shows the service status and active agent count.
+    ///
+    /// # Examples
+    ///
+    /// ```bash
+    /// agent orchestrator health
+    /// ```
+    Health,
+
     /// List all managed agents.
     ///
     /// Returns all agents tracked by the orchestrator, optionally filtered
@@ -252,6 +263,7 @@ impl OrchestratorCommand {
     /// * `json` - If true, output raw JSON instead of formatted text
     pub async fn execute(&self, client: &ApiClient, json: bool) -> Result<()> {
         match self {
+            OrchestratorCommand::Health => orchestrator_health(client, json).await,
             OrchestratorCommand::ListAgents { status } => {
                 list_agents(client, status.as_deref(), json).await
             }
@@ -333,6 +345,32 @@ impl OrchestratorCommand {
             OrchestratorCommand::WorkflowHistory { id } => workflow_history(client, id, json).await,
         }
     }
+}
+
+// -- Health --
+
+async fn orchestrator_health(client: &ApiClient, json: bool) -> Result<()> {
+    let response: serde_json::Value = client
+        .get("/health")
+        .await
+        .context("Failed to reach orchestrator service. Is it running?")?;
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&response)?);
+    } else {
+        let agents_active = response
+            .get("agents_active")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0);
+        println!(
+            "{} {} ({} agents active)",
+            "orchestrator:".bold(),
+            "ok".green().bold(),
+            agents_active.to_string().cyan()
+        );
+    }
+
+    Ok(())
 }
 
 // -- Agent operations --

--- a/crates/cli/src/commands/wrap.rs
+++ b/crates/cli/src/commands/wrap.rs
@@ -51,6 +51,15 @@ use wrap::types::*;
 /// All commands communicate with the wrap service REST API on port 7002.
 #[derive(Subcommand)]
 pub enum WrapCommand {
+    /// Check the health of the wrap service.
+    ///
+    /// # Examples
+    ///
+    /// ```bash
+    /// agent wrap health
+    /// ```
+    Health,
+
     /// List all active tmux sessions.
     ///
     /// Shows all tmux sessions managed by the wrap service.
@@ -126,6 +135,7 @@ impl WrapCommand {
     /// Returns `Ok(())` on success, or an error if the command fails.
     pub async fn execute(&self, client: &WrapClient, json: bool) -> Result<()> {
         match self {
+            WrapCommand::Health => wrap_health(client, json).await,
             WrapCommand::List => list_sessions(client, json).await,
             WrapCommand::Kill { name } => kill_session(client, name, json).await,
             WrapCommand::Launch { session_name, path, agent, provider, model, layout_json } => {
@@ -143,6 +153,25 @@ impl WrapCommand {
             }
         }
     }
+}
+
+/// Check the health of the wrap service.
+async fn wrap_health(client: &WrapClient, json: bool) -> Result<()> {
+    client
+        .health()
+        .await
+        .context("Failed to reach wrap service. Is it running?")?;
+
+    if json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&serde_json::json!({"status": "ok"}))?
+        );
+    } else {
+        println!("{} {}", "wrap:".bold(), "ok".green().bold());
+    }
+
+    Ok(())
 }
 
 /// List all active tmux sessions.

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -79,6 +79,7 @@ use anyhow::Result;
 use ask::client::AskClient;
 use clap::{Parser, Subcommand};
 use cli::client::ApiClient;
+use colored::*;
 use commands::{AskCommand, NotifyCommand, OrchestratorCommand, WrapCommand};
 use notify::client::NotifyClient;
 use std::env;
@@ -143,6 +144,19 @@ enum Commands {
         #[command(subcommand)]
         command: OrchestratorCommand,
     },
+    /// Check the health of all agentd services.
+    ///
+    /// Checks all services concurrently and displays a summary table.
+    /// Unreachable services are shown as errors (expected for unimplemented services).
+    ///
+    /// # Examples
+    ///
+    /// ```bash
+    /// agent status
+    /// agent status --json
+    /// ```
+    Status,
+
     /// Start the hook daemon
     ///
     /// The hook daemon monitors git hooks and other system hooks, creating
@@ -204,6 +218,9 @@ async fn main() -> Result<()> {
             let client = ApiClient::new(url);
             command.execute(&client, cli.json).await?;
         }
+        Commands::Status => {
+            check_all_services(cli.json).await?;
+        }
         Commands::Hook => {
             println!("Starting hook daemon...");
             // TODO: Start hook daemon
@@ -213,6 +230,180 @@ async fn main() -> Result<()> {
             // TODO: Start monitor daemon
         }
     }
+
+    Ok(())
+}
+
+/// Service definition for health checking.
+struct ServiceDef {
+    name: &'static str,
+    env_var: &'static str,
+    default_url: &'static str,
+}
+
+const SERVICES: &[ServiceDef] = &[
+    ServiceDef {
+        name: "orchestrator",
+        env_var: "ORCHESTRATOR_SERVICE_URL",
+        default_url: "http://localhost:7006",
+    },
+    ServiceDef {
+        name: "notify",
+        env_var: "NOTIFY_SERVICE_URL",
+        default_url: "http://localhost:7004",
+    },
+    ServiceDef {
+        name: "ask",
+        env_var: "ASK_SERVICE_URL",
+        default_url: "http://localhost:7001",
+    },
+    ServiceDef {
+        name: "wrap",
+        env_var: "WRAP_SERVICE_URL",
+        default_url: "http://localhost:7005",
+    },
+    ServiceDef {
+        name: "hook",
+        env_var: "HOOK_SERVICE_URL",
+        default_url: "http://localhost:7002",
+    },
+    ServiceDef {
+        name: "monitor",
+        env_var: "MONITOR_SERVICE_URL",
+        default_url: "http://localhost:7003",
+    },
+];
+
+/// Result of a single service health check.
+#[derive(serde::Serialize)]
+struct ServiceStatus {
+    name: String,
+    url: String,
+    healthy: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    detail: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    error: Option<String>,
+}
+
+/// Check all services concurrently and display a summary.
+async fn check_all_services(json: bool) -> Result<()> {
+    let http = reqwest::Client::builder()
+        .timeout(std::time::Duration::from_secs(3))
+        .build()?;
+
+    // Build (url, name) pairs
+    let checks: Vec<(&str, String)> = SERVICES
+        .iter()
+        .map(|svc| {
+            let url = env::var(svc.env_var).unwrap_or_else(|_| svc.default_url.to_string());
+            (svc.name, url)
+        })
+        .collect();
+
+    // Run all health checks concurrently
+    let mut handles = Vec::new();
+    for (name, url) in &checks {
+        let client = http.clone();
+        let health_url = format!("{}/health", url);
+        let name = name.to_string();
+        let url = url.clone();
+        handles.push(tokio::spawn(async move {
+            match client.get(&health_url).send().await {
+                Ok(resp) if resp.status().is_success() => {
+                    let body: serde_json::Value =
+                        resp.json().await.unwrap_or(serde_json::json!({}));
+                    let detail = body
+                        .get("agents_active")
+                        .and_then(|v| v.as_u64())
+                        .map(|n| format!("{n} agents active"));
+                    ServiceStatus {
+                        name,
+                        url,
+                        healthy: true,
+                        detail,
+                        error: None,
+                    }
+                }
+                Ok(resp) => ServiceStatus {
+                    name,
+                    url,
+                    healthy: false,
+                    detail: None,
+                    error: Some(format!("HTTP {}", resp.status())),
+                },
+                Err(e) => {
+                    let msg = if e.is_connect() {
+                        "connection refused".to_string()
+                    } else if e.is_timeout() {
+                        "timeout".to_string()
+                    } else {
+                        e.to_string()
+                    };
+                    ServiceStatus {
+                        name,
+                        url,
+                        healthy: false,
+                        detail: None,
+                        error: Some(msg),
+                    }
+                }
+            }
+        }));
+    }
+
+    let mut results = Vec::new();
+    for handle in handles {
+        results.push(handle.await?);
+    }
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&results)?);
+        return Ok(());
+    }
+
+    // Display formatted summary
+    println!("{}", "agentd Service Status".blue().bold());
+    println!("{}", "=".repeat(60).cyan());
+
+    let healthy_count = results.iter().filter(|r| r.healthy).count();
+    let total = results.len();
+
+    for status in &results {
+        let indicator = if status.healthy {
+            "✅".to_string()
+        } else {
+            "❌".to_string()
+        };
+        let name_padded = format!("{:<14}", status.name);
+        let url_display = format!("({})", status.url).bright_black();
+
+        if status.healthy {
+            let detail = status.detail.as_deref().unwrap_or("");
+            let detail_display = if detail.is_empty() {
+                "ok".green().to_string()
+            } else {
+                format!("{}  ({})", "ok".green(), detail.cyan())
+            };
+            println!("  {} {} {}  {}", indicator, name_padded.bold(), url_display, detail_display);
+        } else {
+            let err = status.error.as_deref().unwrap_or("unknown error");
+            println!(
+                "  {} {} {}  {}",
+                indicator,
+                name_padded.bold(),
+                url_display,
+                err.red()
+            );
+        }
+    }
+
+    println!();
+    println!(
+        "{}/{} services healthy",
+        healthy_count.to_string().green().bold(),
+        total
+    );
 
     Ok(())
 }


### PR DESCRIPTION
## Summary
- **Per-service health commands**: `agent orchestrator health`, `agent notify health`, `agent ask health`, `agent wrap health`
- **Global status command**: `agent status` checks all 6 services concurrently with colored summary table
- Orchestrator health shows active agent count
- Unreachable services show "connection refused" (not stack traces)
- `--json` flag works on all health commands for scripting
- 3-second timeout per service to avoid hanging

## Test plan
- [x] All 96 CLI tests pass (3 lib + 28 unit + 56 integration + 9 doc)
- [x] Full workspace tests pass (400+ tests, zero failures)
- [x] Existing CLI behavior unchanged

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)