### PR TITLE
feat(ui): build settings page (#174)

### DIFF
--- a/ui/src/components/settings/AboutSection.tsx
+++ b/ui/src/components/settings/AboutSection.tsx
@@ -1,0 +1,51 @@
+/**
+ * AboutSection — app version, links, and build info.
+ */
+
+const APP_VERSION = import.meta.env.VITE_APP_VERSION ?? '0.1.0'
+
+export function AboutSection() {
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <span className="text-sm font-medium text-gray-700 dark:text-gray-300">Version</span>
+        <span className="text-sm text-gray-600 dark:text-gray-400">{APP_VERSION}</span>
+      </div>
+
+      <div className="flex items-center justify-between">
+        <span className="text-sm font-medium text-gray-700 dark:text-gray-300">Source</span>
+        <a
+          href="https://github.com/geoffjay/agentd"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="GitHub repository"
+          className="text-sm text-primary-600 hover:text-primary-700 hover:underline dark:text-primary-400 dark:hover:text-primary-300"
+        >
+          GitHub
+        </a>
+      </div>
+
+      <div className="flex items-center justify-between">
+        <span className="text-sm font-medium text-gray-700 dark:text-gray-300">Docs</span>
+        <a
+          href="https://github.com/geoffjay/agentd/wiki"
+          target="_blank"
+          rel="noopener noreferrer"
+          aria-label="Documentation"
+          className="text-sm text-primary-600 hover:text-primary-700 hover:underline dark:text-primary-400 dark:hover:text-primary-300"
+        >
+          Documentation
+        </a>
+      </div>
+
+      <div className="flex items-center justify-between">
+        <span className="text-sm font-medium text-gray-700 dark:text-gray-300">Built with</span>
+        <span className="text-sm text-gray-600 dark:text-gray-400">
+          React + Vite + Tailwind CSS
+        </span>
+      </div>
+    </div>
+  )
+}
+
+export default AboutSection

