### PR TITLE
Extract shared SQLite storage utilities to reduce duplication

### DIFF
--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -18,3 +18,6 @@ tower-http = { workspace = true }
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
 chrono = { version = "0.4", features = ["serde"] }
 uuid = { version = "1.11", features = ["v4", "serde"] }
+sqlx = { version = "0.8", features = ["runtime-tokio", "sqlite"] }
+directories = "6.0.0"
+tempfile = "3.14"

--- a/crates/common/src/storage.rs
+++ b/crates/common/src/storage.rs
@@ -1,8 +1,114 @@
 //! Shared SQLite storage utilities.
 //!
-//! This module will contain:
-//! - `get_db_path(service_name)` — resolve XDG-compliant database file paths
-//! - `create_pool(path)` — create and configure a SQLite connection pool
-//! - Test helpers for creating temporary in-memory databases
+//! Provides common database path resolution and connection pool creation
+//! used by all agentd services that persist data to SQLite.
 //!
-//! See #46 for migration details.
+//! # Examples
+//!
+//! ```rust,ignore
+//! use agentd_common::storage::{get_db_path, create_pool};
+//!
+//! let db_path = get_db_path("notify", "notify.db")?;
+//! let pool = create_pool(&db_path).await?;
+//! ```
+
+use anyhow::Result;
+use directories::ProjectDirs;
+use sqlx::sqlite::SqlitePool;
+use std::path::{Path, PathBuf};
+
+/// Resolve the platform-specific database file path for a service.
+///
+/// Uses the XDG base directory specification (via `directories` crate) to
+/// determine the data directory, creates it if necessary, and returns the
+/// full path to the database file.
+///
+/// # Arguments
+///
+/// * `project_name` — XDG project qualifier (e.g., `"agentd-notify"`)
+/// * `db_filename` — Database filename (e.g., `"notify.db"`)
+///
+/// # Examples
+///
+/// ```rust,ignore
+/// let path = agentd_common::storage::get_db_path("agentd-notify", "notify.db")?;
+/// // macOS: ~/Library/Application Support/agentd-notify/notify.db
+/// // Linux: ~/.local/share/agentd-notify/notify.db
+/// ```
+pub fn get_db_path(project_name: &str, db_filename: &str) -> Result<PathBuf> {
+    let proj_dirs = ProjectDirs::from("", "", project_name)
+        .ok_or_else(|| anyhow::anyhow!("Failed to determine project directories"))?;
+
+    let data_dir = proj_dirs.data_dir();
+    std::fs::create_dir_all(data_dir)?;
+
+    Ok(data_dir.join(db_filename))
+}
+
+/// Create a SQLite connection pool for the given database path.
+///
+/// Opens the database file in read-write-create mode. The caller is
+/// responsible for running schema migrations after obtaining the pool.
+///
+/// # Arguments
+///
+/// * `db_path` — Full path to the SQLite database file
+pub async fn create_pool(db_path: &Path) -> Result<SqlitePool> {
+    let db_url = format!("sqlite://{}?mode=rwc", db_path.display());
+    let pool = SqlitePool::connect(&db_url).await?;
+    Ok(pool)
+}
+
+/// Create a temporary SQLite pool for testing.
+///
+/// Returns a pool connected to a temporary file-based database. The caller
+/// should hold onto the `TempDir` to keep the database alive for the
+/// duration of the test.
+///
+/// # Examples
+///
+/// ```rust,ignore
+/// use agentd_common::storage::create_test_pool;
+/// use tempfile::TempDir;
+///
+/// let (pool, _tmp) = create_test_pool().await;
+/// // Use pool for test operations...
+/// // Database is cleaned up when _tmp is dropped
+/// ```
+#[cfg(any(test, feature = "test-utils"))]
+pub async fn create_test_pool() -> (SqlitePool, tempfile::TempDir) {
+    let temp_dir = tempfile::TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("test.db");
+    let db_url = format!("sqlite://{}?mode=rwc", db_path.display());
+    let pool = SqlitePool::connect(&db_url).await.unwrap();
+    (pool, temp_dir)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_get_db_path_returns_path() {
+        // Use a unique project name to avoid interfering with real data
+        let path = get_db_path("agentd-test-common", "test.db").unwrap();
+        assert!(path.to_string_lossy().contains("agentd-test-common"));
+        assert!(path.to_string_lossy().ends_with("test.db"));
+    }
+
+    #[tokio::test]
+    async fn test_create_pool() {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let db_path = temp_dir.path().join("test.db");
+        let pool = create_pool(&db_path).await.unwrap();
+
+        // Verify we can execute a basic query
+        sqlx::query("SELECT 1").execute(&pool).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn test_create_test_pool() {
+        let (pool, _tmp) = create_test_pool().await;
+        sqlx::query("SELECT 1").execute(&pool).await.unwrap();
+    }
+}

--- a/crates/notify/Cargo.toml
+++ b/crates/notify/Cargo.toml
@@ -38,6 +38,7 @@ sqlx = { version = "0.8", features = [
 uuid = { version = "1.11", features = ["v4", "serde"] }
 chrono = { version = "0.4", features = ["serde"] }
 directories = "6.0.0"
+agentd-common = { path = "../common" }
 metrics = { workspace = true }
 metrics-exporter-prometheus = { workspace = true }
 

--- a/crates/notify/src/storage.rs
+++ b/crates/notify/src/storage.rs
@@ -68,7 +68,6 @@ use crate::types::{
 };
 use anyhow::Result;
 use chrono::{DateTime, Utc};
-use directories::ProjectDirs;
 use sqlx::{sqlite::SqlitePool, Row};
 use std::path::{Path, PathBuf};
 use uuid::Uuid;
@@ -141,13 +140,7 @@ impl NotificationStorage {
     /// println!("Database location: {:?}", db_path);
     /// ```
     pub fn get_db_path() -> Result<PathBuf> {
-        let proj_dirs = ProjectDirs::from("", "", "agentd-notify")
-            .ok_or_else(|| anyhow::anyhow!("Failed to determine project directories"))?;
-
-        let data_dir = proj_dirs.data_dir();
-        std::fs::create_dir_all(data_dir)?;
-
-        Ok(data_dir.join("notify.db"))
+        agentd_common::storage::get_db_path("agentd-notify", "notify.db")
     }
 
     /// Creates a new notification storage instance with the default database path.
@@ -220,12 +213,9 @@ impl NotificationStorage {
     /// }
     /// ```
     pub async fn with_path(db_path: &Path) -> Result<Self> {
-        let db_url = format!("sqlite://{}?mode=rwc", db_path.display());
-        let pool = SqlitePool::connect(&db_url).await?;
-
+        let pool = agentd_common::storage::create_pool(db_path).await?;
         let storage = Self { pool };
         storage.init_schema().await?;
-
         Ok(storage)
     }
 

--- a/crates/orchestrator/Cargo.toml
+++ b/crates/orchestrator/Cargo.toml
@@ -39,6 +39,7 @@ uuid = { version = "1.11", features = ["v4", "serde"] }
 chrono = { version = "0.4", features = ["serde"] }
 directories = "6.0.0"
 futures = "0.3"
+agentd-common = { path = "../common" }
 metrics = { workspace = true }
 metrics-exporter-prometheus = { workspace = true }
 

--- a/crates/orchestrator/src/storage.rs
+++ b/crates/orchestrator/src/storage.rs
@@ -1,7 +1,6 @@
 use crate::types::{Agent, AgentConfig, AgentStatus, ToolPolicy};
 use anyhow::Result;
 use chrono::{DateTime, Utc};
-use directories::ProjectDirs;
 use sqlx::{sqlite::SqlitePool, Row};
 use std::path::{Path, PathBuf};
 use uuid::Uuid;
@@ -18,13 +17,7 @@ impl AgentStorage {
     }
 
     pub fn get_db_path() -> Result<PathBuf> {
-        let proj_dirs = ProjectDirs::from("", "", "agentd-orchestrator")
-            .ok_or_else(|| anyhow::anyhow!("Failed to determine project directories"))?;
-
-        let data_dir = proj_dirs.data_dir();
-        std::fs::create_dir_all(data_dir)?;
-
-        Ok(data_dir.join("orchestrator.db"))
+        agentd_common::storage::get_db_path("agentd-orchestrator", "orchestrator.db")
     }
 
     pub async fn new() -> Result<Self> {
@@ -33,12 +26,9 @@ impl AgentStorage {
     }
 
     pub async fn with_path(db_path: &Path) -> Result<Self> {
-        let db_url = format!("sqlite://{}?mode=rwc", db_path.display());
-        let pool = SqlitePool::connect(&db_url).await?;
-
+        let pool = agentd_common::storage::create_pool(db_path).await?;
         let storage = Self { pool };
         storage.init_schema().await?;
-
         Ok(storage)
     }
 


### PR DESCRIPTION
## Summary

Moves duplicated SQLite database path resolution and connection pool creation from `notify` and `orchestrator` into `agentd_common::storage`.

### New functions

| Function | Purpose |
|----------|---------|
| `get_db_path(project, file)` | XDG-compliant database path resolution |
| `create_pool(path)` | SQLite connection pool (rwc mode) |
| `create_test_pool()` | Temporary file-based test database |

### Before (each service, ~10 lines)
```rust
let proj_dirs = ProjectDirs::from("", "", "agentd-notify")...;
let data_dir = proj_dirs.data_dir();
std::fs::create_dir_all(data_dir)?;
Ok(data_dir.join("notify.db"))

let db_url = format!("sqlite://{}?mode=rwc", db_path.display());
let pool = SqlitePool::connect(&db_url).await?;
```

### After (each service, 1-2 lines)
```rust
agentd_common::storage::get_db_path("agentd-notify", "notify.db")
agentd_common::storage::create_pool(db_path).await?
```

### Tests
- 3 new tests: path resolution, pool creation, test pool helper
- All existing storage tests pass unchanged

## Test plan
- [x] All 26 test suites pass, zero failures

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)