### PR TITLE
Add crate-level documentation and architecture overview

### DIFF
--- a/crates/hook/src/main.rs
+++ b/crates/hook/src/main.rs
@@ -1,3 +1,12 @@
+//! agentd-hook — Shell hook integration service.
+//!
+//! Monitors git hooks and other system hooks, creating notifications in the
+//! notify service when user intervention is required.
+//!
+//! **Status:** Stub — service skeleton only, not yet implemented.
+//!
+//! **Default port:** 17002 (dev) / 7002 (production)
+
 use anyhow::Result;
 use tracing::{info, warn};
 

--- a/crates/monitor/src/main.rs
+++ b/crates/monitor/src/main.rs
@@ -1,3 +1,11 @@
+//! agentd-monitor — System monitoring and alerting service.
+//!
+//! Watches system metrics and creates notifications for alerts and anomalies.
+//!
+//! **Status:** Stub — service skeleton only, not yet implemented.
+//!
+//! **Default port:** 17003 (dev) / 7003 (production)
+
 use anyhow::Result;
 use tracing::{info, warn};
 

--- a/crates/ollama/src/lib.rs
+++ b/crates/ollama/src/lib.rs
@@ -1,5 +1,10 @@
-// agentd-ollama library
-// TODO: Implement Ollama integration functionality
+//! agentd-ollama — Ollama integration library.
+//!
+//! Provides a Rust client for interacting with a local Ollama server for
+//! LLM inference. Planned for use as an alternative model provider alongside
+//! the Claude Code SDK.
+//!
+//! **Status:** Placeholder — not yet implemented.
 
 #[cfg(test)]
 mod tests {

--- a/crates/orchestrator/src/lib.rs
+++ b/crates/orchestrator/src/lib.rs
@@ -1,3 +1,26 @@
+//! agentd-orchestrator — Agent lifecycle management and workflow orchestration.
+//!
+//! This crate provides the orchestrator service that manages AI agent processes,
+//! implements the Claude Code SDK WebSocket protocol, schedules autonomous
+//! workflows, and enforces tool policies.
+//!
+//! # Modules
+//!
+//! - [`api`] — REST API handlers and router (agents, workflows, approvals, policies)
+//! - [`approvals`] — In-memory registry for human-in-the-loop tool approval requests
+//! - [`client`] — Typed HTTP client (`OrchestratorClient`) for consuming the REST API
+//! - [`manager`] — Agent lifecycle: spawn, reconcile, terminate tmux sessions
+//! - [`scheduler`] — Autonomous workflow scheduling with GitHub issue polling
+//! - [`storage`] — SQLite persistence for agent and workflow state
+//! - [`types`] — Domain types: `Agent`, `AgentConfig`, `ToolPolicy`, etc.
+//! - [`websocket`] — WebSocket SDK server and real-time monitoring streams
+//!
+//! # Configuration
+//!
+//! - **Default port:** 17006 (dev) / 7006 (production)
+//! - **Database:** `~/Library/Application Support/agentd-orchestrator/orchestrator.db`
+//! - **Environment:** `PORT`, `RUST_LOG`, `LOG_FORMAT`
+
 pub mod api;
 pub mod approvals;
 pub mod client;

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -1,3 +1,16 @@
+//! agentd xtask — Build and installation automation.
+//!
+//! Provides commands for installing agentd binaries, managing LaunchAgent/systemd
+//! service definitions, and generating shell completions.
+//!
+//! # Commands
+//!
+//! - `install-user` — Build and install all binaries for the current user
+//! - `install-completions` — Generate and install shell completions
+//! - `uninstall` — Remove all installed components
+//! - `start-services` / `stop-services` / `restart-services` — Service lifecycle
+//! - `service-status` — Check running state of all services
+
 mod platform;
 
 use anyhow::{Context, Result};


### PR DESCRIPTION
## Summary

Adds `//!` doc comments to all 5 workspace crates that were missing them, ensuring every crate is documented for `cargo doc`.

### Crates updated
| Crate | What was added |
|-------|---------------|
| `orchestrator` (lib.rs) | Module overview with 8 module descriptions, configuration section |
| `hook` (main.rs) | Purpose, stub status, default ports |
| `monitor` (main.rs) | Purpose, stub status, default ports |
| `ollama` (lib.rs) | Purpose, placeholder status |
| `xtask` (main.rs) | Available commands overview |

### Already documented (no changes)
ask, baml, cli, common, notify, wrap — all had comprehensive `//!` comments

### Verification
- `cargo doc --workspace --no-deps` — **0 warnings**
- All 26 test suites pass

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)