--- a/ui/src/components/settings/ServiceConfig.tsx
+++ b/ui/src/components/settings/ServiceConfig.tsx
@@ -1,0 +1,117 @@
+/**
+ * ServiceConfig — per-service URL configuration with health test buttons.
+ */
+
+import { useState } from 'react'
+import type { Settings } from '@/stores/settingsStore'
+
+interface ServiceRow {
+  key: keyof Settings['services']
+  label: string
+  port: number
+}
+
+const SERVICE_ROWS: ServiceRow[] = [
+  { key: 'orchestratorUrl', label: 'Orchestrator', port: 17006 },
+  { key: 'notifyUrl', label: 'Notify', port: 17004 },
+  { key: 'askUrl', label: 'Ask', port: 17001 },
+]
+
+type TestStatus = 'idle' | 'loading' | 'success' | 'error'
+
+interface ServiceConfigProps {
+  services: Settings['services']
+  onSave: (services: Settings['services']) => void
+}
+
+export function ServiceConfig({ services, onSave }: ServiceConfigProps) {
+  const [localServices, setLocalServices] = useState<Settings['services']>(services)
+  const [testStatuses, setTestStatuses] = useState<Record<keyof Settings['services'], TestStatus>>({
+    orchestratorUrl: 'idle',
+    notifyUrl: 'idle',
+    askUrl: 'idle',
+  })
+
+  function handleUrlChange(key: keyof Settings['services'], value: string) {
+    setLocalServices(prev => ({ ...prev, [key]: value }))
+    setTestStatuses(prev => ({ ...prev, [key]: 'idle' }))
+  }
+
+  async function handleTest(key: keyof Settings['services']) {
+    const url = localServices[key]
+    setTestStatuses(prev => ({ ...prev, [key]: 'loading' }))
+    try {
+      const response = await fetch(`${url}/health`)
+      setTestStatuses(prev => ({
+        ...prev,
+        [key]: response.ok ? 'success' : 'error',
+      }))
+    } catch {
+      setTestStatuses(prev => ({ ...prev, [key]: 'error' }))
+    }
+  }
+
+  function handleSave() {
+    onSave(localServices)
+  }
+
+  return (
+    <div className="space-y-4">
+      {SERVICE_ROWS.map(row => {
+        const status = testStatuses[row.key]
+        return (
+          <div key={row.key} className="flex items-center gap-3">
+            <label
+              htmlFor={`service-url-${row.key}`}
+              className="w-32 shrink-0 text-sm font-medium text-gray-700 dark:text-gray-300"
+            >
+              {row.label}
+              <span className="block text-xs font-normal text-gray-400 dark:text-gray-500">
+                Port {row.port}
+              </span>
+            </label>
+            <input
+              id={`service-url-${row.key}`}
+              type="text"
+              value={localServices[row.key]}
+              onChange={e => handleUrlChange(row.key, e.target.value)}
+              className="min-w-0 flex-1 rounded-md border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 placeholder-gray-400 focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white dark:placeholder-gray-500"
+              placeholder={`http://localhost:${row.port}`}
+            />
+            <button
+              type="button"
+              onClick={() => void handleTest(row.key)}
+              disabled={status === 'loading'}
+              aria-label={`Test ${row.label} connection`}
+              className="inline-flex items-center gap-1.5 rounded-md border border-gray-300 bg-white px-3 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50 disabled:cursor-not-allowed disabled:opacity-60 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700"
+            >
+              {status === 'loading' ? (
+                <span
+                  className="inline-block h-4 w-4 animate-spin rounded-full border-2 border-gray-300 border-t-gray-600 dark:border-gray-600 dark:border-t-gray-300"
+                  aria-hidden="true"
+                />
+              ) : status === 'success' ? (
+                <span className="text-green-600 dark:text-green-400" aria-hidden="true">✓</span>
+              ) : status === 'error' ? (
+                <span className="text-red-500 dark:text-red-400" aria-hidden="true">✗</span>
+              ) : null}
+              Test
+            </button>
+          </div>
+        )
+      })}
+
+      <div className="pt-2">
+        <button
+          type="button"
+          onClick={handleSave}
+          className="rounded-md bg-primary-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 dark:focus:ring-offset-gray-900"
+        >
+          Save
+        </button>
+      </div>
+    </div>
+  )
+}
+
+export default ServiceConfig

