### PR TITLE
feat(ui): implement global search palette (#175)

### DIFF
--- a/ui/src/components/search/SearchPalette.tsx
+++ b/ui/src/components/search/SearchPalette.tsx
@@ -1,0 +1,217 @@
+/**
+ * SearchPalette — full-screen command palette overlay.
+ *
+ * Features:
+ * - Opens via Ctrl+K / Cmd+K or by clicking the search button in the header
+ * - Debounced search-as-you-type across agents and notifications
+ * - Keyboard navigation: ↑/↓ to move, Enter to navigate, Escape to close
+ * - Recent searches shown when input is empty
+ * - Backdrop click to close
+ * - Portal to document.body to avoid z-index issues
+ */
+
+import { useEffect, useRef, useCallback, useState } from 'react'
+import { createPortal } from 'react-dom'
+import { useNavigate } from 'react-router-dom'
+import { Search, X } from 'lucide-react'
+import { useSearch } from '@/hooks/useSearch'
+import { SearchResults, RecentSearches } from './SearchResults'
+import type { SearchResult } from '@/hooks/useSearch'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Flatten all result groups into an ordered list for keyboard navigation */
+function flattenResults(
+  results: ReturnType<typeof useSearch>['results'],
+): SearchResult[] {
+  return [...results.actions, ...results.agents, ...results.notifications]
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export interface SearchPaletteProps {
+  isOpen: boolean
+  onClose: () => void
+}
+
+export function SearchPalette({ isOpen, onClose }: SearchPaletteProps) {
+  const navigate = useNavigate()
+  const { query, setQuery, results, loading, recentSearches, addRecentSearch, clearRecentSearches } =
+    useSearch()
+  const inputRef = useRef<HTMLInputElement>(null)
+  const [activeIndex, setActiveIndex] = useState(-1)
+
+  const allResults = flattenResults(results)
+  const activeId = activeIndex >= 0 && activeIndex < allResults.length
+    ? allResults[activeIndex].id
+    : null
+
+  // Focus input when palette opens; reset state when it closes
+  useEffect(() => {
+    if (isOpen) {
+      setActiveIndex(-1)
+      setTimeout(() => inputRef.current?.focus(), 0)
+    } else {
+      setQuery('')
+      setActiveIndex(-1)
+    }
+  }, [isOpen, setQuery])
+
+  // Navigate to a result
+  const selectResult = useCallback(
+    (result: SearchResult) => {
+      if (query.trim()) addRecentSearch(query.trim())
+      onClose()
+      navigate(result.href)
+    },
+    [query, addRecentSearch, onClose, navigate],
+  )
+
+  // Keyboard navigation within palette
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      switch (e.key) {
+        case 'ArrowDown': {
+          e.preventDefault()
+          setActiveIndex((i) => Math.min(i + 1, allResults.length - 1))
+          break
+        }
+        case 'ArrowUp': {
+          e.preventDefault()
+          setActiveIndex((i) => Math.max(i - 1, -1))
+          break
+        }
+        case 'Enter': {
+          e.preventDefault()
+          if (activeIndex >= 0 && activeIndex < allResults.length) {
+            selectResult(allResults[activeIndex])
+          }
+          break
+        }
+        case 'Escape': {
+          e.preventDefault()
+          onClose()
+          break
+        }
+        default:
+          break
+      }
+    },
+    [activeIndex, allResults, selectResult, onClose],
+  )
+
+  // Reset active index when results change
+  useEffect(() => {
+    setActiveIndex(-1)
+  }, [results])
+
+  if (!isOpen) return null
+
+  const showEmpty = !query.trim()
+
+  return createPortal(
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="Global search"
+      className="fixed inset-0 z-[100] flex items-start justify-center pt-[10vh] px-4"
+    >
+      {/* Backdrop */}
+      <div
+        aria-hidden="true"
+        onClick={onClose}
+        className="absolute inset-0 bg-black/50 backdrop-blur-sm"
+      />
+
+      {/* Palette panel */}
+      <div
+        className="relative z-10 w-full max-w-xl overflow-hidden rounded-xl border border-gray-200 bg-white shadow-2xl dark:border-gray-700 dark:bg-gray-900"
+        onKeyDown={handleKeyDown}
+      >
+        {/* Search input row */}
+        <div className="flex items-center gap-3 border-b border-gray-200 px-4 py-3 dark:border-gray-700">
+          <Search
+            size={18}
+            className="shrink-0 text-gray-400 dark:text-gray-500"
+            aria-hidden="true"
+          />
+          <input
+            ref={inputRef}
+            type="search"
+            role="combobox"
+            aria-autocomplete="list"
+            aria-expanded={!showEmpty}
+            aria-controls="search-results"
+            aria-activedescendant={activeId ?? undefined}
+            placeholder="Search agents, notifications, pages…"
+            aria-label="Search"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            className="min-w-0 flex-1 bg-transparent text-sm text-gray-900 placeholder-gray-400 outline-none dark:text-white dark:placeholder-gray-500"
+          />
+          {query && (
+            <button
+              type="button"
+              aria-label="Clear search"
+              onClick={() => setQuery('')}
+              className="shrink-0 rounded p-0.5 text-gray-400 hover:text-gray-600 dark:text-gray-500 dark:hover:text-gray-300"
+            >
+              <X size={14} />
+            </button>
+          )}
+          <kbd className="hidden shrink-0 rounded border border-gray-200 px-1.5 py-0.5 text-[10px] text-gray-400 dark:border-gray-600 dark:text-gray-500 sm:block">
+            Esc
+          </kbd>
+        </div>
+
+        {/* Results area */}
+        <div id="search-results" className="max-h-[60vh] overflow-y-auto">
+          {showEmpty ? (
+            <RecentSearches
+              searches={recentSearches}
+              onSelect={(q) => setQuery(q)}
+              onClear={clearRecentSearches}
+            />
+          ) : (
+            <SearchResults
+              query={query}
+              results={results}
+              loading={loading}
+              activeId={activeId}
+              onSelect={selectResult}
+            />
+          )}
+        </div>
+
+        {/* Footer hint */}
+        <div className="flex items-center gap-4 border-t border-gray-100 px-4 py-2 dark:border-gray-800">
+          <span className="flex items-center gap-1 text-[11px] text-gray-400 dark:text-gray-500">
+            <kbd className="rounded border border-gray-200 px-1 py-0.5 text-[10px] dark:border-gray-600">
+              ↑↓
+            </kbd>
+            navigate
+          </span>
+          <span className="flex items-center gap-1 text-[11px] text-gray-400 dark:text-gray-500">
+            <kbd className="rounded border border-gray-200 px-1 py-0.5 text-[10px] dark:border-gray-600">
+              ↵
+            </kbd>
+            open
+          </span>
+          <span className="flex items-center gap-1 text-[11px] text-gray-400 dark:text-gray-500">
+            <kbd className="rounded border border-gray-200 px-1 py-0.5 text-[10px] dark:border-gray-600">
+              Esc
+            </kbd>
+            close
+          </span>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  )
+}
+
+export default SearchPalette

