### PR TITLE
feat(ui): add dark mode theme support with system preference detection

### DIFF
--- a/ui/index.html
+++ b/ui/index.html
@@ -5,6 +5,29 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>ui</title>
+    <!--
+      Anti-FOUC (Flash of Unstyled Content) theme script.
+      Runs synchronously before React hydrates to apply the correct
+      theme class to <html> before any paint occurs.
+      Reads the theme preference from the 'agentd:settings' localStorage key.
+    -->
+    <script>
+      (function () {
+        try {
+          var settings = JSON.parse(localStorage.getItem('agentd:settings') || '{}')
+          var theme = (settings.ui && settings.ui.theme) || 'system'
+          var isDark =
+            theme === 'dark' ||
+            (theme === 'system' &&
+              window.matchMedia('(prefers-color-scheme: dark)').matches)
+          if (isDark) {
+            document.documentElement.classList.add('dark')
+          }
+        } catch (e) {
+          // Silently ignore errors (private browsing, JSON parse failures, etc.)
+        }
+      })()
+    </script>
   </head>
   <body>
     <div id="root"></div>

--- a/ui/src/components/common/ThemeToggle.tsx
+++ b/ui/src/components/common/ThemeToggle.tsx
@@ -1,0 +1,67 @@
+/**
+ * ThemeToggle — quick theme toggle for the header bar.
+ *
+ * Cycles through: system → light → dark → system
+ * Displays an icon representing the *current* preference:
+ *   - system → Monitor icon
+ *   - light  → Sun icon
+ *   - dark   → Moon icon
+ */
+
+import { Monitor, Moon, Sun } from 'lucide-react'
+import { useTheme } from '@/hooks/useTheme'
+import type { ThemeMode } from '@/stores/themeStore'
+
+const NEXT_THEME: Record<ThemeMode, ThemeMode> = {
+  system: 'light',
+  light: 'dark',
+  dark: 'system',
+}
+
+const LABELS: Record<ThemeMode, string> = {
+  system: 'Theme: System (switch to Light)',
+  light: 'Theme: Light (switch to Dark)',
+  dark: 'Theme: Dark (switch to System)',
+}
+
+function ThemeIcon({ mode }: { mode: ThemeMode }) {
+  const size = 18
+  if (mode === 'dark') return <Moon size={size} aria-hidden="true" />
+  if (mode === 'light') return <Sun size={size} aria-hidden="true" />
+  return <Monitor size={size} aria-hidden="true" />
+}
+
+export interface ThemeToggleProps {
+  /** Additional class names to merge onto the button */
+  className?: string
+}
+
+export function ThemeToggle({ className = '' }: ThemeToggleProps) {
+  const { theme, setTheme } = useTheme()
+
+  function handleClick() {
+    setTheme(NEXT_THEME[theme])
+  }
+
+  return (
+    <button
+      type="button"
+      aria-label={LABELS[theme]}
+      onClick={handleClick}
+      className={[
+        'rounded-md p-2 text-gray-400 transition-colors',
+        'hover:bg-gray-700 hover:text-white',
+        'dark:text-gray-400 dark:hover:bg-gray-700 dark:hover:text-white',
+        'focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2',
+        'dark:focus:ring-offset-gray-900',
+        className,
+      ]
+        .filter(Boolean)
+        .join(' ')}
+    >
+      <ThemeIcon mode={theme} />
+    </button>
+  )
+}
+
+export default ThemeToggle

--- a/ui/src/components/common/index.ts
+++ b/ui/src/components/common/index.ts
@@ -1,3 +1,5 @@
 export { StatusBadge } from './StatusBadge'
 export type { ServiceStatus } from './StatusBadge'
 export { Skeleton, CardSkeleton, ListItemSkeleton, ChartSkeleton } from './LoadingSkeleton'
+export { ThemeToggle } from './ThemeToggle'
+export type { ThemeToggleProps } from './ThemeToggle'

--- a/ui/src/components/settings/UIPreferences.tsx
+++ b/ui/src/components/settings/UIPreferences.tsx
@@ -1,10 +1,14 @@
 /**
  * UIPreferences — UI preferences form for theme, sidebar, refresh interval,
  * notifications, and log view lines.
+ *
+ * Theme changes apply immediately to the DOM via ThemeContext so users
+ * can preview the effect before saving.
  */
 
 import { useState } from 'react'
 import type { Settings } from '@/stores/settingsStore'