--- a/ui/src/components/settings/UIPreferences.tsx
+++ b/ui/src/components/settings/UIPreferences.tsx
@@ -1,0 +1,157 @@
+/**
+ * UIPreferences — UI preferences form for theme, sidebar, refresh interval,
+ * notifications, and log view lines.
+ */
+
+import { useState } from 'react'
+import type { Settings } from '@/stores/settingsStore'
+
+interface UIPreferencesProps {
+  ui: Settings['ui']
+  onSave: (ui: Settings['ui']) => void
+}
+
+export function UIPreferences({ ui, onSave }: UIPreferencesProps) {
+  const [localUI, setLocalUI] = useState<Settings['ui']>(ui)
+
+  function handleSave() {
+    onSave(localUI)
+  }
+
+  return (
+    <div className="space-y-5">
+      {/* Theme */}
+      <div className="flex items-center justify-between">
+        <label
+          htmlFor="ui-theme"
+          className="text-sm font-medium text-gray-700 dark:text-gray-300"
+        >
+          Theme
+        </label>
+        <select
+          id="ui-theme"
+          value={localUI.theme}
+          onChange={e =>
+            setLocalUI(prev => ({
+              ...prev,
+              theme: e.target.value as Settings['ui']['theme'],
+            }))
+          }
+          className="rounded-md border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white"
+        >
+          <option value="light">Light</option>
+          <option value="dark">Dark</option>
+          <option value="system">System</option>
+        </select>
+      </div>
+
+      {/* Sidebar default open */}
+      <div className="flex items-center justify-between">
+        <label
+          htmlFor="ui-sidebar-open"
+          className="text-sm font-medium text-gray-700 dark:text-gray-300"
+        >
+          Sidebar
+        </label>
+        <label className="flex cursor-pointer items-center gap-2 text-sm text-gray-600 dark:text-gray-400">
+          <input
+            id="ui-sidebar-open"
+            type="checkbox"
+            checked={localUI.sidebarDefaultOpen}
+            onChange={e =>
+              setLocalUI(prev => ({ ...prev, sidebarDefaultOpen: e.target.checked }))
+            }
+            className="h-4 w-4 rounded border-gray-300 text-primary-600 focus:ring-primary-500 dark:border-gray-600 dark:bg-gray-800"
+          />
+          Open by default
+        </label>
+      </div>
+
+      {/* Refresh interval */}
+      <div className="flex items-center justify-between">
+        <label
+          htmlFor="ui-refresh-interval"
+          className="text-sm font-medium text-gray-700 dark:text-gray-300"
+        >
+          Refresh interval
+        </label>
+        <select
+          id="ui-refresh-interval"
+          value={localUI.refreshInterval}
+          onChange={e =>
+            setLocalUI(prev => ({
+              ...prev,
+              refreshInterval: Number(e.target.value) as Settings['ui']['refreshInterval'],
+            }))
+          }
+          className="rounded-md border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white"
+        >
+          <option value={30}>30s</option>
+          <option value={60}>60s</option>
+          <option value={120}>2m</option>
+          <option value={300}>5m</option>
+        </select>
+      </div>
+
+      {/* Notifications */}
+      <div className="flex items-center justify-between">
+        <label
+          htmlFor="ui-notifications"
+          className="text-sm font-medium text-gray-700 dark:text-gray-300"
+        >
+          Notifications
+        </label>
+        <label className="flex cursor-pointer items-center gap-2 text-sm text-gray-600 dark:text-gray-400">
+          <input
+            id="ui-notifications"
+            type="checkbox"
+            checked={localUI.notificationsEnabled}
+            onChange={e =>
+              setLocalUI(prev => ({ ...prev, notificationsEnabled: e.target.checked }))
+            }
+            className="h-4 w-4 rounded border-gray-300 text-primary-600 focus:ring-primary-500 dark:border-gray-600 dark:bg-gray-800"
+          />
+          Enable desktop notifications
+        </label>
+      </div>
+
+      {/* Log view lines */}
+      <div className="flex items-center justify-between">
+        <label
+          htmlFor="ui-log-lines"
+          className="text-sm font-medium text-gray-700 dark:text-gray-300"
+        >
+          Log view lines
+        </label>
+        <select
+          id="ui-log-lines"
+          value={localUI.logViewLines}
+          onChange={e =>
+            setLocalUI(prev => ({
+              ...prev,
+              logViewLines: Number(e.target.value) as Settings['ui']['logViewLines'],
+            }))
+          }
+          className="rounded-md border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white"
+        >
+          <option value={100}>100</option>
+          <option value={250}>250</option>
+          <option value={500}>500</option>
+          <option value={1000}>1000</option>
+        </select>
+      </div>
+
+      <div className="pt-2">
+        <button
+          type="button"
+          onClick={handleSave}
+          className="rounded-md bg-primary-600 px-4 py-2 text-sm font-medium text-white transition-colors hover:bg-primary-700 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 dark:focus:ring-offset-gray-900"
+        >
+          Save
+        </button>
+      </div>
+    </div>
+  )
+}
+
+export default UIPreferences

--- a/ui/src/components/settings/index.ts
+++ b/ui/src/components/settings/index.ts
@@ -1,0 +1,3 @@
+export { ServiceConfig } from './ServiceConfig'
+export { UIPreferences } from './UIPreferences'
+export { AboutSection } from './AboutSection'

