### PR TITLE
feat: add Docker support with multi-service compose configuration

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,45 @@
+# Git
+.git
+.gitignore
+
+# Docker
+Dockerfile
+docker-compose*.yml
+.dockerignore
+
+# Build artifacts
+target/
+**/target/
+
+# IDE
+.idea/
+.vscode/
+*.swp
+*.swo
+*~
+
+# Python virtual environment (if present)
+.venv/
+venv/
+__pycache__/
+
+# Node modules (if any)
+node_modules/
+
+# Documentation
+docs/
+*.md
+!README.md
+
+# Test fixtures
+*.lock.bak
+
+# Logs
+*.log
+logs/
+
+# macOS
+.DS_Store
+
+# Linux
+Thumbs.db

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,67 @@
+# Multi-stage Dockerfile for building all agentd services
+# Produces a slim runtime image with all service binaries
+
+# =============================================================================
+# Stage 1: Builder
+# =============================================================================
+FROM rust:1.75-bookworm AS builder
+
+WORKDIR /app
+
+# Install build dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    pkg-config \
+    libssl-dev \
+    && rm -rf /var/lib/apt/lists/*
+
+# Copy workspace manifest and crate metadata
+COPY Cargo.toml Cargo.lock ./
+COPY crates/ ./crates/
+
+# Build all binaries in release mode
+# This creates a single build layer that can be cached
+RUN cargo build --release --workspace --bins
+
+# =============================================================================
+# Stage 2: Runtime
+# =============================================================================
+FROM debian:bookworm-slim AS runtime
+
+# Install runtime dependencies (tmux for wrap/orchestrator, ca-certificates for HTTPS)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    tmux \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/* \
+    && useradd --create-home --shell /bin/bash agentd
+
+# Create directories for data storage
+RUN mkdir -p /var/lib/agentd/notify \
+    && mkdir -p /var/lib/agentd/orchestrator \
+    && mkdir -p /var/log/agentd \
+    && chown -R agentd:agentd /var/lib/agentd \
+    && chown -R agentd:agentd /var/log/agentd
+
+WORKDIR /app
+
+# Copy binaries from builder
+COPY --from=builder /app/target/release/agentd-ask /usr/local/bin/
+COPY --from=builder /app/target/release/agentd-notify /usr/local/bin/
+COPY --from=builder /app/target/release/agentd-orchestrator /usr/local/bin/
+COPY --from=builder /app/target/release/agentd-wrap /usr/local/bin/
+COPY --from=builder /app/target/release/agentd-hook /usr/local/bin/
+COPY --from=builder /app/target/release/agentd-monitor /usr/local/bin/
+COPY --from=builder /app/target/release/agent /usr/local/bin/
+
+# Switch to non-root user
+USER agentd
+
+# Set environment variables
+ENV RUST_LOG=info
+ENV LOG_FORMAT=json
+
+# Expose service ports
+# Ask: 17001, Hook: 17002, Monitor: 17003, Notify: 17004, Wrap: 17005, Orchestrator: 17006
+EXPOSE 17001 17002 17003 17004 17005 17006
+
+# Default command - this is overridden in docker-compose
+CMD ["echo", "agentd services built successfully. Use docker-compose to run services."]

--- a/README.md
+++ b/README.md
@@ -296,6 +296,124 @@ cargo run -p cli -- orchestrator list-agents
 cargo run -p cli -- apply .agentd/
 ```
 
+## Docker Support
+
+agentd provides Docker support for simplified development setup, CI testing, and deployment to cloud environments.
+
+### Prerequisites
+
+- Docker 20.10+
+- Docker Compose 2.0+
+
+### Quick Start
+
+```bash
+# Build the Docker image
+docker build -t agentd:latest .
+
+# Start all services
+docker-compose up -d
+
+# Check service status
+docker-compose ps
+
+# View logs
+docker-compose logs -f
+
+# Stop all services
+docker-compose down
+```
+
+### Service Ports
+
+| Service | Container Port | Host Port | Description |
+|---------|---------------|-----------|-------------|
+| ask | 17001 | 17001 | Interactive question service |
+| hook | 17002 | 17002 | Shell hook integration |
+| monitor | 17003 | 17003 | System monitoring |
+| notify | 17004 | 17004 | Notification service |
+| wrap | 17005 | 17005 | Tmux session management |
+| orchestrator | 17006 | 17006 | Agent orchestration |
+
+### Using the CLI with Docker
+
+```bash
+# Use the CLI to interact with Docker services
+export ORCHESTRATOR_SERVICE_URL=http://localhost:17006
+agent status
+agent orchestrator list-agents
+agent apply .agentd/
+```
+
+### Development Mode
+
+For development with hot reload on code changes:
+
+```bash
+# Start with development override
+docker-compose -f docker-compose.yml -f docker-compose.dev.yml up --watch
+
+# Or rebuild on changes
+docker-compose -f docker-compose.yml -f docker-compose.dev.yml build --no-cache
+```
+
+### Persistent Data
+
+SQLite databases are stored in named volumes:
+- `agentd-notify-data` - Notification service database
+- `agentd-orchestrator-data` - Orchestrator service database
+
+To remove persistent data:
+```bash
+docker-compose down -v
+```
+
+### Environment Variables
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `RUST_LOG` | Logging level | `info` |
+| `LOG_FORMAT` | Set to `json` for structured logging | `json` (in Docker) |
+| `PORT` | Service port (per-service) | See table above |
+| `NOTIFY_SERVICE_URL` | Notification service URL | `http://notify:17004` |
+| `WRAP_SERVICE_URL` | Wrap service URL | `http://wrap:17005` |
+| `ORCHESTRATOR_SERVICE_URL` | Orchestrator URL for CLI | `http://localhost:17006` |
+
+### Health Checks
+
+All services expose `/health` endpoints for health checking:
+
+```bash
+# Check individual service health
+curl http://localhost:17006/health
+
+# Check all services via CLI
+agent status
+```
+
+### Prometheus Metrics
+
+All services expose `/metrics` endpoints for Prometheus scraping:
+
+```bash
+curl http://localhost:17006/metrics
+```
+
+### Troubleshooting
+
+```bash
+# View service logs
+docker-compose logs orchestrator
+docker-compose logs -f notify  # Follow logs
+
+# Restart a service
+docker-compose restart orchestrator
+
+# Rebuild and restart
+docker-compose build --no-cache
+docker-compose up -d --force-recreate
+```
+
 ## Configuration
 
 For the complete configuration reference including all environment variables, data storage paths, and plist/systemd customization, see the **[Configuration Guide](docs/public/configuration.md)**.

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,0 +1,139 @@
+# Docker Compose development override for agentd services
+#
+# This override file provides development-friendly configurations:
+# - Debug logging
+# - Source code volume mounts for hot reload
+# - Development ports exposed
+#
+# Usage:
+#   docker-compose -f docker-compose.yml -f docker-compose.dev.yml up -d
+#   docker-compose -f docker-compose.yml -f docker-compose.dev.yml build --no-cache
+#   docker-compose -f docker-compose.yml -f docker-compose.dev.yml logs -f
+
+services:
+  # ===========================================================================
+  # Notification Service (Dev)
+  # ===========================================================================
+  notify:
+    environment:
+      - RUST_LOG=debug
+      - LOG_FORMAT=json
+      - PORT=17004
+    volumes:
+      - ./crates/notify:/app/crates/notify:ro
+      - ./crates/common:/app/crates/common:ro
+    develop:
+      watch:
+        - action: rebuild
+          path: crates/notify
+          ignore:
+            - target/
+        - action: rebuild
+          path: crates/common
+
+  # ===========================================================================
+  # Ask Service (Dev)
+  # ===========================================================================
+  ask:
+    environment:
+      - RUST_LOG=debug
+      - LOG_FORMAT=json
+      - PORT=17001
+      - NOTIFY_SERVICE_URL=http://notify:17004
+    volumes:
+      - ./crates/ask:/app/crates/ask:ro
+      - ./crates/common:/app/crates/common:ro
+    develop:
+      watch:
+        - action: rebuild
+          path: crates/ask
+          ignore:
+            - target/
+        - action: rebuild
+          path: crates/common
+
+  # ===========================================================================
+  # Wrap Service (Dev)
+  # ===========================================================================
+  wrap:
+    environment:
+      - RUST_LOG=debug
+      - LOG_FORMAT=json
+      - PORT=17005
+    volumes:
+      - ./crates/wrap:/app/crates/wrap:ro
+      - ./crates/common:/app/crates/common:ro
+    develop:
+      watch:
+        - action: rebuild
+          path: crates/wrap
+          ignore:
+            - target/
+        - action: rebuild
+          path: crates/common
+
+  # ===========================================================================
+  # Orchestrator Service (Dev)
+  # ===========================================================================
+  orchestrator:
+    environment:
+      - RUST_LOG=debug
+      - LOG_FORMAT=json
+      - PORT=17006
+      - WRAP_SERVICE_URL=http://wrap:17005
+    volumes:
+      - ./crates/orchestrator:/app/crates/orchestrator:ro
+      - ./crates/wrap:/app/crates/wrap:ro
+      - ./crates/common:/app/crates/common:ro
+    develop:
+      watch:
+        - action: rebuild
+          path: crates/orchestrator
+          ignore:
+            - target/
+        - action: rebuild
+          path: crates/wrap
+        - action: rebuild
+          path: crates/common
+
+  # ===========================================================================
+  # Hook Service (Dev)
+  # ===========================================================================
+  hook:
+    environment:
+      - RUST_LOG=debug
+      - LOG_FORMAT=json
+      - PORT=17002
+      - NOTIFY_SERVICE_URL=http://notify:17004
+    volumes:
+      - ./crates/hook:/app/crates/hook:ro
+      - ./crates/common:/app/crates/common:ro
+    develop:
+      watch:
+        - action: rebuild
+          path: crates/hook
+          ignore:
+            - target/
+        - action: rebuild
+          path: crates/common
+
+  # ===========================================================================
+  # Monitor Service (Dev)
+  # ===========================================================================
+  monitor:
+    environment:
+      - RUST_LOG=debug
+      - LOG_FORMAT=json
+      - PORT=17003
+      - NOTIFY_SERVICE_URL=http://notify:17004
+    volumes:
+      - ./crates/monitor:/app/crates/monitor:ro
+      - ./crates/common:/app/crates/common:ro
+    develop:
+      watch:
+        - action: rebuild
+          path: crates/monitor
+          ignore:
+            - target/
+        - action: rebuild
+          path: crates/common

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,185 @@
+# Docker Compose configuration for agentd services
+#
+# This file defines all services with proper networking, health checks,
+# and volume mounts for persistent storage.
+#
+# Usage:
+#   docker-compose up -d              # Start all services
+#   docker-compose ps                 # Check service status
+#   docker-compose logs -f            # View logs
+#   docker-compose down               # Stop all services
+#   docker-compose down -v            # Stop and remove volumes
+
+services:
+  # ===========================================================================
+  # Notification Service
+  # ===========================================================================
+  notify:
+    image: agentd:latest
+    container_name: agentd-notify
+    command: ["agentd-notify"]
+    restart: unless-stopped
+    ports:
+      - "17004:17004"
+    volumes:
+      - notify_data:/var/lib/agentd/notify
+    environment:
+      - PORT=17004
+      - RUST_LOG=${RUST_LOG:-info}
+      - LOG_FORMAT=json
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:17004/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 5s
+    networks:
+      - agentd-network
+
+  # ===========================================================================
+  # Ask Service
+  # ===========================================================================
+  ask:
+    image: agentd:latest
+    container_name: agentd-ask
+    command: ["agentd-ask"]
+    restart: unless-stopped
+    ports:
+      - "17001:17001"
+    environment:
+      - PORT=17001
+      - RUST_LOG=${RUST_LOG:-info}
+      - LOG_FORMAT=json
+      - NOTIFY_SERVICE_URL=http://notify:17004
+    depends_on:
+      notify:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:17001/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 5s
+    networks:
+      - agentd-network
+
+  # ===========================================================================
+  # Wrap Service (Tmux session management)
+  # ===========================================================================
+  wrap:
+    image: agentd:latest
+    container_name: agentd-wrap
+    command: ["agentd-wrap"]
+    restart: unless-stopped
+    ports:
+      - "17005:17005"
+    environment:
+      - PORT=17005
+      - RUST_LOG=${RUST_LOG:-info}
+      - LOG_FORMAT=json
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:17005/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 5s
+    networks:
+      - agentd-network
+
+  # ===========================================================================
+  # Orchestrator Service (Agent lifecycle + Workflow scheduler)
+  # ===========================================================================
+  orchestrator:
+    image: agentd:latest
+    container_name: agentd-orchestrator
+    command: ["agentd-orchestrator"]
+    restart: unless-stopped
+    ports:
+      - "17006:17006"
+    volumes:
+      - orchestrator_data:/var/lib/agentd/orchestrator
+    environment:
+      - PORT=17006
+      - RUST_LOG=${RUST_LOG:-info}
+      - LOG_FORMAT=json
+      - WRAP_SERVICE_URL=http://wrap:17005
+    depends_on:
+      wrap:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:17006/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 10s
+    networks:
+      - agentd-network
+
+  # ===========================================================================
+  # Hook Service (Shell hook integration) - Stub
+  # ===========================================================================
+  hook:
+    image: agentd:latest
+    container_name: agentd-hook
+    command: ["agentd-hook"]
+    restart: unless-stopped
+    ports:
+      - "17002:17002"
+    environment:
+      - PORT=17002
+      - RUST_LOG=${RUST_LOG:-info}
+      - LOG_FORMAT=json
+      - NOTIFY_SERVICE_URL=http://notify:17004
+    depends_on:
+      - notify
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:17002/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 5s
+    networks:
+      - agentd-network
+
+  # ===========================================================================
+  # Monitor Service (System monitoring) - Stub
+  # ===========================================================================
+  monitor:
+    image: agentd:latest
+    container_name: agentd-monitor
+    command: ["agentd-monitor"]
+    restart: unless-stopped
+    ports:
+      - "17003:17003"
+    environment:
+      - PORT=17003
+      - RUST_LOG=${RUST_LOG:-info}
+      - LOG_FORMAT=json
+      - NOTIFY_SERVICE_URL=http://notify:17004
+    depends_on:
+      - notify
+    healthcheck:
+      test: ["CMD", "wget", "--spider", "-q", "http://localhost:17003/health"]
+      interval: 10s
+      timeout: 5s
+      retries: 3
+      start_period: 5s
+    networks:
+      - agentd-network
+
+# =============================================================================
+# Networks
+# =============================================================================
+networks:
+  agentd-network:
+    driver: bridge
+    name: agentd-network
+
+# =============================================================================
+# Volumes
+# =============================================================================
+volumes:
+  notify_data:
+    name: agentd-notify-data
+  orchestrator_data:
+    name: agentd-orchestrator-data


### PR DESCRIPTION
Adds Docker infrastructure for running the full agentd stack in containers, simplifying development setup, CI testing, and cloud deployment.

## Changes

- **Dockerfile**: Multi-stage build producing slim runtime image with all service binaries (ask, notify, orchestrator, wrap, hook, monitor)
- **docker-compose.yml**: Full service orchestration with:
  - Shared bridge network for service discovery
  - Health checks using /health endpoints for all services
  - Volume mounts for SQLite databases (notify.db, orchestrator.db)
  - Proper dependency ordering (notify → ask/wrap → orchestrator)
  - Environment variable configuration matching existing conventions
- **docker-compose.dev.yml**: Development override with:
  - Debug logging enabled
  - Source code volume mounts for hot reload
  - Docker Compose watch mode support
- **.dockerignore**: Excludes build artifacts, IDE files, and unnecessary files
- **README.md**: Comprehensive Docker documentation including:
  - Quick start guide
  - Service port reference table
  - CLI usage with Docker
  - Development mode instructions
  - Environment variable reference
  - Troubleshooting guide

## Service Ports

All services run on their standard ports:
- ask: 17001
- hook: 17002
- monitor: 17003
- notify: 17004
- wrap: 17005
- orchestrator: 17006

## Usage

```bash
# Build and start all services
docker build -t agentd:latest .
docker-compose up -d

# Development mode with hot reload
docker-compose -f docker-compose.yml -f docker-compose.dev.yml up --watch

# Check service health
agent status
```

Closes #55