### PR TITLE
feat(ui): Create TypeScript API client layer for all backend services

### DIFF
--- a/ui/src/services/ask.ts
+++ b/ui/src/services/ask.ts
@@ -1,0 +1,49 @@
+/**
+ * Client for the Ask service (default port 17001).
+ *
+ * Handles environment checks (tmux sessions, etc.) and the
+ * question/answer workflow for interactive agent approvals.
+ */
+
+import { ApiClient } from './base'
+import { serviceConfig } from './config'
+import type { HealthResponse } from '@/types/common'
+import type { AnswerRequest, AnswerResponse, TriggerResponse } from '@/types/ask'
+
+export class AskClient extends ApiClient {
+  // -------------------------------------------------------------------------
+  // Health
+  // -------------------------------------------------------------------------
+
+  getHealth(): Promise<HealthResponse> {
+    return this.get<HealthResponse>('/health')
+  }
+
+  // -------------------------------------------------------------------------
+  // Environment checks
+  // -------------------------------------------------------------------------
+
+  /**
+   * Run all environment checks (e.g., tmux session detection) and create
+   * notifications for any actionable findings.
+   */
+  trigger(): Promise<TriggerResponse> {
+    return this.post<TriggerResponse>('/trigger')
+  }
+
+  // -------------------------------------------------------------------------
+  // Answers
+  // -------------------------------------------------------------------------
+
+  /**
+   * Submit an answer to a pending question.
+   */
+  answer(request: AnswerRequest): Promise<AnswerResponse> {
+    return this.post<AnswerResponse>('/answer', request)
+  }
+}
+
+/** Singleton client instance using the configured service URL */
+export const askClient = new AskClient({
+  baseUrl: serviceConfig.askServiceUrl,
+})

