### PR TITLE
Create agentd-common crate as umbrella for shared types and utilities

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ members = [
     "crates/ask",
     "crates/baml",
     "crates/cli",
+    "crates/common",
     "crates/hook",
     "crates/monitor",
     "crates/notify",

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "agentd-common"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+
+[dependencies]
+serde = { workspace = true }
+serde_json = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+anyhow = { workspace = true }
+thiserror = { workspace = true }
+axum = { workspace = true }
+tower-http = { workspace = true }
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
+chrono = { version = "0.4", features = ["serde"] }
+uuid = { version = "1.11", features = ["v4", "serde"] }

--- a/crates/common/src/client.rs
+++ b/crates/common/src/client.rs
@@ -1,0 +1,11 @@
+//! Generic HTTP client base for agentd service clients.
+//!
+//! This module will contain:
+//! - `ServiceClient` — base struct with typed `get`, `post`, `put`, `delete`
+//!   methods and consistent error handling
+//! - Response parsing and error context helpers
+//!
+//! Individual service clients (NotifyClient, AskClient, WrapClient,
+//! OrchestratorClient) will compose or extend this base.
+//!
+//! See #49 for migration details.

--- a/crates/common/src/error.rs
+++ b/crates/common/src/error.rs
@@ -1,0 +1,8 @@
+//! Shared API error types with axum `IntoResponse` implementations.
+//!
+//! This module will contain:
+//! - `ApiError` — base error enum (NotFound, InvalidInput, Internal, etc.)
+//! - `IntoResponse` impl for consistent HTTP status code mapping
+//! - Error conversion traits (`From<anyhow::Error>`, etc.)
+//!
+//! See #48 for migration details.

--- a/crates/common/src/lib.rs
+++ b/crates/common/src/lib.rs
@@ -1,0 +1,53 @@
+//! Shared types and utilities for agentd services.
+//!
+//! This crate provides common functionality used across multiple agentd service
+//! crates, reducing duplication and ensuring consistency.
+//!
+//! # Modules
+//!
+//! - **types** — Shared API types: `PaginatedResponse<T>`, `HealthResponse`,
+//!   pagination helpers (`clamp_limit`, `DEFAULT_PAGE_LIMIT`)
+//!
+//! - **error** — Shared API error types with `IntoResponse` implementations
+//!   for consistent HTTP error responses across all services
+//!
+//! - **client** — Generic `ServiceClient` base providing typed HTTP methods
+//!   (`get`, `post`, `put`, `delete`) with consistent error handling
+//!
+//! - **storage** — SQLite utilities: database path resolution, connection pool
+//!   creation, and test helpers
+//!
+//! - **server** — Server initialization helpers: `init_tracing()` for
+//!   structured logging setup, and common middleware configuration
+//!
+//! # Usage
+//!
+//! Add to your crate's `Cargo.toml`:
+//!
+//! ```toml
+//! agentd-common = { path = "../common" }
+//! ```
+//!
+//! Then import the modules you need:
+//!
+//! ```rust,ignore
+//! use agentd_common::types::PaginatedResponse;
+//! use agentd_common::error::ApiError;
+//! ```
+//!
+//! # Migration Plan
+//!
+//! Each module is populated incrementally as individual crates migrate
+//! their duplicated code here. See the following issues for details:
+//!
+//! - #45 — Extract `PaginatedResponse` and pagination helpers → `types`
+//! - #48 — Deduplicate `ApiError` → `error`
+//! - #49 — Extract HTTP client base → `client`
+//! - #46 — Extract SQLite utilities → `storage`
+//! - #47 — Extract tracing/server init → `server`
+
+pub mod client;
+pub mod error;
+pub mod server;
+pub mod storage;
+pub mod types;

--- a/crates/common/src/server.rs
+++ b/crates/common/src/server.rs
@@ -1,0 +1,8 @@
+//! Server initialization and tracing setup helpers.
+//!
+//! This module will contain:
+//! - `init_tracing()` — configure tracing subscriber with env filter
+//!   and optional JSON output (shared across all 4 services)
+//! - Common middleware configuration helpers
+//!
+//! See #47 for migration details.

--- a/crates/common/src/storage.rs
+++ b/crates/common/src/storage.rs
@@ -1,0 +1,8 @@
+//! Shared SQLite storage utilities.
+//!
+//! This module will contain:
+//! - `get_db_path(service_name)` — resolve XDG-compliant database file paths
+//! - `create_pool(path)` — create and configure a SQLite connection pool
+//! - Test helpers for creating temporary in-memory databases
+//!
+//! See #46 for migration details.

--- a/crates/common/src/types.rs
+++ b/crates/common/src/types.rs
@@ -1,0 +1,9 @@
+//! Shared API types used across agentd services.
+//!
+//! This module will contain:
+//! - `PaginatedResponse<T>` — generic paginated list response envelope
+//! - `HealthResponse` — standardized health check response
+//! - `clamp_limit()` — pagination limit clamping utility
+//! - `DEFAULT_PAGE_LIMIT`, `MAX_PAGE_LIMIT` — pagination constants
+//!
+//! See #45 and #80 for migration details.


### PR DESCRIPTION
## Summary

Creates the `crates/common/` crate skeleton — the foundation for consolidating duplicated code across agentd service crates.

### Structure
```
crates/common/
├── Cargo.toml
└── src/
    ├── lib.rs      — module exports + comprehensive doc comments
    ├── types.rs    — placeholder for PaginatedResponse, HealthResponse (#45, #80)
    ├── error.rs    — placeholder for shared ApiError (#48)
    ├── client.rs   — placeholder for generic ServiceClient (#49)
    ├── storage.rs  — placeholder for SQLite utilities (#46)
    └── server.rs   — placeholder for init_tracing() (#47)
```

### What this PR does
- Creates the crate with all module files (documentation-only placeholders)
- Adds `"crates/common"` to workspace members
- Configures dependencies for the target functionality

### What this PR does NOT do
- No code migration yet — that happens incrementally via child issues
- No changes to existing crates — they'll add the dependency as each module lands

### Child issues (migration order)
1. #45 — `types.rs`: `PaginatedResponse<T>`, `clamp_limit()`
2. #80 — `types.rs`: `HealthResponse`
3. #48 — `error.rs`: `ApiError` with `IntoResponse`
4. #47 — `server.rs`: `init_tracing()`
5. #46 — `storage.rs`: SQLite pool/path helpers
6. #49 — `client.rs`: `ServiceClient` base

## Test plan
- [x] `cargo check -p agentd-common` compiles cleanly
- [x] Full workspace: 26 test suites, zero failures

Closes #81

🤖 Generated with [Claude Code](https://claude.com/claude-code)