### PR TITLE
Fix scheduler notify_task_complete matching wrong workflow runner

### DIFF
--- a/crates/orchestrator/src/scheduler/mod.rs
+++ b/crates/orchestrator/src/scheduler/mod.rs
@@ -18,6 +18,8 @@ use uuid::Uuid;
 
 /// Tracks a running workflow's control handles.
 struct RunningWorkflow {
+    /// The agent this workflow dispatches to.
+    agent_id: Uuid,
     shutdown_tx: watch::Sender<bool>,
     busy: Arc<Mutex<runner::BusyState>>,
 }
@@ -42,6 +44,7 @@ impl Scheduler {
     /// Start a workflow runner as a background tokio task.
     pub async fn start_workflow(&self, config: WorkflowConfig) -> anyhow::Result<()> {
         let workflow_id = config.id;
+        let agent_id = config.agent_id;
 
         // Check if already running.
         {
@@ -62,7 +65,7 @@ impl Scheduler {
 
         // Track the runner.
         let mut runners = self.runners.write().await;
-        runners.insert(workflow_id, RunningWorkflow { shutdown_tx, busy });
+        runners.insert(workflow_id, RunningWorkflow { agent_id, shutdown_tx, busy });
 
         info!(%workflow_id, "Workflow started");
         Ok(())
@@ -82,10 +85,18 @@ impl Scheduler {
 
     /// Called when an agent produces a "result" message, to clear the busy flag
     /// and update the dispatch record.
+    ///
+    /// Only notifies the runner whose workflow is dispatched to the matching
+    /// `agent_id` — prevents the wrong runner from being notified when
+    /// multiple workflows are running concurrently with different agents.
     pub async fn notify_task_complete(&self, agent_id: Uuid, is_error: bool) {
         let runners = self.runners.read().await;
         for (_wf_id, running) in runners.iter() {
-            // Check each runner's busy state — the one with an active dispatch for this agent.
+            // Only consider runners that target the completing agent.
+            if running.agent_id != agent_id {
+                continue;
+            }
+
             let has_active = {
                 let busy = running.busy.lock().await;
                 busy.active_dispatch_id.is_some()


### PR DESCRIPTION
## Summary

Fixes a bug where `notify_task_complete` could notify the wrong workflow runner when multiple workflows run concurrently with different agents.

### The bug

The method iterated all runners and picked the first with *any* active dispatch, without checking whether the dispatch's agent matched the completing agent:

```rust
// Before: notifies the FIRST busy runner regardless of agent
for runner in runners {
    if runner.has_active_dispatch() { notify(runner); return; }
}
```

### The fix

Store `agent_id` in `RunningWorkflow` and filter by it:

```rust
// After: only notifies the runner targeting the correct agent
for runner in runners {
    if runner.agent_id != agent_id { continue; }
    if runner.has_active_dispatch() { notify(runner); return; }
}
```

### Changes (1 file, 13 lines)
- Add `agent_id: Uuid` field to `RunningWorkflow` struct
- Store `config.agent_id` in `start_workflow`
- Check `running.agent_id != agent_id` in `notify_task_complete`

## Test plan
- [x] All 87 orchestrator tests pass
- [x] Full workspace: 24 test suites, zero failures

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)