--- a/ui/src/components/search/SearchResultItem.tsx
+++ b/ui/src/components/search/SearchResultItem.tsx
@@ -1,0 +1,114 @@
+/**
+ * SearchResultItem — a single row in the search palette results list.
+ *
+ * Shows: icon, title, subtitle, and a category badge.
+ * Supports keyboard focus highlighting.
+ */
+
+import { Bot, Bell, Zap, ChevronRight } from 'lucide-react'
+import type { SearchResult } from '@/hooks/useSearch'
+
+// ---------------------------------------------------------------------------
+// Category icon + badge colour
+// ---------------------------------------------------------------------------
+
+const CATEGORY_META: Record<
+  SearchResult['category'],
+  { label: string; iconEl: React.ReactNode; badgeClass: string }
+> = {
+  agent: {
+    label: 'Agent',
+    iconEl: <Bot size={16} className="text-primary-400" />,
+    badgeClass: 'bg-primary-100 text-primary-700 dark:bg-primary-900/40 dark:text-primary-300',
+  },
+  notification: {
+    label: 'Notification',
+    iconEl: <Bell size={16} className="text-yellow-400" />,
+    badgeClass: 'bg-yellow-100 text-yellow-700 dark:bg-yellow-900/40 dark:text-yellow-300',
+  },
+  action: {
+    label: 'Action',
+    iconEl: <Zap size={16} className="text-green-400" />,
+    badgeClass: 'bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-300',
+  },
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export interface SearchResultItemProps {
+  result: SearchResult
+  isActive: boolean
+  onClick: (result: SearchResult) => void
+}
+
+export function SearchResultItem({ result, isActive, onClick }: SearchResultItemProps) {
+  const meta = CATEGORY_META[result.category]
+
+  function handleClick() {
+    onClick(result)
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent) {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault()
+      onClick(result)
+    }
+  }
+
+  return (
+    <li role="option" aria-selected={isActive}>
+      <div
+        role="button"
+        tabIndex={-1}
+        onClick={handleClick}
+        onKeyDown={handleKeyDown}
+        data-active={isActive}
+        className={[
+          'flex cursor-pointer items-center gap-3 px-4 py-2.5 transition-colors',
+          isActive
+            ? 'bg-primary-50 dark:bg-primary-900/20'
+            : 'hover:bg-gray-50 dark:hover:bg-gray-800',
+        ].join(' ')}
+      >
+        {/* Category icon */}
+        <span
+          className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-gray-100 dark:bg-gray-700"
+          aria-hidden="true"
+        >
+          {meta.iconEl}
+        </span>
+
+        {/* Text */}
+        <span className="min-w-0 flex-1">
+          <span className="block truncate text-sm font-medium text-gray-900 dark:text-white">
+            {result.title}
+          </span>
+          <span className="block truncate text-xs text-gray-500 dark:text-gray-400">
+            {result.subtitle}
+          </span>
+        </span>
+
+        {/* Category badge */}
+        <span
+          className={[
+            'shrink-0 rounded-full px-2 py-0.5 text-[10px] font-medium',
+            meta.badgeClass,
+          ].join(' ')}
+        >
+          {meta.label}
+        </span>
+
+        {/* Arrow hint */}
+        <ChevronRight
+          size={14}
+          className="shrink-0 text-gray-300 dark:text-gray-600"
+          aria-hidden="true"
+        />
+      </div>
+    </li>
+  )
+}
+
+export default SearchResultItem