--- a/ui/src/hooks/useSettings.ts
+++ b/ui/src/hooks/useSettings.ts
@@ -1,0 +1,40 @@
+import { useState, useCallback } from 'react'
+import { loadSettings, saveSettings, resetSettings } from '@/stores/settingsStore'
+import type { Settings } from '@/stores/settingsStore'
+
+export type { Settings }
+
+export function useSettings() {
+  const [settings, setSettings] = useState<Settings>(loadSettings)
+
+  const update = useCallback((patch: Partial<Settings>) => {
+    setSettings(prev => {
+      const next = { ...prev, ...patch }
+      saveSettings(next)
+      return next
+    })
+  }, [])
+
+  const updateServices = useCallback((patch: Partial<Settings['services']>) => {
+    setSettings(prev => {
+      const next = { ...prev, services: { ...prev.services, ...patch } }
+      saveSettings(next)
+      return next
+    })
+  }, [])
+
+  const updateUI = useCallback((patch: Partial<Settings['ui']>) => {
+    setSettings(prev => {
+      const next = { ...prev, ui: { ...prev.ui, ...patch } }
+      saveSettings(next)
+      return next
+    })
+  }, [])
+
+  const reset = useCallback(() => {
+    const defaults = resetSettings()
+    setSettings(defaults)
+  }, [])
+
+  return { settings, update, updateServices, updateUI, reset }
+}

--- a/ui/src/pages/SettingsPage.tsx
+++ b/ui/src/pages/SettingsPage.tsx
@@ -1,10 +1,145 @@
+/**
+ * SettingsPage — assembles all settings sections including service config,
+ * UI preferences, about info, and data management actions.
+ */
+
+import { useRef, useState } from 'react'
+import { ServiceConfig } from '@/components/settings/ServiceConfig'
+import { UIPreferences } from '@/components/settings/UIPreferences'
+import { AboutSection } from '@/components/settings/AboutSection'
+import { useSettings } from '@/hooks/useSettings'
+import { resetSettings } from '@/stores/settingsStore'
+import type { Settings } from '@/stores/settingsStore'
+
 export function SettingsPage() {
+  const { settings, updateServices, updateUI, reset } = useSettings()
+  const [clearConfirmed, setClearConfirmed] = useState(false)
+  const importInputRef = useRef<HTMLInputElement>(null)
+
+  function handleClearAll() {
+    if (!clearConfirmed) {
+      setClearConfirmed(true)
+      return
+    }
+    resetSettings()
+    reset()
+    setClearConfirmed(false)
+  }
+
+  function handleExport() {
+    const blob = new Blob([JSON.stringify(settings, null, 2)], {
+      type: 'application/json',
+    })
+    const url = URL.createObjectURL(blob)
+    const a = document.createElement('a')
+    a.href = url
+    a.download = 'agentd-settings.json'
+    a.click()
+    URL.revokeObjectURL(url)
+  }
+
+  function handleImportClick() {
+    importInputRef.current?.click()
+  }
+
+  function handleImportFile(e: React.ChangeEvent<HTMLInputElement>) {
+    const file = e.target.files?.[0]
+    if (!file) return
+    const reader = new FileReader()
+    reader.onload = event => {
+      try {
+        const parsed = JSON.parse(event.target?.result as string) as Partial<Settings>
+        if (parsed.services) updateServices(parsed.services)
+        if (parsed.ui) updateUI(parsed.ui)
+      } catch {
+        // silently ignore malformed JSON
+      }
+    }
+    reader.readAsText(file)
+    // Reset input so the same file can be re-imported
+    e.target.value = ''
+  }
+
   return (
-    <div>
-      <h1 className="text-2xl font-semibold text-gray-900 dark:text-white">Settings</h1>
-      <p className="mt-2 text-gray-500 dark:text-gray-400">
-        Application settings and preferences.
-      </p>
+    <div className="space-y-8">
+      <div>
+        <h1 className="text-2xl font-semibold text-gray-900 dark:text-white">Settings</h1>
+        <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+          Manage service connections, UI preferences, and application data.
+        </p>
+      </div>
+
+      {/* Service Configuration */}
+      <section className="rounded-lg border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-700 dark:bg-gray-800">
+        <h2 className="mb-4 text-lg font-semibold text-gray-900 dark:text-white">
+          Service Configuration
+        </h2>
+        <ServiceConfig
+          services={settings.services}
+          onSave={updateServices}
+        />
+      </section>
+
+      {/* UI Preferences */}
+      <section className="rounded-lg border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-700 dark:bg-gray-800">
+        <h2 className="mb-4 text-lg font-semibold text-gray-900 dark:text-white">
+          UI Preferences
+        </h2>
+        <UIPreferences
+          ui={settings.ui}
+          onSave={updateUI}
+        />
+      </section>
+
+      {/* About */}
+      <section className="rounded-lg border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-700 dark:bg-gray-800">
+        <h2 className="mb-4 text-lg font-semibold text-gray-900 dark:text-white">About</h2>
+        <AboutSection />
+      </section>
+
+      {/* Data Management */}
+      <section className="rounded-lg border border-gray-200 bg-white p-6 shadow-sm dark:border-gray-700 dark:bg-gray-800">
+        <h2 className="mb-4 text-lg font-semibold text-gray-900 dark:text-white">
+          Data Management
+        </h2>
+        <div className="flex flex-wrap gap-3">
+          <button
+            type="button"
+            onClick={handleClearAll}
+            className={`rounded-md px-4 py-2 text-sm font-medium transition-colors focus:outline-none focus:ring-2 focus:ring-offset-2 dark:focus:ring-offset-gray-900 ${
+              clearConfirmed
+                ? 'bg-red-600 text-white hover:bg-red-700 focus:ring-red-500'
+                : 'border border-red-300 text-red-600 hover:bg-red-50 focus:ring-red-500 dark:border-red-700 dark:text-red-400 dark:hover:bg-red-900/20'
+            }`}
+          >
+            {clearConfirmed ? 'Confirm Clear All Settings' : 'Clear All Settings'}
+          </button>
+
+          <button
+            type="button"
+            onClick={handleExport}
+            className="rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700 dark:focus:ring-offset-gray-900"
+          >
+            Export Settings
+          </button>
+
+          <button
+            type="button"
+            onClick={handleImportClick}
+            className="rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700 dark:focus:ring-offset-gray-900"
+          >
+            Import Settings
+          </button>
+          <input
+            ref={importInputRef}
+            type="file"
+            accept=".json"
+            className="hidden"
+            onChange={handleImportFile}
+            aria-label="Import settings file"
+          />
+        </div>
+      </section>
     </div>
   )
 }

