### PR TITLE
Add model selection to agent creation

### DIFF
--- a/crates/cli/src/commands/apply.rs
+++ b/crates/cli/src/commands/apply.rs
@@ -41,6 +41,8 @@ pub struct AgentTemplate {
     pub system_prompt: Option<String>,
     #[serde(default)]
     pub tool_policy: ToolPolicy,
+    /// Model to use for the claude session (e.g. sonnet, opus, haiku).
+    pub model: Option<String>,
 }
 
 fn default_working_dir() -> String {
@@ -445,6 +447,7 @@ async fn apply_agent(
         worktree: tmpl.worktree,
         system_prompt: tmpl.system_prompt.clone(),
         tool_policy: tmpl.tool_policy.clone(),
+        model: tmpl.model.clone(),
     };
 
     let agent = client.create_agent(&request).await?;
@@ -591,6 +594,30 @@ name: minimal
         assert!(!tmpl.interactive);
         assert!(!tmpl.worktree);
         assert_eq!(tmpl.tool_policy, ToolPolicy::AllowAll);
+        assert_eq!(tmpl.model, None);
+    }
+
+    #[test]
+    fn test_parse_agent_with_model() {
+        let yaml = r#"
+name: planner
+model: opus
+working_dir: "."
+system_prompt: "You are a planning agent"
+"#;
+        let tmpl: AgentTemplate = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(tmpl.name, "planner");
+        assert_eq!(tmpl.model, Some("opus".to_string()));
+    }
+
+    #[test]
+    fn test_parse_agent_with_full_model_name() {
+        let yaml = r#"
+name: worker
+model: claude-sonnet-4-6
+"#;
+        let tmpl: AgentTemplate = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(tmpl.model, Some("claude-sonnet-4-6".to_string()));
     }
 
     #[test]

