### PR TITLE
Extract shared pagination types and utilities into agentd-common crate

### DIFF
--- a/crates/common/src/types.rs
+++ b/crates/common/src/types.rs
@@ -1,9 +1,96 @@
 //! Shared API types used across agentd services.
 //!
-//! This module will contain:
-//! - `PaginatedResponse<T>` — generic paginated list response envelope
-//! - `HealthResponse` — standardized health check response
-//! - `clamp_limit()` — pagination limit clamping utility
-//! - `DEFAULT_PAGE_LIMIT`, `MAX_PAGE_LIMIT` — pagination constants
-//!
-//! See #45 and #80 for migration details.
+//! - [`PaginatedResponse<T>`] — generic paginated list response envelope
+//! - [`clamp_limit()`] — pagination limit clamping utility
+//! - [`DEFAULT_PAGE_LIMIT`], [`MAX_PAGE_LIMIT`] — pagination constants
+
+use serde::{Deserialize, Serialize};
+
+/// Paginated response envelope for list endpoints.
+///
+/// Used by all services that return paginated lists (notify, orchestrator).
+///
+/// # Examples
+///
+/// ```rust
+/// use agentd_common::types::PaginatedResponse;
+///
+/// let response = PaginatedResponse {
+///     items: vec!["a", "b", "c"],
+///     total: 10,
+///     limit: 3,
+///     offset: 0,
+/// };
+/// assert_eq!(response.items.len(), 3);
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PaginatedResponse<T> {
+    pub items: Vec<T>,
+    pub total: usize,
+    pub limit: usize,
+    pub offset: usize,
+}
+
+/// Default page size for list endpoints.
+pub const DEFAULT_PAGE_LIMIT: usize = 50;
+
+/// Maximum page size for list endpoints.
+pub const MAX_PAGE_LIMIT: usize = 200;
+
+/// Clamp a requested pagination limit to valid bounds.
+///
+/// Returns `DEFAULT_PAGE_LIMIT` if `None`, otherwise clamps to `[1, MAX_PAGE_LIMIT]`.
+///
+/// # Examples
+///
+/// ```rust
+/// use agentd_common::types::clamp_limit;
+///
+/// assert_eq!(clamp_limit(None), 50);
+/// assert_eq!(clamp_limit(Some(10)), 10);
+/// assert_eq!(clamp_limit(Some(0)), 1);
+/// assert_eq!(clamp_limit(Some(999)), 200);
+/// ```
+pub fn clamp_limit(limit: Option<usize>) -> usize {
+    limit.unwrap_or(DEFAULT_PAGE_LIMIT).clamp(1, MAX_PAGE_LIMIT)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_clamp_limit_default() {
+        assert_eq!(clamp_limit(None), DEFAULT_PAGE_LIMIT);
+    }
+
+    #[test]
+    fn test_clamp_limit_within_bounds() {
+        assert_eq!(clamp_limit(Some(10)), 10);
+        assert_eq!(clamp_limit(Some(100)), 100);
+    }
+
+    #[test]
+    fn test_clamp_limit_below_minimum() {
+        assert_eq!(clamp_limit(Some(0)), 1);
+    }
+
+    #[test]
+    fn test_clamp_limit_above_maximum() {
+        assert_eq!(clamp_limit(Some(500)), MAX_PAGE_LIMIT);
+    }
+
+    #[test]
+    fn test_paginated_response_serde() {
+        let response = PaginatedResponse {
+            items: vec![1, 2, 3],
+            total: 10,
+            limit: 3,
+            offset: 0,
+        };
+        let json = serde_json::to_string(&response).unwrap();
+        let deserialized: PaginatedResponse<i32> = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.items, vec![1, 2, 3]);
+        assert_eq!(deserialized.total, 10);
+    }
+}