--- a/ui/src/stores/settingsStore.ts
+++ b/ui/src/stores/settingsStore.ts
@@ -1,0 +1,79 @@
+/**
+ * settingsStore — versioned localStorage settings store.
+ *
+ * Key: 'agentd:settings', version: 1
+ * Merges with defaults on load so new keys added in future versions
+ * are always present.
+ */
+
+export interface ServiceSettings {
+  orchestratorUrl: string
+  notifyUrl: string
+  askUrl: string
+}
+
+export interface UISettings {
+  theme: 'light' | 'dark' | 'system'
+  sidebarDefaultOpen: boolean
+  refreshInterval: 30 | 60 | 120 | 300
+  notificationsEnabled: boolean
+  logViewLines: 100 | 250 | 500 | 1000
+}
+
+export interface Settings {
+  version: number
+  services: ServiceSettings
+  ui: UISettings
+}
+
+const STORAGE_KEY = 'agentd:settings'
+const CURRENT_VERSION = 1
+
+export const DEFAULT_SETTINGS: Settings = {
+  version: CURRENT_VERSION,
+  services: {
+    orchestratorUrl: import.meta.env.VITE_ORCHESTRATOR_URL ?? 'http://localhost:17006',
+    notifyUrl: import.meta.env.VITE_NOTIFY_URL ?? 'http://localhost:17004',
+    askUrl: import.meta.env.VITE_ASK_URL ?? 'http://localhost:17001',
+  },
+  ui: {
+    theme: 'system',
+    sidebarDefaultOpen: true,
+    refreshInterval: 30,
+    notificationsEnabled: true,
+    logViewLines: 100,
+  },
+}
+
+export function loadSettings(): Settings {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY)
+    if (!raw) return { ...DEFAULT_SETTINGS }
+    const parsed = JSON.parse(raw) as Partial<Settings>
+    // Deep-merge with defaults so newly added keys are always present
+    return {
+      ...DEFAULT_SETTINGS,
+      ...parsed,
+      services: {
+        ...DEFAULT_SETTINGS.services,
+        ...(parsed.services ?? {}),
+      },
+      ui: {
+        ...DEFAULT_SETTINGS.ui,
+        ...(parsed.ui ?? {}),
+      },
+    }
+  } catch {
+    return { ...DEFAULT_SETTINGS }
+  }
+}
+
+export function saveSettings(s: Settings): void {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(s))
+}
+
+export function resetSettings(): Settings {
+  const defaults = { ...DEFAULT_SETTINGS }
+  saveSettings(defaults)
+  return defaults
+}