+import { useTheme } from '@/hooks/useTheme'
 
 interface UIPreferencesProps {
   ui: Settings['ui']
@@ -13,6 +17,7 @@ interface UIPreferencesProps {
 
 export function UIPreferences({ ui, onSave }: UIPreferencesProps) {
   const [localUI, setLocalUI] = useState<Settings['ui']>(ui)
+  const { setTheme } = useTheme()
 
   function handleSave() {
     onSave(localUI)
@@ -31,12 +36,12 @@ export function UIPreferences({ ui, onSave }: UIPreferencesProps) {
         <select
           id="ui-theme"
           value={localUI.theme}
-          onChange={e =>
-            setLocalUI(prev => ({
-              ...prev,
-              theme: e.target.value as Settings['ui']['theme'],
-            }))
-          }
+          onChange={e => {
+            const theme = e.target.value as Settings['ui']['theme']
+            setLocalUI(prev => ({ ...prev, theme }))
+            // Apply immediately so the user sees the change in real time
+            setTheme(theme)
+          }}
           className="rounded-md border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white"
         >
           <option value="light">Light</option>

--- a/ui/src/hooks/index.ts
+++ b/ui/src/hooks/index.ts
@@ -9,3 +9,8 @@ export type { NotificationPriorityCounts, UseNotificationSummaryResult } from '.
 
 export { useSearch } from './useSearch'
 export type { SearchResult, GroupedSearchResults, UseSearchResult, SearchCategory } from './useSearch'
+
+export { useTheme, ThemeProvider } from './useTheme'
+export type { ThemeContextValue } from './useTheme'
+
+export { useNivoTheme } from './useNivoTheme'

--- a/ui/src/hooks/useNivoTheme.ts
+++ b/ui/src/hooks/useNivoTheme.ts
@@ -1,0 +1,16 @@
+/**
+ * useNivoTheme — returns the appropriate Nivo chart theme for the active theme.
+ *
+ * Usage:
+ *   const nivoTheme = useNivoTheme()
+ *   <ResponsiveLine theme={nivoTheme} ... />
+ */
+
+import { useTheme } from './useTheme'
+import { lightNivoTheme, darkNivoTheme } from '@/styles/themes'
+import type { PartialTheme as NivoTheme } from '@nivo/theming'
+
+export function useNivoTheme(): NivoTheme {
+  const { resolvedTheme } = useTheme()
+  return resolvedTheme === 'dark' ? darkNivoTheme : lightNivoTheme
+}

--- a/ui/src/hooks/useTheme.tsx
+++ b/ui/src/hooks/useTheme.tsx
@@ -1,0 +1,97 @@
+/**
+ * useTheme — React hook + context for theme management.
+ *
+ * Provides:
+ * - `theme`: the stored preference ('light' | 'dark' | 'system')
+ * - `resolvedTheme`: the concrete theme after resolving 'system' ('light' | 'dark')
+ * - `setTheme`: update theme preference (persists + applies to DOM)
+ *
+ * Usage: wrap your app with <ThemeProvider> and consume via useTheme().
+ */
+
+import { createContext, useCallback, useContext, useEffect, useState } from 'react'
+import type { ReactNode } from 'react'
+import { loadSettings, saveSettings } from '@/stores/settingsStore'
+import { applyTheme, resolveTheme } from '@/stores/themeStore'
+import type { ThemeMode } from '@/stores/themeStore'
+
+// ---------------------------------------------------------------------------
+// Context
+// ---------------------------------------------------------------------------
+
+export interface ThemeContextValue {
+  /** Stored theme preference */
+  theme: ThemeMode
+  /** Resolved (concrete) theme — never 'system' */
+  resolvedTheme: 'light' | 'dark'
+  /** Update the theme preference */
+  setTheme: (mode: ThemeMode) => void
+}
+
+export const ThemeContext = createContext<ThemeContextValue | null>(null)
+
+// ---------------------------------------------------------------------------
+// Provider
+// ---------------------------------------------------------------------------
+
+interface ThemeProviderProps {
+  children: ReactNode
+}
+
+export function ThemeProvider({ children }: ThemeProviderProps) {
+  const [theme, setThemeState] = useState<ThemeMode>(() => {
+    return loadSettings().ui.theme
+  })
+
+  const resolvedTheme = resolveTheme(theme)
+
+  // Apply theme to DOM on every theme change
+  useEffect(() => {
+    applyTheme(theme)
+  }, [theme])
+
+  // Watch for OS preference changes when using 'system' mode
+  useEffect(() => {
+    if (theme !== 'system') return
+
+    const mediaQuery = window.matchMedia('(prefers-color-scheme: dark)')
+
+    function handleChange() {
+      // Re-apply — resolveTheme() will pick up the new OS value
+      applyTheme('system')
+      // Force a re-render so resolvedTheme updates
+      setThemeState('system')
+    }
+
+    mediaQuery.addEventListener('change', handleChange)
+    return () => mediaQuery.removeEventListener('change', handleChange)
+  }, [theme])
+
+  const setTheme = useCallback((mode: ThemeMode) => {
+    // Persist to settings store
+    const current = loadSettings()
+    saveSettings({ ...current, ui: { ...current.ui, theme: mode } })
+    // Apply immediately
+    applyTheme(mode)
+    setThemeState(mode)
+  }, [])
+
+  return (
+    <ThemeContext.Provider value={{ theme, resolvedTheme, setTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+/** Consume the theme context — must be used within <ThemeProvider> */
+export function useTheme(): ThemeContextValue {
+  const ctx = useContext(ThemeContext)
+  if (!ctx) {
+    throw new Error('useTheme must be used within a ThemeProvider')
+  }
+  return ctx
+}

--- a/ui/src/index.css
+++ b/ui/src/index.css
@@ -1,5 +1,8 @@
 @import "tailwindcss";
 
+/* Configure class-based dark mode — adds `dark:` variant support via .dark class */
+@custom-variant dark (&:where(.dark, .dark *));
+
 @theme {
   /* Color tokens */
   --color-primary-50: #eff6ff;
@@ -68,7 +71,111 @@
   --shadow-xl: 0 20px 25px -5px rgb(0 0 0 / 0.1), 0 8px 10px -6px rgb(0 0 0 / 0.1);
 }
 
-/* Base styles */
+/* ---------------------------------------------------------------------------
+   Semantic CSS custom properties — light theme (default)
+   --------------------------------------------------------------------------- */
+:root {
+  /* Backgrounds */
+  --bg-primary: var(--color-secondary-50);
+  --bg-secondary: var(--color-secondary-100);
+  --bg-tertiary: var(--color-secondary-200);
+
+  /* Surface (cards, panels) */
+  --surface-default: #ffffff;
+  --surface-raised: var(--color-secondary-50);
+  --surface-overlay: #ffffff;
+
+  /* Navigation */
+  --nav-bg: var(--color-secondary-900);
+  --nav-border: var(--color-secondary-700);
+  --nav-text: var(--color-secondary-400);
+  --nav-text-active: #ffffff;
+  --nav-item-hover: var(--color-secondary-700);
+  --nav-item-active: var(--color-primary-700);
+
+  /* Text */
+  --text-primary: var(--color-secondary-900);
+  --text-secondary: var(--color-secondary-700);
+  --text-muted: var(--color-secondary-500);
+  --text-inverse: #ffffff;
+
+  /* Borders */
+  --border-default: var(--color-secondary-200);
+  --border-strong: var(--color-secondary-300);
+  --border-focus: var(--color-primary-500);
+
+  /* Accent / brand */
+  --accent-primary: var(--color-primary-500);
+  --accent-primary-hover: var(--color-primary-600);
+  --accent-secondary: var(--color-primary-100);
+
+  /* Status */
+  --status-success: var(--color-success-500);
+  --status-warning: var(--color-warning-500);
+  --status-error: var(--color-error-500);
+  --status-info: var(--color-info-500);
+
+  /* Form elements */
+  --input-bg: #ffffff;
+  --input-border: var(--color-secondary-300);
+  --input-text: var(--color-secondary-900);
+  --input-placeholder: var(--color-secondary-400);
+}
+
+/* ---------------------------------------------------------------------------
+   Semantic CSS custom properties — dark theme
+   --------------------------------------------------------------------------- */
+.dark {
+  /* Backgrounds */
+  --bg-primary: var(--color-secondary-950);
+  --bg-secondary: var(--color-secondary-900);
+  --bg-tertiary: var(--color-secondary-800);
+
+  /* Surface (cards, panels) */
+  --surface-default: var(--color-secondary-900);
+  --surface-raised: var(--color-secondary-800);
+  --surface-overlay: var(--color-secondary-800);
+
+  /* Navigation */
+  --nav-bg: var(--color-secondary-900);
+  --nav-border: var(--color-secondary-700);
+  --nav-text: var(--color-secondary-400);
+  --nav-text-active: #ffffff;
+  --nav-item-hover: var(--color-secondary-700);
+  --nav-item-active: var(--color-primary-700);
+
+  /* Text */
+  --text-primary: var(--color-secondary-50);
+  --text-secondary: var(--color-secondary-300);
+  --text-muted: var(--color-secondary-400);
+  --text-inverse: var(--color-secondary-900);
+
+  /* Borders */
+  --border-default: var(--color-secondary-800);
+  --border-strong: var(--color-secondary-700);
+  --border-focus: var(--color-primary-400);
+
+  /* Accent / brand */
+  --accent-primary: var(--color-primary-400);
+  --accent-primary-hover: var(--color-primary-300);
+  --accent-secondary: var(--color-primary-900);
+
+  /* Status */
+  --status-success: var(--color-success-500);
+  --status-warning: var(--color-warning-500);
+  --status-error: var(--color-error-500);
+  --status-info: var(--color-info-500);
+
+  /* Form elements */
+  --input-bg: var(--color-secondary-800);
+  --input-border: var(--color-secondary-600);
+  --input-text: var(--color-secondary-50);
+  --input-placeholder: var(--color-secondary-500);
+}
+
+/* ---------------------------------------------------------------------------
+   Base styles
+   --------------------------------------------------------------------------- */
 *,
 *::before,
 *::after {
@@ -83,20 +190,32 @@ html {
   text-rendering: optimizeLegibility;
 }
 
+/* Smooth theme transitions — only on background-color to keep performance good */
+html,
+body,
+*,
+*::before,
+*::after {
+  transition-property: background-color, border-color;
+  transition-duration: 150ms;
+  transition-timing-function: ease;
+}
+
+/* Opt-out of transitions for elements that should change instantly */
+.no-theme-transition,
+.no-theme-transition *,
+svg,
+svg * {
+  transition: none !important;
+}
+
 body {
   margin: 0;
   min-height: 100vh;
-  background-color: var(--color-secondary-50);
-  color: var(--color-secondary-900);
+  background-color: var(--bg-primary);
+  color: var(--text-primary);
 }
 
 #root {
   min-height: 100vh;
-}
-
-@media (prefers-color-scheme: dark) {
-  body {
-    background-color: var(--color-secondary-950);
-    color: var(--color-secondary-50);
-  }
 }

--- a/ui/src/layouts/AppShell.tsx
+++ b/ui/src/layouts/AppShell.tsx
@@ -2,8 +2,8 @@
  * AppShell — root layout wrapper.
  *
  * Manages sidebar open/closed state (persisted to localStorage),
- * global search palette visibility, provides LayoutContext to all
- * children, and handles keyboard shortcuts:
+ * global search palette visibility, provides LayoutContext and
+ * ThemeProvider to all children, and handles keyboard shortcuts:
  *   - Ctrl+B: toggle sidebar
  *   - Ctrl+K / Cmd+K: open search palette
  */
@@ -15,6 +15,7 @@ import { Header } from './Header'
 import { Sidebar } from './Sidebar'
 import { ContentArea } from './ContentArea'
 import { SearchPalette } from '@/components/search/SearchPalette'
+import { ThemeProvider } from '@/hooks/useTheme'
 
 const STORAGE_KEY = 'agentd:sidebar:open'
 
@@ -65,18 +66,20 @@ export function AppShell() {
   }, [sidebarOpen, setSidebarOpen])
 
   return (
-    <LayoutContext.Provider
-      value={{ sidebarOpen, setSidebarOpen, toggleSidebar, searchOpen, openSearch, closeSearch }}
-    >
-      <div className="min-h-screen bg-gray-50 dark:bg-gray-950">
-        <Header />
-        <Sidebar />
-        <ContentArea>
-          <Outlet />
-        </ContentArea>
-        <SearchPalette isOpen={searchOpen} onClose={closeSearch} />
-      </div>
-    </LayoutContext.Provider>
+    <ThemeProvider>
+      <LayoutContext.Provider
+        value={{ sidebarOpen, setSidebarOpen, toggleSidebar, searchOpen, openSearch, closeSearch }}
+      >
+        <div className="min-h-screen bg-gray-50 dark:bg-gray-950 transition-colors duration-150">
+          <Header />
+          <Sidebar />
+          <ContentArea>
+            <Outlet />
+          </ContentArea>
+          <SearchPalette isOpen={searchOpen} onClose={closeSearch} />
+        </div>
+      </LayoutContext.Provider>
+    </ThemeProvider>
   )
 }
 

--- a/ui/src/layouts/Header.tsx
+++ b/ui/src/layouts/Header.tsx
@@ -1,5 +1,6 @@
 /**
- * Header — fixed top bar with sidebar toggle, logo, search, notifications, and settings.
+ * Header — fixed top bar with sidebar toggle, logo, search, theme toggle,
+ * notifications, and settings.
  *
  * The search button opens the global SearchPalette (managed by AppShell).
  * Ctrl+K / Cmd+K is handled at the AppShell level.
@@ -8,6 +9,7 @@
 import { Link } from 'react-router-dom'
 import { Bell, Menu, Search, Settings } from 'lucide-react'
 import { useLayout } from './context'
+import { ThemeToggle } from '@/components/common/ThemeToggle'
 
 // ---------------------------------------------------------------------------
 // Notification badge
@@ -66,7 +68,7 @@ export function Header({ unreadCount = 0 }: HeaderProps) {
   const { toggleSidebar } = useLayout()
 
   return (
-    <header className="fixed inset-x-0 top-0 z-50 flex h-16 items-center gap-3 border-b border-gray-700 bg-gray-900 px-4">
+    <header className="fixed inset-x-0 top-0 z-50 flex h-16 items-center gap-3 border-b border-gray-700 bg-gray-900 px-4 transition-colors duration-150">
       {/* Sidebar toggle */}
       <button
         type="button"
@@ -92,6 +94,9 @@ export function Header({ unreadCount = 0 }: HeaderProps) {
 
       {/* Search trigger */}
       <SearchTrigger />
+
+      {/* Theme toggle */}
+      <ThemeToggle />
 
       {/* Notification bell */}
       <Link

--- a/ui/src/stores/themeStore.ts
+++ b/ui/src/stores/themeStore.ts
@@ -1,0 +1,55 @@
+/**
+ * themeStore — pure DOM/localStorage theme application logic.
+ *
+ * Handles:
+ * - Resolving 'system' mode against OS preference
+ * - Toggling the `dark` class on <html>
+ * - Reading/writing the theme preference to localStorage (via settingsStore key)
+ *
+ * These are plain functions (no React) so they can be called from:
+ * - The anti-FOUC inline script in index.html (before React mounts)
+ * - React hooks / event handlers
+ */
+
+export type ThemeMode = 'light' | 'dark' | 'system'
+
+/**
+ * Resolve the effective (concrete) theme from a mode value.
+ * 'system' → checks prefers-color-scheme media query.
+ */
+export function resolveTheme(mode: ThemeMode): 'light' | 'dark' {
+  if (mode === 'system') {
+    try {
+      return window.matchMedia('(prefers-color-scheme: dark)').matches ? 'dark' : 'light'
+    } catch {
+      return 'light'
+    }
+  }
+  return mode
+}
+
+/**
+ * Apply the given theme mode to the DOM by toggling the `dark` class
+ * on `document.documentElement`.
+ */
+export function applyTheme(mode: ThemeMode): void {
+  const resolved = resolveTheme(mode)
+  document.documentElement.classList.toggle('dark', resolved === 'dark')
+}
+
+/**
+ * Read the persisted theme preference from localStorage.
+ * Returns 'system' if nothing is stored or parsing fails.
+ */
+export function readPersistedTheme(): ThemeMode {
+  try {
+    const raw = localStorage.getItem('agentd:settings')
+    if (!raw) return 'system'
+    const parsed = JSON.parse(raw) as { ui?: { theme?: ThemeMode } }
+    const mode = parsed?.ui?.theme
+    if (mode === 'light' || mode === 'dark' || mode === 'system') return mode
+    return 'system'
+  } catch {
+    return 'system'
+  }
+}

--- a/ui/src/styles/themes.ts
+++ b/ui/src/styles/themes.ts
@@ -1,0 +1,142 @@
+/**
+ * themes.ts — theme color definitions.
+ *
+ * Exports:
+ * - `lightColors` / `darkColors`: full color maps for each theme
+ * - `lightNivoTheme` / `darkNivoTheme`: Nivo chart theme objects (PartialTheme)
+ *
+ * These can be used with the `useNivoTheme()` hook which returns the
+ * appropriate Nivo theme based on the active theme.
+ */
+
+import type { PartialTheme as NivoTheme } from '@nivo/theming'
+
+// ---------------------------------------------------------------------------
+// Color palettes
+// ---------------------------------------------------------------------------
+
+export const lightColors = {
+  // Backgrounds
+  bgPrimary: '#f8fafc',      // secondary-50 — page background
+  bgSecondary: '#f1f5f9',    // secondary-100 — card background
+  bgTertiary: '#e2e8f0',     // secondary-200 — subtle surface
+
+  // Text
+  textPrimary: '#0f172a',    // secondary-900
+  textSecondary: '#334155',  // secondary-700
+  textMuted: '#64748b',      // secondary-500
+
+  // Borders
+  borderDefault: '#e2e8f0',  // secondary-200
+  borderStrong: '#cbd5e1',   // secondary-300
+
+  // Accent
+  accentPrimary: '#3b82f6',  // primary-500
+  accentSecondary: '#2563eb', // primary-600
+
+  // Status
+  success: '#22c55e',
+  warning: '#f59e0b',
+  error: '#ef4444',
+  info: '#06b6d4',
+} as const
+
+export const darkColors = {
+  // Backgrounds
+  bgPrimary: '#020617',      // secondary-950 — page background
+  bgSecondary: '#0f172a',    // secondary-900 — card background
+  bgTertiary: '#1e293b',     // secondary-800 — subtle surface
+
+  // Text
+  textPrimary: '#f8fafc',    // secondary-50
+  textSecondary: '#cbd5e1',  // secondary-300
+  textMuted: '#94a3b8',      // secondary-400
+
+  // Borders
+  borderDefault: '#1e293b',  // secondary-800
+  borderStrong: '#334155',   // secondary-700
+
+  // Accent
+  accentPrimary: '#60a5fa',  // primary-400
+  accentSecondary: '#93c5fd', // primary-300
+
+  // Status
+  success: '#22c55e',
+  warning: '#f59e0b',
+  error: '#ef4444',
+  info: '#06b6d4',
+} as const
+
+// ---------------------------------------------------------------------------
+// Nivo chart themes
+// ---------------------------------------------------------------------------
+
+export const lightNivoTheme: NivoTheme = {
+  background: lightColors.bgSecondary,
+  axis: {
+    domain: {
+      line: { stroke: lightColors.borderStrong, strokeWidth: 1 },
+    },
+    ticks: {
+      line: { stroke: lightColors.borderDefault, strokeWidth: 1 },
+      text: { fill: lightColors.textMuted, fontSize: 11 },
+    },
+    legend: {
+      text: { fill: lightColors.textSecondary, fontSize: 12, fontWeight: 500 },
+    },
+  },
+  grid: {
+    line: { stroke: lightColors.borderDefault, strokeWidth: 1 },
+  },
+  legends: {
+    text: { fill: lightColors.textSecondary, fontSize: 12 },
+  },
+  tooltip: {
+    container: {
+      background: '#ffffff',
+      color: lightColors.textPrimary,
+      fontSize: 12,
+      borderRadius: 6,
+      boxShadow: '0 4px 6px -1px rgb(0 0 0 / 0.1)',
+      border: `1px solid ${lightColors.borderDefault}`,
+    },
+  },
+  labels: {
+    text: { fill: lightColors.textSecondary, fontSize: 11 },
+  },
+}
+
+export const darkNivoTheme: NivoTheme = {
+  background: darkColors.bgSecondary,
+  axis: {
+    domain: {
+      line: { stroke: darkColors.borderStrong, strokeWidth: 1 },
+    },
+    ticks: {
+      line: { stroke: darkColors.borderDefault, strokeWidth: 1 },
+      text: { fill: darkColors.textMuted, fontSize: 11 },
+    },
+    legend: {
+      text: { fill: darkColors.textSecondary, fontSize: 12, fontWeight: 500 },
+    },
+  },
+  grid: {
+    line: { stroke: darkColors.borderDefault, strokeWidth: 1 },
+  },
+  legends: {
+    text: { fill: darkColors.textSecondary, fontSize: 12 },
+  },
+  tooltip: {
+    container: {
+      background: darkColors.bgTertiary,
+      color: darkColors.textPrimary,
+      fontSize: 12,
+      borderRadius: 6,
+      boxShadow: '0 4px 6px -1px rgb(0 0 0 / 0.25)',
+      border: `1px solid ${darkColors.borderStrong}`,
+    },
+  },
+  labels: {
+    text: { fill: darkColors.textSecondary, fontSize: 11 },
+  },
+}

--- a/ui/src/test/components/common/ThemeToggle.test.tsx
+++ b/ui/src/test/components/common/ThemeToggle.test.tsx
@@ -1,0 +1,102 @@
+/**
+ * Tests for ThemeToggle component.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { ThemeToggle } from '@/components/common/ThemeToggle'
+import { ThemeProvider } from '@/hooks/useTheme'
+
+function wrapper({ children }: { children: ReactNode }) {
+  return <ThemeProvider>{children}</ThemeProvider>
+}
+
+describe('ThemeToggle', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    document.documentElement.classList.remove('dark')
+  })
+
+  it('renders a button', () => {
+    render(<ThemeToggle />, { wrapper })
+    expect(screen.getByRole('button')).toBeInTheDocument()
+  })
+
+  it('has an accessible aria-label', () => {
+    render(<ThemeToggle />, { wrapper })
+    const btn = screen.getByRole('button')
+    expect(btn).toHaveAttribute('aria-label')
+    expect(btn.getAttribute('aria-label')).toMatch(/theme/i)
+  })
+
+  it('cycles from system to light on click', () => {
+    // Default stored theme is 'system'
+    render(<ThemeToggle />, { wrapper })
+    const btn = screen.getByRole('button')
+
+    fireEvent.click(btn)
+
+    // After clicking system → light, dark class should be removed
+    expect(document.documentElement.classList.contains('dark')).toBe(false)
+  })
+
+  it('applies custom className', () => {
+    render(<ThemeToggle className="custom-class" />, { wrapper })
+    expect(screen.getByRole('button')).toHaveClass('custom-class')
+  })
+
+  it('calls setTheme on click', () => {
+    // Spy via module mock would be complex; verify DOM effect instead
+    localStorage.setItem(
+      'agentd:settings',
+      JSON.stringify({ version: 1, ui: { theme: 'light' } }),
+    )
+    render(<ThemeToggle />, { wrapper })
+    const btn = screen.getByRole('button')
+
+    fireEvent.click(btn)
+
+    // light → dark
+    expect(document.documentElement.classList.contains('dark')).toBe(true)
+  })
+
+  it('label reflects current system mode', () => {
+    render(<ThemeToggle />, { wrapper })
+    expect(screen.getByRole('button')).toHaveAttribute(
+      'aria-label',
+      expect.stringContaining('System'),
+    )
+  })
+
+  it('label reflects current light mode', () => {
+    localStorage.setItem(
+      'agentd:settings',
+      JSON.stringify({ version: 1, ui: { theme: 'light' } }),
+    )
+    render(<ThemeToggle />, { wrapper })
+    expect(screen.getByRole('button')).toHaveAttribute(
+      'aria-label',
+      expect.stringContaining('Light'),
+    )
+  })
+
+  it('label reflects current dark mode', () => {
+    localStorage.setItem(
+      'agentd:settings',
+      JSON.stringify({ version: 1, ui: { theme: 'dark' } }),
+    )
+    render(<ThemeToggle />, { wrapper })
+    expect(screen.getByRole('button')).toHaveAttribute(
+      'aria-label',
+      expect.stringContaining('Dark'),
+    )
+  })
+
+  it('does not throw when ThemeProvider is missing', () => {
+    // suppress error boundary output
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    expect(() => render(<ThemeToggle />)).toThrow()
+    spy.mockRestore()
+  })
+})

--- a/ui/src/test/components/settings/UIPreferences.test.tsx
+++ b/ui/src/test/components/settings/UIPreferences.test.tsx
@@ -1,7 +1,14 @@
 import { describe, it, expect, vi } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
+import type { ReactNode } from 'react'
 import { UIPreferences } from '@/components/settings/UIPreferences'
+import { ThemeProvider } from '@/hooks/useTheme'
 import type { Settings } from '@/stores/settingsStore'
+
+// UIPreferences now calls useTheme() → must be wrapped in ThemeProvider
+function wrapper({ children }: { children: ReactNode }) {
+  return <ThemeProvider>{children}</ThemeProvider>
+}
 
 const defaultUI: Settings['ui'] = {
   theme: 'system',
@@ -13,7 +20,7 @@ const defaultUI: Settings['ui'] = {
 
 describe('UIPreferences', () => {
   it('renders all preference fields', () => {
-    render(<UIPreferences ui={defaultUI} onSave={vi.fn()} />)
+    render(<UIPreferences ui={defaultUI} onSave={vi.fn()} />, { wrapper })
     expect(screen.getByLabelText(/theme/i)).toBeInTheDocument()
     expect(screen.getByLabelText(/open by default/i)).toBeInTheDocument()
     expect(screen.getByLabelText(/refresh interval/i)).toBeInTheDocument()
@@ -23,7 +30,7 @@ describe('UIPreferences', () => {
 
   it('calls onSave when Save is clicked with current values', () => {
     const onSave = vi.fn()
-    render(<UIPreferences ui={defaultUI} onSave={onSave} />)
+    render(<UIPreferences ui={defaultUI} onSave={onSave} />, { wrapper })
 
     fireEvent.click(screen.getByRole('button', { name: /^save$/i }))
 
@@ -32,7 +39,7 @@ describe('UIPreferences', () => {
 
   it('changing theme select updates the value passed to onSave', () => {
     const onSave = vi.fn()
-    render(<UIPreferences ui={defaultUI} onSave={onSave} />)
+    render(<UIPreferences ui={defaultUI} onSave={onSave} />, { wrapper })
 
     const themeSelect = screen.getByLabelText(/theme/i)
     fireEvent.change(themeSelect, { target: { value: 'dark' } })
@@ -44,9 +51,18 @@ describe('UIPreferences', () => {
     )
   })
 
+  it('changing theme select applies theme immediately to DOM', () => {
+    render(<UIPreferences ui={defaultUI} onSave={vi.fn()} />, { wrapper })
+
+    const themeSelect = screen.getByLabelText(/theme/i)
+    fireEvent.change(themeSelect, { target: { value: 'dark' } })
+
+    expect(document.documentElement.classList.contains('dark')).toBe(true)
+  })
+
   it('unchecking sidebar checkbox updates the value passed to onSave', () => {
     const onSave = vi.fn()
-    render(<UIPreferences ui={defaultUI} onSave={onSave} />)
+    render(<UIPreferences ui={defaultUI} onSave={onSave} />, { wrapper })
 
     const sidebarCheckbox = screen.getByLabelText(/open by default/i)
     fireEvent.click(sidebarCheckbox)
@@ -60,7 +76,7 @@ describe('UIPreferences', () => {
 
   it('changing refresh interval updates the value passed to onSave', () => {
     const onSave = vi.fn()
-    render(<UIPreferences ui={defaultUI} onSave={onSave} />)
+    render(<UIPreferences ui={defaultUI} onSave={onSave} />, { wrapper })
 
     const intervalSelect = screen.getByLabelText(/refresh interval/i)
     fireEvent.change(intervalSelect, { target: { value: '120' } })

--- a/ui/src/test/hooks/useTheme.test.tsx
+++ b/ui/src/test/hooks/useTheme.test.tsx
@@ -1,0 +1,155 @@
+/**
+ * Tests for useTheme hook and ThemeProvider.
+ *
+ * These are unit tests that verify:
+ * - ThemeProvider reads initial theme from settingsStore
+ * - setTheme updates DOM class and persists to localStorage
+ * - System mode responds to prefers-color-scheme changes
+ * - resolvedTheme correctly reflects the active theme
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import type { ReactNode } from 'react'
+import { ThemeProvider, useTheme } from '@/hooks/useTheme'
+
+// ---------------------------------------------------------------------------
+// Test wrapper
+// ---------------------------------------------------------------------------
+
+function wrapper({ children }: { children: ReactNode }) {
+  return <ThemeProvider>{children}</ThemeProvider>
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function setStoredTheme(theme: 'light' | 'dark' | 'system') {
+  localStorage.setItem(
+    'agentd:settings',
+    JSON.stringify({ version: 1, ui: { theme } }),
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('useTheme', () => {
+  beforeEach(() => {
+    localStorage.clear()
+    document.documentElement.classList.remove('dark')
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    document.documentElement.classList.remove('dark')
+  })
+
+  it('defaults to system theme when no preference is stored', () => {
+    const { result } = renderHook(() => useTheme(), { wrapper })
+    expect(result.current.theme).toBe('system')
+  })
+
+  it('reads stored light preference', () => {
+    setStoredTheme('light')
+    const { result } = renderHook(() => useTheme(), { wrapper })
+    expect(result.current.theme).toBe('light')
+  })
+
+  it('reads stored dark preference', () => {
+    setStoredTheme('dark')
+    const { result } = renderHook(() => useTheme(), { wrapper })
+    expect(result.current.theme).toBe('dark')
+  })
+
+  it('adds dark class to documentElement when theme is dark', () => {
+    setStoredTheme('dark')
+    renderHook(() => useTheme(), { wrapper })
+    expect(document.documentElement.classList.contains('dark')).toBe(true)
+  })
+
+  it('removes dark class when theme is light', () => {
+    document.documentElement.classList.add('dark')
+    setStoredTheme('light')
+    renderHook(() => useTheme(), { wrapper })
+    expect(document.documentElement.classList.contains('dark')).toBe(false)
+  })
+
+  it('setTheme updates the theme and applies to DOM', () => {
+    const { result } = renderHook(() => useTheme(), { wrapper })
+
+    act(() => {
+      result.current.setTheme('dark')
+    })
+
+    expect(result.current.theme).toBe('dark')
+    expect(document.documentElement.classList.contains('dark')).toBe(true)
+  })
+
+  it('setTheme light removes dark class', () => {
+    document.documentElement.classList.add('dark')
+    const { result } = renderHook(() => useTheme(), { wrapper })
+
+    act(() => {
+      result.current.setTheme('light')
+    })
+
+    expect(result.current.theme).toBe('light')
+    expect(document.documentElement.classList.contains('dark')).toBe(false)
+  })
+
+  it('setTheme persists to localStorage', () => {
+    const { result } = renderHook(() => useTheme(), { wrapper })
+
+    act(() => {
+      result.current.setTheme('dark')
+    })
+
+    const stored = JSON.parse(localStorage.getItem('agentd:settings') ?? '{}')
+    expect(stored.ui.theme).toBe('dark')
+  })
+
+  it('resolvedTheme is light when theme is light', () => {
+    setStoredTheme('light')
+    const { result } = renderHook(() => useTheme(), { wrapper })
+    expect(result.current.resolvedTheme).toBe('light')
+  })
+
+  it('resolvedTheme is dark when theme is dark', () => {
+    setStoredTheme('dark')
+    const { result } = renderHook(() => useTheme(), { wrapper })
+    expect(result.current.resolvedTheme).toBe('dark')
+  })
+
+  it('resolvedTheme follows system preference in system mode', () => {
+    // Mock matchMedia to report dark preference
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      value: vi.fn().mockImplementation((query: string) => ({
+        matches: query === '(prefers-color-scheme: dark)',
+        media: query,
+        onchange: null,
+        addListener: vi.fn(),
+        removeListener: vi.fn(),
+        addEventListener: vi.fn(),
+        removeEventListener: vi.fn(),
+        dispatchEvent: vi.fn(),
+      })),
+    })
+
+    const { result } = renderHook(() => useTheme(), { wrapper })
+    // system mode → dark OS preference → resolvedTheme = dark
+    expect(result.current.resolvedTheme).toBe('dark')
+  })
+
+  it('throws when used outside ThemeProvider', () => {
+    // Suppress the error boundary console output
+    const spy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    expect(() => renderHook(() => useTheme())).toThrow(
+      'useTheme must be used within a ThemeProvider',
+    )
+    spy.mockRestore()
+  })
+})

--- a/ui/src/test/integration/accessibility.test.tsx
+++ b/ui/src/test/integration/accessibility.test.tsx
@@ -10,6 +10,7 @@ import { render } from '@testing-library/react'
 import { axe } from '@/test/setup'
 import { MemoryRouter } from 'react-router-dom'
 import { LayoutContext } from '@/layouts/context'
+import { ThemeProvider } from '@/hooks/useTheme'
 import type { LayoutContextValue } from '@/layouts/context'
 import { vi } from 'vitest'
 import { StatusBadge } from '@/components/common/StatusBadge'
@@ -35,9 +36,11 @@ function makeCtx(): LayoutContextValue {
 
 function withRouter(element: React.ReactElement) {
   return (
-    <MemoryRouter>
-      <LayoutContext.Provider value={makeCtx()}>{element}</LayoutContext.Provider>
-    </MemoryRouter>
+    <ThemeProvider>
+      <MemoryRouter>
+        <LayoutContext.Provider value={makeCtx()}>{element}</LayoutContext.Provider>
+      </MemoryRouter>
+    </ThemeProvider>
   )
 }
 

--- a/ui/src/test/layouts/Header.test.tsx
+++ b/ui/src/test/layouts/Header.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, fireEvent } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import { Header } from '@/layouts/Header'
 import { LayoutContext } from '@/layouts/context'
+import { ThemeProvider } from '@/hooks/useTheme'
 import type { LayoutContextValue } from '@/layouts/context'
 
 // ---------------------------------------------------------------------------
@@ -26,11 +27,13 @@ function renderHeader(props = {}, contextOverrides: Partial<LayoutContextValue> 
   return {
     ctx,
     ...render(
-      <MemoryRouter>
-        <LayoutContext.Provider value={ctx}>
-          <Header {...props} />
-        </LayoutContext.Provider>
-      </MemoryRouter>,
+      <ThemeProvider>
+        <MemoryRouter>
+          <LayoutContext.Provider value={ctx}>
+            <Header {...props} />
+          </LayoutContext.Provider>
+        </MemoryRouter>
+      </ThemeProvider>,
     ),
   }
 }
@@ -101,5 +104,10 @@ describe('Header', () => {
     renderHeader()
     const btn = screen.getByRole('button', { name: /global search/i })
     expect(btn).toHaveAttribute('aria-keyshortcuts', 'Control+k Meta+k')
+  })
+
+  it('renders the theme toggle button', () => {
+    renderHeader()
+    expect(screen.getByRole('button', { name: /theme/i })).toBeInTheDocument()
   })
 })

--- a/ui/src/test/setup.ts
+++ b/ui/src/test/setup.ts
@@ -9,8 +9,28 @@
 
 import '@testing-library/jest-dom'
 import { configureAxe, toHaveNoViolations } from 'jest-axe'
-import { expect, beforeAll, afterEach, afterAll } from 'vitest'
+import { expect, beforeAll, afterEach, afterAll, vi } from 'vitest'
 import { server } from './mocks/server'
+
+// ---------------------------------------------------------------------------
+// window.matchMedia — jsdom does not implement matchMedia, so we provide a
+// functional stub that defaults to the light colour scheme. Individual tests
+// can override this with vi.fn() if they need to test dark-mode behaviour.
+// ---------------------------------------------------------------------------
+
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn().mockImplementation((query: string) => ({
+    matches: false, // default: light theme / no special media query match
+    media: query,
+    onchange: null,
+    addListener: vi.fn(),
+    removeListener: vi.fn(),
+    addEventListener: vi.fn(),
+    removeEventListener: vi.fn(),
+    dispatchEvent: vi.fn(),
+  })),
+})
 
 // ---------------------------------------------------------------------------
 // Extend Vitest's expect with jest-axe accessibility matchers

--- a/ui/src/test/stores/themeStore.test.ts
+++ b/ui/src/test/stores/themeStore.test.ts
@@ -1,0 +1,118 @@
+/**
+ * Tests for themeStore pure functions.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { resolveTheme, applyTheme, readPersistedTheme } from '@/stores/themeStore'
+
+function mockMatchMedia(prefersDark: boolean) {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: vi.fn().mockImplementation((query: string) => ({
+      matches: prefersDark && query === '(prefers-color-scheme: dark)',
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    })),
+  })
+}
+
+describe('resolveTheme', () => {
+  afterEach(() => vi.restoreAllMocks())
+
+  it('returns light for light mode', () => {
+    expect(resolveTheme('light')).toBe('light')
+  })
+
+  it('returns dark for dark mode', () => {
+    expect(resolveTheme('dark')).toBe('dark')
+  })
+
+  it('returns dark when system prefers dark', () => {
+    mockMatchMedia(true)
+    expect(resolveTheme('system')).toBe('dark')
+  })
+
+  it('returns light when system prefers light', () => {
+    mockMatchMedia(false)
+    expect(resolveTheme('system')).toBe('light')
+  })
+})
+
+describe('applyTheme', () => {
+  beforeEach(() => {
+    document.documentElement.classList.remove('dark')
+  })
+
+  afterEach(() => {
+    document.documentElement.classList.remove('dark')
+    vi.restoreAllMocks()
+  })
+
+  it('adds dark class for dark mode', () => {
+    applyTheme('dark')
+    expect(document.documentElement.classList.contains('dark')).toBe(true)
+  })
+
+  it('removes dark class for light mode', () => {
+    document.documentElement.classList.add('dark')
+    applyTheme('light')
+    expect(document.documentElement.classList.contains('dark')).toBe(false)
+  })
+
+  it('adds dark class when system prefers dark', () => {
+    mockMatchMedia(true)
+    applyTheme('system')
+    expect(document.documentElement.classList.contains('dark')).toBe(true)
+  })
+
+  it('removes dark class when system prefers light', () => {
+    document.documentElement.classList.add('dark')
+    mockMatchMedia(false)
+    applyTheme('system')
+    expect(document.documentElement.classList.contains('dark')).toBe(false)
+  })
+})
+
+describe('readPersistedTheme', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('returns system when nothing is stored', () => {
+    expect(readPersistedTheme()).toBe('system')
+  })
+
+  it('returns light from stored settings', () => {
+    localStorage.setItem(
+      'agentd:settings',
+      JSON.stringify({ ui: { theme: 'light' } }),
+    )
+    expect(readPersistedTheme()).toBe('light')
+  })
+
+  it('returns dark from stored settings', () => {
+    localStorage.setItem(
+      'agentd:settings',
+      JSON.stringify({ ui: { theme: 'dark' } }),
+    )
+    expect(readPersistedTheme()).toBe('dark')
+  })
+
+  it('returns system for invalid stored value', () => {
+    localStorage.setItem(
+      'agentd:settings',
+      JSON.stringify({ ui: { theme: 'rainbow' } }),
+    )
+    expect(readPersistedTheme()).toBe('system')
+  })
+
+  it('returns system on malformed JSON', () => {
+    localStorage.setItem('agentd:settings', 'not json {{{')
+    expect(readPersistedTheme()).toBe('system')
+  })
+})

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -25,6 +25,7 @@ export default defineConfig(({ mode }) => {
         '@/utils': path.resolve(__dirname, './src/utils'),
         '@/stores': path.resolve(__dirname, './src/stores'),
         '@/test': path.resolve(__dirname, './src/test'),
+        '@/styles': path.resolve(__dirname, './src/styles'),
       },
     },
     server: {


### PR DESCRIPTION
## Summary

- **`themeStore.ts`** — Pure DOM helpers: `resolveTheme()`, `applyTheme()`, `readPersistedTheme()`; toggles the `dark` class on `<html>`
- **`useTheme.tsx`** — `ThemeProvider` + `useTheme()` context hook; reads from `settingsStore`, applies on mount, watches `prefers-color-scheme` media query changes for system mode
- **`styles/themes.ts`** — Light/dark color palettes (`lightColors`/`darkColors`) and matching Nivo chart theme objects (`lightNivoTheme`/`darkNivoTheme`)
- **`useNivoTheme.ts`** — Hook returning the active Nivo `PartialTheme` based on resolved theme
- **`ThemeToggle.tsx`** — Header icon button cycling `system → light → dark → system` with Monitor/Sun/Moon icons and descriptive `aria-label`
- **Anti-FOUC** — Inline synchronous `<script>` in `index.html` reads `agentd:settings` before React hydration and applies the `dark` class if needed (no flash)
- **Tailwind class strategy** — `@custom-variant dark (&:where(.dark, .dark *))` in `index.css` enables `dark:` variants via `.dark` class on `<html>`
- **Semantic CSS variables** — `--bg-primary/secondary/tertiary`, `--text-primary/secondary/muted`, `--border-default/strong`, `--accent-primary`, status colors; defined for both `:root` and `.dark`
- **Smooth transitions** — 150ms `transition-property: background-color, border-color` globally; `.no-theme-transition` opt-out class for SVG/chart elements
- **Settings integration** — `UIPreferences` theme select calls `setTheme()` immediately so the user sees the change in real time before clicking Save

## Test plan

- [x] 249 tests passing across 31 test files (added 36 new tests)
- [x] `themeStore.test.ts` — 13 tests covering `resolveTheme`, `applyTheme`, `readPersistedTheme`
- [x] `useTheme.test.tsx` — 12 tests: context reads preferences, updates DOM class, persists to localStorage, follows system preference
- [x] `ThemeToggle.test.tsx` — 8 tests: renders, click cycling, aria labels, custom className
- [x] `UIPreferences.test.tsx` — Updated with `ThemeProvider` wrapper + live-apply test
- [x] `Header.test.tsx` — Updated with `ThemeProvider` wrapper + theme toggle button test
- [x] `accessibility.test.tsx` — Updated with `ThemeProvider` wrapper
- [x] `setup.ts` — Global `window.matchMedia` stub added for jsdom
- [x] TypeScript compiles clean (`tsc --noEmit`)

Closes #180

🤖 Generated with [Claude Code](https://claude.com/claude-code)