--- a/crates/notify/Cargo.toml
+++ b/crates/notify/Cargo.toml
@@ -38,6 +38,7 @@ sqlx = { version = "0.8", features = [
 uuid = { version = "1.11", features = ["v4", "serde"] }
 chrono = { version = "0.4", features = ["serde"] }
 directories = "6.0.0"
+agentd-common = { path = "../common" }
 metrics = { workspace = true }
 metrics-exporter-prometheus = { workspace = true }
 

--- a/crates/notify/src/types.rs
+++ b/crates/notify/src/types.rs
@@ -602,28 +602,8 @@ pub struct CountResponse {
 ///   "offset": 0
 /// }
 /// ```
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct PaginatedResponse<T> {
-    /// The items in this page.
-    pub items: Vec<T>,
-    /// Total number of items matching the query (across all pages).
-    pub total: usize,
-    /// Maximum items per page.
-    pub limit: usize,
-    /// Offset from the start.
-    pub offset: usize,
-}
-
-/// Default page size when `limit` is not specified.
-pub const DEFAULT_PAGE_LIMIT: usize = 50;
-
-/// Maximum allowed page size.
-pub const MAX_PAGE_LIMIT: usize = 200;
-
-/// Clamp a requested limit to valid bounds.
-pub fn clamp_limit(limit: Option<usize>) -> usize {
-    limit.unwrap_or(DEFAULT_PAGE_LIMIT).clamp(1, MAX_PAGE_LIMIT)
-}
+// Re-export pagination types from agentd-common.
+pub use agentd_common::types::{clamp_limit, PaginatedResponse, DEFAULT_PAGE_LIMIT, MAX_PAGE_LIMIT};
 
 #[cfg(test)]
 mod tests {

--- a/crates/orchestrator/Cargo.toml
+++ b/crates/orchestrator/Cargo.toml
@@ -39,6 +39,7 @@ uuid = { version = "1.11", features = ["v4", "serde"] }
 chrono = { version = "0.4", features = ["serde"] }
 directories = "6.0.0"
 futures = "0.3"
+agentd-common = { path = "../common" }
 metrics = { workspace = true }
 metrics-exporter-prometheus = { workspace = true }
 

--- a/crates/orchestrator/src/types.rs
+++ b/crates/orchestrator/src/types.rs
@@ -204,24 +204,8 @@ impl From<Agent> for AgentResponse {
     }
 }
 
-/// Paginated response envelope for list endpoints.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct PaginatedResponse<T> {
-    pub items: Vec<T>,
-    pub total: usize,
-    pub limit: usize,
-    pub offset: usize,
-}
-
-/// Default page size.
-pub const DEFAULT_PAGE_LIMIT: usize = 50;
-/// Maximum page size.
-pub const MAX_PAGE_LIMIT: usize = 200;
-
-/// Clamp a requested limit to valid bounds.
-pub fn clamp_limit(limit: Option<usize>) -> usize {
-    limit.unwrap_or(DEFAULT_PAGE_LIMIT).clamp(1, MAX_PAGE_LIMIT)
-}
+// Re-export pagination types from agentd-common.
+pub use agentd_common::types::{clamp_limit, PaginatedResponse, DEFAULT_PAGE_LIMIT, MAX_PAGE_LIMIT};
 
 /// Health check response.
 #[derive(Debug, Serialize, Deserialize)]


### PR DESCRIPTION
## Summary

Moves duplicated `PaginatedResponse<T>`, `clamp_limit()`, and pagination constants from `notify` and `orchestrator` into the `agentd-common` crate.

### What moved
| Type/Function | From | To |
|---|---|---|
| `PaginatedResponse<T>` | notify/types.rs, orchestrator/types.rs | common/types.rs |
| `clamp_limit()` | notify/types.rs, orchestrator/types.rs | common/types.rs |
| `DEFAULT_PAGE_LIMIT` | notify/types.rs, orchestrator/types.rs | common/types.rs |
| `MAX_PAGE_LIMIT` | notify/types.rs, orchestrator/types.rs | common/types.rs |

### Backward compatibility
Both crates re-export from `agentd_common::types`, so all existing imports in api.rs, client.rs, scheduler/api.rs, CLI, and tests continue to work unchanged. Zero import changes needed in any consuming code.

### New in common/types.rs
- Full doc comments with examples
- 5 unit tests (clamp bounds, defaults, serde round-trip)
- 2 doc-tests

## Test plan
- [x] 5 new tests in agentd-common
- [x] All 26 test suites pass, zero failures

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)