### PR TITLE
Add ability to change the model of a running agent

### DIFF
--- a/crates/cli/src/commands/orchestrator.rs
+++ b/crates/cli/src/commands/orchestrator.rs
@@ -293,6 +293,50 @@ pub enum OrchestratorCommand {
         policy: String,
     },
 
+    /// Set or change the model for an agent.
+    ///
+    /// Updates the model in the agent's config. Use --restart to immediately
+    /// kill and re-launch the agent with the new model.
+    ///
+    /// # Examples
+    ///
+    /// Change model and restart immediately:
+    ///
+    ///   agent orchestrator set-model <ID> --model opus --restart
+    ///
+    /// Change model for next restart (no disruption):
+    ///
+    ///   agent orchestrator set-model <ID> --model sonnet
+    ///
+    /// Change by agent name:
+    ///
+    ///   agent orchestrator set-model --name worker --model opus --restart
+    ///
+    /// Clear model (inherit default):
+    ///
+    ///   agent orchestrator set-model <ID> --clear
+    SetModel {
+        /// Agent ID (UUID)
+        #[arg(conflicts_with = "name")]
+        id: Option<String>,
+
+        /// Agent name (resolves to first matching agent)
+        #[arg(long, conflicts_with = "id")]
+        name: Option<String>,
+
+        /// Model to use (e.g. sonnet, opus, haiku, claude-sonnet-4-6)
+        #[arg(long, conflicts_with = "clear")]
+        model: Option<String>,
+
+        /// Clear the model (inherit Claude Code's default)
+        #[arg(long, conflicts_with = "model")]
+        clear: bool,
+
+        /// Restart the agent process immediately with the new model
+        #[arg(long)]
+        restart: bool,
+    },
+
     /// Check the health of the orchestrator service.
     ///
     /// Shows the service status and active agent count.
@@ -532,6 +576,9 @@ impl OrchestratorCommand {
             OrchestratorCommand::GetPolicy { id } => get_policy(client, id, json).await,
             OrchestratorCommand::SetPolicy { id, policy } => {
                 set_policy(client, id, policy, json).await
+            }
+            OrchestratorCommand::SetModel { id, name, model, clear, restart } => {
+                set_model_cmd(client, id.as_deref(), name.as_deref(), model.as_deref(), *clear, *restart, json).await
             }
             OrchestratorCommand::Health => orchestrator_health(client, json).await,
             OrchestratorCommand::ListApprovals { agent_id, status } => {
@@ -1032,6 +1079,67 @@ async fn set_policy(
         println!("{}", "Policy updated successfully!".green().bold());
         println!();
         display_policy(&updated);
+    }
+
+    Ok(())
+}
+
+// -- Model --
+
+#[allow(clippy::too_many_arguments)]
+async fn set_model_cmd(
+    client: &OrchestratorClient,
+    id: Option<&str>,
+    name: Option<&str>,
+    model: Option<&str>,
+    clear: bool,
+    restart: bool,
+    json: bool,
+) -> Result<()> {
+    // Resolve agent ID
+    let agent_id = match (id, name) {
+        (Some(agent_id), _) => parse_uuid(agent_id)?,
+        (_, Some(agent_name)) => resolve_agent_id(client, None, Some(agent_name)).await?,
+        (None, None) => bail!("Either an agent ID or --name must be provided."),
+    };
+
+    // Resolve model value: --clear sets to None, otherwise use the provided model
+    let resolved_model = if clear {
+        None
+    } else {
+        match model {
+            Some(m) => Some(m.to_string()),
+            None => bail!("Either a model name or --clear must be provided."),
+        }
+    };
+
+    let agent = client
+        .set_model(&agent_id, resolved_model.clone(), restart)
+        .await
+        .context("Failed to set agent model")?;
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&agent)?);
+    } else {
+        let model_display = agent
+            .config
+            .model
+            .as_deref()
+            .unwrap_or("(default)");
+        println!(
+            "{}",
+            format!(
+                "Model updated for agent '{}' ({}): {}",
+                agent.name, agent.id, model_display
+            )
+            .green()
+            .bold()
+        );
+        if restart {
+            println!("{}", "Agent restarted with new model.".cyan());
+        } else {
+            println!("{}", "Model will take effect on next agent restart.".yellow());
+        }
     }
 
     Ok(())