--- a/ui/src/components/search/SearchResults.tsx
+++ b/ui/src/components/search/SearchResults.tsx
@@ -1,0 +1,203 @@
+/**
+ * SearchResults — grouped result sections displayed inside the search palette.
+ *
+ * Renders three sections: Quick Actions, Agents, Notifications.
+ * Each section shows a heading, up to 5 items, and a "View all" link.
+ */
+
+import { Search } from 'lucide-react'
+import { SearchResultItem } from './SearchResultItem'
+import type { GroupedSearchResults, SearchResult } from '@/hooks/useSearch'
+
+// ---------------------------------------------------------------------------
+// Section
+// ---------------------------------------------------------------------------
+
+interface ResultSectionProps {
+  heading: string
+  items: SearchResult[]
+  activeId: string | null
+  onSelect: (result: SearchResult) => void
+  viewAllHref?: string
+  viewAllLabel?: string
+}
+
+function ResultSection({
+  heading,
+  items,
+  activeId,
+  onSelect,
+  viewAllHref,
+  viewAllLabel,
+}: ResultSectionProps) {
+  if (items.length === 0) return null
+
+  return (
+    <div>
+      <div className="px-4 py-1.5">
+        <span className="text-[11px] font-semibold uppercase tracking-wider text-gray-400 dark:text-gray-500">
+          {heading}
+        </span>
+      </div>
+      <ul role="group" aria-label={heading}>
+        {items.map((result) => (
+          <SearchResultItem
+            key={result.id}
+            result={result}
+            isActive={result.id === activeId}
+            onClick={onSelect}
+          />
+        ))}
+      </ul>
+      {viewAllHref && (
+        <div className="px-4 py-1">
+          <a
+            href={viewAllHref}
+            className="text-xs text-primary-600 hover:text-primary-500 dark:text-primary-400"
+          >
+            {viewAllLabel ?? `View all results →`}
+          </a>
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Empty / no-results state
+// ---------------------------------------------------------------------------
+
+function NoResults({ query }: { query: string }) {
+  return (
+    <div className="flex flex-col items-center gap-3 px-6 py-10 text-center">
+      <Search size={28} className="text-gray-300 dark:text-gray-600" />
+      <p className="text-sm font-medium text-gray-700 dark:text-gray-300">
+        No results for <span className="font-semibold">"{query}"</span>
+      </p>
+      <p className="text-xs text-gray-500 dark:text-gray-400">
+        Try searching for an agent name, notification title, or a page name.
+      </p>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Recent searches (shown when query is empty)
+// ---------------------------------------------------------------------------
+
+interface RecentSearchesProps {
+  searches: string[]
+  onSelect: (q: string) => void
+  onClear: () => void
+}
+
+export function RecentSearches({ searches, onSelect, onClear }: RecentSearchesProps) {
+  if (searches.length === 0) {
+    return (
+      <div className="px-6 py-8 text-center text-sm text-gray-500 dark:text-gray-400">
+        Start typing to search agents, notifications, and more.
+      </div>
+    )
+  }
+
+  return (
+    <div>
+      <div className="flex items-center justify-between px-4 py-1.5">
+        <span className="text-[11px] font-semibold uppercase tracking-wider text-gray-400 dark:text-gray-500">
+          Recent Searches
+        </span>
+        <button
+          type="button"
+          onClick={onClear}
+          className="text-[11px] text-gray-400 hover:text-gray-600 dark:text-gray-500 dark:hover:text-gray-300"
+        >
+          Clear
+        </button>
+      </div>
+      <ul role="list" aria-label="Recent searches">
+        {searches.map((q) => (
+          <li key={q}>
+            <button
+              type="button"
+              onClick={() => onSelect(q)}
+              className="flex w-full items-center gap-3 px-4 py-2 text-left text-sm text-gray-700 hover:bg-gray-50 dark:text-gray-300 dark:hover:bg-gray-800"
+            >
+              <Search size={14} className="shrink-0 text-gray-400" aria-hidden="true" />
+              {q}
+            </button>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// SearchResults
+// ---------------------------------------------------------------------------
+
+export interface SearchResultsProps {
+  query: string
+  results: GroupedSearchResults
+  loading: boolean
+  activeId: string | null
+  onSelect: (result: SearchResult) => void
+}
+
+export function SearchResults({ query, results, loading, activeId, onSelect }: SearchResultsProps) {
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-10">
+        <span
+          className="h-5 w-5 animate-spin rounded-full border-2 border-primary-500 border-t-transparent"
+          role="status"
+          aria-label="Searching…"
+        />
+      </div>
+    )
+  }
+
+  const hasResults =
+    results.actions.length > 0 || results.agents.length > 0 || results.notifications.length > 0
+
+  if (!hasResults) {
+    return <NoResults query={query} />
+  }
+
+  return (
+    <div
+      role="listbox"
+      aria-label="Search results"
+      className="divide-y divide-gray-100 dark:divide-gray-800"
+    >
+      <ResultSection
+        heading="Quick Actions"
+        items={results.actions}
+        activeId={activeId}
+        onSelect={onSelect}
+      />
+      <ResultSection
+        heading={`Agents${results.agents.length === 5 ? ' (showing top 5)' : ''}`}
+        items={results.agents}
+        activeId={activeId}
+        onSelect={onSelect}
+        viewAllHref={results.agents.length === 5 ? `/agents?search=${encodeURIComponent(query)}` : undefined}
+        viewAllLabel={`View all agent results for "${query}" →`}
+      />
+      <ResultSection
+        heading={`Notifications${results.notifications.length === 5 ? ' (showing top 5)' : ''}`}
+        items={results.notifications}
+        activeId={activeId}
+        onSelect={onSelect}
+        viewAllHref={
+          results.notifications.length === 5
+            ? `/notifications?search=${encodeURIComponent(query)}`
+            : undefined
+        }
+        viewAllLabel={`View all notification results for "${query}" →`}
+      />
+    </div>
+  )
+}
+
+export default SearchResults

--- a/ui/src/components/search/index.ts
+++ b/ui/src/components/search/index.ts
@@ -1,0 +1,6 @@
+export { SearchPalette } from './SearchPalette'
+export { SearchResults, RecentSearches } from './SearchResults'
+export { SearchResultItem } from './SearchResultItem'
+export type { SearchResultItemProps } from './SearchResultItem'
+export type { SearchResultsProps } from './SearchResults'
+export type { SearchPaletteProps } from './SearchPalette'

--- a/ui/src/hooks/index.ts
+++ b/ui/src/hooks/index.ts
@@ -6,3 +6,6 @@ export type { AgentStatusCounts, UseAgentSummaryResult } from './useAgentSummary
 
 export { useNotificationSummary } from './useNotificationSummary'
 export type { NotificationPriorityCounts, UseNotificationSummaryResult } from './useNotificationSummary'
+
+export { useSearch } from './useSearch'
+export type { SearchResult, GroupedSearchResults, UseSearchResult, SearchCategory } from './useSearch'

--- a/ui/src/hooks/useSearch.ts
+++ b/ui/src/hooks/useSearch.ts
@@ -1,0 +1,313 @@
+/**
+ * useSearch — global search hook with debouncing, parallel API calls, and
+ * result ranking.
+ *
+ * Features:
+ * - 300 ms debounce before issuing API calls
+ * - Parallel searches across Agents and Notifications
+ * - Client-side quick-action filtering
+ * - Relevance ranking: exact > prefix > contains
+ * - Max 5 results per category
+ * - Recent-search history persisted to localStorage
+ */
+
+import { useState, useCallback, useEffect, useRef } from 'react'
+import { orchestratorClient } from '@/services/orchestrator'
+import { notifyClient } from '@/services/notify'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type SearchCategory = 'agent' | 'notification' | 'action'
+
+export interface SearchResult {
+  id: string
+  category: SearchCategory
+  title: string
+  subtitle: string
+  href: string
+}
+
+export interface GroupedSearchResults {
+  actions: SearchResult[]
+  agents: SearchResult[]
+  notifications: SearchResult[]
+  /** Total across all groups */
+  total: number
+}
+
+export interface UseSearchResult {
+  query: string
+  setQuery: (q: string) => void
+  results: GroupedSearchResults
+  loading: boolean
+  recentSearches: string[]
+  addRecentSearch: (q: string) => void
+  clearRecentSearches: () => void
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const RECENT_SEARCHES_KEY = 'agentd:recent-searches'
+const MAX_RECENT = 5
+const MAX_PER_CATEGORY = 5
+const DEBOUNCE_MS = 300
+
+// ---------------------------------------------------------------------------
+// Quick actions (always available, filtered by query)
+// ---------------------------------------------------------------------------
+
+const QUICK_ACTIONS: SearchResult[] = [
+  {
+    id: 'action-dashboard',
+    category: 'action',
+    title: 'Go to Dashboard',
+    subtitle: 'Navigate to the home dashboard',
+    href: '/',
+  },
+  {
+    id: 'action-agents',
+    category: 'action',
+    title: 'Go to Agents',
+    subtitle: 'Navigate to the agents page',
+    href: '/agents',
+  },
+  {
+    id: 'action-create-agent',
+    category: 'action',
+    title: 'Create Agent',
+    subtitle: 'Open create agent dialog',
+    href: '/agents?action=create',
+  },
+  {
+    id: 'action-approvals',
+    category: 'action',
+    title: 'View Approvals',
+    subtitle: 'Navigate to pending approvals',
+    href: '/agents?tab=approvals',
+  },
+  {
+    id: 'action-notifications',
+    category: 'action',
+    title: 'Go to Notifications',
+    subtitle: 'Navigate to the notifications page',
+    href: '/notifications',
+  },
+  {
+    id: 'action-questions',
+    category: 'action',
+    title: 'Go to Questions',
+    subtitle: 'Navigate to the questions page',
+    href: '/questions',
+  },
+  {
+    id: 'action-workflows',
+    category: 'action',
+    title: 'Go to Workflows',
+    subtitle: 'Navigate to the workflows page',
+    href: '/workflows',
+  },
+  {
+    id: 'action-monitoring',
+    category: 'action',
+    title: 'Go to Monitoring',
+    subtitle: 'Navigate to the monitoring page',
+    href: '/monitoring',
+  },
+  {
+    id: 'action-settings',
+    category: 'action',
+    title: 'Go to Settings',
+    subtitle: 'Open application settings',
+    href: '/settings',
+  },
+  {
+    id: 'action-run-checks',
+    category: 'action',
+    title: 'Run Checks',
+    subtitle: 'Trigger the ask service health checks',
+    href: '/questions?action=run',
+  },
+]
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Returns 3 = exact, 2 = prefix, 1 = contains, 0 = no match */
+function scoreMatch(text: string, query: string): number {
+  const lower = text.toLowerCase()
+  const q = query.toLowerCase()
+  if (lower === q) return 3
+  if (lower.startsWith(q)) return 2
+  if (lower.includes(q)) return 1
+  return 0
+}
+
+function loadRecentSearches(): string[] {
+  try {
+    const stored = localStorage.getItem(RECENT_SEARCHES_KEY)
+    if (!stored) return []
+    return JSON.parse(stored) as string[]
+  } catch {
+    return []
+  }
+}
+
+function saveRecentSearches(searches: string[]): void {
+  try {
+    localStorage.setItem(RECENT_SEARCHES_KEY, JSON.stringify(searches))
+  } catch {
+    // ignore storage errors
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+const EMPTY_RESULTS: GroupedSearchResults = {
+  actions: [],
+  agents: [],
+  notifications: [],
+  total: 0,
+}
+
+export function useSearch(): UseSearchResult {
+  const [query, setQuery] = useState('')
+  const [debouncedQuery, setDebouncedQuery] = useState('')
+  const [results, setResults] = useState<GroupedSearchResults>(EMPTY_RESULTS)
+  const [loading, setLoading] = useState(false)
+  const [recentSearches, setRecentSearches] = useState<string[]>(loadRecentSearches)
+  const abortRef = useRef<AbortController | null>(null)
+
+  // Debounce the raw query
+  useEffect(() => {
+    const timer = setTimeout(() => setDebouncedQuery(query), DEBOUNCE_MS)
+    return () => clearTimeout(timer)
+  }, [query])
+
+  // Execute search when debounced query changes
+  useEffect(() => {
+    if (!debouncedQuery.trim()) {
+      setResults(EMPTY_RESULTS)
+      setLoading(false)
+      return
+    }
+
+    // Abort any in-flight request
+    abortRef.current?.abort()
+    abortRef.current = new AbortController()
+
+    const q = debouncedQuery.trim()
+
+    // Filter quick actions client-side
+    const filteredActions = QUICK_ACTIONS.map((action) => ({
+      action,
+      score: Math.max(scoreMatch(action.title, q), scoreMatch(action.subtitle, q)),
+    }))
+      .filter(({ score }) => score > 0)
+      .sort((a, b) => b.score - a.score)
+      .slice(0, MAX_PER_CATEGORY)
+      .map(({ action }) => action)
+
+    setLoading(true)
+
+    async function doSearch() {
+      try {
+        const [agentsResult, notifResult] = await Promise.allSettled([
+          orchestratorClient.listAgents({ limit: 200 }),
+          notifyClient.listNotifications({ limit: 200 }),
+        ])
+
+        // --- Agents ---
+        type ScoredResult = SearchResult & { _score: number }
+        const agentResults: ScoredResult[] = []
+        if (agentsResult.status === 'fulfilled') {
+          for (const agent of agentsResult.value.items) {
+            const score = scoreMatch(agent.name, q)
+            if (score > 0) {
+              agentResults.push({
+                id: `agent-${agent.id}`,
+                category: 'agent',
+                title: agent.name,
+                subtitle: `Status: ${agent.status}`,
+                href: `/agents/${agent.id}`,
+                _score: score,
+              })
+            }
+          }
+          agentResults.sort((a, b) => b._score - a._score)
+        }
+
+        // --- Notifications ---
+        const notifResults: ScoredResult[] = []
+        if (notifResult.status === 'fulfilled') {
+          for (const notif of notifResult.value.items) {
+            const score = Math.max(
+              scoreMatch(notif.title, q),
+              scoreMatch(notif.message, q),
+            )
+            if (score > 0) {
+              notifResults.push({
+                id: `notif-${notif.id}`,
+                category: 'notification',
+                title: notif.title,
+                subtitle: `${notif.priority} — ${notif.status}`,
+                href: `/notifications/${notif.id}`,
+                _score: score,
+              })
+            }
+          }
+          notifResults.sort((a, b) => b._score - a._score)
+        }
+
+        const agents = agentResults.slice(0, MAX_PER_CATEGORY)
+        const notifications = notifResults.slice(0, MAX_PER_CATEGORY)
+
+        setResults({
+          actions: filteredActions,
+          agents,
+          notifications,
+          total: filteredActions.length + agents.length + notifications.length,
+        })
+      } catch (err) {
+        if (err instanceof Error && err.name === 'AbortError') return
+        // On network error still show quick actions
+        setResults({ ...EMPTY_RESULTS, actions: filteredActions, total: filteredActions.length })
+      } finally {
+        setLoading(false)
+      }
+    }
+
+    void doSearch()
+  }, [debouncedQuery])
+
+  const addRecentSearch = useCallback((q: string) => {
+    if (!q.trim()) return
+    setRecentSearches((prev) => {
+      const filtered = prev.filter((s) => s !== q)
+      const next = [q, ...filtered].slice(0, MAX_RECENT)
+      saveRecentSearches(next)
+      return next
+    })
+  }, [])
+
+  const clearRecentSearches = useCallback(() => {
+    setRecentSearches([])
+    saveRecentSearches([])
+  }, [])
+
+  return {
+    query,
+    setQuery,
+    results,
+    loading,
+    recentSearches,
+    addRecentSearch,
+    clearRecentSearches,
+  }
+}

--- a/ui/src/layouts/AppShell.tsx
+++ b/ui/src/layouts/AppShell.tsx
@@ -2,8 +2,10 @@
  * AppShell — root layout wrapper.
  *
  * Manages sidebar open/closed state (persisted to localStorage),
- * provides LayoutContext to all children, and handles Ctrl+B
- * keyboard shortcut to toggle the sidebar.
+ * global search palette visibility, provides LayoutContext to all
+ * children, and handles keyboard shortcuts:
+ *   - Ctrl+B: toggle sidebar
+ *   - Ctrl+K / Cmd+K: open search palette
  */
 
 import { useCallback, useEffect, useState } from 'react'
@@ -12,6 +14,7 @@ import { LayoutContext } from './context'
 import { Header } from './Header'
 import { Sidebar } from './Sidebar'
 import { ContentArea } from './ContentArea'
+import { SearchPalette } from '@/components/search/SearchPalette'
 
 const STORAGE_KEY = 'agentd:sidebar:open'
 
@@ -27,6 +30,7 @@ function readPersistedSidebarState(): boolean {
 
 export function AppShell() {
   const [sidebarOpen, setSidebarOpenState] = useState<boolean>(readPersistedSidebarState)
+  const [searchOpen, setSearchOpen] = useState(false)
 
   const setSidebarOpen = useCallback((open: boolean) => {
     setSidebarOpenState(open)
@@ -41,12 +45,19 @@ export function AppShell() {
     setSidebarOpen(!sidebarOpen)
   }, [sidebarOpen, setSidebarOpen])
 
-  // Ctrl+B to toggle sidebar
+  const openSearch = useCallback(() => setSearchOpen(true), [])
+  const closeSearch = useCallback(() => setSearchOpen(false), [])
+
+  // Ctrl+B to toggle sidebar; Ctrl+K / Cmd+K to open search
   useEffect(() => {
     function handleKeyDown(e: KeyboardEvent) {
       if ((e.ctrlKey || e.metaKey) && e.key === 'b') {
         e.preventDefault()
         setSidebarOpen(!sidebarOpen)
+      }
+      if ((e.ctrlKey || e.metaKey) && e.key === 'k') {
+        e.preventDefault()
+        setSearchOpen(true)
       }
     }
     document.addEventListener('keydown', handleKeyDown)
@@ -54,13 +65,16 @@ export function AppShell() {
   }, [sidebarOpen, setSidebarOpen])
 
   return (
-    <LayoutContext.Provider value={{ sidebarOpen, setSidebarOpen, toggleSidebar }}>
+    <LayoutContext.Provider
+      value={{ sidebarOpen, setSidebarOpen, toggleSidebar, searchOpen, openSearch, closeSearch }}
+    >
       <div className="min-h-screen bg-gray-50 dark:bg-gray-950">
         <Header />
         <Sidebar />
         <ContentArea>
           <Outlet />
         </ContentArea>
+        <SearchPalette isOpen={searchOpen} onClose={closeSearch} />
       </div>
     </LayoutContext.Provider>
   )

--- a/ui/src/layouts/Header.tsx
+++ b/ui/src/layouts/Header.tsx
@@ -1,10 +1,12 @@
 /**
  * Header — fixed top bar with sidebar toggle, logo, search, notifications, and settings.
+ *
+ * The search button opens the global SearchPalette (managed by AppShell).
+ * Ctrl+K / Cmd+K is handled at the AppShell level.
  */
 
-import { useEffect, useRef, useState } from 'react'
 import { Link } from 'react-router-dom'
-import { Bell, Menu, Search, Settings, X } from 'lucide-react'
+import { Bell, Menu, Search, Settings } from 'lucide-react'
 import { useLayout } from './context'
 
 // ---------------------------------------------------------------------------
@@ -28,71 +30,26 @@ function NotificationBadge({ count }: NotificationBadgeProps) {
 }
 
 // ---------------------------------------------------------------------------
-// Search bar
+// Search trigger button
 // ---------------------------------------------------------------------------
 
-interface SearchBarProps {
-  /** Whether the search bar is in collapsed (icon-only) mode */
-  collapsed?: boolean
-}
-
-function SearchBar({ collapsed = false }: SearchBarProps) {
-  const inputRef = useRef<HTMLInputElement>(null)
-  const [expanded, setExpanded] = useState(false)
-
-  // Ctrl+K shortcut
-  useEffect(() => {
-    function handleKeyDown(e: KeyboardEvent) {
-      if ((e.ctrlKey || e.metaKey) && e.key === 'k') {
-        e.preventDefault()
-        inputRef.current?.focus()
-        setExpanded(true)
-      }
-      if (e.key === 'Escape') {
-        inputRef.current?.blur()
-        setExpanded(false)
-      }
-    }
-    document.addEventListener('keydown', handleKeyDown)
-    return () => document.removeEventListener('keydown', handleKeyDown)
-  }, [])
-
-  if (collapsed && !expanded) {
-    return (
-      <button
-        type="button"
-        aria-label="Open search"
-        onClick={() => setExpanded(true)}
-        className="rounded-md p-2 text-gray-400 transition-colors hover:bg-gray-700 hover:text-white"
-      >
-        <Search size={20} />
-      </button>
-    )
-  }
+function SearchTrigger() {
+  const { openSearch } = useLayout()
 
   return (
-    <div className="relative flex items-center">
-      <Search size={16} className="absolute left-3 text-gray-400" aria-hidden="true" />
-      <input
-        ref={inputRef}
-        type="search"
-        placeholder="Search… (Ctrl+K)"
-        aria-label="Global search"
-        className="w-48 rounded-md border border-gray-700 bg-gray-800 py-1.5 pl-9 pr-3 text-sm text-gray-200 placeholder-gray-500 transition-all focus:w-72 focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500 md:w-64"
-        onBlur={() => setExpanded(false)}
-        autoFocus={expanded}
-      />
-      {expanded && (
-        <button
-          type="button"
-          aria-label="Close search"
-          onClick={() => setExpanded(false)}
-          className="absolute right-2 text-gray-400 hover:text-white"
-        >
-          <X size={14} />
-        </button>
-      )}
-    </div>
+    <button
+      type="button"
+      aria-label="Global search"
+      aria-keyshortcuts="Control+k Meta+k"
+      onClick={openSearch}
+      className="flex items-center gap-2 rounded-md border border-gray-700 bg-gray-800 py-1.5 pl-3 pr-4 text-sm text-gray-400 transition-colors hover:border-gray-600 hover:text-gray-300"
+    >
+      <Search size={14} aria-hidden="true" />
+      <span className="hidden md:inline">Search…</span>
+      <kbd className="hidden rounded border border-gray-600 px-1 py-0.5 text-[10px] text-gray-500 md:inline">
+        Ctrl+K
+      </kbd>
+    </button>
   )
 }
 
@@ -133,13 +90,8 @@ export function Header({ unreadCount = 0 }: HeaderProps) {
       {/* Spacer */}
       <div className="flex-1" />
 
-      {/* Search — collapses to icon on small screens */}
-      <div className="hidden sm:block">
-        <SearchBar />
-      </div>
-      <div className="sm:hidden">
-        <SearchBar collapsed />
-      </div>
+      {/* Search trigger */}
+      <SearchTrigger />
 
       {/* Notification bell */}
       <Link

--- a/ui/src/layouts/context.tsx
+++ b/ui/src/layouts/context.tsx
@@ -11,6 +11,12 @@ export interface LayoutContextValue {
   toggleSidebar: () => void
   /** Explicitly set sidebar open/closed */
   setSidebarOpen: (open: boolean) => void
+  /** Whether the global search palette is open */
+  searchOpen: boolean
+  /** Open the global search palette */
+  openSearch: () => void
+  /** Close the global search palette */
+  closeSearch: () => void
 }
 
 export const LayoutContext = createContext<LayoutContextValue | null>(null)

--- a/ui/src/test/components/search/SearchPalette.test.tsx
+++ b/ui/src/test/components/search/SearchPalette.test.tsx
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { SearchPalette } from '@/components/search/SearchPalette'
+
+// Mock useSearch to avoid real API calls
+vi.mock('@/hooks/useSearch', () => ({
+  useSearch: () => ({
+    query: '',
+    setQuery: vi.fn(),
+    results: { actions: [], agents: [], notifications: [], total: 0 },
+    loading: false,
+    recentSearches: [],
+    addRecentSearch: vi.fn(),
+    clearRecentSearches: vi.fn(),
+  }),
+}))
+
+// Mock useNavigate
+const mockNavigate = vi.fn()
+vi.mock('react-router-dom', async (importOriginal) => {
+  const mod = await importOriginal()
+  return {
+    ...(mod as object),
+    useNavigate: () => mockNavigate,
+  }
+})
+
+function renderPalette(props: { isOpen: boolean; onClose?: () => void }) {
+  return render(
+    <MemoryRouter>
+      <SearchPalette isOpen={props.isOpen} onClose={props.onClose ?? vi.fn()} />
+    </MemoryRouter>,
+  )
+}
+
+describe('SearchPalette', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('does not render when closed', () => {
+    renderPalette({ isOpen: false })
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument()
+  })
+
+  it('renders when open', () => {
+    renderPalette({ isOpen: true })
+    expect(screen.getByRole('dialog')).toBeInTheDocument()
+  })
+
+  it('has aria-modal="true"', () => {
+    renderPalette({ isOpen: true })
+    expect(screen.getByRole('dialog')).toHaveAttribute('aria-modal', 'true')
+  })
+
+  it('renders the search input', () => {
+    renderPalette({ isOpen: true })
+    expect(screen.getByRole('combobox')).toBeInTheDocument()
+  })
+
+  it('calls onClose when Escape is pressed', () => {
+    const onClose = vi.fn()
+    renderPalette({ isOpen: true, onClose })
+    fireEvent.keyDown(screen.getByRole('dialog').children[1], { key: 'Escape' })
+    expect(onClose).toHaveBeenCalledOnce()
+  })
+
+  it('calls onClose when backdrop is clicked', () => {
+    const onClose = vi.fn()
+    renderPalette({ isOpen: true, onClose })
+    // The backdrop is the first child (aria-hidden div)
+    const backdrop = screen.getByRole('dialog').querySelector('[aria-hidden="true"]')
+    if (backdrop) fireEvent.click(backdrop)
+    expect(onClose).toHaveBeenCalledOnce()
+  })
+
+  it('shows keyboard shortcut hints in footer', () => {
+    renderPalette({ isOpen: true })
+    expect(screen.getByText('navigate')).toBeInTheDocument()
+    expect(screen.getByText('open')).toBeInTheDocument()
+    expect(screen.getByText('close')).toBeInTheDocument()
+  })
+
+  it('shows empty state with no recent searches', () => {
+    renderPalette({ isOpen: true })
+    expect(screen.getByText(/start typing/i)).toBeInTheDocument()
+  })
+})

--- a/ui/src/test/components/search/SearchResultItem.test.tsx
+++ b/ui/src/test/components/search/SearchResultItem.test.tsx
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { SearchResultItem } from '@/components/search/SearchResultItem'
+import type { SearchResult } from '@/hooks/useSearch'
+
+const agentResult: SearchResult = {
+  id: 'agent-1',
+  category: 'agent',
+  title: 'build-bot',
+  subtitle: 'Status: Running',
+  href: '/agents/1',
+}
+
+const notifResult: SearchResult = {
+  id: 'notif-1',
+  category: 'notification',
+  title: 'High memory alert',
+  subtitle: 'High — Pending',
+  href: '/notifications/1',
+}
+
+const actionResult: SearchResult = {
+  id: 'action-agents',
+  category: 'action',
+  title: 'Go to Agents',
+  subtitle: 'Navigate to the agents page',
+  href: '/agents',
+}
+
+describe('SearchResultItem', () => {
+  it('renders the result title', () => {
+    render(<SearchResultItem result={agentResult} isActive={false} onClick={vi.fn()} />)
+    expect(screen.getByText('build-bot')).toBeInTheDocument()
+  })
+
+  it('renders the result subtitle', () => {
+    render(<SearchResultItem result={agentResult} isActive={false} onClick={vi.fn()} />)
+    expect(screen.getByText('Status: Running')).toBeInTheDocument()
+  })
+
+  it('shows Agent category badge for agent results', () => {
+    render(<SearchResultItem result={agentResult} isActive={false} onClick={vi.fn()} />)
+    expect(screen.getByText('Agent')).toBeInTheDocument()
+  })
+
+  it('shows Notification category badge for notification results', () => {
+    render(<SearchResultItem result={notifResult} isActive={false} onClick={vi.fn()} />)
+    expect(screen.getByText('Notification')).toBeInTheDocument()
+  })
+
+  it('shows Action category badge for action results', () => {
+    render(<SearchResultItem result={actionResult} isActive={false} onClick={vi.fn()} />)
+    expect(screen.getByText('Action')).toBeInTheDocument()
+  })
+
+  it('calls onClick when clicked', () => {
+    const onClick = vi.fn()
+    render(<SearchResultItem result={agentResult} isActive={false} onClick={onClick} />)
+    fireEvent.click(screen.getByRole('button'))
+    expect(onClick).toHaveBeenCalledWith(agentResult)
+  })
+
+  it('calls onClick on Enter key', () => {
+    const onClick = vi.fn()
+    render(<SearchResultItem result={agentResult} isActive={false} onClick={onClick} />)
+    fireEvent.keyDown(screen.getByRole('button'), { key: 'Enter' })
+    expect(onClick).toHaveBeenCalledWith(agentResult)
+  })
+
+  it('calls onClick on Space key', () => {
+    const onClick = vi.fn()
+    render(<SearchResultItem result={agentResult} isActive={false} onClick={onClick} />)
+    fireEvent.keyDown(screen.getByRole('button'), { key: ' ' })
+    expect(onClick).toHaveBeenCalledWith(agentResult)
+  })
+
+  it('sets aria-selected=true when active', () => {
+    render(<SearchResultItem result={agentResult} isActive={true} onClick={vi.fn()} />)
+    expect(screen.getByRole('option')).toHaveAttribute('aria-selected', 'true')
+  })
+
+  it('sets aria-selected=false when not active', () => {
+    render(<SearchResultItem result={agentResult} isActive={false} onClick={vi.fn()} />)
+    expect(screen.getByRole('option')).toHaveAttribute('aria-selected', 'false')
+  })
+})

--- a/ui/src/test/components/search/SearchResults.test.tsx
+++ b/ui/src/test/components/search/SearchResults.test.tsx
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { SearchResults, RecentSearches } from '@/components/search/SearchResults'
+import type { GroupedSearchResults } from '@/hooks/useSearch'
+
+const emptyResults: GroupedSearchResults = {
+  actions: [],
+  agents: [],
+  notifications: [],
+  total: 0,
+}
+
+const richResults: GroupedSearchResults = {
+  actions: [
+    { id: 'action-agents', category: 'action', title: 'Go to Agents', subtitle: 'Navigate to agents', href: '/agents' },
+  ],
+  agents: [
+    { id: 'agent-1', category: 'agent', title: 'build-bot', subtitle: 'Status: Running', href: '/agents/1' },
+    { id: 'agent-2', category: 'agent', title: 'deploy-bot', subtitle: 'Status: Pending', href: '/agents/2' },
+  ],
+  notifications: [
+    { id: 'notif-1', category: 'notification', title: 'Alert', subtitle: 'High — Pending', href: '/notifications/1' },
+  ],
+  total: 4,
+}
+
+describe('SearchResults', () => {
+  it('shows no-results state when results are empty', () => {
+    render(
+      <SearchResults
+        query="foobar"
+        results={emptyResults}
+        loading={false}
+        activeId={null}
+        onSelect={vi.fn()}
+      />,
+    )
+    expect(screen.getByText(/no results for/i)).toBeInTheDocument()
+    expect(screen.getByText(/"foobar"/)).toBeInTheDocument()
+  })
+
+  it('shows a loading spinner while loading', () => {
+    render(
+      <SearchResults
+        query="agent"
+        results={emptyResults}
+        loading={true}
+        activeId={null}
+        onSelect={vi.fn()}
+      />,
+    )
+    expect(screen.getByRole('status', { name: /searching/i })).toBeInTheDocument()
+  })
+
+  it('renders section headings for each category', () => {
+    render(
+      <SearchResults
+        query="bot"
+        results={richResults}
+        loading={false}
+        activeId={null}
+        onSelect={vi.fn()}
+      />,
+    )
+    // Use role="group" with aria-label to target section headings specifically
+    expect(screen.getByRole('group', { name: /quick actions/i })).toBeInTheDocument()
+    expect(screen.getByRole('group', { name: /agents/i })).toBeInTheDocument()
+    expect(screen.getByRole('group', { name: /notifications/i })).toBeInTheDocument()
+  })
+
+  it('renders all result items', () => {
+    render(
+      <SearchResults
+        query="bot"
+        results={richResults}
+        loading={false}
+        activeId={null}
+        onSelect={vi.fn()}
+      />,
+    )
+    expect(screen.getByText('Go to Agents')).toBeInTheDocument()
+    expect(screen.getByText('build-bot')).toBeInTheDocument()
+    expect(screen.getByText('deploy-bot')).toBeInTheDocument()
+    expect(screen.getByText('Alert')).toBeInTheDocument()
+  })
+
+  it('calls onSelect when a result is clicked', () => {
+    const onSelect = vi.fn()
+    render(
+      <SearchResults
+        query="bot"
+        results={richResults}
+        loading={false}
+        activeId={null}
+        onSelect={onSelect}
+      />,
+    )
+    fireEvent.click(screen.getAllByRole('button')[0])
+    expect(onSelect).toHaveBeenCalled()
+  })
+})
+
+describe('RecentSearches', () => {
+  it('shows empty state when no recent searches', () => {
+    render(<RecentSearches searches={[]} onSelect={vi.fn()} onClear={vi.fn()} />)
+    expect(screen.getByText(/start typing/i)).toBeInTheDocument()
+  })
+
+  it('renders recent search terms', () => {
+    render(
+      <RecentSearches
+        searches={['build-bot', 'alert']}
+        onSelect={vi.fn()}
+        onClear={vi.fn()}
+      />,
+    )
+    expect(screen.getByText('build-bot')).toBeInTheDocument()
+    expect(screen.getByText('alert')).toBeInTheDocument()
+  })
+
+  it('calls onSelect when a recent search is clicked', () => {
+    const onSelect = vi.fn()
+    render(
+      <RecentSearches searches={['build-bot']} onSelect={onSelect} onClear={vi.fn()} />,
+    )
+    fireEvent.click(screen.getByText('build-bot'))
+    expect(onSelect).toHaveBeenCalledWith('build-bot')
+  })
+
+  it('calls onClear when Clear button is clicked', () => {
+    const onClear = vi.fn()
+    render(
+      <RecentSearches searches={['build-bot']} onSelect={vi.fn()} onClear={onClear} />,
+    )
+    fireEvent.click(screen.getByRole('button', { name: /clear/i }))
+    expect(onClear).toHaveBeenCalledOnce()
+  })
+})

--- a/ui/src/test/hooks/useSearch.test.ts
+++ b/ui/src/test/hooks/useSearch.test.ts
@@ -1,0 +1,208 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useSearch } from '@/hooks/useSearch'
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock('@/services/orchestrator', () => ({
+  orchestratorClient: {
+    listAgents: vi.fn().mockResolvedValue({
+      items: [
+        { id: '1', name: 'build-bot', status: 'Running', config: {}, created_at: '', updated_at: '' },
+        { id: '2', name: 'deploy-bot', status: 'Pending', config: {}, created_at: '', updated_at: '' },
+        { id: '3', name: 'test-runner', status: 'Stopped', config: {}, created_at: '', updated_at: '' },
+      ],
+      total: 3,
+      limit: 200,
+      offset: 0,
+    }),
+  },
+}))
+
+vi.mock('@/services/notify', () => ({
+  notifyClient: {
+    listNotifications: vi.fn().mockResolvedValue({
+      items: [
+        {
+          id: 'n1',
+          title: 'High memory alert',
+          message: 'Memory usage above 90%',
+          priority: 'High',
+          status: 'Pending',
+          source: 'MonitorService',
+          lifetime: { type: 'Persistent' },
+          requires_response: false,
+          created_at: '',
+          updated_at: '',
+        },
+      ],
+      total: 1,
+      limit: 200,
+      offset: 0,
+    }),
+  },
+}))
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  localStorage.clear()
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+/** Advance debounce timer and flush all pending promises */
+async function flushDebounce() {
+  await act(async () => {
+    await vi.advanceTimersByTimeAsync(300)
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('useSearch', () => {
+  it('returns empty results for an empty query', () => {
+    const { result } = renderHook(() => useSearch())
+    expect(result.current.results.total).toBe(0)
+    expect(result.current.loading).toBe(false)
+  })
+
+  it('debounces — does not fire before 300ms have elapsed', async () => {
+    const { result } = renderHook(() => useSearch())
+
+    act(() => {
+      result.current.setQuery('build')
+    })
+
+    // Only advance 100ms — debounce has not fired
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(100)
+    })
+
+    // No results yet, not loading
+    expect(result.current.results.total).toBe(0)
+    expect(result.current.loading).toBe(false)
+  })
+
+  it('finds agent results matching the query after debounce', async () => {
+    const { result } = renderHook(() => useSearch())
+
+    act(() => {
+      result.current.setQuery('build')
+    })
+    await flushDebounce()
+
+    expect(result.current.results.agents.length).toBeGreaterThan(0)
+    expect(result.current.results.agents[0].title).toBe('build-bot')
+  })
+
+  it('finds notification results matching the query after debounce', async () => {
+    const { result } = renderHook(() => useSearch())
+
+    act(() => {
+      result.current.setQuery('memory')
+    })
+    await flushDebounce()
+
+    expect(result.current.results.notifications.length).toBeGreaterThan(0)
+    expect(result.current.results.notifications[0].title).toBe('High memory alert')
+  })
+
+  it('filters quick actions matching the query', async () => {
+    const { result } = renderHook(() => useSearch())
+
+    act(() => {
+      result.current.setQuery('agents')
+    })
+    await flushDebounce()
+
+    expect(result.current.results.actions.length).toBeGreaterThan(0)
+    expect(result.current.results.actions.some((a) => a.title.includes('Agent'))).toBe(true)
+  })
+
+  it('clears results when query is set back to empty', async () => {
+    const { result } = renderHook(() => useSearch())
+
+    act(() => {
+      result.current.setQuery('build')
+    })
+    await flushDebounce()
+    expect(result.current.results.agents.length).toBeGreaterThan(0)
+
+    act(() => {
+      result.current.setQuery('')
+    })
+    await flushDebounce()
+
+    expect(result.current.results.total).toBe(0)
+  })
+
+  it('ranks exact matches above prefix/contains', async () => {
+    const { result } = renderHook(() => useSearch())
+
+    act(() => {
+      result.current.setQuery('build-bot')
+    })
+    await flushDebounce()
+
+    const agents = result.current.results.agents
+    expect(agents.length).toBeGreaterThan(0)
+    // build-bot is an exact match → should be ranked first
+    expect(agents[0].title).toBe('build-bot')
+  })
+
+  it('persists recent searches to localStorage', () => {
+    const { result } = renderHook(() => useSearch())
+
+    act(() => {
+      result.current.addRecentSearch('build-bot')
+    })
+
+    expect(result.current.recentSearches).toContain('build-bot')
+    const stored = JSON.parse(localStorage.getItem('agentd:recent-searches') ?? '[]') as string[]
+    expect(stored).toContain('build-bot')
+  })
+
+  it('deduplicates recent searches', () => {
+    const { result } = renderHook(() => useSearch())
+
+    act(() => {
+      result.current.addRecentSearch('build-bot')
+      result.current.addRecentSearch('build-bot')
+    })
+
+    expect(result.current.recentSearches.filter((s) => s === 'build-bot')).toHaveLength(1)
+  })
+
+  it('limits recent searches to 5 entries', () => {
+    const { result } = renderHook(() => useSearch())
+
+    act(() => {
+      for (let i = 0; i < 7; i++) {
+        result.current.addRecentSearch(`search-${i}`)
+      }
+    })
+
+    expect(result.current.recentSearches).toHaveLength(5)
+  })
+
+  it('clears all recent searches', () => {
+    const { result } = renderHook(() => useSearch())
+
+    act(() => {
+      result.current.addRecentSearch('build-bot')
+    })
+
+    act(() => {
+      result.current.clearRecentSearches()
+    })
+
+    expect(result.current.recentSearches).toHaveLength(0)
+    expect(localStorage.getItem('agentd:recent-searches')).toBe('[]')
+  })
+})

--- a/ui/src/test/layouts/ContentArea.test.tsx
+++ b/ui/src/test/layouts/ContentArea.test.tsx
@@ -9,6 +9,9 @@ function makeContext(overrides: Partial<LayoutContextValue> = {}): LayoutContext
     sidebarOpen: true,
     setSidebarOpen: vi.fn(),
     toggleSidebar: vi.fn(),
+    searchOpen: false,
+    openSearch: vi.fn(),
+    closeSearch: vi.fn(),
     ...overrides,
   }
 }

--- a/ui/src/test/layouts/Header.test.tsx
+++ b/ui/src/test/layouts/Header.test.tsx
@@ -14,6 +14,9 @@ function makeContext(overrides: Partial<LayoutContextValue> = {}): LayoutContext
     sidebarOpen: true,
     setSidebarOpen: vi.fn(),
     toggleSidebar: vi.fn(),
+    searchOpen: false,
+    openSearch: vi.fn(),
+    closeSearch: vi.fn(),
     ...overrides,
   }
 }
@@ -83,8 +86,20 @@ describe('Header', () => {
     expect(screen.getByText('99+')).toBeInTheDocument()
   })
 
-  it('search input has an accessible label', () => {
+  it('renders the global search button', () => {
     renderHeader()
-    expect(screen.getByRole('searchbox', { name: /global search/i })).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: /global search/i })).toBeInTheDocument()
+  })
+
+  it('calls openSearch when the search button is clicked', () => {
+    const { ctx } = renderHeader()
+    fireEvent.click(screen.getByRole('button', { name: /global search/i }))
+    expect(ctx.openSearch).toHaveBeenCalledOnce()
+  })
+
+  it('search button has Ctrl+K keyboard shortcut hint', () => {
+    renderHeader()
+    const btn = screen.getByRole('button', { name: /global search/i })
+    expect(btn).toHaveAttribute('aria-keyshortcuts', 'Control+k Meta+k')
   })
 })

--- a/ui/src/test/layouts/Sidebar.test.tsx
+++ b/ui/src/test/layouts/Sidebar.test.tsx
@@ -14,6 +14,9 @@ function makeContext(overrides: Partial<LayoutContextValue> = {}): LayoutContext
     sidebarOpen: true,
     setSidebarOpen: vi.fn(),
     toggleSidebar: vi.fn(),
+    searchOpen: false,
+    openSearch: vi.fn(),
+    closeSearch: vi.fn(),
     ...overrides,
   }
 }


### PR DESCRIPTION
## Summary

- Add `useSearch` hook with 300ms debounce, parallel API searches across agents and notifications, client-side quick-action filtering, and relevance ranking (exact > prefix > contains)
- Build `SearchResultItem`, `SearchResults`, `SearchPalette` components
- Full-screen portal overlay with Ctrl+K/Cmd+K to open, Escape/backdrop to close, arrow-key + Enter keyboard navigation, recent-searches history (localStorage)
- Extend `LayoutContext` with `searchOpen / openSearch / closeSearch`
- 40 new tests; 173 total passing

Closes #175

🤖 Generated with [Claude Code](https://claude.com/claude-code)