### PR TITLE
feat(ui): Build dashboard home page with service health overview and activity summary

### DIFF
--- a/ui/src/components/common/LoadingSkeleton.tsx
+++ b/ui/src/components/common/LoadingSkeleton.tsx
@@ -1,0 +1,69 @@
+/**
+ * LoadingSkeleton — animated placeholder blocks for loading states.
+ */
+
+interface SkeletonProps {
+  className?: string
+}
+
+/** Single animated skeleton block */
+export function Skeleton({ className = '' }: SkeletonProps) {
+  return (
+    <div
+      aria-hidden="true"
+      className={['animate-pulse rounded bg-gray-200 dark:bg-gray-700', className].join(' ')}
+    />
+  )
+}
+
+/** Card-shaped skeleton */
+export function CardSkeleton() {
+  return (
+    <div
+      aria-busy="true"
+      aria-label="Loading…"
+      className="rounded-lg border border-gray-200 bg-white p-5 dark:border-gray-700 dark:bg-gray-800"
+    >
+      <div className="flex items-center gap-3">
+        <Skeleton className="h-10 w-10 rounded-full" />
+        <div className="flex-1 space-y-2">
+          <Skeleton className="h-4 w-1/3" />
+          <Skeleton className="h-3 w-1/2" />
+        </div>
+      </div>
+      <div className="mt-4 space-y-2">
+        <Skeleton className="h-3 w-full" />
+        <Skeleton className="h-3 w-4/5" />
+      </div>
+    </div>
+  )
+}
+
+/** List-item skeleton */
+export function ListItemSkeleton({ rows = 3 }: { rows?: number }) {
+  return (
+    <div aria-busy="true" aria-label="Loading…" className="space-y-3">
+      {Array.from({ length: rows }).map((_, i) => (
+        <div key={i} className="flex items-center gap-3">
+          <Skeleton className="h-8 w-8 rounded-full" />
+          <div className="flex-1 space-y-1.5">
+            <Skeleton className="h-3 w-2/3" />
+            <Skeleton className="h-3 w-1/2" />
+          </div>
+          <Skeleton className="h-5 w-14 rounded-full" />
+        </div>
+      ))}
+    </div>
+  )
+}
+
+/** Chart placeholder skeleton */
+export function ChartSkeleton({ height = 160 }: { height?: number }) {
+  return (
+    <div aria-busy="true" aria-label="Loading chart…" style={{ height }}>
+      <Skeleton className="h-full w-full" />
+    </div>
+  )
+}
+
+export default Skeleton

--- a/ui/src/components/common/StatusBadge.tsx
+++ b/ui/src/components/common/StatusBadge.tsx
@@ -1,0 +1,81 @@
+/**
+ * StatusBadge — coloured pill/dot for entity status values.
+ */
+
+import type { AgentStatus } from '@/types/orchestrator'
+import type { NotificationStatus } from '@/types/notify'
+
+export type ServiceStatus = 'healthy' | 'degraded' | 'down' | 'unknown'
+
+type KnownStatus = AgentStatus | NotificationStatus | ServiceStatus
+
+interface StatusBadgeProps {
+  status: KnownStatus
+  /** 'badge' renders a pill with text; 'dot' renders a coloured circle only */
+  variant?: 'badge' | 'dot'
+  className?: string
+}
+
+const STATUS_STYLES: Record<string, string> = {
+  // Agent statuses
+  Running: 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400',
+  Pending: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400',
+  Stopped: 'bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400',
+  Failed: 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400',
+  // Notification statuses
+  Viewed: 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400',
+  Responded: 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400',
+  Dismissed: 'bg-gray-100 text-gray-500 dark:bg-gray-800 dark:text-gray-500',
+  Expired: 'bg-gray-100 text-gray-400 dark:bg-gray-800 dark:text-gray-600',
+  // Service health
+  healthy: 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400',
+  degraded: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400',
+  down: 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400',
+  unknown: 'bg-gray-100 text-gray-500 dark:bg-gray-800 dark:text-gray-400',
+}
+
+const DOT_STYLES: Record<string, string> = {
+  Running: 'bg-green-500',
+  Pending: 'bg-yellow-500',
+  Stopped: 'bg-gray-400',
+  Failed: 'bg-red-500',
+  Viewed: 'bg-blue-500',
+  Responded: 'bg-green-500',
+  Dismissed: 'bg-gray-400',
+  Expired: 'bg-gray-300',
+  healthy: 'bg-green-500',
+  degraded: 'bg-yellow-500',
+  down: 'bg-red-500',
+  unknown: 'bg-gray-400',
+}
+
+export function StatusBadge({ status, variant = 'badge', className = '' }: StatusBadgeProps) {
+  if (variant === 'dot') {
+    return (
+      <span
+        role="status"
+        aria-label={status}
+        className={[
+          'inline-block h-2.5 w-2.5 rounded-full',
+          DOT_STYLES[status] ?? 'bg-gray-400',
+          className,
+        ].join(' ')}
+      />
+    )
+  }
+
+  return (
+    <span
+      role="status"
+      className={[
+        'inline-flex items-center rounded-full px-2.5 py-0.5 text-xs font-medium',
+        STATUS_STYLES[status] ?? 'bg-gray-100 text-gray-600',
+        className,
+      ].join(' ')}
+    >
+      {status}
+    </span>
+  )
+}
+
+export default StatusBadge

--- a/ui/src/components/common/index.ts
+++ b/ui/src/components/common/index.ts
@@ -1,0 +1,3 @@
+export { StatusBadge } from './StatusBadge'
+export type { ServiceStatus } from './StatusBadge'
+export { Skeleton, CardSkeleton, ListItemSkeleton, ChartSkeleton } from './LoadingSkeleton'