@@ -2070,5 +2178,138 @@ mod tests {
         } else {
             panic!("Expected CreateWorkflow variant");
         }
+    }
+
+    #[test]
+    fn test_set_model_by_id() {
+        use clap::Parser;
+
+        #[derive(Parser)]
+        struct Cli {
+            #[command(subcommand)]
+            command: OrchestratorCommand,
+        }
+
+        let cli = Cli::try_parse_from([
+            "test",
+            "set-model",
+            "550e8400-e29b-41d4-a716-446655440000",
+            "--model",
+            "opus",
+            "--restart",
+        ])
+        .expect("Should parse set-model with ID");
+
+        if let OrchestratorCommand::SetModel { id, name, model, clear, restart } = cli.command {
+            assert_eq!(id, Some("550e8400-e29b-41d4-a716-446655440000".to_string()));
+            assert_eq!(name, None);
+            assert_eq!(model, Some("opus".to_string()));
+            assert!(!clear);
+            assert!(restart);
+        } else {
+            panic!("Expected SetModel variant");
+        }
+    }
+
+    #[test]
+    fn test_set_model_by_name() {
+        use clap::Parser;
+
+        #[derive(Parser)]
+        struct Cli {
+            #[command(subcommand)]
+            command: OrchestratorCommand,
+        }
+
+        let cli = Cli::try_parse_from([
+            "test",
+            "set-model",
+            "--name",
+            "worker",
+            "--model",
+            "sonnet",
+        ])
+        .expect("Should parse set-model with --name");
+
+        if let OrchestratorCommand::SetModel { id, name, model, restart, .. } = cli.command {
+            assert_eq!(id, None);
+            assert_eq!(name, Some("worker".to_string()));
+            assert_eq!(model, Some("sonnet".to_string()));
+            assert!(!restart);
+        } else {
+            panic!("Expected SetModel variant");
+        }
+    }
+
+    #[test]
+    fn test_set_model_clear() {
+        use clap::Parser;
+
+        #[derive(Parser)]
+        struct Cli {
+            #[command(subcommand)]
+            command: OrchestratorCommand,
+        }
+
+        let cli = Cli::try_parse_from([
+            "test",
+            "set-model",
+            "550e8400-e29b-41d4-a716-446655440000",
+            "--clear",
+        ])
+        .expect("Should parse set-model with --clear");
+
+        if let OrchestratorCommand::SetModel { id, model, clear, .. } = cli.command {
+            assert_eq!(id, Some("550e8400-e29b-41d4-a716-446655440000".to_string()));
+            assert_eq!(model, None);
+            assert!(clear);
+        } else {
+            panic!("Expected SetModel variant");
+        }
+    }
+
+    #[test]
+    fn test_set_model_clear_and_model_conflict() {
+        use clap::Parser;
+
+        #[derive(Parser)]
+        struct Cli {
+            #[command(subcommand)]
+            command: OrchestratorCommand,
+        }
+
+        let result = Cli::try_parse_from([
+            "test",
+            "set-model",
+            "550e8400-e29b-41d4-a716-446655440000",
+            "--model",
+            "opus",
+            "--clear",
+        ]);
+
+        assert!(result.is_err(), "--clear and --model should conflict");
+    }
+
+    #[test]
+    fn test_set_model_id_and_name_conflict() {
+        use clap::Parser;
+
+        #[derive(Parser)]
+        struct Cli {
+            #[command(subcommand)]
+            command: OrchestratorCommand,
+        }
+
+        let result = Cli::try_parse_from([
+            "test",
+            "set-model",
+            "550e8400-e29b-41d4-a716-446655440000",
+            "--name",
+            "worker",
+            "--model",
+            "opus",
+        ]);
+
+        assert!(result.is_err(), "ID and --name should conflict");
     }
 }