--- a/ui/src/test/components/settings/AboutSection.test.tsx
+++ b/ui/src/test/components/settings/AboutSection.test.tsx
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { AboutSection } from '@/components/settings/AboutSection'
+
+describe('AboutSection', () => {
+  it('renders app version', () => {
+    render(<AboutSection />)
+    // VITE_APP_VERSION is not set in tests, so falls back to '0.1.0'
+    expect(screen.getByText('0.1.0')).toBeInTheDocument()
+  })
+
+  it('renders GitHub link', () => {
+    render(<AboutSection />)
+    const githubLink = screen.getByRole('link', { name: /github/i })
+    expect(githubLink).toBeInTheDocument()
+    expect(githubLink).toHaveAttribute('href', expect.stringContaining('github.com'))
+  })
+
+  it('renders documentation link', () => {
+    render(<AboutSection />)
+    const docsLink = screen.getByRole('link', { name: /documentation/i })
+    expect(docsLink).toBeInTheDocument()
+  })
+})

--- a/ui/src/test/components/settings/ServiceConfig.test.tsx
+++ b/ui/src/test/components/settings/ServiceConfig.test.tsx
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { ServiceConfig } from '@/components/settings/ServiceConfig'
+import type { Settings } from '@/stores/settingsStore'
+
+const defaultServices: Settings['services'] = {
+  orchestratorUrl: 'http://localhost:17006',
+  notifyUrl: 'http://localhost:17004',
+  askUrl: 'http://localhost:17001',
+}
+
+describe('ServiceConfig', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('renders three service rows', () => {
+    render(<ServiceConfig services={defaultServices} onSave={vi.fn()} />)
+    const inputs = screen.getAllByRole('textbox')
+    expect(inputs).toHaveLength(3)
+  })
+
+  it('shows service names: Orchestrator, Notify, Ask', () => {
+    render(<ServiceConfig services={defaultServices} onSave={vi.fn()} />)
+    expect(screen.getByText('Orchestrator')).toBeInTheDocument()
+    expect(screen.getByText('Notify')).toBeInTheDocument()
+    expect(screen.getByText('Ask')).toBeInTheDocument()
+  })
+
+  it('calls onSave with updated URL when Save is clicked', () => {
+    const onSave = vi.fn()
+    render(<ServiceConfig services={defaultServices} onSave={onSave} />)
+
+    const orchestratorInput = screen.getByRole('textbox', { name: /orchestrator/i }) as HTMLInputElement
+    fireEvent.change(orchestratorInput, { target: { value: 'http://localhost:9999' } })
+
+    fireEvent.click(screen.getByRole('button', { name: /^save$/i }))
+
+    expect(onSave).toHaveBeenCalledWith(
+      expect.objectContaining({ orchestratorUrl: 'http://localhost:9999' }),
+    )
+  })
+
+  it('shows loading state when testing', async () => {
+    // Mock fetch to never resolve during this test
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(
+        () =>
+          new Promise<Response>(() => {
+            // intentionally never resolves
+          }),
+      ),
+    )
+
+    render(<ServiceConfig services={defaultServices} onSave={vi.fn()} />)
+
+    const testButtons = screen.getAllByRole('button', { name: /test/i })
+    fireEvent.click(testButtons[0])
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole('button', { name: /test orchestrator/i }),
+      ).toBeDisabled()
+    })
+  })
+
+  it('shows success indicator after successful health test', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({ ok: true } as Response),
+    )
+
+    render(<ServiceConfig services={defaultServices} onSave={vi.fn()} />)
+
+    const testButtons = screen.getAllByRole('button', { name: /test/i })
+    fireEvent.click(testButtons[0])
+
+    await waitFor(() => {
+      expect(screen.getByText('✓')).toBeInTheDocument()
+    })
+  })
+
+  it('shows error indicator after failed health test', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new Error('Network error')))
+
+    render(<ServiceConfig services={defaultServices} onSave={vi.fn()} />)
+
+    const testButtons = screen.getAllByRole('button', { name: /test/i })
+    fireEvent.click(testButtons[0])
+
+    await waitFor(() => {
+      expect(screen.getByText('✗')).toBeInTheDocument()
+    })
+  })
+})