--- a/ui/src/services/base.ts
+++ b/ui/src/services/base.ts
@@ -1,0 +1,234 @@
+/**
+ * ApiClient – base class for all agentd service clients.
+ *
+ * Features:
+ * - Configurable base URL
+ * - Automatic JSON serialization/deserialization
+ * - Typed error responses (ApiError)
+ * - Request timeout via AbortController
+ * - Exponential-backoff retry for transient network errors
+ * - Interceptor hooks for auth headers (future use)
+ */
+
+import { ApiError } from '@/types/common'
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+export interface ApiClientOptions {
+  /** Base URL for all requests (no trailing slash) */
+  baseUrl: string
+  /** Request timeout in milliseconds (default 10 000) */
+  timeoutMs?: number
+  /** Max retry attempts for transient errors (default 3) */
+  maxRetries?: number
+  /** Initial backoff delay in milliseconds (default 200) */
+  initialBackoffMs?: number
+  /** Optional hook called before every request — useful for injecting auth headers */
+  onRequest?: (init: RequestInit) => RequestInit | Promise<RequestInit>
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const DEFAULT_TIMEOUT_MS = 10_000
+const DEFAULT_MAX_RETRIES = 3
+const DEFAULT_INITIAL_BACKOFF_MS = 200
+
+/** Returns true if the error is worth retrying */
+function isTransient(err: unknown): boolean {
+  // Network errors (TypeError from fetch) and 5xx responses are transient
+  if (err instanceof TypeError) return true
+  if (err instanceof ApiError && err.status >= 500) return true
+  return false
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms))
+}
+
+// ---------------------------------------------------------------------------
+// ApiClient
+// ---------------------------------------------------------------------------
+
+export class ApiClient {
+  protected readonly baseUrl: string
+  private readonly timeoutMs: number
+  private readonly maxRetries: number
+  private readonly initialBackoffMs: number
+  private readonly onRequest?: ApiClientOptions['onRequest']
+
+  constructor(options: ApiClientOptions) {
+    this.baseUrl = options.baseUrl.replace(/\/$/, '')
+    this.timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS
+    this.maxRetries = options.maxRetries ?? DEFAULT_MAX_RETRIES
+    this.initialBackoffMs = options.initialBackoffMs ?? DEFAULT_INITIAL_BACKOFF_MS
+    this.onRequest = options.onRequest
+  }
+
+  // -------------------------------------------------------------------------
+  // Core request method (with retry)
+  // -------------------------------------------------------------------------
+
+  protected async request<T>(
+    method: string,
+    path: string,
+    body?: unknown,
+    queryParams?: Record<string, string | number | boolean | undefined>,
+  ): Promise<T> {
+    const url = this.buildUrl(path, queryParams)
+    let attempt = 0
+
+    while (true) {
+      try {
+        return await this.executeRequest<T>(method, url, body)
+      } catch (err) {
+        attempt++
+        if (attempt >= this.maxRetries || !isTransient(err)) {
+          throw err
+        }
+        const backoff = this.initialBackoffMs * 2 ** (attempt - 1)
+        await sleep(backoff)
+      }
+    }
+  }
+
+  private async executeRequest<T>(method: string, url: string, body?: unknown): Promise<T> {
+    const controller = new AbortController()
+    const timerId = setTimeout(() => controller.abort(), this.timeoutMs)
+
+    let init: RequestInit = {
+      method,
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+      },
+      signal: controller.signal,
+    }
+
+    if (body !== undefined) {
+      init = { ...init, body: JSON.stringify(body) }
+    }
+
+    if (this.onRequest) {
+      init = await this.onRequest(init)
+    }
+
+    try {
+      const response = await fetch(url, init)
+      clearTimeout(timerId)
+      return await this.parseResponse<T>(response)
+    } catch (err) {
+      clearTimeout(timerId)
+      if (err instanceof ApiError) throw err
+      // AbortController fires a DOMException with name 'AbortError'
+      if (err instanceof DOMException && err.name === 'AbortError') {
+        throw new ApiError(408, `Request timed out after ${this.timeoutMs}ms`)
+      }
+      throw new ApiError(0, err instanceof Error ? err.message : String(err))
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Response parsing
+  // -------------------------------------------------------------------------
+
+  private async parseResponse<T>(response: Response): Promise<T> {
+    const contentType = response.headers.get('content-type') ?? ''
+
+    if (response.status === 204 || response.headers.get('content-length') === '0') {
+      return undefined as T
+    }
+
+    if (!response.ok) {
+      let message = `HTTP ${response.status}`
+      let errorBody: unknown
+
+      if (contentType.includes('application/json')) {
+        try {
+          errorBody = await response.json()
+          if (
+            errorBody &&
+            typeof errorBody === 'object' &&
+            'error' in errorBody &&
+            typeof (errorBody as Record<string, unknown>).error === 'string'
+          ) {
+            message = (errorBody as { error: string }).error
+          }
+        } catch {
+          // fall through with default message
+        }
+      } else {
+        message = (await response.text().catch(() => message)) || message
+      }
+
+      throw new ApiError(response.status, message, errorBody)
+    }
+
+    if (contentType.includes('application/json')) {
+      return response.json() as Promise<T>
+    }
+
+    // Fallback: return raw text cast to T
+    return response.text() as unknown as T
+  }
+
+  // -------------------------------------------------------------------------
+  // URL construction
+  // -------------------------------------------------------------------------
+
+  private buildUrl(
+    path: string,
+    params?: Record<string, string | number | boolean | undefined>,
+  ): string {
+    const url = new URL(`${this.baseUrl}${path}`)
+
+    if (params) {
+      for (const [key, value] of Object.entries(params)) {
+        if (value !== undefined) {
+          url.searchParams.set(key, String(value))
+        }
+      }
+    }
+
+    return url.toString()
+  }
+
+  // -------------------------------------------------------------------------
+  // Convenience wrappers
+  // -------------------------------------------------------------------------
+
+  protected get<T>(
+    path: string,
+    params?: Record<string, string | number | boolean | undefined>,
+  ): Promise<T> {
+    return this.request<T>('GET', path, undefined, params)
+  }
+
+  protected post<T>(path: string, body?: unknown): Promise<T> {
+    return this.request<T>('POST', path, body)
+  }
+
+  protected put<T>(path: string, body?: unknown): Promise<T> {
+    return this.request<T>('PUT', path, body)
+  }
+
+  protected delete<T>(path: string): Promise<T> {
+    return this.request<T>('DELETE', path)
+  }
+
+  // -------------------------------------------------------------------------
+  // WebSocket helper
+  // -------------------------------------------------------------------------
+
+  /**
+   * Opens a WebSocket connection, converting the base URL scheme if needed:
+   * http → ws, https → wss
+   */
+  protected openWebSocket(path: string): WebSocket {
+    const wsBase = this.baseUrl.replace(/^http/, 'ws')
+    return new WebSocket(`${wsBase}${path}`)
+  }
+}

--- a/ui/src/services/index.ts
+++ b/ui/src/services/index.ts
@@ -1,0 +1,7 @@
+export { ApiClient } from './base'
+export type { ApiClientOptions } from './base'
+
+export { OrchestratorClient, orchestratorClient } from './orchestrator'
+export { NotifyClient, notifyClient } from './notify'
+export { AskClient, askClient } from './ask'
+export { serviceConfig } from './config'

--- a/ui/src/services/notify.ts
+++ b/ui/src/services/notify.ts
@@ -1,0 +1,87 @@
+/**
+ * Client for the Notify service (default port 17004).
+ *
+ * Manages notification CRUD with status filtering.
+ */
+
+import { ApiClient } from './base'
+import { serviceConfig } from './config'
+import type { HealthResponse, PaginatedResponse } from '@/types/common'
+import type {
+  CountResponse,
+  CreateNotificationRequest,
+  ListNotificationsParams,
+  Notification,
+  UpdateNotificationRequest,
+} from '@/types/notify'
+
+export class NotifyClient extends ApiClient {
+  // -------------------------------------------------------------------------
+  // Health
+  // -------------------------------------------------------------------------
+
+  getHealth(): Promise<HealthResponse> {
+    return this.get<HealthResponse>('/health')
+  }
+
+  // -------------------------------------------------------------------------
+  // Notifications – CRUD
+  // -------------------------------------------------------------------------
+
+  listNotifications(params?: ListNotificationsParams): Promise<PaginatedResponse<Notification>> {
+    return this.get<PaginatedResponse<Notification>>(
+      '/notifications',
+      params as Record<string, string>,
+    )
+  }
+
+  createNotification(request: CreateNotificationRequest): Promise<Notification> {
+    return this.post<Notification>('/notifications', request)
+  }
+
+  getNotification(id: string): Promise<Notification> {
+    return this.get<Notification>(`/notifications/${id}`)
+  }
+
+  updateNotification(id: string, request: UpdateNotificationRequest): Promise<Notification> {
+    return this.put<Notification>(`/notifications/${id}`, request)
+  }
+
+  deleteNotification(id: string): Promise<void> {
+    return this.delete<void>(`/notifications/${id}`)
+  }
+
+  // -------------------------------------------------------------------------
+  // Filtered views
+  // -------------------------------------------------------------------------
+
+  /** Returns actionable notifications (Pending or Viewed, not expired) */
+  listActionable(params?: ListNotificationsParams): Promise<PaginatedResponse<Notification>> {
+    return this.get<PaginatedResponse<Notification>>(
+      '/notifications/actionable',
+      params as Record<string, string>,
+    )
+  }
+
+  /** Returns completed/dismissed notification history */
+  listHistory(params?: ListNotificationsParams): Promise<PaginatedResponse<Notification>> {
+    return this.get<PaginatedResponse<Notification>>(
+      '/notifications/history',
+      params as Record<string, string>,
+    )
+  }
+
+  // -------------------------------------------------------------------------
+  // Count
+  // -------------------------------------------------------------------------
+
+  /** Returns total count and breakdown by status */
+  getCount(): Promise<CountResponse> {
+    return this.get<CountResponse>('/notifications/count')
+  }
+}
+
+/** Singleton client instance using the configured service URL */
+export const notifyClient = new NotifyClient({
+  baseUrl: serviceConfig.notifyServiceUrl,
+})

--- a/ui/src/services/orchestrator.ts
+++ b/ui/src/services/orchestrator.ts
@@ -1,0 +1,144 @@
+/**
+ * Client for the Orchestrator service (default port 17006).
+ *
+ * Manages agent lifecycle, tool policies, approvals, and exposes
+ * WebSocket helpers for real-time agent output streaming.
+ */
+
+import { ApiClient } from './base'
+import { serviceConfig } from './config'
+import type { HealthResponse, PaginatedResponse } from '@/types/common'
+import type {
+  Agent,
+  ApprovalActionRequest,
+  CreateAgentRequest,
+  ListAgentsParams,
+  ListApprovalsParams,
+  PendingApproval,
+  SendMessageRequest,
+  SendMessageResponse,
+  SetModelRequest,
+  ToolPolicy,
+  UpdatePolicyRequest,
+} from '@/types/orchestrator'
+
+export class OrchestratorClient extends ApiClient {
+  // -------------------------------------------------------------------------
+  // Health
+  // -------------------------------------------------------------------------
+
+  getHealth(): Promise<HealthResponse> {
+    return this.get<HealthResponse>('/health')
+  }
+
+  // -------------------------------------------------------------------------
+  // Agents
+  // -------------------------------------------------------------------------
+
+  listAgents(params?: ListAgentsParams): Promise<PaginatedResponse<Agent>> {
+    return this.get<PaginatedResponse<Agent>>('/agents', params as Record<string, string>)
+  }
+
+  createAgent(request: CreateAgentRequest): Promise<Agent> {
+    return this.post<Agent>('/agents', request)
+  }
+
+  getAgent(id: string): Promise<Agent> {
+    return this.get<Agent>(`/agents/${id}`)
+  }
+
+  deleteAgent(id: string): Promise<Agent> {
+    return this.delete<Agent>(`/agents/${id}`)
+  }
+
+  // -------------------------------------------------------------------------
+  // Agent actions
+  // -------------------------------------------------------------------------
+
+  sendMessage(agentId: string, message: string): Promise<SendMessageResponse> {
+    const body: SendMessageRequest = { content: message }
+    return this.post<SendMessageResponse>(`/agents/${agentId}/message`, body)
+  }
+
+  updateModel(agentId: string, request: SetModelRequest): Promise<Agent> {
+    return this.put<Agent>(`/agents/${agentId}/model`, request)
+  }
+
+  // -------------------------------------------------------------------------
+  // Tool policy
+  // -------------------------------------------------------------------------
+
+  getPolicy(agentId: string): Promise<ToolPolicy> {
+    return this.get<ToolPolicy>(`/agents/${agentId}/policy`)
+  }
+
+  updatePolicy(agentId: string, policy: UpdatePolicyRequest): Promise<ToolPolicy> {
+    return this.put<ToolPolicy>(`/agents/${agentId}/policy`, policy)
+  }
+
+  // -------------------------------------------------------------------------
+  // Approvals
+  // -------------------------------------------------------------------------
+
+  listApprovals(params?: ListApprovalsParams): Promise<PaginatedResponse<PendingApproval>> {
+    return this.get<PaginatedResponse<PendingApproval>>(
+      '/approvals',
+      params as Record<string, string>,
+    )
+  }
+
+  listAgentApprovals(
+    agentId: string,
+    params?: ListApprovalsParams,
+  ): Promise<PaginatedResponse<PendingApproval>> {
+    return this.get<PaginatedResponse<PendingApproval>>(
+      `/agents/${agentId}/approvals`,
+      params as Record<string, string>,
+    )
+  }
+
+  getApproval(id: string): Promise<PendingApproval> {
+    return this.get<PendingApproval>(`/approvals/${id}`)
+  }
+
+  approveRequest(id: string, body?: ApprovalActionRequest): Promise<PendingApproval> {
+    return this.post<PendingApproval>(`/approvals/${id}/approve`, body ?? {})
+  }
+
+  denyRequest(id: string, body?: ApprovalActionRequest): Promise<PendingApproval> {
+    return this.post<PendingApproval>(`/approvals/${id}/deny`, body ?? {})
+  }
+
+  // -------------------------------------------------------------------------
+  // WebSocket streaming
+  // -------------------------------------------------------------------------
+
+  /**
+   * Opens a WebSocket to stream output from a specific agent.
+   * URL: ws://<host>/ws/<agentId>
+   */
+  connectAgentStream(agentId: string): WebSocket {
+    return this.openWebSocket(`/ws/${agentId}`)
+  }
+
+  /**
+   * Opens a WebSocket to monitor all agents.
+   * URL: ws://<host>/stream
+   */
+  connectAllStream(): WebSocket {
+    return this.openWebSocket('/stream')
+  }
+
+  /**
+   * Opens a WebSocket to monitor a specific agent.
+   * URL: ws://<host>/stream/<agentId>
+   */
+  connectAgentMonitor(agentId: string): WebSocket {
+    return this.openWebSocket(`/stream/${agentId}`)
+  }
+}
+
+/** Singleton client instance using the configured service URL */
+export const orchestratorClient = new OrchestratorClient({
+  baseUrl: serviceConfig.orchestratorServiceUrl,
+})

--- a/ui/src/test/services/ask.test.ts
+++ b/ui/src/test/services/ask.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { AskClient } from '@/services/ask'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeJsonResponse(status: number, body: unknown) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: new Headers({ 'content-type': 'application/json' }),
+  })
+}
+
+function mockFetch(status: number, body: unknown) {
+  vi.stubGlobal('fetch', vi.fn().mockResolvedValue(makeJsonResponse(status, body)))
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('AskClient', () => {
+  let client: AskClient
+
+  beforeEach(() => {
+    client = new AskClient({
+      baseUrl: 'http://localhost:17001',
+      maxRetries: 1,
+    })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  describe('getHealth', () => {
+    it('calls GET /health', async () => {
+      mockFetch(200, { service: 'ask', version: '0.2.0', status: 'ok' })
+      const result = await client.getHealth()
+      expect(result.service).toBe('ask')
+
+      const calledUrl = vi.mocked(fetch).mock.calls[0][0] as string
+      expect(calledUrl).toContain('/health')
+    })
+  })
+
+  describe('trigger', () => {
+    it('calls POST /trigger and returns TriggerResponse', async () => {
+      const mockResponse = {
+        checks_run: ['tmux_sessions'],
+        notifications_sent: ['notif-uuid-1'],
+        results: {
+          tmux_sessions: {
+            running: true,
+            session_count: 2,
+            sessions: ['main', 'dev'],
+          },
+        },
+      }
+      mockFetch(200, mockResponse)
+      const result = await client.trigger()
+      expect(result.checks_run).toContain('tmux_sessions')
+      expect(result.results.tmux_sessions.running).toBe(true)
+      expect(result.results.tmux_sessions.session_count).toBe(2)
+
+      const callInit = vi.mocked(fetch).mock.calls[0][1] as RequestInit
+      expect(callInit.method).toBe('POST')
+
+      const calledUrl = vi.mocked(fetch).mock.calls[0][0] as string
+      expect(calledUrl).toContain('/trigger')
+    })
+
+    it('handles no tmux sessions running', async () => {
+      mockFetch(200, {
+        checks_run: ['tmux_sessions'],
+        notifications_sent: [],
+        results: {
+          tmux_sessions: {
+            running: false,
+            session_count: 0,
+            sessions: null,
+          },
+        },
+      })
+      const result = await client.trigger()
+      expect(result.results.tmux_sessions.running).toBe(false)
+      expect(result.results.tmux_sessions.session_count).toBe(0)
+      expect(result.notifications_sent).toHaveLength(0)
+    })
+  })
+
+  describe('answer', () => {
+    it('calls POST /answer with the request body', async () => {
+      mockFetch(200, {
+        success: true,
+        message: 'Answer recorded',
+        question_id: 'q-uuid-1',
+      })
+      const result = await client.answer({
+        question_id: 'q-uuid-1',
+        answer: 'yes',
+      })
+      expect(result.success).toBe(true)
+      expect(result.question_id).toBe('q-uuid-1')
+
+      const callInit = vi.mocked(fetch).mock.calls[0][1] as RequestInit
+      expect(callInit.method).toBe('POST')
+      const body = JSON.parse(callInit.body as string)
+      expect(body.question_id).toBe('q-uuid-1')
+      expect(body.answer).toBe('yes')
+
+      const calledUrl = vi.mocked(fetch).mock.calls[0][0] as string
+      expect(calledUrl).toContain('/answer')
+    })
+
+    it('handles failure response', async () => {
+      mockFetch(200, {
+        success: false,
+        message: 'Question already answered',
+        question_id: 'q-uuid-1',
+      })
+      const result = await client.answer({ question_id: 'q-uuid-1', answer: 'no' })
+      expect(result.success).toBe(false)
+    })
+  })
+})

--- a/ui/src/test/services/base.test.ts
+++ b/ui/src/test/services/base.test.ts
@@ -1,0 +1,259 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { ApiClient } from '@/services/base'
+import { ApiError } from '@/types/common'
+
+// ---------------------------------------------------------------------------
+// Concrete subclass for testing (exposes protected methods)
+// ---------------------------------------------------------------------------
+
+class TestClient extends ApiClient {
+  testGet<T>(path: string, params?: Record<string, string | number | boolean | undefined>) {
+    return this.get<T>(path, params)
+  }
+  testPost<T>(path: string, body?: unknown) {
+    return this.post<T>(path, body)
+  }
+  testPut<T>(path: string, body?: unknown) {
+    return this.put<T>(path, body)
+  }
+  testDelete<T>(path: string) {
+    return this.delete<T>(path)
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Fetch mock helpers
+// ---------------------------------------------------------------------------
+
+function mockFetch(status: number, body: unknown, headers: Record<string, string> = {}) {
+  const responseHeaders = new Headers({
+    'content-type': 'application/json',
+    ...headers,
+  })
+
+  const response = new Response(JSON.stringify(body), {
+    status,
+    headers: responseHeaders,
+  })
+
+  vi.stubGlobal('fetch', vi.fn().mockResolvedValue(response))
+}
+
+function mockFetchError(message = 'Network error') {
+  vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new TypeError(message)))
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('ApiClient', () => {
+  let client: TestClient
+
+  beforeEach(() => {
+    client = new TestClient({
+      baseUrl: 'http://localhost:9999',
+      maxRetries: 1, // disable retries for most tests
+      timeoutMs: 5000,
+    })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  // -------------------------------------------------------------------------
+  // Successful responses
+  // -------------------------------------------------------------------------
+
+  describe('successful responses', () => {
+    it('parses a JSON body on 200', async () => {
+      mockFetch(200, { hello: 'world' })
+      const result = await client.testGet<{ hello: string }>('/test')
+      expect(result).toEqual({ hello: 'world' })
+    })
+
+    it('returns undefined on 204 No Content', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue(
+          new Response(null, {
+            status: 204,
+            headers: new Headers({ 'content-length': '0' }),
+          }),
+        ),
+      )
+      const result = await client.testDelete<void>('/resource/1')
+      expect(result).toBeUndefined()
+    })
+
+    it('sends POST body as JSON', async () => {
+      mockFetch(201, { id: '123' })
+      await client.testPost('/resource', { name: 'test' })
+
+      const fetchMock = vi.mocked(fetch)
+      const callInit = fetchMock.mock.calls[0][1] as RequestInit
+      expect(callInit.body).toBe('{"name":"test"}')
+      expect((callInit.headers as Record<string, string>)['Content-Type']).toBe('application/json')
+    })
+
+    it('appends query params to the URL', async () => {
+      mockFetch(200, { items: [], total: 0, limit: 10, offset: 0 })
+      await client.testGet('/items', { limit: 10, offset: 0, status: 'Pending' })
+
+      const fetchMock = vi.mocked(fetch)
+      const calledUrl = fetchMock.mock.calls[0][0] as string
+      expect(calledUrl).toContain('limit=10')
+      expect(calledUrl).toContain('offset=0')
+      expect(calledUrl).toContain('status=Pending')
+    })
+
+    it('omits undefined query params', async () => {
+      mockFetch(200, {})
+      await client.testGet('/items', { limit: 10, status: undefined })
+
+      const fetchMock = vi.mocked(fetch)
+      const calledUrl = fetchMock.mock.calls[0][0] as string
+      expect(calledUrl).not.toContain('status')
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // Error handling
+  // -------------------------------------------------------------------------
+
+  describe('error handling', () => {
+    it('throws ApiError on 4xx with error field', async () => {
+      mockFetch(404, { error: 'Not found' })
+
+      await expect(client.testGet('/missing')).rejects.toMatchObject({
+        status: 404,
+        message: 'Not found',
+      })
+    })
+
+    it('throws ApiError on 500', async () => {
+      mockFetch(500, { error: 'Internal server error' })
+
+      await expect(client.testGet('/fail')).rejects.toBeInstanceOf(ApiError)
+    })
+
+    it('throws ApiError on network failure', async () => {
+      mockFetchError('Failed to fetch')
+
+      await expect(client.testGet('/fail')).rejects.toBeInstanceOf(ApiError)
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // Retry logic
+  // -------------------------------------------------------------------------
+
+  describe('retry logic', () => {
+    it('retries on 503 and succeeds on second attempt', async () => {
+      const okResponse = new Response(JSON.stringify({ ok: true }), {
+        status: 200,
+        headers: new Headers({ 'content-type': 'application/json' }),
+      })
+      const errResponse = new Response(JSON.stringify({ error: 'unavailable' }), {
+        status: 503,
+        headers: new Headers({ 'content-type': 'application/json' }),
+      })
+
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValueOnce(errResponse).mockResolvedValueOnce(okResponse),
+      )
+
+      // Build a client with 2 retries and zero backoff for speed
+      const retryClient = new TestClient({
+        baseUrl: 'http://localhost:9999',
+        maxRetries: 2,
+        initialBackoffMs: 0,
+      })
+
+      const result = await retryClient.testGet<{ ok: boolean }>('/flaky')
+      expect(result).toEqual({ ok: true })
+      expect(vi.mocked(fetch)).toHaveBeenCalledTimes(2)
+    })
+
+    it('does not retry on 4xx errors', async () => {
+      mockFetch(400, { error: 'Bad request' })
+
+      const retryClient = new TestClient({
+        baseUrl: 'http://localhost:9999',
+        maxRetries: 3,
+        initialBackoffMs: 0,
+      })
+
+      await expect(retryClient.testGet('/bad')).rejects.toBeInstanceOf(ApiError)
+      expect(vi.mocked(fetch)).toHaveBeenCalledTimes(1)
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // onRequest interceptor
+  // -------------------------------------------------------------------------
+
+  describe('onRequest interceptor', () => {
+    it('calls the onRequest hook and merges headers', async () => {
+      mockFetch(200, { ok: true })
+
+      const interceptedClient = new TestClient({
+        baseUrl: 'http://localhost:9999',
+        maxRetries: 1,
+        onRequest: (init) => ({
+          ...init,
+          headers: {
+            ...(init.headers as Record<string, string>),
+            Authorization: 'Bearer token',
+          },
+        }),
+      })
+
+      await interceptedClient.testGet('/secure')
+
+      const fetchMock = vi.mocked(fetch)
+      const callInit = fetchMock.mock.calls[0][1] as RequestInit
+      expect((callInit.headers as Record<string, string>)['Authorization']).toBe('Bearer token')
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // WebSocket helper
+  // -------------------------------------------------------------------------
+
+  describe('openWebSocket', () => {
+    it('converts http to ws scheme', () => {
+      class WsTestClient extends ApiClient {
+        ws(path: string) {
+          return this.openWebSocket(path)
+        }
+      }
+
+      // Mock WebSocket constructor
+      const MockWS = vi.fn()
+      vi.stubGlobal('WebSocket', MockWS)
+
+      const wsClient = new WsTestClient({ baseUrl: 'http://localhost:17006' })
+      wsClient.ws('/ws/agent-1')
+
+      expect(MockWS).toHaveBeenCalledWith('ws://localhost:17006/ws/agent-1')
+    })
+
+    it('converts https to wss scheme', () => {
+      const MockWS = vi.fn()
+      vi.stubGlobal('WebSocket', MockWS)
+
+      class WsTestClient extends ApiClient {
+        ws(path: string) {
+          return this.openWebSocket(path)
+        }
+      }
+      const wsClient = new WsTestClient({ baseUrl: 'https://agentd.example.com' })
+      wsClient.ws('/stream')
+
+      expect(MockWS).toHaveBeenCalledWith('wss://agentd.example.com/stream')
+    })
+  })
+})

--- a/ui/src/test/services/notify.test.ts
+++ b/ui/src/test/services/notify.test.ts
@@ -1,0 +1,198 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { NotifyClient } from '@/services/notify'
+import type { Notification } from '@/types/notify'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeJsonResponse(status: number, body: unknown) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: new Headers({ 'content-type': 'application/json' }),
+  })
+}
+
+function mockFetch(status: number, body: unknown) {
+  vi.stubGlobal('fetch', vi.fn().mockResolvedValue(makeJsonResponse(status, body)))
+}
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const mockNotification: Notification = {
+  id: 'notif-uuid-1',
+  source: 'AskService',
+  lifetime: { type: 'Persistent' },
+  priority: 'Normal',
+  status: 'Pending',
+  title: 'Test Notification',
+  message: 'Something happened',
+  requires_response: false,
+  created_at: '2024-01-01T00:00:00Z',
+  updated_at: '2024-01-01T00:00:00Z',
+}
+
+const paginatedNotifications = {
+  items: [mockNotification],
+  total: 1,
+  limit: 20,
+  offset: 0,
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('NotifyClient', () => {
+  let client: NotifyClient
+
+  beforeEach(() => {
+    client = new NotifyClient({
+      baseUrl: 'http://localhost:17004',
+      maxRetries: 1,
+    })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  describe('getHealth', () => {
+    it('calls GET /health', async () => {
+      mockFetch(200, { service: 'notify', version: '0.2.0', status: 'ok' })
+      const result = await client.getHealth()
+      expect(result.service).toBe('notify')
+    })
+  })
+
+  describe('listNotifications', () => {
+    it('returns paginated response', async () => {
+      mockFetch(200, paginatedNotifications)
+      const result = await client.listNotifications()
+      expect(result.items).toHaveLength(1)
+      expect(result.total).toBe(1)
+    })
+
+    it('passes status filter', async () => {
+      mockFetch(200, { ...paginatedNotifications, items: [] })
+      await client.listNotifications({ status: 'Pending' })
+
+      const calledUrl = vi.mocked(fetch).mock.calls[0][0] as string
+      expect(calledUrl).toContain('status=Pending')
+    })
+  })
+
+  describe('createNotification', () => {
+    it('calls POST /notifications', async () => {
+      mockFetch(201, mockNotification)
+      const result = await client.createNotification({
+        source: 'System',
+        lifetime: { type: 'Persistent' },
+        priority: 'High',
+        title: 'Alert',
+        message: 'Critical update',
+        requires_response: true,
+      })
+      expect(result.id).toBe('notif-uuid-1')
+
+      const callInit = vi.mocked(fetch).mock.calls[0][1] as RequestInit
+      expect(callInit.method).toBe('POST')
+      const body = JSON.parse(callInit.body as string)
+      expect(body.priority).toBe('High')
+    })
+  })
+
+  describe('getNotification', () => {
+    it('calls GET /notifications/:id', async () => {
+      mockFetch(200, mockNotification)
+      const result = await client.getNotification('notif-uuid-1')
+      expect(result.title).toBe('Test Notification')
+
+      const calledUrl = vi.mocked(fetch).mock.calls[0][0] as string
+      expect(calledUrl).toContain('/notifications/notif-uuid-1')
+    })
+  })
+
+  describe('updateNotification', () => {
+    it('calls PUT /notifications/:id', async () => {
+      const updated = { ...mockNotification, status: 'Viewed' as const }
+      mockFetch(200, updated)
+      const result = await client.updateNotification('notif-uuid-1', { status: 'Viewed' })
+      expect(result.status).toBe('Viewed')
+
+      const callInit = vi.mocked(fetch).mock.calls[0][1] as RequestInit
+      expect(callInit.method).toBe('PUT')
+    })
+  })
+
+  describe('deleteNotification', () => {
+    it('calls DELETE /notifications/:id and returns void', async () => {
+      vi.stubGlobal(
+        'fetch',
+        vi.fn().mockResolvedValue(
+          new Response(null, {
+            status: 204,
+            headers: new Headers({ 'content-length': '0' }),
+          }),
+        ),
+      )
+      const result = await client.deleteNotification('notif-uuid-1')
+      expect(result).toBeUndefined()
+
+      const callInit = vi.mocked(fetch).mock.calls[0][1] as RequestInit
+      expect(callInit.method).toBe('DELETE')
+    })
+  })
+
+  describe('listActionable', () => {
+    it('calls GET /notifications/actionable', async () => {
+      mockFetch(200, paginatedNotifications)
+      await client.listActionable()
+
+      const calledUrl = vi.mocked(fetch).mock.calls[0][0] as string
+      expect(calledUrl).toContain('/notifications/actionable')
+    })
+  })
+
+  describe('listHistory', () => {
+    it('calls GET /notifications/history', async () => {
+      mockFetch(200, paginatedNotifications)
+      await client.listHistory()
+
+      const calledUrl = vi.mocked(fetch).mock.calls[0][0] as string
+      expect(calledUrl).toContain('/notifications/history')
+    })
+  })
+
+  describe('getCount', () => {
+    it('calls GET /notifications/count and returns CountResponse', async () => {
+      mockFetch(200, {
+        total: 5,
+        by_status: [
+          { status: 'Pending', count: 3 },
+          { status: 'Viewed', count: 2 },
+        ],
+      })
+      const result = await client.getCount()
+      expect(result.total).toBe(5)
+      expect(result.by_status).toHaveLength(2)
+
+      const calledUrl = vi.mocked(fetch).mock.calls[0][0] as string
+      expect(calledUrl).toContain('/notifications/count')
+    })
+  })
+
+  describe('ephemeral notification lifetime', () => {
+    it('handles Ephemeral lifetime with expires_at', async () => {
+      const ephemeral: Notification = {
+        ...mockNotification,
+        lifetime: { type: 'Ephemeral', expires_at: '2024-12-31T23:59:59Z' },
+      }
+      mockFetch(200, ephemeral)
+      const result = await client.getNotification('notif-uuid-1')
+      expect(result.lifetime).toEqual({ type: 'Ephemeral', expires_at: '2024-12-31T23:59:59Z' })
+    })
+  })
+})

--- a/ui/src/test/services/orchestrator.test.ts
+++ b/ui/src/test/services/orchestrator.test.ts
@@ -1,0 +1,235 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { OrchestratorClient } from '@/services/orchestrator'
+import { ApiError } from '@/types/common'
+import type { Agent, PendingApproval } from '@/types/orchestrator'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeJsonResponse(status: number, body: unknown) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: new Headers({ 'content-type': 'application/json' }),
+  })
+}
+
+function mockFetch(status: number, body: unknown) {
+  vi.stubGlobal('fetch', vi.fn().mockResolvedValue(makeJsonResponse(status, body)))
+}
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const mockAgent: Agent = {
+  id: 'agent-uuid-1',
+  name: 'test-agent',
+  status: 'Running',
+  config: {
+    working_dir: '/tmp',
+    shell: 'bash',
+    interactive: false,
+    tool_policy: { type: 'AllowAll' },
+  },
+  created_at: '2024-01-01T00:00:00Z',
+  updated_at: '2024-01-01T00:00:00Z',
+}
+
+const mockApproval: PendingApproval = {
+  id: 'approval-uuid-1',
+  agent_id: 'agent-uuid-1',
+  request_id: 'req-1',
+  tool_name: 'bash',
+  tool_input: { command: 'ls' },
+  status: 'Pending',
+  created_at: '2024-01-01T00:00:00Z',
+  expires_at: '2024-01-01T00:10:00Z',
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('OrchestratorClient', () => {
+  let client: OrchestratorClient
+
+  beforeEach(() => {
+    client = new OrchestratorClient({
+      baseUrl: 'http://localhost:17006',
+      maxRetries: 1,
+    })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  describe('getHealth', () => {
+    it('calls GET /health', async () => {
+      mockFetch(200, { service: 'orchestrator', version: '0.2.0', status: 'ok' })
+      const result = await client.getHealth()
+      expect(result.service).toBe('orchestrator')
+
+      const calledUrl = vi.mocked(fetch).mock.calls[0][0] as string
+      expect(calledUrl).toContain('/health')
+    })
+  })
+
+  describe('listAgents', () => {
+    it('calls GET /agents and returns paginated response', async () => {
+      mockFetch(200, { items: [mockAgent], total: 1, limit: 20, offset: 0 })
+      const result = await client.listAgents()
+      expect(result.items).toHaveLength(1)
+      expect(result.items[0].id).toBe('agent-uuid-1')
+    })
+
+    it('passes status filter as query param', async () => {
+      mockFetch(200, { items: [], total: 0, limit: 20, offset: 0 })
+      await client.listAgents({ status: 'Running' })
+
+      const calledUrl = vi.mocked(fetch).mock.calls[0][0] as string
+      expect(calledUrl).toContain('status=Running')
+    })
+  })
+
+  describe('createAgent', () => {
+    it('calls POST /agents with the request body', async () => {
+      mockFetch(201, mockAgent)
+      const request = {
+        name: 'test-agent',
+        working_dir: '/tmp',
+        shell: 'bash',
+        interactive: false,
+        tool_policy: { type: 'AllowAll' as const },
+      }
+      const result = await client.createAgent(request)
+      expect(result.id).toBe('agent-uuid-1')
+
+      const callInit = vi.mocked(fetch).mock.calls[0][1] as RequestInit
+      const body = JSON.parse(callInit.body as string)
+      expect(body.name).toBe('test-agent')
+    })
+  })
+
+  describe('getAgent', () => {
+    it('calls GET /agents/:id', async () => {
+      mockFetch(200, mockAgent)
+      const result = await client.getAgent('agent-uuid-1')
+      expect(result.status).toBe('Running')
+
+      const calledUrl = vi.mocked(fetch).mock.calls[0][0] as string
+      expect(calledUrl).toContain('/agents/agent-uuid-1')
+    })
+
+    it('throws ApiError on 404', async () => {
+      mockFetch(404, { error: 'Agent not found' })
+      await expect(client.getAgent('missing')).rejects.toMatchObject({
+        status: 404,
+        message: 'Agent not found',
+      })
+    })
+  })
+
+  describe('deleteAgent', () => {
+    it('calls DELETE /agents/:id', async () => {
+      mockFetch(200, mockAgent)
+      await client.deleteAgent('agent-uuid-1')
+
+      const fetchMock = vi.mocked(fetch)
+      const callInit = fetchMock.mock.calls[0][1] as RequestInit
+      expect(callInit.method).toBe('DELETE')
+    })
+  })
+
+  describe('sendMessage', () => {
+    it('calls POST /agents/:id/message', async () => {
+      mockFetch(200, { status: 'ok', agent_id: 'agent-uuid-1' })
+      const result = await client.sendMessage('agent-uuid-1', 'Hello agent')
+      expect(result.status).toBe('ok')
+
+      const callInit = vi.mocked(fetch).mock.calls[0][1] as RequestInit
+      const body = JSON.parse(callInit.body as string)
+      expect(body.content).toBe('Hello agent')
+    })
+  })
+
+  describe('getPolicy / updatePolicy', () => {
+    it('calls GET /agents/:id/policy', async () => {
+      mockFetch(200, { type: 'AllowAll' })
+      const policy = await client.getPolicy('agent-uuid-1')
+      expect(policy.type).toBe('AllowAll')
+    })
+
+    it('calls PUT /agents/:id/policy', async () => {
+      const newPolicy = { type: 'RequireApproval' as const }
+      mockFetch(200, newPolicy)
+      const result = await client.updatePolicy('agent-uuid-1', newPolicy)
+      expect(result.type).toBe('RequireApproval')
+    })
+  })
+
+  describe('approvals', () => {
+    it('listApprovals calls GET /approvals', async () => {
+      mockFetch(200, { items: [mockApproval], total: 1, limit: 20, offset: 0 })
+      const result = await client.listApprovals()
+      expect(result.items[0].tool_name).toBe('bash')
+    })
+
+    it('approveRequest calls POST /approvals/:id/approve', async () => {
+      mockFetch(200, { ...mockApproval, status: 'Approved' })
+      const result = await client.approveRequest('approval-uuid-1')
+      expect(result.status).toBe('Approved')
+
+      const calledUrl = vi.mocked(fetch).mock.calls[0][0] as string
+      expect(calledUrl).toContain('/approvals/approval-uuid-1/approve')
+    })
+
+    it('denyRequest calls POST /approvals/:id/deny', async () => {
+      mockFetch(200, { ...mockApproval, status: 'Denied' })
+      const result = await client.denyRequest('approval-uuid-1', { reason: 'Too dangerous' })
+      expect(result.status).toBe('Denied')
+
+      const callInit = vi.mocked(fetch).mock.calls[0][1] as RequestInit
+      const body = JSON.parse(callInit.body as string)
+      expect(body.reason).toBe('Too dangerous')
+    })
+  })
+
+  describe('WebSocket helpers', () => {
+    it('connectAgentStream opens ws://.../ws/:id', () => {
+      const MockWS = vi.fn()
+      vi.stubGlobal('WebSocket', MockWS)
+      client.connectAgentStream('agent-uuid-1')
+      expect(MockWS).toHaveBeenCalledWith('ws://localhost:17006/ws/agent-uuid-1')
+    })
+
+    it('connectAllStream opens ws://.../stream', () => {
+      const MockWS = vi.fn()
+      vi.stubGlobal('WebSocket', MockWS)
+      client.connectAllStream()
+      expect(MockWS).toHaveBeenCalledWith('ws://localhost:17006/stream')
+    })
+  })
+
+  describe('error propagation', () => {
+    it('throws ApiError with correct status and message', async () => {
+      mockFetch(422, { error: 'Invalid config' })
+      let caught: ApiError | null = null
+      try {
+        await client.createAgent({
+          name: '',
+          working_dir: '',
+          shell: '',
+          interactive: false,
+          tool_policy: { type: 'AllowAll' },
+        })
+      } catch (e) {
+        caught = e as ApiError
+      }
+      expect(caught).toBeInstanceOf(ApiError)
+      expect(caught?.status).toBe(422)
+      expect(caught?.message).toBe('Invalid config')
+    })
+  })
+})

--- a/ui/src/types/ask.ts
+++ b/ui/src/types/ask.ts
@@ -1,0 +1,62 @@
+/**
+ * TypeScript types for the Ask service.
+ * Mirrors the Rust types in crates/ask.
+ */
+
+// ---------------------------------------------------------------------------
+// Enums
+// ---------------------------------------------------------------------------
+
+/** The category of environment check */
+export type CheckType = 'TmuxSessions'
+
+/** Current state of a question */
+export type QuestionStatus = 'Pending' | 'Answered' | 'Expired'
+
+// ---------------------------------------------------------------------------
+// Models
+// ---------------------------------------------------------------------------
+
+/** Info about an outstanding question */
+export interface QuestionInfo {
+  question_id: string
+  notification_id: string
+  check_type: CheckType
+  asked_at: string
+  status: QuestionStatus
+  answer?: string
+}
+
+/** Result of a tmux-sessions check */
+export interface TmuxCheckResult {
+  running: boolean
+  session_count: number
+  sessions?: string[]
+}
+
+/** Aggregated trigger results keyed by check type */
+export interface TriggerResults {
+  tmux_sessions: TmuxCheckResult
+}
+
+/** Response from POST /trigger */
+export interface TriggerResponse {
+  checks_run: string[]
+  notifications_sent: string[]
+  results: TriggerResults
+}
+
+// ---------------------------------------------------------------------------
+// Request / response bodies
+// ---------------------------------------------------------------------------
+
+export interface AnswerRequest {
+  question_id: string
+  answer: string
+}
+
+export interface AnswerResponse {
+  success: boolean
+  message: string
+  question_id: string
+}

--- a/ui/src/types/common.ts
+++ b/ui/src/types/common.ts
@@ -1,0 +1,42 @@
+/**
+ * Common shared types used across all agentd services.
+ */
+
+/** Standard paginated response wrapper */
+export interface PaginatedResponse<T> {
+  items: T[]
+  total: number
+  limit: number
+  offset: number
+}
+
+/** Standard health-check response */
+export interface HealthResponse {
+  service: string
+  version: string
+  status: string
+}
+
+/** Typed API error thrown by all client methods */
+export class ApiError extends Error {
+  readonly status: number
+  readonly body: unknown
+
+  constructor(status: number, message: string, body?: unknown) {
+    super(message)
+    this.name = 'ApiError'
+    this.status = status
+    this.body = body
+  }
+}
+
+/** Pagination query parameters accepted by list endpoints */
+export interface PaginationParams {
+  limit?: number
+  offset?: number
+}
+
+/** Generic status-filter params (extends pagination) */
+export interface StatusFilterParams extends PaginationParams {
+  status?: string
+}

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -1,0 +1,4 @@
+export * from './common'
+export * from './orchestrator'
+export * from './notify'
+export * from './ask'

--- a/ui/src/types/notify.ts
+++ b/ui/src/types/notify.ts
@@ -1,0 +1,82 @@
+/**
+ * TypeScript types for the Notify service.
+ * Mirrors the Rust types in crates/notify.
+ */
+
+// ---------------------------------------------------------------------------
+// Enums / discriminated unions
+// ---------------------------------------------------------------------------
+
+/** Where the notification originated */
+export type NotificationSource = 'AgentHook' | 'AskService' | 'MonitorService' | 'System'
+
+/** How long the notification lives */
+export type NotificationLifetime =
+  | { type: 'Persistent' }
+  | { type: 'Ephemeral'; expires_at: string }
+
+/** Display priority */
+export type NotificationPriority = 'Low' | 'Normal' | 'High' | 'Urgent'
+
+/** Current state of a notification */
+export type NotificationStatus = 'Pending' | 'Viewed' | 'Responded' | 'Dismissed' | 'Expired'
+
+// ---------------------------------------------------------------------------
+// Notification model
+// ---------------------------------------------------------------------------
+
+export interface Notification {
+  id: string
+  source: NotificationSource
+  lifetime: NotificationLifetime
+  priority: NotificationPriority
+  status: NotificationStatus
+  title: string
+  message: string
+  requires_response: boolean
+  response?: string
+  created_at: string
+  updated_at: string
+}
+
+// ---------------------------------------------------------------------------
+// Request bodies
+// ---------------------------------------------------------------------------
+
+export interface CreateNotificationRequest {
+  source: NotificationSource
+  lifetime: NotificationLifetime
+  priority: NotificationPriority
+  title: string
+  message: string
+  requires_response: boolean
+}
+
+export interface UpdateNotificationRequest {
+  status?: NotificationStatus
+  response?: string
+}
+
+// ---------------------------------------------------------------------------
+// Count response
+// ---------------------------------------------------------------------------
+
+export interface StatusCount {
+  status: string
+  count: number
+}
+
+export interface CountResponse {
+  total: number
+  by_status: StatusCount[]
+}
+
+// ---------------------------------------------------------------------------
+// Query params
+// ---------------------------------------------------------------------------
+
+export interface ListNotificationsParams {
+  status?: NotificationStatus
+  limit?: number
+  offset?: number
+}

--- a/ui/src/types/orchestrator.ts
+++ b/ui/src/types/orchestrator.ts
@@ -1,0 +1,163 @@
+/**
+ * TypeScript types for the Orchestrator service.
+ * Mirrors the Rust types in crates/orchestrator.
+ */
+
+/** Lifecycle state of an agent */
+export type AgentStatus = 'Pending' | 'Running' | 'Stopped' | 'Failed'
+
+/** Approval lifecycle state */
+export type ApprovalStatus = 'Pending' | 'Approved' | 'Denied' | 'TimedOut'
+
+// ---------------------------------------------------------------------------
+// ToolPolicy – discriminated union mirroring the Rust enum
+// ---------------------------------------------------------------------------
+
+export type ToolPolicy =
+  | { type: 'AllowAll' }
+  | { type: 'DenyAll' }
+  | { type: 'AllowList'; tools: string[] }
+  | { type: 'DenyList'; tools: string[] }
+  | { type: 'RequireApproval' }
+
+// ---------------------------------------------------------------------------
+// AgentConfig
+// ---------------------------------------------------------------------------
+
+/** Full agent configuration */
+export interface AgentConfig {
+  working_dir: string
+  user?: string
+  shell: string
+  interactive: boolean
+  prompt?: string
+  worktree?: string
+  system_prompt?: string
+  tool_policy: ToolPolicy
+  model?: string
+  env?: Record<string, string>
+}
+
+// ---------------------------------------------------------------------------
+// Agent / AgentResponse
+// ---------------------------------------------------------------------------
+
+/** Agent as returned by the API (env values are redacted) */
+export interface Agent {
+  id: string
+  name: string
+  status: AgentStatus
+  config: AgentConfig
+  tmux_session?: string
+  created_at: string
+  updated_at: string
+}
+
+// ---------------------------------------------------------------------------
+// Request bodies
+// ---------------------------------------------------------------------------
+
+/** Create-agent request: all AgentConfig fields plus a name */
+export interface CreateAgentRequest {
+  name: string
+  working_dir: string
+  user?: string
+  shell: string
+  interactive: boolean
+  prompt?: string
+  worktree?: string
+  system_prompt?: string
+  tool_policy: ToolPolicy
+  model?: string
+  env?: Record<string, string>
+}
+
+/** Send a message to an agent */
+export interface SendMessageRequest {
+  content: string
+}
+
+/** Response after sending a message */
+export interface SendMessageResponse {
+  status: string
+  agent_id: string
+}
+
+/** Change the model used by an agent */
+export interface SetModelRequest {
+  model?: string
+  restart: boolean
+}
+
+/** Update the tool policy for an agent */
+export type UpdatePolicyRequest = ToolPolicy
+
+// ---------------------------------------------------------------------------
+// Approvals
+// ---------------------------------------------------------------------------
+
+/** A pending tool-use approval */
+export interface PendingApproval {
+  id: string
+  agent_id: string
+  request_id: string
+  tool_name: string
+  tool_input: unknown
+  status: ApprovalStatus
+  created_at: string
+  expires_at: string
+}
+
+/** Body for approve/deny endpoints */
+export interface ApprovalActionRequest {
+  reason?: string
+}
+
+// ---------------------------------------------------------------------------
+// Workflow / Task types (scheduler integration)
+// ---------------------------------------------------------------------------
+
+export type TaskStatus = 'Pending' | 'Running' | 'Completed' | 'Failed' | 'Cancelled'
+
+export interface TaskSourceConfig {
+  type: string
+  [key: string]: unknown
+}
+
+export interface Task {
+  id: string
+  workflow_id: string
+  name: string
+  status: TaskStatus
+  source: TaskSourceConfig
+  created_at: string
+  updated_at: string
+}
+
+export interface WorkflowConfig {
+  name: string
+  tasks: TaskSourceConfig[]
+}
+
+export interface DispatchRecord {
+  id: string
+  workflow_id: string
+  dispatched_at: string
+  status: TaskStatus
+}
+
+// ---------------------------------------------------------------------------
+// Query params
+// ---------------------------------------------------------------------------
+
+export interface ListAgentsParams {
+  status?: AgentStatus
+  limit?: number
+  offset?: number
+}
+
+export interface ListApprovalsParams {
+  status?: ApprovalStatus
+  limit?: number
+  offset?: number
+}


### PR DESCRIPTION
## Summary

Implements a fully-typed HTTP/WebSocket client layer that mirrors the backend service APIs, providing a clean abstraction for UI components to interact with all three agentd services.

## Changes

### Shared Types (`src/types/`)

| File | Contents |
|------|----------|
| `common.ts` | `PaginatedResponse<T>`, `HealthResponse`, `ApiError` class, `PaginationParams`, `StatusFilterParams` |
| `orchestrator.ts` | `Agent`, `AgentConfig`, `AgentStatus`, `ToolPolicy` (discriminated union), `PendingApproval`, `ApprovalStatus`, all request/response types, workflow/task types |
| `notify.ts` | `Notification`, `NotificationSource`, `NotificationLifetime` (discriminated union), `NotificationPriority`, `NotificationStatus`, CRUD request types, `CountResponse` |
| `ask.ts` | `QuestionInfo`, `CheckType`, `QuestionStatus`, `TriggerResponse`, `TmuxCheckResult`, `AnswerRequest`, `AnswerResponse` |
| `index.ts` | Barrel re-export of all types |

### Base Infrastructure (`src/services/base.ts`)

`ApiClient` base class featuring:
- Configurable base URL with trailing-slash normalization
- Automatic JSON serialization/deserialization
- Typed `ApiError` parsing from `{"error": "message"}` responses
- Request timeouts via `AbortController`
- Exponential-backoff retry for 5xx and network errors
- `onRequest` interceptor hook (for future auth header injection)
- `openWebSocket()` helper for automatic `http→ws` / `https→wss` scheme conversion
- Protected convenience wrappers: `get`, `post`, `put`, `delete`

### Service Clients

| Client | Methods |
|--------|---------|
| `OrchestratorClient` | `getHealth`, `listAgents`, `createAgent`, `getAgent`, `deleteAgent`, `sendMessage`, `updateModel`, `getPolicy`, `updatePolicy`, `listApprovals`, `listAgentApprovals`, `getApproval`, `approveRequest`, `denyRequest`, `connectAgentStream`, `connectAllStream`, `connectAgentMonitor` |
| `NotifyClient` | `getHealth`, `listNotifications`, `createNotification`, `getNotification`, `updateNotification`, `deleteNotification`, `listActionable`, `listHistory`, `getCount` |
| `AskClient` | `getHealth`, `trigger`, `answer` |

All clients are exported as singleton instances (`orchestratorClient`, `notifyClient`, `askClient`) pre-configured with environment-variable-backed service URLs.

## Test plan

- [x] `bun run test` — 48 tests pass (45 new + 3 existing)
  - `base.test.ts`: 13 tests (responses, errors, retry, interceptors, WebSocket)
  - `orchestrator.test.ts`: 16 tests (all methods + error propagation)
  - `notify.test.ts`: 11 tests (all methods including ephemeral lifetimes)
  - `ask.test.ts`: 5 tests (health, trigger, answer)
- [x] `bun run build` — TypeScript strict-mode compilation + Vite production build succeed
- [x] `bun run lint` — ESLint passes with no errors

Closes #163