--- a/crates/orchestrator/src/api.rs
+++ b/crates/orchestrator/src/api.rs
@@ -44,6 +44,7 @@ pub fn create_router(state: ApiState) -> Router {
         .route("/agents", get(list_agents).post(create_agent))
         .route("/agents/{id}", get(get_agent).delete(terminate_agent))
         .route("/agents/{id}/message", post(send_message))
+        .route("/agents/{id}/model", axum::routing::put(set_agent_model))
         .route("/agents/{id}/policy", get(get_agent_policy).put(update_agent_policy))
         .route("/agents/{id}/approvals", get(list_agent_approvals))
         .route("/approvals", get(list_all_approvals))
@@ -185,6 +186,22 @@ async fn update_agent_policy(
     info!(agent_id = %id, ?policy, "Agent tool policy updated");
 
     Ok(Json(policy))
+}
+
+/// Set or change the model for an agent.
+///
+/// Updates the stored model. If `restart: true`, kills and re-launches
+/// the agent process with the new `--model` flag.
+async fn set_agent_model(
+    State(state): State<ApiState>,
+    Path(id): Path<Uuid>,
+    Json(req): Json<SetModelRequest>,
+) -> Result<impl IntoResponse, ApiError> {
+    let agent = state.manager.set_model(&id, req.model, req.restart).await?;
+
+    info!(agent_id = %id, model = ?agent.config.model, restart = req.restart, "Agent model changed via API");
+
+    Ok(Json(AgentResponse::from(agent)))
 }
 
 // -- Tool approval endpoints --

--- a/crates/orchestrator/src/client.rs
+++ b/crates/orchestrator/src/client.rs
@@ -33,7 +33,7 @@ use crate::scheduler::types::{
 };
 use crate::types::{
     AgentResponse, ApprovalActionRequest, CreateAgentRequest, HealthResponse, PaginatedResponse,
-    PendingApproval, SendMessageRequest, SendMessageResponse, ToolPolicy,
+    PendingApproval, SendMessageRequest, SendMessageResponse, SetModelRequest, ToolPolicy,
 };
 
 /// Typed HTTP client for the orchestrator service.
@@ -119,6 +119,20 @@ impl OrchestratorClient {
     /// Update the tool policy for an agent.
     pub async fn update_agent_policy(&self, id: &Uuid, policy: &ToolPolicy) -> Result<ToolPolicy> {
         self.put(&format!("/agents/{}/policy", id), policy).await
+    }
+
+    /// Set or change the model for an agent.
+    ///
+    /// If `restart` is true and the agent is running, the agent process will
+    /// be killed and re-launched with the new model.
+    pub async fn set_model(
+        &self,
+        id: &Uuid,
+        model: Option<String>,
+        restart: bool,
+    ) -> Result<AgentResponse> {
+        let request = SetModelRequest { model, restart };
+        self.put(&format!("/agents/{}/model", id), &request).await
     }
 
     // -- Approval operations --

--- a/crates/orchestrator/src/manager.rs
+++ b/crates/orchestrator/src/manager.rs
@@ -185,6 +185,93 @@ impl AgentManager {
     pub async fn update_agent(&self, agent: &Agent) -> anyhow::Result<()> {
         self.storage.update(agent).await
     }
+
+    /// Change the model for an agent.
+    ///
+    /// Updates the stored config. If `restart` is true and the agent is running,
+    /// kills the current tmux session and re-launches Claude with the new model.
+    pub async fn set_model(
+        &self,
+        id: &Uuid,
+        model: Option<String>,
+        restart: bool,
+    ) -> anyhow::Result<Agent> {
+        let mut agent =
+            self.storage.get(id).await?.ok_or_else(|| anyhow::anyhow!("Agent not found"))?;
+
+        agent.config.model = model.clone();
+        agent.updated_at = Utc::now();
+        self.storage.update(&agent).await?;
+
+        info!(
+            agent_id = %id,
+            model = ?model,
+            restart,
+            "Agent model updated"
+        );
+
+        if restart && agent.status == AgentStatus::Running {
+            agent = self.restart_agent(&agent).await?;
+        }
+
+        Ok(agent)
+    }
+
+    /// Restart a running agent: kill the current tmux session and re-launch Claude.
+    ///
+    /// Preserves the agent's ID, name, and config. The prompt is NOT re-sent
+    /// since the agent is being restarted mid-lifecycle.
+    async fn restart_agent(&self, agent: &Agent) -> anyhow::Result<Agent> {
+        let mut agent = agent.clone();
+
+        // Kill the existing tmux session.
+        if let Some(ref session) = agent.tmux_session {
+            if let Err(e) = self.tmux.kill_session(session) {
+                warn!(agent_id = %agent.id, %e, "Failed to kill tmux session during restart");
+            }
+        }
+
+        // Create a new tmux session.
+        let session_name = format!("{}-{}", self.tmux.prefix(), agent.id);
+        if let Err(e) =
+            self.tmux.create_session(&session_name, &agent.config.working_dir, None)
+        {
+            agent.status = AgentStatus::Failed;
+            agent.updated_at = Utc::now();
+            let _ = self.storage.update(&agent).await;
+            return Err(anyhow::anyhow!("Failed to create tmux session on restart: {}", e));
+        }
+
+        // Build and send the claude command with the updated config.
+        let ws_url = format!("{}/ws/{}", self.ws_base_url, agent.id);
+        let claude_cmd = build_claude_command(&agent.config, &ws_url);
+
+        if let Err(e) = self.tmux.send_command(&session_name, &claude_cmd) {
+            let _ = self.tmux.kill_session(&session_name);
+            agent.status = AgentStatus::Failed;
+            agent.updated_at = Utc::now();
+            let _ = self.storage.update(&agent).await;
+            return Err(anyhow::anyhow!("Failed to launch claude on restart: {}", e));
+        }
+
+        // Update state.
+        agent.status = AgentStatus::Running;
+        agent.tmux_session = Some(session_name.clone());
+        agent.updated_at = Utc::now();
+        self.storage.update(&agent).await?;
+
+        // Re-register tool policy.
+        self.registry.set_policy(agent.id, agent.config.tool_policy.clone()).await;
+
+        info!(
+            agent_id = %agent.id,
+            session = %session_name,
+            model = ?agent.config.model,
+            "Agent restarted with new model"
+        );
+
+        Ok(agent)
+    }
 }
 
 fn build_claude_command(config: &AgentConfig, ws_url: &str) -> String {

--- a/crates/orchestrator/src/storage.rs
+++ b/crates/orchestrator/src/storage.rs
@@ -108,13 +108,14 @@ impl AgentStorage {
         let result = sqlx::query(
             r#"
             UPDATE agents
-            SET status = ?, tmux_session = ?, tool_policy = ?, updated_at = ?
+            SET status = ?, tmux_session = ?, tool_policy = ?, model = ?, updated_at = ?
             WHERE id = ?
             "#,
         )
         .bind(agent.status.to_string())
         .bind(agent.tmux_session.as_deref())
         .bind(serde_json::to_string(&agent.config.tool_policy).unwrap_or_default())
+        .bind(agent.config.model.as_deref())
         .bind(agent.updated_at.to_rfc3339())
         .bind(agent.id.to_string())
         .execute(&self.pool)
@@ -318,5 +319,49 @@ mod tests {
 
         let all = storage.list(None).await.unwrap();
         assert_eq!(all.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_update_persists_model() {
+        let (storage, _tmp) = create_test_storage().await;
+        let mut agent = test_agent("model-test");
+        assert_eq!(agent.config.model, None);
+
+        storage.add(&agent).await.unwrap();
+
+        // Set model and update
+        agent.config.model = Some("opus".to_string());
+        agent.updated_at = chrono::Utc::now();
+        storage.update(&agent).await.unwrap();
+
+        let retrieved = storage.get(&agent.id).await.unwrap().unwrap();
+        assert_eq!(retrieved.config.model, Some("opus".to_string()));
+
+        // Change model
+        agent.config.model = Some("sonnet".to_string());
+        agent.updated_at = chrono::Utc::now();
+        storage.update(&agent).await.unwrap();
+
+        let retrieved = storage.get(&agent.id).await.unwrap().unwrap();
+        assert_eq!(retrieved.config.model, Some("sonnet".to_string()));
+
+        // Clear model
+        agent.config.model = None;
+        agent.updated_at = chrono::Utc::now();
+        storage.update(&agent).await.unwrap();
+
+        let retrieved = storage.get(&agent.id).await.unwrap().unwrap();
+        assert_eq!(retrieved.config.model, None);
+    }
+
+    #[tokio::test]
+    async fn test_add_with_model() {
+        let (storage, _tmp) = create_test_storage().await;
+        let mut agent = test_agent("model-agent");
+        agent.config.model = Some("haiku".to_string());
+
+        storage.add(&agent).await.unwrap();
+        let retrieved = storage.get(&agent.id).await.unwrap().unwrap();
+        assert_eq!(retrieved.config.model, Some("haiku".to_string()));
     }
 }

--- a/crates/orchestrator/src/types.rs
+++ b/crates/orchestrator/src/types.rs
@@ -223,6 +223,18 @@ pub use agentd_common::types::{
 // Re-export shared HealthResponse from agentd-common.
 pub use agentd_common::types::HealthResponse;
 
+/// Request body for PUT /agents/{id}/model.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SetModelRequest {
+    /// Model to use (e.g. "sonnet", "opus", "haiku", "claude-sonnet-4-6").
+    /// Use `null` to clear the model and inherit Claude Code's default.
+    pub model: Option<String>,
+    /// If true, restart the agent process immediately with the new model.
+    /// If false (default), the model change takes effect on next restart.
+    #[serde(default)]
+    pub restart: bool,
+}
+
 /// Request body for POST /agents/{id}/message.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SendMessageRequest {
@@ -482,6 +494,36 @@ mod tests {
 
         let deserialized: CreateAgentRequest = serde_json::from_str(&json).unwrap();
         assert_eq!(deserialized.model, Some("sonnet".to_string()));
+    }
+
+    #[test]
+    fn test_set_model_request_serialization() {
+        let request = SetModelRequest { model: Some("opus".to_string()), restart: true };
+        let json = serde_json::to_string(&request).unwrap();
+        assert!(json.contains("\"model\":\"opus\""));
+        assert!(json.contains("\"restart\":true"));
+
+        let deserialized: SetModelRequest = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.model, Some("opus".to_string()));
+        assert!(deserialized.restart);
+    }
+
+    #[test]
+    fn test_set_model_request_restart_defaults_false() {
+        let json = r#"{"model":"sonnet"}"#;
+        let request: SetModelRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(request.model, Some("sonnet".to_string()));
+        assert!(!request.restart);
+    }
+
+    #[test]
+    fn test_set_model_request_clear_model() {
+        let request = SetModelRequest { model: None, restart: false };
+        let json = serde_json::to_string(&request).unwrap();
+        assert!(json.contains("\"model\":null"));
+
+        let deserialized: SetModelRequest = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.model, None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Add `PUT /agents/{id}/model` API endpoint to change an agent's model at runtime
- Add `SetModelRequest` type with `model` (nullable) and `restart` (default false) fields
- Add `AgentManager::set_model()` that persists the model change and optionally restarts the agent
- Add `AgentManager::restart_agent()` to kill the current tmux session and re-launch Claude with the updated config
- Update storage `update()` to persist model changes to SQLite
- Add `OrchestratorClient::set_model()` typed client method
- Add `agent orchestrator set-model` CLI command supporting `--name`, `--model`, `--clear`, and `--restart` flags

### Behavior

- Without `--restart`: updates config only; new model takes effect on next agent restart
- With `--restart`: kills the running tmux session and re-launches Claude with the new `--model` flag
- `--clear` sets model to `None` to inherit Claude Code's default

## Test plan

- [x] 3 unit tests for `SetModelRequest` serialization (with model, restart defaults, clear)
- [x] 2 unit tests for storage model persistence (update round-trip, add with model)
- [x] 5 unit tests for CLI `set-model` argument parsing (by ID, by name, clear, conflicts)
- [x] All existing tests continue to pass (`cargo test` — 0 failures)

Closes #115

🤖 Generated with [Claude Code](https://claude.com/claude-code)