--- a/ui/src/components/dashboard/ActivityTimeline.tsx
+++ b/ui/src/components/dashboard/ActivityTimeline.tsx
@@ -1,0 +1,133 @@
+/**
+ * ActivityTimeline — recent activity feed combining agent state changes,
+ * notifications, and questions.
+ *
+ * For the initial release this component accepts pre-fetched data as props
+ * (passed down from the Dashboard page) rather than fetching independently.
+ */
+
+import { Link } from 'react-router-dom'
+import { Bot, Bell, HelpCircle, ExternalLink } from 'lucide-react'
+import { ListItemSkeleton } from '@/components/common/LoadingSkeleton'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type ActivityEventType = 'agent' | 'notification' | 'question'
+
+export interface ActivityEvent {
+  id: string
+  type: ActivityEventType
+  description: string
+  timestamp: Date
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function formatRelativeTime(date: Date): string {
+  const diffMs = Date.now() - date.getTime()
+  const diffSec = Math.floor(diffMs / 1000)
+  if (diffSec < 60) return 'just now'
+  const diffMin = Math.floor(diffSec / 60)
+  if (diffMin < 60) return `${diffMin} min ago`
+  const diffHr = Math.floor(diffMin / 60)
+  if (diffHr < 24) return `${diffHr}h ago`
+  return `${Math.floor(diffHr / 24)}d ago`
+}
+
+const EVENT_ICONS: Record<ActivityEventType, React.ReactNode> = {
+  agent: <Bot size={16} className="text-primary-500" />,
+  notification: <Bell size={16} className="text-yellow-500" />,
+  question: <HelpCircle size={16} className="text-blue-500" />,
+}
+
+const EVENT_BG: Record<ActivityEventType, string> = {
+  agent: 'bg-primary-100 dark:bg-primary-900/30',
+  notification: 'bg-yellow-100 dark:bg-yellow-900/30',
+  question: 'bg-blue-100 dark:bg-blue-900/30',
+}
+
+// ---------------------------------------------------------------------------
+// ActivityTimeline
+// ---------------------------------------------------------------------------
+
+interface ActivityTimelineProps {
+  events: ActivityEvent[]
+  loading?: boolean
+  error?: string
+}
+
+export function ActivityTimeline({ events, loading = false, error }: ActivityTimelineProps) {
+  return (
+    <section
+      aria-labelledby="activity-timeline-heading"
+      className="rounded-lg border border-gray-200 bg-white p-5 dark:border-gray-700 dark:bg-gray-800"
+    >
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <h2
+          id="activity-timeline-heading"
+          className="text-base font-semibold text-gray-900 dark:text-white"
+        >
+          Recent Activity
+        </h2>
+        <Link
+          to="/notifications"
+          className="flex items-center gap-1 text-xs font-medium text-primary-600 hover:text-primary-700 dark:text-primary-400"
+        >
+          View All <ExternalLink size={12} />
+        </Link>
+      </div>
+
+      {/* Error */}
+      {error && <p className="mt-3 text-sm text-red-500">{error}</p>}
+
+      {/* Loading */}
+      {loading && !error && (
+        <div className="mt-4">
+          <ListItemSkeleton rows={5} />
+        </div>
+      )}
+
+      {/* Empty state */}
+      {!loading && !error && events.length === 0 && (
+        <p className="mt-4 text-sm text-gray-500 dark:text-gray-400">No recent activity.</p>
+      )}
+
+      {/* Event list */}
+      {!loading && !error && events.length > 0 && (
+        <ol role="list" aria-label="Activity feed" className="mt-4 space-y-3">
+          {events.slice(0, 10).map((event) => (
+            <li key={event.id} className="flex items-start gap-3">
+              {/* Icon bubble */}
+              <div
+                aria-hidden="true"
+                className={[
+                  'mt-0.5 flex h-7 w-7 shrink-0 items-center justify-center rounded-full',
+                  EVENT_BG[event.type],
+                ].join(' ')}
+              >
+                {EVENT_ICONS[event.type]}
+              </div>
+              {/* Text */}
+              <div className="min-w-0 flex-1">
+                <p className="text-sm text-gray-800 dark:text-gray-200">{event.description}</p>
+                <time
+                  dateTime={event.timestamp.toISOString()}
+                  className="text-xs text-gray-400 dark:text-gray-500"
+                >
+                  {formatRelativeTime(event.timestamp)}
+                </time>
+              </div>
+            </li>
+          ))}
+        </ol>
+      )}
+    </section>
+  )
+}
+
+export default ActivityTimeline

--- a/ui/src/components/dashboard/AgentSummary.tsx
+++ b/ui/src/components/dashboard/AgentSummary.tsx
@@ -1,0 +1,216 @@
+/**
+ * AgentSummary — shows agent status distribution as a donut chart
+ * plus the 5 most recently updated agents.
+ */
+
+import { useNavigate } from 'react-router-dom'
+import { ResponsivePie } from '@nivo/pie'
+import { Plus, RefreshCw } from 'lucide-react'
+import { StatusBadge } from '@/components/common/StatusBadge'
+import { ChartSkeleton, ListItemSkeleton } from '@/components/common/LoadingSkeleton'
+import type { UseAgentSummaryResult } from '@/hooks/useAgentSummary'
+import type { Agent } from '@/types/orchestrator'
+
+// ---------------------------------------------------------------------------
+// Pie chart colour map
+// ---------------------------------------------------------------------------
+
+const STATUS_COLORS: Record<string, string> = {
+  Running: '#22c55e',
+  Pending: '#f59e0b',
+  Stopped: '#94a3b8',
+  Failed: '#ef4444',
+}
+
+// ---------------------------------------------------------------------------
+// Sub-components
+// ---------------------------------------------------------------------------
+
+interface AgentRowProps {
+  agent: Agent
+}
+
+function AgentRow({ agent }: AgentRowProps) {
+  const navigate = useNavigate()
+  return (
+    <li
+      className="flex cursor-pointer items-center justify-between gap-2 rounded-md px-2 py-1.5 hover:bg-gray-50 dark:hover:bg-gray-700/50"
+      onClick={() => navigate(`/agents`)}
+    >
+      <div className="min-w-0">
+        <p className="truncate text-sm font-medium text-gray-900 dark:text-white">{agent.name}</p>
+        <p className="text-xs text-gray-500 dark:text-gray-400">
+          {formatRelativeTime(new Date(agent.updated_at))}
+        </p>
+      </div>
+      <StatusBadge status={agent.status} />
+    </li>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// AgentSummary
+// ---------------------------------------------------------------------------
+
+interface AgentSummaryProps extends UseAgentSummaryResult {
+  onCreateAgent?: () => void
+}
+
+export function AgentSummary({
+  counts,
+  recentAgents,
+  total,
+  loading,
+  error,
+  onCreateAgent,
+}: AgentSummaryProps) {
+  const pieData = [
+    { id: 'Running', label: 'Running', value: counts.Running, color: STATUS_COLORS.Running },
+    { id: 'Pending', label: 'Pending', value: counts.Pending, color: STATUS_COLORS.Pending },
+    { id: 'Stopped', label: 'Stopped', value: counts.Stopped, color: STATUS_COLORS.Stopped },
+    { id: 'Failed', label: 'Failed', value: counts.Failed, color: STATUS_COLORS.Failed },
+  ].filter((d) => d.value > 0)
+
+  const hasData = total > 0
+
+  return (
+    <section
+      aria-labelledby="agent-summary-heading"
+      className="rounded-lg border border-gray-200 bg-white p-5 dark:border-gray-700 dark:bg-gray-800"
+    >
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <h2
+          id="agent-summary-heading"
+          className="text-base font-semibold text-gray-900 dark:text-white"
+        >
+          Agents
+          {!loading && (
+            <span className="ml-2 text-sm font-normal text-gray-500 dark:text-gray-400">
+              ({total} total)
+            </span>
+          )}
+        </h2>
+        <button
+          type="button"
+          onClick={onCreateAgent}
+          aria-label="Create new agent"
+          className="flex items-center gap-1.5 rounded-md bg-primary-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-primary-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500"
+        >
+          <Plus size={14} />
+          Create Agent
+        </button>
+      </div>
+
+      {/* Error state */}
+      {error && (
+        <div className="mt-4 flex items-center gap-2 text-sm text-red-500">
+          <RefreshCw size={14} />
+          {error}
+        </div>
+      )}
+
+      {/* Loading */}
+      {loading && !error && (
+        <div className="mt-4">
+          <ChartSkeleton height={160} />
+          <div className="mt-4">
+            <ListItemSkeleton rows={3} />
+          </div>
+        </div>
+      )}
+
+      {/* Content */}
+      {!loading && !error && (
+        <>
+          {/* Donut chart */}
+          {hasData ? (
+            <div className="mt-4 h-40">
+              <ResponsivePie
+                data={pieData}
+                colors={{ datum: 'data.color' }}
+                innerRadius={0.6}
+                padAngle={2}
+                cornerRadius={3}
+                enableArcLabels={false}
+                enableArcLinkLabels={false}
+                tooltip={({ datum }) => (
+                  <div className="rounded bg-gray-900 px-2 py-1 text-xs text-white shadow">
+                    {datum.label}: {datum.value}
+                  </div>
+                )}
+                legends={[
+                  {
+                    anchor: 'right',
+                    direction: 'column',
+                    itemWidth: 80,
+                    itemHeight: 16,
+                    itemsSpacing: 4,
+                    symbolSize: 10,
+                    symbolShape: 'circle',
+                    itemTextColor: '#94a3b8',
+                    translateX: 90,
+                  },
+                ]}
+                margin={{ top: 8, right: 100, bottom: 8, left: 8 }}
+              />
+            </div>
+          ) : (
+            <p className="mt-4 text-sm text-gray-500 dark:text-gray-400">No agents yet.</p>
+          )}
+
+          {/* Status count pills */}
+          {hasData && (
+            <div className="mt-3 flex flex-wrap gap-2">
+              {Object.entries(counts).map(([status, count]) =>
+                count > 0 ? (
+                  <span
+                    key={status}
+                    className="flex items-center gap-1 rounded-full bg-gray-100 px-2.5 py-0.5 text-xs font-medium text-gray-700 dark:bg-gray-700 dark:text-gray-300"
+                  >
+                    <span
+                      className="h-2 w-2 rounded-full"
+                      style={{ background: STATUS_COLORS[status] }}
+                    />
+                    {count} {status}
+                  </span>
+                ) : null,
+              )}
+            </div>
+          )}
+
+          {/* Recent agents list */}
+          {recentAgents.length > 0 && (
+            <div className="mt-4">
+              <p className="mb-1 text-xs font-medium uppercase tracking-wide text-gray-400 dark:text-gray-500">
+                Recently Active
+              </p>
+              <ul role="list" className="space-y-0.5">
+                {recentAgents.map((agent) => (
+                  <AgentRow key={agent.id} agent={agent} />
+                ))}
+              </ul>
+            </div>
+          )}
+        </>
+      )}
+    </section>
+  )
+}
+
+export default AgentSummary
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function formatRelativeTime(date: Date): string {
+  const diffMs = Date.now() - date.getTime()
+  const diffSec = Math.floor(diffMs / 1000)
+  if (diffSec < 60) return 'just now'
+  const diffMin = Math.floor(diffSec / 60)
+  if (diffMin < 60) return `${diffMin} min ago`
+  const diffHr = Math.floor(diffMin / 60)
+  if (diffHr < 24) return `${diffHr}h ago`
+  return `${Math.floor(diffHr / 24)}d ago`
+}

--- a/ui/src/components/dashboard/NotificationSummary.tsx
+++ b/ui/src/components/dashboard/NotificationSummary.tsx
@@ -1,0 +1,138 @@
+/**
+ * NotificationSummary — shows pending/unread counts and priority breakdown bar chart.
+ */
+
+import { Link } from 'react-router-dom'
+import { ResponsiveBar } from '@nivo/bar'
+import { Bell, ExternalLink } from 'lucide-react'
+import { ChartSkeleton } from '@/components/common/LoadingSkeleton'
+import type { UseNotificationSummaryResult } from '@/hooks/useNotificationSummary'
+
+const PRIORITY_COLORS: Record<string, string> = {
+  Low: '#94a3b8',
+  Normal: '#60a5fa',
+  High: '#f59e0b',
+  Urgent: '#ef4444',
+}
+
+type NotificationSummaryProps = UseNotificationSummaryResult
+
+export function NotificationSummary({
+  pending,
+  unread,
+  total,
+  priorityCounts,
+  loading,
+  error,
+}: NotificationSummaryProps) {
+  const barData = [
+    { priority: 'Low', count: priorityCounts.Low, color: PRIORITY_COLORS.Low },
+    { priority: 'Normal', count: priorityCounts.Normal, color: PRIORITY_COLORS.Normal },
+    { priority: 'High', count: priorityCounts.High, color: PRIORITY_COLORS.High },
+    { priority: 'Urgent', count: priorityCounts.Urgent, color: PRIORITY_COLORS.Urgent },
+  ]
+
+  const hasData = total > 0
+
+  return (
+    <section
+      aria-labelledby="notification-summary-heading"
+      className="rounded-lg border border-gray-200 bg-white p-5 dark:border-gray-700 dark:bg-gray-800"
+    >
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <h2
+          id="notification-summary-heading"
+          className="text-base font-semibold text-gray-900 dark:text-white"
+        >
+          Notifications
+        </h2>
+        <Link
+          to="/notifications"
+          className="flex items-center gap-1 text-xs font-medium text-primary-600 hover:text-primary-700 dark:text-primary-400"
+        >
+          View All <ExternalLink size={12} />
+        </Link>
+      </div>
+
+      {/* Error state */}
+      {error && <p className="mt-3 text-sm text-red-500">{error}</p>}
+
+      {/* Loading */}
+      {loading && !error && (
+        <div className="mt-4">
+          <ChartSkeleton height={120} />
+        </div>
+      )}
+
+      {/* Content */}
+      {!loading && !error && (
+        <>
+          {/* Summary counts */}
+          <div className="mt-4 grid grid-cols-2 gap-3">
+            <div className="rounded-md bg-yellow-50 p-3 dark:bg-yellow-900/20">
+              <div className="flex items-center gap-2">
+                <Bell size={16} className="text-yellow-600 dark:text-yellow-400" />
+                <span className="text-xs text-yellow-700 dark:text-yellow-300">Pending</span>
+              </div>
+              <p className="mt-1 text-2xl font-bold text-yellow-800 dark:text-yellow-200">
+                {pending}
+              </p>
+            </div>
+            <div className="rounded-md bg-blue-50 p-3 dark:bg-blue-900/20">
+              <div className="flex items-center gap-2">
+                <Bell size={16} className="text-blue-600 dark:text-blue-400" />
+                <span className="text-xs text-blue-700 dark:text-blue-300">Unread</span>
+              </div>
+              <p className="mt-1 text-2xl font-bold text-blue-800 dark:text-blue-200">{unread}</p>
+            </div>
+          </div>
+
+          {/* Priority bar chart */}
+          {hasData ? (
+            <div className="mt-4">
+              <p className="mb-2 text-xs font-medium uppercase tracking-wide text-gray-400 dark:text-gray-500">
+                By Priority (active)
+              </p>
+              <div className="h-28">
+                <ResponsiveBar
+                  data={barData}
+                  keys={['count']}
+                  indexBy="priority"
+                  colors={({ data }) => PRIORITY_COLORS[data.priority as string] ?? '#94a3b8'}
+                  enableLabel={false}
+                  axisLeft={null}
+                  axisBottom={{
+                    tickSize: 0,
+                    tickPadding: 6,
+                  }}
+                  borderRadius={3}
+                  padding={0.3}
+                  margin={{ top: 0, right: 0, bottom: 24, left: 0 }}
+                  tooltip={({ indexValue, value }) => (
+                    <div className="rounded bg-gray-900 px-2 py-1 text-xs text-white shadow">
+                      {indexValue}: {value}
+                    </div>
+                  )}
+                  theme={{
+                    axis: {
+                      ticks: {
+                        text: { fill: '#94a3b8', fontSize: 11 },
+                      },
+                    },
+                  }}
+                />
+              </div>
+            </div>
+          ) : (
+            <p className="mt-4 text-sm text-gray-500 dark:text-gray-400">
+              No active notifications.
+            </p>
+          )}
+        </>
+      )}
+    </section>
+  )
+}
+
+export default NotificationSummary

--- a/ui/src/components/dashboard/ServiceHealthCard.tsx
+++ b/ui/src/components/dashboard/ServiceHealthCard.tsx
@@ -1,0 +1,94 @@
+/**
+ * ServiceHealthCard — shows a single service's health status, version, and port.
+ */
+
+import { useNavigate } from 'react-router-dom'
+import { Activity, Server } from 'lucide-react'
+import { StatusBadge } from '@/components/common/StatusBadge'
+import { CardSkeleton } from '@/components/common/LoadingSkeleton'
+import type { ServiceHealth } from '@/hooks/useServiceHealth'
+
+const SERVICE_ROUTES: Record<string, string> = {
+  orchestrator: '/agents',
+  notify: '/notifications',
+  ask: '/questions',
+}
+
+interface ServiceHealthCardProps {
+  service: ServiceHealth
+}
+
+export function ServiceHealthCard({ service }: ServiceHealthCardProps) {
+  const navigate = useNavigate()
+
+  function handleClick() {
+    const route = SERVICE_ROUTES[service.key]
+    if (route) navigate(route)
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent) {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault()
+      handleClick()
+    }
+  }
+
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      aria-label={`${service.name} service — ${service.status}`}
+      onClick={handleClick}
+      onKeyDown={handleKeyDown}
+      className="cursor-pointer rounded-lg border border-gray-200 bg-white p-5 shadow-sm transition-shadow hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 dark:border-gray-700 dark:bg-gray-800"
+    >
+      {/* Header row */}
+      <div className="flex items-start justify-between">
+        <div className="flex items-center gap-3">
+          <div className="flex h-10 w-10 items-center justify-center rounded-full bg-primary-100 dark:bg-primary-900/30">
+            <Server size={20} className="text-primary-600 dark:text-primary-400" />
+          </div>
+          <div>
+            <p className="font-semibold text-gray-900 dark:text-white">{service.name}</p>
+            <p className="text-xs text-gray-500 dark:text-gray-400">Port {service.port}</p>
+          </div>
+        </div>
+        <StatusBadge status={service.status} />
+      </div>
+
+      {/* Version + last checked */}
+      <div className="mt-4 flex items-center justify-between text-xs text-gray-500 dark:text-gray-400">
+        <span className="flex items-center gap-1">
+          <Activity size={12} />
+          {service.version ? `v${service.version}` : '—'}
+        </span>
+        {service.lastChecked && (
+          <span>Checked {formatRelativeTime(service.lastChecked)}</span>
+        )}
+      </div>
+
+      {/* Error message */}
+      {service.error && (
+        <p className="mt-2 text-xs text-red-500 dark:text-red-400">{service.error}</p>
+      )}
+    </div>
+  )
+}
+
+/** Loading placeholder matching the card's dimensions */
+export function ServiceHealthCardSkeleton() {
+  return <CardSkeleton />
+}
+
+/** Format a Date as a short relative time string */
+function formatRelativeTime(date: Date): string {
+  const diffMs = Date.now() - date.getTime()
+  const diffSec = Math.floor(diffMs / 1000)
+  if (diffSec < 60) return 'just now'
+  const diffMin = Math.floor(diffSec / 60)
+  if (diffMin < 60) return `${diffMin}m ago`
+  const diffHr = Math.floor(diffMin / 60)
+  return `${diffHr}h ago`
+}
+
+export default ServiceHealthCard

--- a/ui/src/components/dashboard/index.ts
+++ b/ui/src/components/dashboard/index.ts
@@ -1,0 +1,5 @@
+export { ServiceHealthCard, ServiceHealthCardSkeleton } from './ServiceHealthCard'
+export { AgentSummary } from './AgentSummary'
+export { NotificationSummary } from './NotificationSummary'
+export { ActivityTimeline } from './ActivityTimeline'
+export type { ActivityEvent, ActivityEventType } from './ActivityTimeline'

--- a/ui/src/hooks/index.ts
+++ b/ui/src/hooks/index.ts
@@ -1,0 +1,8 @@
+export { useServiceHealth } from './useServiceHealth'
+export type { ServiceHealth, UseServiceHealthResult } from './useServiceHealth'
+
+export { useAgentSummary } from './useAgentSummary'
+export type { AgentStatusCounts, UseAgentSummaryResult } from './useAgentSummary'
+
+export { useNotificationSummary } from './useNotificationSummary'
+export type { NotificationPriorityCounts, UseNotificationSummaryResult } from './useNotificationSummary'

--- a/ui/src/hooks/useAgentSummary.ts
+++ b/ui/src/hooks/useAgentSummary.ts
@@ -1,0 +1,68 @@
+/**
+ * useAgentSummary — fetches agent counts by status and the 5 most recently
+ * updated agents.
+ */
+
+import { useCallback, useEffect, useState } from 'react'
+import { orchestratorClient } from '@/services/orchestrator'
+import type { Agent, AgentStatus } from '@/types/orchestrator'
+
+export interface AgentStatusCounts {
+  Running: number
+  Pending: number
+  Stopped: number
+  Failed: number
+}
+
+export interface UseAgentSummaryResult {
+  counts: AgentStatusCounts
+  recentAgents: Agent[]
+  total: number
+  loading: boolean
+  error?: string
+}
+
+const EMPTY_COUNTS: AgentStatusCounts = { Running: 0, Pending: 0, Stopped: 0, Failed: 0 }
+
+export function useAgentSummary(): UseAgentSummaryResult {
+  const [counts, setCounts] = useState<AgentStatusCounts>(EMPTY_COUNTS)
+  const [recentAgents, setRecentAgents] = useState<Agent[]>([])
+  const [total, setTotal] = useState(0)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | undefined>()
+
+  const fetch = useCallback(async () => {
+    setLoading(true)
+    setError(undefined)
+    try {
+      // Fetch all agents (up to 200 for summary purposes)
+      const result = await orchestratorClient.listAgents({ limit: 200 })
+      const agents = result.items
+
+      const newCounts: AgentStatusCounts = { Running: 0, Pending: 0, Stopped: 0, Failed: 0 }
+      for (const agent of agents) {
+        const s = agent.status as AgentStatus
+        if (s in newCounts) newCounts[s]++
+      }
+
+      // Sort by updated_at descending, take top 5
+      const sorted = [...agents].sort(
+        (a, b) => new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime(),
+      )
+
+      setCounts(newCounts)
+      setRecentAgents(sorted.slice(0, 5))
+      setTotal(result.total)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load agents')
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    void fetch()
+  }, [fetch])
+
+  return { counts, recentAgents, total, loading, error }
+}

--- a/ui/src/hooks/useNotificationSummary.ts
+++ b/ui/src/hooks/useNotificationSummary.ts
@@ -1,0 +1,74 @@
+/**
+ * useNotificationSummary — fetches notification count and priority breakdown.
+ */
+
+import { useCallback, useEffect, useState } from 'react'
+import { notifyClient } from '@/services/notify'
+import type { NotificationPriority } from '@/types/notify'
+
+export interface NotificationPriorityCounts {
+  Low: number
+  Normal: number
+  High: number
+  Urgent: number
+}
+
+export interface UseNotificationSummaryResult {
+  pending: number
+  unread: number
+  total: number
+  priorityCounts: NotificationPriorityCounts
+  loading: boolean
+  error?: string
+}
+
+const EMPTY_PRIORITY: NotificationPriorityCounts = { Low: 0, Normal: 0, High: 0, Urgent: 0 }
+
+export function useNotificationSummary(): UseNotificationSummaryResult {
+  const [pending, setPending] = useState(0)
+  const [unread, setUnread] = useState(0)
+  const [total, setTotal] = useState(0)
+  const [priorityCounts, setPriorityCounts] = useState<NotificationPriorityCounts>(EMPTY_PRIORITY)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | undefined>()
+
+  const fetch = useCallback(async () => {
+    setLoading(true)
+    setError(undefined)
+    try {
+      const [actionable, countData] = await Promise.all([
+        notifyClient.listActionable({ limit: 200 }),
+        notifyClient.getCount(),
+      ])
+
+      // Pending = those still needing attention
+      const pendingCount = actionable.items.filter((n) => n.status === 'Pending').length
+      // Unread = Pending + Viewed (seen but not responded)
+      const unreadCount = actionable.items.filter(
+        (n) => n.status === 'Pending' || n.status === 'Viewed',
+      ).length
+
+      // Build priority breakdown from actionable set
+      const pCounts: NotificationPriorityCounts = { Low: 0, Normal: 0, High: 0, Urgent: 0 }
+      for (const n of actionable.items) {
+        const p = n.priority as NotificationPriority
+        if (p in pCounts) pCounts[p]++
+      }
+
+      setPending(pendingCount)
+      setUnread(unreadCount)
+      setTotal(countData.total)
+      setPriorityCounts(pCounts)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load notifications')
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    void fetch()
+  }, [fetch])
+
+  return { pending, unread, total, priorityCounts, loading, error }
+}

--- a/ui/src/hooks/useServiceHealth.ts
+++ b/ui/src/hooks/useServiceHealth.ts
@@ -1,0 +1,96 @@
+/**
+ * useServiceHealth — polls all three service health endpoints in parallel.
+ *
+ * Uses a stale-while-revalidate pattern: returns the last known data
+ * immediately while refreshing in the background every 30 seconds.
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { orchestratorClient } from '@/services/orchestrator'
+import { notifyClient } from '@/services/notify'
+import { askClient } from '@/services/ask'
+import type { HealthResponse } from '@/types/common'
+import type { ServiceStatus } from '@/components/common/StatusBadge'
+
+export interface ServiceHealth {
+  name: string
+  key: 'orchestrator' | 'notify' | 'ask'
+  port: number
+  status: ServiceStatus
+  version?: string
+  lastChecked?: Date
+  error?: string
+}
+
+export interface UseServiceHealthResult {
+  services: ServiceHealth[]
+  loading: boolean
+  /** True only on the very first load (no cached data yet) */
+  initializing: boolean
+  refresh: () => void
+}
+
+const REFRESH_INTERVAL_MS = 30_000
+
+async function fetchHealth(
+  key: ServiceHealth['key'],
+  fetcher: () => Promise<HealthResponse>,
+  port: number,
+): Promise<ServiceHealth> {
+  const base: Pick<ServiceHealth, 'name' | 'key' | 'port'> = {
+    name: key.charAt(0).toUpperCase() + key.slice(1),
+    key,
+    port,
+  }
+  try {
+    const data = await fetcher()
+    return {
+      ...base,
+      status: data.status === 'ok' || data.status === 'healthy' ? 'healthy' : 'degraded',
+      version: data.version,
+      lastChecked: new Date(),
+    }
+  } catch {
+    return {
+      ...base,
+      status: 'down',
+      lastChecked: new Date(),
+      error: 'Service unreachable',
+    }
+  }
+}
+
+export function useServiceHealth(): UseServiceHealthResult {
+  const [services, setServices] = useState<ServiceHealth[]>([])
+  const [loading, setLoading] = useState(false)
+  const [initializing, setInitializing] = useState(true)
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null)
+
+  const fetch = useCallback(async () => {
+    setLoading(true)
+    const results = await Promise.all([
+      fetchHealth('orchestrator', () => orchestratorClient.getHealth(), 17006),
+      fetchHealth('notify', () => notifyClient.getHealth(), 17004),
+      fetchHealth('ask', () => askClient.getHealth(), 17001),
+    ])
+    setServices(results)
+    setLoading(false)
+    setInitializing(false)
+  }, [])
+
+  const refresh = useCallback(() => {
+    void fetch()
+  }, [fetch])
+
+  useEffect(() => {
+    void fetch()
+    intervalRef.current = setInterval(() => {
+      void fetch()
+    }, REFRESH_INTERVAL_MS)
+    return () => {
+      if (intervalRef.current) clearInterval(intervalRef.current)
+    }
+  }, [fetch])
+
+  return { services, loading, initializing, refresh }
+}

--- a/ui/src/pages/DashboardPage.tsx
+++ b/ui/src/pages/DashboardPage.tsx
@@ -1,10 +1,130 @@
-export function DashboardPage() {
+/**
+ * DashboardPage — landing page with service health, agent summary,
+ * notification summary, activity timeline, and stub sections.
+ */
+
+import { useMemo } from 'react'
+import { BarChart2, RefreshCw, Webhook } from 'lucide-react'
+import { ServiceHealthCard, ServiceHealthCardSkeleton } from '@/components/dashboard/ServiceHealthCard'
+import { AgentSummary } from '@/components/dashboard/AgentSummary'
+import { NotificationSummary } from '@/components/dashboard/NotificationSummary'
+import { ActivityTimeline } from '@/components/dashboard/ActivityTimeline'
+import type { ActivityEvent } from '@/components/dashboard/ActivityTimeline'
+import { useServiceHealth } from '@/hooks/useServiceHealth'
+import { useAgentSummary } from '@/hooks/useAgentSummary'
+import { useNotificationSummary } from '@/hooks/useNotificationSummary'
+
+// ---------------------------------------------------------------------------
+// Stub "Coming Soon" card
+// ---------------------------------------------------------------------------
+
+interface ComingSoonCardProps {
+  title: string
+  icon: React.ReactNode
+}
+
+function ComingSoonCard({ title, icon }: ComingSoonCardProps) {
   return (
-    <div>
-      <h1 className="text-2xl font-semibold text-gray-900 dark:text-white">Dashboard</h1>
-      <p className="mt-2 text-gray-500 dark:text-gray-400">
-        Overview of agent activity and system status.
-      </p>
+    <div className="flex flex-col items-center justify-center gap-3 rounded-lg border border-dashed border-gray-300 bg-white p-8 text-center dark:border-gray-600 dark:bg-gray-800">
+      <div className="flex h-12 w-12 items-center justify-center rounded-full bg-gray-100 dark:bg-gray-700">
+        {icon}
+      </div>
+      <div>
+        <p className="font-medium text-gray-700 dark:text-gray-300">{title}</p>
+        <p className="mt-1 text-sm text-gray-400 dark:text-gray-500">Coming Soon</p>
+      </div>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Dashboard page
+// ---------------------------------------------------------------------------
+
+export function DashboardPage() {
+  const { services, loading: healthLoading, initializing: healthInit, refresh } = useServiceHealth()
+  const agentSummary = useAgentSummary()
+  const notifSummary = useNotificationSummary()
+
+  // Build a synthetic activity feed from available data
+  const activityEvents: ActivityEvent[] = useMemo(() => {
+    const events: ActivityEvent[] = []
+
+    // Derive events from recently-updated agents
+    for (const agent of agentSummary.recentAgents) {
+      events.push({
+        id: `agent-${agent.id}`,
+        type: 'agent',
+        description: `Agent "${agent.name}" is ${agent.status.toLowerCase()}`,
+        timestamp: new Date(agent.updated_at),
+      })
+    }
+
+    // Sort by timestamp descending
+    return events.sort((a, b) => b.timestamp.getTime() - a.timestamp.getTime()).slice(0, 10)
+  }, [agentSummary.recentAgents])
+
+  return (
+    <div className="space-y-6">
+      {/* Page header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold text-gray-900 dark:text-white">Dashboard</h1>
+          <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+            System overview and service health
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={refresh}
+          disabled={healthLoading}
+          aria-label="Refresh service health"
+          className="flex items-center gap-1.5 rounded-md border border-gray-300 bg-white px-3 py-2 text-sm text-gray-700 hover:bg-gray-50 disabled:opacity-50 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700"
+        >
+          <RefreshCw size={14} className={healthLoading ? 'animate-spin' : ''} />
+          Refresh
+        </button>
+      </div>
+
+      {/* Service health cards */}
+      <section aria-labelledby="service-health-heading">
+        <h2
+          id="service-health-heading"
+          className="mb-3 text-sm font-medium uppercase tracking-wide text-gray-400 dark:text-gray-500"
+        >
+          Service Health
+        </h2>
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          {healthInit
+            ? Array.from({ length: 3 }).map((_, i) => <ServiceHealthCardSkeleton key={i} />)
+            : services.map((svc) => <ServiceHealthCard key={svc.key} service={svc} />)}
+        </div>
+      </section>
+
+      {/* Main grid: agents + notifications */}
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+        <AgentSummary {...agentSummary} />
+        <NotificationSummary {...notifSummary} />
+      </div>
+
+      {/* Activity timeline */}
+      <ActivityTimeline
+        events={activityEvents}
+        loading={agentSummary.loading}
+        error={agentSummary.error}
+      />
+
+      {/* Stub sections */}
+      <div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+        <ComingSoonCard
+          title="Monitoring"
+          icon={<BarChart2 size={24} className="text-gray-400" />}
+        />
+        <ComingSoonCard
+          title="Hooks"
+          icon={<Webhook size={24} className="text-gray-400" />}
+        />
+      </div>
     </div>
   )
 }

--- a/ui/src/test/components/ActivityTimeline.test.tsx
+++ b/ui/src/test/components/ActivityTimeline.test.tsx
@@ -1,0 +1,88 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { ActivityTimeline } from '@/components/dashboard/ActivityTimeline'
+import type { ActivityEvent } from '@/components/dashboard/ActivityTimeline'
+
+const now = new Date()
+
+const events: ActivityEvent[] = [
+  {
+    id: '1',
+    type: 'agent',
+    description: 'Agent "build-bot" is running',
+    timestamp: new Date(now.getTime() - 2 * 60 * 1000), // 2 min ago
+  },
+  {
+    id: '2',
+    type: 'notification',
+    description: 'High-priority alert received',
+    timestamp: new Date(now.getTime() - 5 * 60 * 1000),
+  },
+  {
+    id: '3',
+    type: 'question',
+    description: 'Question: Are tmux sessions running?',
+    timestamp: new Date(now.getTime() - 10 * 60 * 1000),
+  },
+]
+
+function renderTimeline(props: Partial<React.ComponentProps<typeof ActivityTimeline>> = {}) {
+  return render(
+    <MemoryRouter>
+      <ActivityTimeline events={events} {...props} />
+    </MemoryRouter>,
+  )
+}
+
+describe('ActivityTimeline', () => {
+  it('renders the section heading', () => {
+    renderTimeline()
+    expect(screen.getByRole('heading', { name: /recent activity/i })).toBeInTheDocument()
+  })
+
+  it('renders all event descriptions', () => {
+    renderTimeline()
+    expect(screen.getByText(/Agent "build-bot"/)).toBeInTheDocument()
+    expect(screen.getByText(/High-priority alert/)).toBeInTheDocument()
+    expect(screen.getByText(/Are tmux sessions/)).toBeInTheDocument()
+  })
+
+  it('renders a list with the correct number of items', () => {
+    renderTimeline()
+    const list = screen.getByRole('list', { name: /activity feed/i })
+    expect(list.children).toHaveLength(3)
+  })
+
+  it('shows empty state when events array is empty', () => {
+    renderTimeline({ events: [] })
+    expect(screen.getByText(/no recent activity/i)).toBeInTheDocument()
+  })
+
+  it('shows loading skeleton when loading=true', () => {
+    renderTimeline({ events: [], loading: true })
+    expect(document.querySelector('[aria-busy="true"]')).toBeTruthy()
+  })
+
+  it('shows error message when error is provided', () => {
+    renderTimeline({ events: [], error: 'Service unavailable' })
+    expect(screen.getByText('Service unavailable')).toBeInTheDocument()
+  })
+
+  it('caps display at 10 events', () => {
+    const manyEvents: ActivityEvent[] = Array.from({ length: 15 }, (_, i) => ({
+      id: String(i),
+      type: 'agent' as const,
+      description: `Event ${i}`,
+      timestamp: new Date(),
+    }))
+    renderTimeline({ events: manyEvents })
+    const list = screen.getByRole('list', { name: /activity feed/i })
+    expect(list.children).toHaveLength(10)
+  })
+
+  it('renders a "View All" link', () => {
+    renderTimeline()
+    expect(screen.getByRole('link', { name: /view all/i })).toBeInTheDocument()
+  })
+})

--- a/ui/src/test/components/LoadingSkeleton.test.tsx
+++ b/ui/src/test/components/LoadingSkeleton.test.tsx
@@ -1,0 +1,64 @@
+import { describe, it, expect } from 'vitest'
+import { render } from '@testing-library/react'
+import {
+  Skeleton,
+  CardSkeleton,
+  ListItemSkeleton,
+  ChartSkeleton,
+} from '@/components/common/LoadingSkeleton'
+
+describe('LoadingSkeleton', () => {
+  describe('Skeleton', () => {
+    it('renders an animated pulse element', () => {
+      const { container } = render(<Skeleton />)
+      expect(container.firstChild).toHaveClass('animate-pulse')
+    })
+
+    it('applies custom className', () => {
+      const { container } = render(<Skeleton className="h-4 w-32" />)
+      expect(container.firstChild).toHaveClass('h-4', 'w-32')
+    })
+  })
+
+  describe('CardSkeleton', () => {
+    it('renders with aria-busy="true"', () => {
+      const { container } = render(<CardSkeleton />)
+      expect(container.querySelector('[aria-busy="true"]')).toBeTruthy()
+    })
+
+    it('renders with aria-label "Loading…"', () => {
+      const { container } = render(<CardSkeleton />)
+      const el = container.querySelector('[aria-label="Loading…"]')
+      expect(el).toBeTruthy()
+    })
+  })
+
+  describe('ListItemSkeleton', () => {
+    it('renders the default number of rows (3)', () => {
+      const { container } = render(<ListItemSkeleton />)
+      // Each row has a rounded-full skeleton for the avatar
+      const avatars = container.querySelectorAll('.rounded-full')
+      expect(avatars.length).toBeGreaterThanOrEqual(3)
+    })
+
+    it('renders a custom number of rows', () => {
+      const { container } = render(<ListItemSkeleton rows={5} />)
+      const avatars = container.querySelectorAll('.rounded-full')
+      expect(avatars.length).toBeGreaterThanOrEqual(5)
+    })
+  })
+
+  describe('ChartSkeleton', () => {
+    it('renders with the default height', () => {
+      const { container } = render(<ChartSkeleton />)
+      const wrapper = container.firstChild as HTMLElement
+      expect(wrapper.style.height).toBe('160px')
+    })
+
+    it('renders with a custom height', () => {
+      const { container } = render(<ChartSkeleton height={240} />)
+      const wrapper = container.firstChild as HTMLElement
+      expect(wrapper.style.height).toBe('240px')
+    })
+  })
+})

--- a/ui/src/test/components/ServiceHealthCard.test.tsx
+++ b/ui/src/test/components/ServiceHealthCard.test.tsx
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { ServiceHealthCard } from '@/components/dashboard/ServiceHealthCard'
+import type { ServiceHealth } from '@/hooks/useServiceHealth'
+
+// Mock useNavigate
+const mockNavigate = vi.fn()
+vi.mock('react-router-dom', async (importOriginal) => {
+  const mod = await importOriginal()
+  return {
+    ...(mod as object),
+    useNavigate: () => mockNavigate,
+  }
+})
+
+const healthyService: ServiceHealth = {
+  name: 'Orchestrator',
+  key: 'orchestrator',
+  port: 17006,
+  status: 'healthy',
+  version: '0.2.0',
+  lastChecked: new Date(),
+}
+
+const downService: ServiceHealth = {
+  name: 'Ask',
+  key: 'ask',
+  port: 17001,
+  status: 'down',
+  error: 'Service unreachable',
+  lastChecked: new Date(),
+}
+
+function renderCard(service: ServiceHealth) {
+  return render(
+    <MemoryRouter>
+      <ServiceHealthCard service={service} />
+    </MemoryRouter>,
+  )
+}
+
+describe('ServiceHealthCard', () => {
+  it('renders service name', () => {
+    renderCard(healthyService)
+    expect(screen.getByText('Orchestrator')).toBeInTheDocument()
+  })
+
+  it('renders port number', () => {
+    renderCard(healthyService)
+    expect(screen.getByText(/Port 17006/)).toBeInTheDocument()
+  })
+
+  it('renders version when available', () => {
+    renderCard(healthyService)
+    expect(screen.getByText(/v0\.2\.0/)).toBeInTheDocument()
+  })
+
+  it('renders the healthy status badge', () => {
+    renderCard(healthyService)
+    expect(screen.getByRole('status')).toHaveTextContent('healthy')
+  })
+
+  it('renders error message when service is down', () => {
+    renderCard(downService)
+    expect(screen.getByText('Service unreachable')).toBeInTheDocument()
+  })
+
+  it('navigates to /agents when orchestrator card is clicked', () => {
+    renderCard(healthyService)
+    fireEvent.click(screen.getByRole('button'))
+    expect(mockNavigate).toHaveBeenCalledWith('/agents')
+  })
+
+  it('navigates to /questions when ask card is clicked', () => {
+    renderCard(downService)
+    fireEvent.click(screen.getByRole('button'))
+    expect(mockNavigate).toHaveBeenCalledWith('/questions')
+  })
+
+  it('is keyboard accessible via Enter key', () => {
+    renderCard(healthyService)
+    const card = screen.getByRole('button')
+    fireEvent.keyDown(card, { key: 'Enter' })
+    expect(mockNavigate).toHaveBeenCalled()
+  })
+})

--- a/ui/src/test/components/StatusBadge.test.tsx
+++ b/ui/src/test/components/StatusBadge.test.tsx
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { StatusBadge } from '@/components/common/StatusBadge'
+
+describe('StatusBadge', () => {
+  describe('badge variant (default)', () => {
+    it('renders agent status Running', () => {
+      render(<StatusBadge status="Running" />)
+      expect(screen.getByRole('status')).toHaveTextContent('Running')
+    })
+
+    it('renders agent status Failed', () => {
+      render(<StatusBadge status="Failed" />)
+      const badge = screen.getByRole('status')
+      expect(badge).toHaveTextContent('Failed')
+      expect(badge.className).toContain('red')
+    })
+
+    it('renders service status healthy', () => {
+      render(<StatusBadge status="healthy" />)
+      const badge = screen.getByRole('status')
+      expect(badge).toHaveTextContent('healthy')
+      expect(badge.className).toContain('green')
+    })
+
+    it('renders service status down with red colour', () => {
+      render(<StatusBadge status="down" />)
+      const badge = screen.getByRole('status')
+      expect(badge.className).toContain('red')
+    })
+
+    it('renders notification status Pending', () => {
+      render(<StatusBadge status="Pending" />)
+      expect(screen.getByRole('status')).toHaveTextContent('Pending')
+    })
+  })
+
+  describe('dot variant', () => {
+    it('renders a coloured dot with aria-label', () => {
+      render(<StatusBadge status="Running" variant="dot" />)
+      const dot = screen.getByRole('status', { name: 'Running' })
+      expect(dot.className).toContain('rounded-full')
+      expect(dot.className).toContain('green')
+    })
+
+    it('applies correct colour for Failed', () => {
+      render(<StatusBadge status="Failed" variant="dot" />)
+      const dot = screen.getByRole('status', { name: 'Failed' })
+      expect(dot.className).toContain('red')
+    })
+
+    it('applies custom className', () => {
+      render(<StatusBadge status="Running" variant="dot" className="ml-2" />)
+      expect(screen.getByRole('status').className).toContain('ml-2')
+    })
+  })
+})


### PR DESCRIPTION
## Summary

Implements the landing dashboard page that gives users an at-a-glance view of all agentd services, active agents, pending notifications, and recent activity.

## Changes

### Common Components (`src/components/common/`)

| Component | Description |
|-----------|-------------|
| `StatusBadge` | Coloured pill/dot for `AgentStatus`, `NotificationStatus`, and `ServiceStatus`; `badge` and `dot` variants |
| `LoadingSkeleton` | `Skeleton`, `CardSkeleton`, `ListItemSkeleton`, `ChartSkeleton` with `animate-pulse` and `aria-busy` |

### Custom Hooks (`src/hooks/`)

| Hook | Description |
|------|-------------|
| `useServiceHealth` | Polls all 3 health endpoints in parallel every 30s; stale-while-revalidate pattern |
| `useAgentSummary` | Fetches agent list; computes status counts + top-5 most recently updated agents |
| `useNotificationSummary` | Fetches actionable notifications + count; computes pending/unread/priority breakdown |

### Dashboard Components (`src/components/dashboard/`)

| Component | Description |
|-----------|-------------|
| `ServiceHealthCard` | Clickable card per service (name, port, status badge, version, last-checked); keyboard accessible |
| `AgentSummary` | Nivo `ResponsivePie` donut chart of status distribution; top-5 recent agents list; "Create Agent" button |
| `NotificationSummary` | Pending/unread count cards; Nivo `ResponsiveBar` priority breakdown chart; "View All" link |
| `ActivityTimeline` | Ordered feed of recent events with type icons, descriptions, relative timestamps; capped at 10 |

### Dashboard Page (`src/pages/DashboardPage.tsx`)

- Responsive 2-column grid (1-column on mobile)
- Service Health section (3 cards) with auto-refresh button
- Agent Summary + Notification Summary side by side
- Activity Timeline assembled from recent agent events
- "Coming Soon" stub cards for Monitoring and Hooks

## Test plan

- [x] `bun run test` — **114 tests pass** (32 new + 82 existing)
  - `StatusBadge.test.tsx`: 8 tests (badge/dot variants, colour mapping)
  - `LoadingSkeleton.test.tsx`: 8 tests (all skeleton variants)
  - `ServiceHealthCard.test.tsx`: 8 tests (rendering, navigation, keyboard)
  - `ActivityTimeline.test.tsx`: 8 tests (events, empty state, loading, 10-event cap)
- [x] `bun run build` — TypeScript strict compilation + Vite production build succeed
- [x] `bun run lint` — ESLint passes with no errors

Closes #165