--- a/ui/src/test/components/settings/UIPreferences.test.tsx
+++ b/ui/src/test/components/settings/UIPreferences.test.tsx
@@ -1,0 +1,74 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { UIPreferences } from '@/components/settings/UIPreferences'
+import type { Settings } from '@/stores/settingsStore'
+
+const defaultUI: Settings['ui'] = {
+  theme: 'system',
+  sidebarDefaultOpen: true,
+  refreshInterval: 30,
+  notificationsEnabled: true,
+  logViewLines: 100,
+}
+
+describe('UIPreferences', () => {
+  it('renders all preference fields', () => {
+    render(<UIPreferences ui={defaultUI} onSave={vi.fn()} />)
+    expect(screen.getByLabelText(/theme/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/open by default/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/refresh interval/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/enable desktop notifications/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/log view lines/i)).toBeInTheDocument()
+  })
+
+  it('calls onSave when Save is clicked with current values', () => {
+    const onSave = vi.fn()
+    render(<UIPreferences ui={defaultUI} onSave={onSave} />)
+
+    fireEvent.click(screen.getByRole('button', { name: /^save$/i }))
+
+    expect(onSave).toHaveBeenCalledWith(defaultUI)
+  })
+
+  it('changing theme select updates the value passed to onSave', () => {
+    const onSave = vi.fn()
+    render(<UIPreferences ui={defaultUI} onSave={onSave} />)
+
+    const themeSelect = screen.getByLabelText(/theme/i)
+    fireEvent.change(themeSelect, { target: { value: 'dark' } })
+
+    fireEvent.click(screen.getByRole('button', { name: /^save$/i }))
+
+    expect(onSave).toHaveBeenCalledWith(
+      expect.objectContaining({ theme: 'dark' }),
+    )
+  })
+
+  it('unchecking sidebar checkbox updates the value passed to onSave', () => {
+    const onSave = vi.fn()
+    render(<UIPreferences ui={defaultUI} onSave={onSave} />)
+
+    const sidebarCheckbox = screen.getByLabelText(/open by default/i)
+    fireEvent.click(sidebarCheckbox)
+
+    fireEvent.click(screen.getByRole('button', { name: /^save$/i }))
+
+    expect(onSave).toHaveBeenCalledWith(
+      expect.objectContaining({ sidebarDefaultOpen: false }),
+    )
+  })
+
+  it('changing refresh interval updates the value passed to onSave', () => {
+    const onSave = vi.fn()
+    render(<UIPreferences ui={defaultUI} onSave={onSave} />)
+
+    const intervalSelect = screen.getByLabelText(/refresh interval/i)
+    fireEvent.change(intervalSelect, { target: { value: '120' } })
+
+    fireEvent.click(screen.getByRole('button', { name: /^save$/i }))
+
+    expect(onSave).toHaveBeenCalledWith(
+      expect.objectContaining({ refreshInterval: 120 }),
+    )
+  })
+})