--- a/crates/cli/src/commands/orchestrator.rs
+++ b/crates/cli/src/commands/orchestrator.rs
@@ -150,6 +150,10 @@ pub enum OrchestratorCommand {
         #[arg(long)]
         attach: bool,
 
+        /// Model to use for the claude session (e.g. sonnet, opus, haiku, claude-sonnet-4-6)
+        #[arg(long)]
+        model: Option<String>,
+
         /// Tool policy as JSON (default: allow all tools)
         ///
         /// Examples: '{"mode":"allow_all"}', '{"mode":"deny_list","tools":["Bash"]}'
@@ -492,6 +496,7 @@ impl OrchestratorCommand {
                 worktree,
                 system_prompt,
                 attach,
+                model,
                 tool_policy,
             } => {
                 create_agent(
@@ -507,6 +512,7 @@ impl OrchestratorCommand {
                     *worktree,
                     system_prompt.as_deref(),
                     *attach,
+                    model.as_deref(),
                     tool_policy.as_deref(),
                     json,
                 )
@@ -627,6 +633,7 @@ async fn create_agent(
     worktree: bool,
     system_prompt: Option<&str>,
     attach: bool,
+    model: Option<&str>,
     tool_policy_json: Option<&str>,
     json: bool,
 ) -> Result<()> {
@@ -652,6 +659,7 @@ async fn create_agent(
         worktree,
         system_prompt: system_prompt.map(|s| s.to_string()),
         tool_policy,
+        model: model.map(|s| s.to_string()),
     };
 
     let agent = client.create_agent(&request).await.context("Failed to create agent")?;
@@ -1494,6 +1502,9 @@ fn display_agent(agent: &AgentResponse) {
     }
     println!("{}: {}", "Working Dir".bold(), agent.config.working_dir);
     println!("{}: {}", "Shell".bold(), agent.config.shell);
+    if let Some(ref model) = agent.config.model {
+        println!("{}: {}", "Model".bold(), model.cyan());
+    }
     let policy_display = match &agent.config.tool_policy {
         ToolPolicy::AllowAll => "allow_all".green().to_string(),
         ToolPolicy::DenyAll => "deny_all".red().to_string(),
@@ -1572,6 +1583,7 @@ mod tests {
                 worktree: false,
                 system_prompt: None,
                 tool_policy: Default::default(),
+                model: None,
             },
             tmux_session: Some("agentd-orch-abc123".to_string()),
             created_at: Utc::now(),
@@ -1874,6 +1886,56 @@ mod tests {
             assert_eq!(prompt_file, None);
             assert!(!stdin);
             assert!(!attach);
+        } else {
+            panic!("Expected CreateAgent variant");
+        }
+    }
+
+    #[test]
+    fn test_create_agent_with_model_flag() {
+        use clap::Parser;
+
+        #[derive(Parser)]
+        struct Cli {
+            #[command(subcommand)]
+            command: OrchestratorCommand,
+        }
+
+        let cli = Cli::try_parse_from([
+            "test",
+            "create-agent",
+            "--name",
+            "planner",
+            "--model",
+            "opus",
+            "--prompt",
+            "Plan the work",
+        ])
+        .expect("Should parse with --model");
+
+        if let OrchestratorCommand::CreateAgent { name, model, .. } = cli.command {
+            assert_eq!(name, "planner");
+            assert_eq!(model, Some("opus".to_string()));
+        } else {
+            panic!("Expected CreateAgent variant");
+        }
+    }
+
+    #[test]
+    fn test_create_agent_model_defaults_to_none() {
+        use clap::Parser;
+
+        #[derive(Parser)]
+        struct Cli {
+            #[command(subcommand)]
+            command: OrchestratorCommand,
+        }
+
+        let cli = Cli::try_parse_from(["test", "create-agent", "--name", "worker"])
+            .expect("Should parse without --model");
+
+        if let OrchestratorCommand::CreateAgent { model, .. } = cli.command {
+            assert_eq!(model, None);
         } else {
             panic!("Expected CreateAgent variant");
         }

--- a/crates/orchestrator/src/api.rs
+++ b/crates/orchestrator/src/api.rs
@@ -104,6 +104,7 @@ async fn create_agent(
         worktree: req.worktree,
         system_prompt: req.system_prompt,
         tool_policy: req.tool_policy,
+        model: req.model,
     };
 
     let agent = state.manager.spawn_agent(req.name, config).await?;

--- a/crates/orchestrator/src/manager.rs
+++ b/crates/orchestrator/src/manager.rs
@@ -200,6 +200,10 @@ fn build_claude_command(config: &AgentConfig, ws_url: &str) -> String {
         args.push("--input-format stream-json".to_string());
     }
 
+    if let Some(ref model) = config.model {
+        args.push(format!("--model {}", model));
+    }
+
     if config.worktree {
         args.push("--worktree".to_string());
     }
@@ -218,5 +222,73 @@ fn build_claude_command(config: &AgentConfig, ws_url: &str) -> String {
     match config.user.as_deref() {
         Some(user) => format!("sudo -u {} {}", user, base),
         None => base,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::ToolPolicy;
+
+    fn base_config() -> AgentConfig {
+        AgentConfig {
+            working_dir: "/tmp/test".to_string(),
+            user: None,
+            shell: "zsh".to_string(),
+            interactive: false,
+            prompt: None,
+            worktree: false,
+            system_prompt: None,
+            tool_policy: ToolPolicy::default(),
+            model: None,
+        }
+    }
+
+    #[test]
+    fn test_build_claude_command_no_model() {
+        let config = base_config();
+        let cmd = build_claude_command(&config, "ws://localhost:7006/ws/abc");
+        assert!(!cmd.contains("--model"));
+        assert!(cmd.contains("claude"));
+        assert!(cmd.contains("--sdk-url"));
+    }
+
+    #[test]
+    fn test_build_claude_command_with_model_alias() {
+        let config = AgentConfig { model: Some("opus".to_string()), ..base_config() };
+        let cmd = build_claude_command(&config, "ws://localhost:7006/ws/abc");
+        assert!(cmd.contains("--model opus"));
+    }
+
+    #[test]
+    fn test_build_claude_command_with_full_model_name() {
+        let config =
+            AgentConfig { model: Some("claude-sonnet-4-6".to_string()), ..base_config() };
+        let cmd = build_claude_command(&config, "ws://localhost:7006/ws/abc");
+        assert!(cmd.contains("--model claude-sonnet-4-6"));
+    }
+
+    #[test]
+    fn test_build_claude_command_model_with_interactive() {
+        let config = AgentConfig {
+            model: Some("haiku".to_string()),
+            interactive: true,
+            ..base_config()
+        };
+        let cmd = build_claude_command(&config, "ws://localhost:7006/ws/abc");
+        assert!(cmd.contains("--model haiku"));
+        assert!(!cmd.contains("--sdk-url"));
+    }
+
+    #[test]
+    fn test_build_claude_command_model_with_sudo() {
+        let config = AgentConfig {
+            model: Some("sonnet".to_string()),
+            user: Some("deploy".to_string()),
+            ..base_config()
+        };
+        let cmd = build_claude_command(&config, "ws://localhost:7006/ws/abc");
+        assert!(cmd.starts_with("sudo -u deploy"));
+        assert!(cmd.contains("--model sonnet"));
     }
 }

--- a/crates/orchestrator/src/storage.rs
+++ b/crates/orchestrator/src/storage.rs
@@ -48,6 +48,7 @@ impl AgentStorage {
                 system_prompt TEXT,
                 tmux_session TEXT,
                 tool_policy TEXT NOT NULL DEFAULT '{"mode":"allow_all"}',
+                model TEXT,
                 created_at TEXT NOT NULL,
                 updated_at TEXT NOT NULL
             )
@@ -66,8 +67,8 @@ impl AgentStorage {
     pub async fn add(&self, agent: &Agent) -> Result<Uuid> {
         sqlx::query(
             r#"
-            INSERT INTO agents (id, name, status, working_dir, user, shell, interactive, prompt, worktree, system_prompt, tmux_session, tool_policy, created_at, updated_at)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            INSERT INTO agents (id, name, status, working_dir, user, shell, interactive, prompt, worktree, system_prompt, tmux_session, tool_policy, model, created_at, updated_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             "#,
         )
         .bind(agent.id.to_string())
@@ -82,6 +83,7 @@ impl AgentStorage {
         .bind(agent.config.system_prompt.as_deref())
         .bind(agent.tmux_session.as_deref())
         .bind(serde_json::to_string(&agent.config.tool_policy).unwrap_or_default())
+        .bind(agent.config.model.as_deref())
         .bind(agent.created_at.to_rfc3339())
         .bind(agent.updated_at.to_rfc3339())
         .execute(&self.pool)
@@ -206,6 +208,7 @@ fn row_to_agent(row: &sqlx::sqlite::SqliteRow) -> Result<Agent> {
     let tmux_session: Option<String> = row.get("tmux_session");
     let tool_policy_str: String = row.get("tool_policy");
     let tool_policy: ToolPolicy = serde_json::from_str(&tool_policy_str).unwrap_or_default();
+    let model: Option<String> = row.get("model");
     let created_at: String = row.get("created_at");
     let updated_at: String = row.get("updated_at");
 
@@ -222,6 +225,7 @@ fn row_to_agent(row: &sqlx::sqlite::SqliteRow) -> Result<Agent> {
             worktree,
             system_prompt,
             tool_policy,
+            model,
         },
         tmux_session,
         created_at: DateTime::parse_from_rfc3339(&created_at)?.with_timezone(&Utc),
@@ -253,6 +257,7 @@ mod tests {
                 worktree: false,
                 system_prompt: None,
                 tool_policy: ToolPolicy::default(),
+                model: None,
             },
         )
     }

--- a/crates/orchestrator/src/types.rs
+++ b/crates/orchestrator/src/types.rs
@@ -116,6 +116,11 @@ pub struct AgentConfig {
     /// Tool-use policy for this agent.
     #[serde(default)]
     pub tool_policy: ToolPolicy,
+    /// Model to use for the claude session.
+    /// Maps to --model flag. Accepts aliases (sonnet, opus, haiku)
+    /// or full model names (claude-sonnet-4-6).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
 }
 
 fn default_shell() -> String {
@@ -175,6 +180,11 @@ pub struct CreateAgentRequest {
     /// Tool-use policy for this agent.
     #[serde(default)]
     pub tool_policy: ToolPolicy,
+    /// Model to use for the claude session.
+    /// Maps to --model flag. Accepts aliases (sonnet, opus, haiku)
+    /// or full model names (claude-sonnet-4-6).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub model: Option<String>,
 }
 
 /// Response body for agent endpoints.
@@ -414,6 +424,64 @@ mod tests {
             assert_eq!(status.to_string(), expected);
             assert_eq!(expected.parse::<ApprovalStatus>().unwrap(), status);
         }
+    }
+
+    #[test]
+    fn test_agent_config_model_serialization() {
+        let config = AgentConfig {
+            working_dir: "/tmp".to_string(),
+            user: None,
+            shell: "zsh".to_string(),
+            interactive: false,
+            prompt: None,
+            worktree: false,
+            system_prompt: None,
+            tool_policy: ToolPolicy::default(),
+            model: Some("opus".to_string()),
+        };
+        let json = serde_json::to_string(&config).unwrap();
+        assert!(json.contains("\"model\":\"opus\""));
+
+        let deserialized: AgentConfig = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.model, Some("opus".to_string()));
+    }
+
+    #[test]
+    fn test_agent_config_model_none_omitted() {
+        let config = AgentConfig {
+            working_dir: "/tmp".to_string(),
+            user: None,
+            shell: "zsh".to_string(),
+            interactive: false,
+            prompt: None,
+            worktree: false,
+            system_prompt: None,
+            tool_policy: ToolPolicy::default(),
+            model: None,
+        };
+        let json = serde_json::to_string(&config).unwrap();
+        assert!(!json.contains("model"));
+    }
+
+    #[test]
+    fn test_create_agent_request_model_field() {
+        let request = CreateAgentRequest {
+            name: "test".to_string(),
+            working_dir: "/tmp".to_string(),
+            user: None,
+            shell: "zsh".to_string(),
+            interactive: false,
+            prompt: None,
+            worktree: false,
+            system_prompt: None,
+            tool_policy: ToolPolicy::default(),
+            model: Some("sonnet".to_string()),
+        };
+        let json = serde_json::to_string(&request).unwrap();
+        assert!(json.contains("\"model\":\"sonnet\""));
+
+        let deserialized: CreateAgentRequest = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.model, Some("sonnet".to_string()));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Add optional `model` field to `AgentConfig`, `CreateAgentRequest`, and `AgentTemplate` across all layers
- Pass `--model` flag to Claude CLI in `build_claude_command()` when set
- Persist model in SQLite `agents` table (new `model TEXT` column)
- Add `--model` CLI flag to `agent orchestrator create-agent`
- Support `model:` field in YAML agent templates (`.agentd/agents/*.yml`)
- Display model in agent detail and list output
- Default to `None` (inherit Claude Code's configured model) for backward compatibility

## Test plan

- [x] 5 unit tests for `build_claude_command()` with model set/unset, aliases, full names, interactive mode, and sudo
- [x] 3 unit tests for `AgentConfig`/`CreateAgentRequest` model serialization round-trips
- [x] 2 unit tests for CLI `--model` flag parsing (present and absent)
- [x] 2 unit tests for YAML agent template parsing with model field
- [x] All existing tests continue to pass (`cargo test` — 0 failures)

Closes #114

🤖 Generated with [Claude Code](https://claude.com/claude-code)