### PR TITLE
feat(orchestrator): inject environment variables into agent tmux session at launch

### DIFF
--- a/crates/orchestrator/src/manager.rs
+++ b/crates/orchestrator/src/manager.rs
@@ -449,11 +449,7 @@ mod tests {
     fn test_build_claude_command_with_env_vars_and_sudo() {
         let mut env = HashMap::new();
         env.insert("ANTHROPIC_API_KEY".to_string(), "sk-ant-test".to_string());
-        let config = AgentConfig {
-            user: Some("deploy".to_string()),
-            env,
-            ..base_config()
-        };
+        let config = AgentConfig { user: Some("deploy".to_string()), env, ..base_config() };
         let cmd = build_claude_command(&config, "ws://localhost:7006/ws/abc");
 
         // For sudo, env vars are injected via `env` to cross the sudo boundary


### PR DESCRIPTION
## Summary

- Modifies `build_claude_command()` in `manager.rs` to inject environment variables from `AgentConfig.env` when launching Claude Code in a tmux session
- Without `sudo`: variables are prepended as shell assignments — `KEY='val' claude --sdk-url ...`
- With `sudo -u user`: variables are passed via `env` to cross the privilege boundary — `sudo -u user env KEY='val' claude ...`
- Works for both interactive and SDK (non-interactive) modes

## Security

- **Name validation**: `is_valid_env_var_name()` only accepts `[A-Za-z_][A-Za-z0-9_]*`; invalid names are silently dropped, preventing injection through malformed key names
- **Value escaping**: `shell_escape_value()` wraps all values in single quotes and escapes embedded single quotes (`'` → `'\''`), neutralizing `$`, backticks, semicolons, newlines, and other special characters

## Test plan

- [x] All existing tests pass (`cargo test` — 76 tests, 0 failures)
- [x] Env vars appear before `claude` in the generated command string
- [x] Sudo path uses `sudo -u user env KEY='val' claude ...`
- [x] Single-quote in value is correctly shell-escaped
- [x] Invalid/malicious key names are rejected and stripped from the command
- [x] Empty env map produces no prefix (command starts with `claude` as before)
- [x] Works in both interactive and SDK modes
- [x] Multiple env vars produce deterministic (sorted) output
- [x] `is_valid_env_var_name` — valid and invalid identifier coverage
- [x] `shell_escape_value` — simple, quoted, special-char, and empty cases

Closes #141

🤖 Generated with [Claude Code](https://claude.com/claude-code)