--- a/ui/src/test/stores/settingsStore.test.ts
+++ b/ui/src/test/stores/settingsStore.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  loadSettings,
+  saveSettings,
+  resetSettings,
+  DEFAULT_SETTINGS,
+} from '@/stores/settingsStore'
+
+const STORAGE_KEY = 'agentd:settings'
+
+describe('settingsStore', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('loadSettings returns defaults when localStorage is empty', () => {
+    const settings = loadSettings()
+    expect(settings).toEqual(DEFAULT_SETTINGS)
+  })
+
+  it('saveSettings persists to localStorage', () => {
+    const custom = {
+      ...DEFAULT_SETTINGS,
+      services: {
+        ...DEFAULT_SETTINGS.services,
+        orchestratorUrl: 'http://example.com:17006',
+      },
+    }
+    saveSettings(custom)
+    const raw = localStorage.getItem(STORAGE_KEY)
+    expect(raw).not.toBeNull()
+    const parsed = JSON.parse(raw!) as typeof custom
+    expect(parsed.services.orchestratorUrl).toBe('http://example.com:17006')
+  })
+
+  it('loadSettings merges saved values with defaults', () => {
+    // Save only a partial shape
+    localStorage.setItem(
+      STORAGE_KEY,
+      JSON.stringify({
+        version: 1,
+        services: { orchestratorUrl: 'http://custom:9000' },
+      }),
+    )
+    const settings = loadSettings()
+    expect(settings.services.orchestratorUrl).toBe('http://custom:9000')
+    // notifyUrl should fall back to default
+    expect(settings.services.notifyUrl).toBe(DEFAULT_SETTINGS.services.notifyUrl)
+    // ui should be fully default
+    expect(settings.ui).toEqual(DEFAULT_SETTINGS.ui)
+  })
+
+  it('resetSettings returns defaults and clears localStorage entry', () => {
+    saveSettings({
+      ...DEFAULT_SETTINGS,
+      services: {
+        ...DEFAULT_SETTINGS.services,
+        orchestratorUrl: 'http://custom:9000',
+      },
+    })
+
+    const result = resetSettings()
+    expect(result).toEqual(DEFAULT_SETTINGS)
+
+    // After reset, loading should give defaults
+    const reloaded = loadSettings()
+    expect(reloaded.services.orchestratorUrl).toBe(DEFAULT_SETTINGS.services.orchestratorUrl)
+  })
+
+  it('loadSettings returns defaults when localStorage contains malformed JSON', () => {
+    localStorage.setItem(STORAGE_KEY, 'not-valid-json{{{')
+    const settings = loadSettings()
+    expect(settings).toEqual(DEFAULT_SETTINGS)
+  })
+})


### PR DESCRIPTION
Resolves #174 

## Summary
- Add versioned localStorage settings store (`settingsStore.ts`)
- Add `useSettings` hook for reactive settings management
- Build `ServiceConfig` component with per-service URL fields and health test buttons
- Build `UIPreferences` component with theme, sidebar, refresh interval, and notification prefs
- Build `AboutSection` component with version info and links
- Assemble `SettingsPage` with data management (clear/export/import)
- Add tests for all new components and the settings store

## Test plan
- [ ] Settings page renders all sections
- [ ] Service URL fields show current values
- [ ] Health test button shows success/failure
- [ ] UI preferences save correctly
- [ ] Clear/export/import data management works
- [ ] All new tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)