### PR TITLE
Standardize HealthResponse types across all services

### DIFF
--- a/crates/ask/src/api.rs
+++ b/crates/ask/src/api.rs
@@ -163,14 +163,13 @@ pub fn create_router(state: ApiState) -> Router {
 /// }
 /// ```
 async fn health_check(State(state): State<ApiState>) -> impl IntoResponse {
-    let response = HealthResponse {
-        status: "ok".to_string(),
-        service: "agentd-ask".to_string(),
-        version: env!("CARGO_PKG_VERSION").to_string(),
-        notification_service_url: state.notification_service_url.clone(),
-    };
-
-    Json(response)
+    Json(
+        HealthResponse::ok("agentd-ask", env!("CARGO_PKG_VERSION"))
+            .with_detail(
+                "notification_service_url",
+                serde_json::json!(state.notification_service_url),
+            ),
+    )
 }
 
 /// Triggers environment checks and creates notifications if conditions are met.

--- a/crates/ask/src/types.rs
+++ b/crates/ask/src/types.rs
@@ -218,31 +218,8 @@ pub struct AnswerResponse {
     pub question_id: Uuid,
 }
 
-/// Response from the `/health` endpoint.
-///
-/// Provides service status and configuration information.
-///
-/// # JSON Example
-///
-/// ```json
-/// {
-///   "status": "ok",
-///   "service": "ask",
-///   "version": "0.1.0",
-///   "notification_service_url": "http://localhost:7004"
-/// }
-/// ```
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct HealthResponse {
-    /// Service status ("ok" if healthy)
-    pub status: String,
-    /// Service name identifier
-    pub service: String,
-    /// Service version number
-    pub version: String,
-    /// URL of the notification service
-    pub notification_service_url: String,
-}
+// Re-export shared HealthResponse from agentd-common.
+pub use agentd_common::types::HealthResponse;
 
 #[cfg(test)]
 mod tests {
@@ -356,12 +333,8 @@ mod tests {
 
     #[test]
     fn test_health_response_serialization() {
-        let response = HealthResponse {
-            status: "ok".to_string(),
-            service: "ask".to_string(),
-            version: "0.1.0".to_string(),
-            notification_service_url: "http://localhost:7004".to_string(),
-        };
+        let response = HealthResponse::ok("agentd-ask", "0.1.0")
+            .with_detail("notification_service_url", serde_json::json!("http://localhost:7004"));
 
         let json = serde_json::to_string(&response).unwrap();
         let deserialized: HealthResponse = serde_json::from_str(&json).unwrap();

--- a/crates/ask/tests/api_test.rs
+++ b/crates/ask/tests/api_test.rs
@@ -451,8 +451,8 @@ async fn test_health_response_structure() {
     assert!(body.get("status").is_some());
     assert!(body.get("service").is_some());
     assert!(body.get("version").is_some());
-    assert!(body.get("notification_service_url").is_some());
-    assert_eq!(body["notification_service_url"], "http://test:9999");
+    assert!(body.get("details").is_some());
+    assert_eq!(body["details"]["notification_service_url"], "http://test:9999");
 }
 
 // Test /trigger endpoint response structure

--- a/crates/cli/src/commands/orchestrator.rs
+++ b/crates/cli/src/commands/orchestrator.rs
@@ -1146,11 +1146,16 @@ async fn orchestrator_health(client: &OrchestratorClient, json: bool) -> Result<
     if json {
         println!("{}", serde_json::to_string_pretty(&response)?);
     } else {
+        let agents_active = response
+            .details
+            .get("agents_active")
+            .and_then(|v| v.as_u64())
+            .unwrap_or(0);
         println!(
             "{} {} ({} agents active)",
             "orchestrator:".bold(),
             "ok".green().bold(),
-            response.agents_active.to_string().cyan()
+            agents_active.to_string().cyan()
         );
     }
 

--- a/crates/common/src/types.rs
+++ b/crates/common/src/types.rs
@@ -5,6 +5,7 @@
 //! - [`DEFAULT_PAGE_LIMIT`], [`MAX_PAGE_LIMIT`] — pagination constants
 
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 
 /// Paginated response envelope for list endpoints.
 ///
@@ -55,6 +56,60 @@ pub fn clamp_limit(limit: Option<usize>) -> usize {
     limit.unwrap_or(DEFAULT_PAGE_LIMIT).clamp(1, MAX_PAGE_LIMIT)
 }
 
+/// Standard health check response returned by all agentd services.
+///
+/// Provides a uniform schema for health endpoints, with service-specific
+/// details in an extensible `details` map.
+///
+/// # Examples
+///
+/// ```rust
+/// use agentd_common::types::HealthResponse;
+///
+/// let resp = HealthResponse::ok("agentd-wrap", "0.1.0");
+/// assert_eq!(resp.status, "ok");
+/// assert_eq!(resp.service, "agentd-wrap");
+/// assert!(resp.details.is_empty());
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct HealthResponse {
+    /// Service status: `"ok"` or `"degraded"`.
+    pub status: String,
+    /// Service name (e.g., `"agentd-notify"`).
+    pub service: String,
+    /// Crate version from `Cargo.toml`.
+    pub version: String,
+    /// Service-specific details (optional, varies per service).
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub details: HashMap<String, serde_json::Value>,
+}
+
+impl HealthResponse {
+    /// Create a standard "ok" health response for a service.
+    ///
+    /// The `version` is populated at compile time from the *calling* crate's
+    /// `CARGO_PKG_VERSION`. Since this is a library function, callers should
+    /// pass their own version:
+    ///
+    /// ```rust,ignore
+    /// HealthResponse::ok("agentd-notify", env!("CARGO_PKG_VERSION"))
+    /// ```
+    pub fn ok(service: &str, version: &str) -> Self {
+        Self {
+            status: "ok".to_string(),
+            service: service.to_string(),
+            version: version.to_string(),
+            details: HashMap::new(),
+        }
+    }
+
+    /// Add a service-specific detail to the response.
+    pub fn with_detail(mut self, key: &str, value: serde_json::Value) -> Self {
+        self.details.insert(key.to_string(), value);
+        self
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -87,5 +142,40 @@ mod tests {
         let deserialized: PaginatedResponse<i32> = serde_json::from_str(&json).unwrap();
         assert_eq!(deserialized.items, vec![1, 2, 3]);
         assert_eq!(deserialized.total, 10);
+    }
+
+    #[test]
+    fn test_health_response_ok() {
+        let resp = HealthResponse::ok("agentd-test", "1.0.0");
+        assert_eq!(resp.status, "ok");
+        assert_eq!(resp.service, "agentd-test");
+        assert_eq!(resp.version, "1.0.0");
+        assert!(resp.details.is_empty());
+    }
+
+    #[test]
+    fn test_health_response_with_details() {
+        let resp = HealthResponse::ok("agentd-test", "1.0.0")
+            .with_detail("agents_active", serde_json::json!(5));
+        assert_eq!(resp.details.len(), 1);
+        assert_eq!(resp.details["agents_active"], serde_json::json!(5));
+    }
+
+    #[test]
+    fn test_health_response_serde_no_details() {
+        let resp = HealthResponse::ok("svc", "1.0");
+        let json = serde_json::to_string(&resp).unwrap();
+        // details should be omitted when empty
+        assert!(!json.contains("details"));
+        let deserialized: HealthResponse = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.status, "ok");
+    }
+
+    #[test]
+    fn test_health_response_serde_with_details() {
+        let resp = HealthResponse::ok("svc", "1.0")
+            .with_detail("count", serde_json::json!(42));
+        let json = serde_json::to_string(&resp).unwrap();
+        assert!(json.contains("\"count\":42"));
     }
 }

--- a/crates/notify/src/api.rs
+++ b/crates/notify/src/api.rs
@@ -184,11 +184,10 @@ pub fn create_router(state: ApiState) -> Router {
 /// curl http://localhost:17004/health
 /// ```
 async fn health_check() -> impl IntoResponse {
-    Json(serde_json::json!({
-        "status": "ok",
-        "service": "agentd-notify",
-        "version": env!("CARGO_PKG_VERSION")
-    }))
+    Json(agentd_common::types::HealthResponse::ok(
+        "agentd-notify",
+        env!("CARGO_PKG_VERSION"),
+    ))
 }
 
 /// Lists all notifications with optional status filter.

--- a/crates/orchestrator/src/api.rs
+++ b/crates/orchestrator/src/api.rs
@@ -65,7 +65,10 @@ pub struct ListQuery {
 async fn health_check(State(state): State<ApiState>) -> impl IntoResponse {
     let active = state.manager.registry().connected_count().await;
     metrics::gauge!("websocket_connections_active").set(active as f64);
-    Json(HealthResponse { status: "ok".to_string(), agents_active: active })
+    Json(
+        HealthResponse::ok("agentd-orchestrator", env!("CARGO_PKG_VERSION"))
+            .with_detail("agents_active", serde_json::json!(active)),
+    )
 }
 
 async fn list_agents(

--- a/crates/orchestrator/src/types.rs
+++ b/crates/orchestrator/src/types.rs
@@ -210,12 +210,8 @@ pub use agentd_common::types::{
     clamp_limit, PaginatedResponse, DEFAULT_PAGE_LIMIT, MAX_PAGE_LIMIT,
 };
 
-/// Health check response.
-#[derive(Debug, Serialize, Deserialize)]
-pub struct HealthResponse {
-    pub status: String,
-    pub agents_active: usize,
-}
+// Re-export shared HealthResponse from agentd-common.
+pub use agentd_common::types::HealthResponse;
 
 /// Request body for POST /agents/{id}/message.
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/crates/wrap/src/api.rs
+++ b/crates/wrap/src/api.rs
@@ -105,10 +105,7 @@ pub fn create_router() -> Router {
 /// curl http://localhost:17005/health
 /// ```
 async fn health_check() -> impl IntoResponse {
-    Json(HealthResponse {
-        status: "ok".to_string(),
-        version: Some(env!("CARGO_PKG_VERSION").to_string()),
-    })
+    Json(HealthResponse::ok("agentd-wrap", env!("CARGO_PKG_VERSION")))
 }
 
 /// Launch an agent session in a tmux environment.

--- a/crates/wrap/src/types.rs
+++ b/crates/wrap/src/types.rs
@@ -51,16 +51,8 @@ pub struct LaunchResponse {
     pub error: Option<String>,
 }
 
-/// Health check response.
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct HealthResponse {
-    /// Service status
-    pub status: String,
-
-    /// Service version
-    #[serde(skip_serializing_if = "Option::is_none")]
-    pub version: Option<String>,
-}
+// Re-export shared HealthResponse from agentd-common.
+pub use agentd_common::types::HealthResponse;
 
 /// Information about a single tmux session.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -173,14 +165,12 @@ mod tests {
 
     #[test]
     fn test_health_response_deserialization() {
-        let json = r#"{
-            "status": "ok",
-            "version": "0.1.0"
-        }"#;
-
-        let response: HealthResponse = serde_json::from_str(json).unwrap();
-        assert_eq!(response.status, "ok");
-        assert_eq!(response.version, Some("0.1.0".to_string()));
+        let response = HealthResponse::ok("agentd-wrap", "0.1.0");
+        let json = serde_json::to_string(&response).unwrap();
+        let deserialized: HealthResponse = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.status, "ok");
+        assert_eq!(deserialized.service, "agentd-wrap");
+        assert_eq!(deserialized.version, "0.1.0");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Replaces 4 different `HealthResponse` definitions (and 1 inline JSON) with a single shared type from `agentd-common`.

### Shared type
```rust
pub struct HealthResponse {
    pub status: String,           // "ok" or "degraded"
    pub service: String,          // e.g. "agentd-notify"
    pub version: String,          // from CARGO_PKG_VERSION
    pub details: HashMap<String, Value>,  // service-specific (omitted when empty)
}
```

### Migration per service
| Service | Before | After |
|---------|--------|-------|
| orchestrator | `{ status, agents_active }` | `{ status, service, version, details: { agents_active } }` |
| ask | `{ status, service, version, notification_service_url }` | `{ ..., details: { notification_service_url } }` |
| wrap | `{ status, version? }` | `{ status, service, version }` |
| notify | inline `json!({...})` | `HealthResponse::ok("agentd-notify", ...)` |

### Builder API
```rust
HealthResponse::ok("agentd-orchestrator", env!("CARGO_PKG_VERSION"))
    .with_detail("agents_active", json!(5))
```

## Test plan
- [x] 4 new common tests + 1 doc-test
- [x] Updated ask integration test for new details structure
- [x] All 26 test suites pass, zero failures

Closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)