### PR TITLE
feat(ui): implement WebSocket infrastructure for real-time agent streaming

### DIFF
--- a/ui/src/components/common/ConnectionStatus.tsx
+++ b/ui/src/components/common/ConnectionStatus.tsx
@@ -1,0 +1,90 @@
+/**
+ * ConnectionStatus — visual indicator for a WebSocket connection state.
+ *
+ * Renders a small coloured dot plus an optional text label.
+ * Pass the `connectionState` from useWebSocket, useAllAgentsStream,
+ * or useAgentStream to drive the indicator.
+ *
+ * States:
+ *   Connected    — green dot
+ *   Connecting   — yellow pulsing dot
+ *   Reconnecting — yellow pulsing dot
+ *   Disconnected — red dot
+ */
+
+import type { ConnectionState } from '@/services/websocket'
+
+// ---------------------------------------------------------------------------
+// Props
+// ---------------------------------------------------------------------------
+
+export interface ConnectionStatusProps {
+  connectionState: ConnectionState
+  /** Optional label override (default: state name) */
+  label?: string
+  /** Hide the text label — show only the dot (default: false) */
+  iconOnly?: boolean
+  className?: string
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function stateClasses(state: ConnectionState): { dot: string; text: string } {
+  switch (state) {
+    case 'Connected':
+      return {
+        dot: 'bg-green-500',
+        text: 'text-green-500 dark:text-green-400',
+      }
+    case 'Connecting':
+    case 'Reconnecting':
+      return {
+        dot: 'animate-pulse bg-yellow-400',
+        text: 'text-yellow-500 dark:text-yellow-400',
+      }
+    case 'Disconnected':
+      return {
+        dot: 'bg-red-500',
+        text: 'text-red-500 dark:text-red-400',
+      }
+  }
+}
+
+const STATE_LABELS: Record<ConnectionState, string> = {
+  Connected: 'Connected',
+  Connecting: 'Connecting',
+  Reconnecting: 'Reconnecting',
+  Disconnected: 'Disconnected',
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function ConnectionStatus({
+  connectionState,
+  label,
+  iconOnly = false,
+  className = '',
+}: ConnectionStatusProps) {
+  const { dot, text } = stateClasses(connectionState)
+  const displayLabel = label ?? STATE_LABELS[connectionState]
+
+  return (
+    <span
+      role="status"
+      aria-label={`Stream: ${displayLabel}`}
+      className={`flex items-center gap-1.5 text-xs ${text} ${className}`}
+    >
+      <span
+        aria-hidden="true"
+        className={`h-2 w-2 flex-shrink-0 rounded-full ${dot}`}
+      />
+      {!iconOnly && <span>{displayLabel}</span>}
+    </span>
+  )
+}
+
+export default ConnectionStatus

--- a/ui/src/components/common/index.ts
+++ b/ui/src/components/common/index.ts
@@ -1,5 +1,7 @@
 export { StatusBadge } from './StatusBadge'
 export type { ServiceStatus } from './StatusBadge'
+export { ConnectionStatus } from './ConnectionStatus'
+export type { ConnectionStatusProps } from './ConnectionStatus'
 export { Skeleton, CardSkeleton, ListItemSkeleton, ChartSkeleton } from './LoadingSkeleton'
 export { ThemeToggle } from './ThemeToggle'
 export type { ThemeToggleProps } from './ThemeToggle'

--- a/ui/src/hooks/index.ts
+++ b/ui/src/hooks/index.ts
@@ -23,3 +23,12 @@ export type { UseAgentDetailOptions, UseAgentDetailResult } from './useAgentDeta
 
 export { useAgentStream } from './useAgentStream'
 export type { StreamStatus, LogLine, UseAgentStreamResult } from './useAgentStream'
+
+export { useWebSocket } from './useWebSocket'
+export type { ConnectionState, UseWebSocketResult, UseWebSocketOptions } from './useWebSocket'
+
+export { useAllAgentsStream } from './useAllAgentsStream'
+export type { UseAllAgentsStreamResult } from './useAllAgentsStream'
+
+export { useAgentEvents } from './useAgentEvents'
+export type { UseAgentEventsResult } from './useAgentEvents'

--- a/ui/src/hooks/useAgentEvents.ts
+++ b/ui/src/hooks/useAgentEvents.ts
@@ -1,0 +1,64 @@
+/**
+ * useAgentEvents — subscribes to typed events emitted by the central
+ * agentEventBus.
+ *
+ * Events are produced by useAllAgentsStream as it parses WebSocket messages
+ * from the /stream endpoint.
+ *
+ * Usage:
+ *   const { subscribe } = useAgentEvents()
+ *
+ *   useEffect(() => {
+ *     return subscribe('agent:status_change', event => {
+ *       console.log(event.agentId, event.status)
+ *     })
+ *   }, [subscribe])
+ */
+
+import { useCallback, useEffect, useRef } from 'react'
+import { agentEventBus } from '@/services/eventBus'
+import type { AgentEvent } from '@/types/orchestrator'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface UseAgentEventsResult {
+  /**
+   * Subscribe to a specific event type.
+   * @returns Cleanup function — store and call in useEffect cleanup.
+   */
+  subscribe: <T extends AgentEvent>(
+    type: T['type'],
+    handler: (event: T) => void,
+  ) => () => void
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+export function useAgentEvents(): UseAgentEventsResult {
+  // Track active subscriptions for cleanup on unmount
+  const cleanupFns = useRef<Array<() => void>>([])
+
+  useEffect(() => {
+    return () => {
+      for (const fn of cleanupFns.current) {
+        fn()
+      }
+      cleanupFns.current = []
+    }
+  }, [])
+
+  const subscribe = useCallback(
+    <T extends AgentEvent>(type: T['type'], handler: (event: T) => void) => {
+      const cleanup = agentEventBus.on(type, handler)
+      cleanupFns.current.push(cleanup)
+      return cleanup
+    },
+    [],
+  )
+
+  return { subscribe }
+}

--- a/ui/src/hooks/useAgentStream.ts
+++ b/ui/src/hooks/useAgentStream.ts
@@ -1,16 +1,17 @@
 /**
  * useAgentStream — WebSocket hook for real-time agent log streaming.
  *
- * Features:
- * - Connects to ws://<host>/ws/<agentId> on mount
- * - Auto-reconnect on disconnect with exponential backoff
- * - Maintains a capped circular buffer of the last MAX_LINES log lines
- * - Exposes stream status: 'connecting' | 'connected' | 'disconnected'
- * - clear() resets the visible buffer without affecting the stream
+ * Connects to ws://<host>/ws/<agentId> via WebSocketManager, which
+ * handles auto-reconnect (exponential backoff), heartbeat detection,
+ * and message buffering.
+ *
+ * Returns a capped circular buffer of up to MAX_LINES log lines plus
+ * a connection status indicator.
  */
 
 import { useCallback, useEffect, useRef, useState } from 'react'
-import { orchestratorClient } from '@/services/orchestrator'
+import { WebSocketManager } from '@/services/websocket'
+import { serviceConfig } from '@/services/config'
 
 // ---------------------------------------------------------------------------
 // Types
@@ -36,9 +37,7 @@ export interface UseAgentStreamResult {
 // Constants
 // ---------------------------------------------------------------------------
 
-const MAX_LINES = 5000
-const MIN_RECONNECT_DELAY_MS = 1_000
-const MAX_RECONNECT_DELAY_MS = 30_000
+const MAX_LINES = 5_000
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -54,11 +53,15 @@ function makeLogLine(text: string): LogLine {
   }
 }
 
-/** Cap the buffer at MAX_LINES, discarding oldest entries */
 function capLines(prev: LogLine[], incoming: LogLine[]): LogLine[] {
   const combined = [...prev, ...incoming]
   if (combined.length <= MAX_LINES) return combined
   return combined.slice(combined.length - MAX_LINES)
+}
+
+function agentStreamUrl(agentId: string): string {
+  const wsBase = serviceConfig.orchestratorServiceUrl.replace(/^http/, 'ws')
+  return `${wsBase}/ws/${agentId}`
 }
 
 // ---------------------------------------------------------------------------
@@ -69,71 +72,45 @@ export function useAgentStream(agentId: string): UseAgentStreamResult {
   const [lines, setLines] = useState<LogLine[]>([])
   const [status, setStatus] = useState<StreamStatus>('connecting')
 
-  const wsRef = useRef<WebSocket | null>(null)
-  const reconnectDelayRef = useRef(MIN_RECONNECT_DELAY_MS)
-  const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
-  const unmountedRef = useRef(false)
-
-  const connect = useCallback(() => {
-    if (unmountedRef.current) return
-
-    setStatus('connecting')
-
-    const ws = orchestratorClient.connectAgentStream(agentId)
-    wsRef.current = ws
-
-    ws.onopen = () => {
-      if (unmountedRef.current) { ws.close(); return }
-      setStatus('connected')
-      reconnectDelayRef.current = MIN_RECONNECT_DELAY_MS
-    }
-
-    ws.onmessage = (event: MessageEvent) => {
-      if (unmountedRef.current) return
-      // Each message may be a single line or newline-separated block
-      const rawText = String(event.data)
-      const incoming = rawText
-        .split('\n')
-        .filter(Boolean)
-        .map(makeLogLine)
-      setLines(prev => capLines(prev, incoming))
-    }
-
-    ws.onerror = () => {
-      // onerror fires before onclose; the actual reconnect is scheduled in onclose
-    }
-
-    ws.onclose = () => {
-      if (unmountedRef.current) return
-      setStatus('disconnected')
-      wsRef.current = null
-
-      // Exponential backoff reconnect
-      const delay = reconnectDelayRef.current
-      reconnectDelayRef.current = Math.min(delay * 2, MAX_RECONNECT_DELAY_MS)
-
-      reconnectTimerRef.current = setTimeout(() => {
-        if (!unmountedRef.current) connect()
-      }, delay)
-    }
-  }, [agentId])
+  const managerRef = useRef<WebSocketManager | null>(null)
 
   useEffect(() => {
-    unmountedRef.current = false
-    connect()
+    const manager = new WebSocketManager(agentStreamUrl(agentId), {
+      // Disable heartbeat — agent output arrives irregularly; a ping
+      // would be noise in the log stream
+      heartbeatInterval: 0,
+    })
+    managerRef.current = manager
+
+    const unsubState = manager.onStateChange(state => {
+      switch (state) {
+        case 'Connected':
+          setStatus('connected')
+          break
+        case 'Disconnected':
+          setStatus('disconnected')
+          break
+        default:
+          // Connecting | Reconnecting → show as 'connecting'
+          setStatus('connecting')
+      }
+    })
+
+    const unsubMsg = manager.onMessage((event: MessageEvent) => {
+      const rawText = String(event.data)
+      const incoming = rawText.split('\n').filter(Boolean).map(makeLogLine)
+      setLines(prev => capLines(prev, incoming))
+    })
+
+    manager.connect()
 
     return () => {
-      unmountedRef.current = true
-      if (reconnectTimerRef.current) {
-        clearTimeout(reconnectTimerRef.current)
-      }
-      if (wsRef.current) {
-        wsRef.current.onclose = null // prevent reconnect on intentional close
-        wsRef.current.close()
-        wsRef.current = null
-      }
+      unsubState()
+      unsubMsg()
+      manager.disconnect()
+      managerRef.current = null
     }
-  }, [connect])
+  }, [agentId])
 
   const clear = useCallback(() => setLines([]), [])
 

--- a/ui/src/hooks/useAllAgentsStream.ts
+++ b/ui/src/hooks/useAllAgentsStream.ts
@@ -1,0 +1,124 @@
+/**
+ * useAllAgentsStream — monitors the multiplexed /stream endpoint.
+ *
+ * Connects to ws://<host>/stream and demultiplexes incoming JSON messages
+ * by agent ID. Each message is expected to be a JSON object conforming to
+ * one of the AgentEvent shapes defined in @/types/orchestrator.
+ *
+ * Non-JSON messages are treated as plain text output for an 'unknown' sender
+ * to ensure graceful fallback.
+ *
+ * Returns:
+ *   agentMessages   - Map of agentId → log lines (last MAX_LINES_PER_AGENT)
+ *   connectionState - WebSocket connection state
+ */
+
+import { useEffect, useRef, useState } from 'react'
+import { WebSocketManager } from '@/services/websocket'
+import { serviceConfig } from '@/services/config'
+import { agentEventBus } from '@/services/eventBus'
+import type { ConnectionState } from '@/services/websocket'
+import type { AgentEvent } from '@/types/orchestrator'
+import type { LogLine } from './useAgentStream'
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const MAX_LINES_PER_AGENT = 1_000
+
+let msgId = 0
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function allStreamUrl(): string {
+  const wsBase = serviceConfig.orchestratorServiceUrl.replace(/^http/, 'ws')
+  return `${wsBase}/stream`
+}
+
+function makeLine(text: string): LogLine {
+  return { id: ++msgId, text, timestamp: new Date().toISOString() }
+}
+
+function addLine(
+  prev: Map<string, LogLine[]>,
+  agentId: string,
+  line: LogLine,
+): Map<string, LogLine[]> {
+  const existing = prev.get(agentId) ?? []
+  const updated = [...existing, line]
+  const capped =
+    updated.length > MAX_LINES_PER_AGENT
+      ? updated.slice(updated.length - MAX_LINES_PER_AGENT)
+      : updated
+  const next = new Map(prev)
+  next.set(agentId, capped)
+  return next
+}
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface UseAllAgentsStreamResult {
+  /** Map of agentId → buffered log lines from the /stream endpoint */
+  agentMessages: Map<string, LogLine[]>
+  connectionState: ConnectionState
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+export function useAllAgentsStream(): UseAllAgentsStreamResult {
+  const [agentMessages, setAgentMessages] = useState<Map<string, LogLine[]>>(
+    new Map(),
+  )
+  const [connectionState, setConnectionState] =
+    useState<ConnectionState>('Disconnected')
+
+  const managerRef = useRef<WebSocketManager | null>(null)
+
+  useEffect(() => {
+    const manager = new WebSocketManager(allStreamUrl())
+    managerRef.current = manager
+
+    const unsubState = manager.onStateChange(setConnectionState)
+
+    const unsubMsg = manager.onMessage((event: MessageEvent) => {
+      const raw = String(event.data)
+
+      let parsed: AgentEvent | null = null
+      try {
+        parsed = JSON.parse(raw) as AgentEvent
+      } catch {
+        // Non-JSON fallback: treat as plain output
+        setAgentMessages(prev => addLine(prev, 'unknown', makeLine(raw)))
+        return
+      }
+
+      // Broadcast to all event bus subscribers
+      agentEventBus.emit(parsed)
+
+      // Maintain the per-agent log buffer for output events
+      if (parsed.type === 'agent:output') {
+        setAgentMessages(prev =>
+          addLine(prev, parsed.agentId, makeLine(parsed.line)),
+        )
+      }
+    })
+
+    manager.connect()
+
+    return () => {
+      unsubState()
+      unsubMsg()
+      manager.disconnect()
+      managerRef.current = null
+    }
+  }, [])
+
+  return { agentMessages, connectionState }
+}

--- a/ui/src/hooks/useWebSocket.ts
+++ b/ui/src/hooks/useWebSocket.ts
@@ -1,0 +1,94 @@
+/**
+ * useWebSocket — low-level React hook wrapping WebSocketManager.
+ *
+ * Auto-connects on mount and disconnects on unmount.
+ * Re-connects whenever the URL changes.
+ *
+ * Returns:
+ *   messages        - received MessageEvents (newest-last, capped at maxMessages)
+ *   connectionState - current ConnectionState
+ *   send            - send a text message (buffered while disconnected)
+ *   disconnect      - manually close the connection
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { WebSocketManager } from '@/services/websocket'
+import type { ConnectionState, WebSocketManagerOptions } from '@/services/websocket'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type { ConnectionState }
+
+export interface UseWebSocketResult {
+  /** Received MessageEvents — newest last, capped at maxMessages */
+  messages: MessageEvent[]
+  connectionState: ConnectionState
+  /** Send a text message; buffers up to messageBufferSize msgs if disconnected */
+  send: (message: string) => void
+  /** Manually close the connection */
+  disconnect: () => void
+}
+
+export interface UseWebSocketOptions extends WebSocketManagerOptions {
+  /** Max number of messages to retain in state (default 200) */
+  maxMessages?: number
+  /** When true, suppresses auto-connect (default false) */
+  paused?: boolean
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+export function useWebSocket(
+  url: string,
+  options: UseWebSocketOptions = {},
+): UseWebSocketResult {
+  const { maxMessages = 200, paused = false, ...managerOpts } = options
+
+  const managerRef = useRef<WebSocketManager | null>(null)
+  const maxRef = useRef(maxMessages)
+  maxRef.current = maxMessages
+
+  const [messages, setMessages] = useState<MessageEvent[]>([])
+  const [connectionState, setConnectionState] = useState<ConnectionState>('Disconnected')
+
+  const send = useCallback((message: string) => {
+    managerRef.current?.send(message)
+  }, [])
+
+  const disconnect = useCallback(() => {
+    managerRef.current?.disconnect()
+  }, [])
+
+  useEffect(() => {
+    if (paused) return
+
+    const manager = new WebSocketManager(url, managerOpts)
+    managerRef.current = manager
+
+    const unsubState = manager.onStateChange(setConnectionState)
+    const unsubMsg = manager.onMessage((event: MessageEvent) => {
+      setMessages(prev => {
+        const next = [...prev, event]
+        const max = maxRef.current
+        return next.length > max ? next.slice(next.length - max) : next
+      })
+    })
+
+    manager.connect()
+
+    return () => {
+      unsubState()
+      unsubMsg()
+      manager.disconnect()
+      managerRef.current = null
+    }
+    // managerOpts is intentionally omitted — URL/paused changes drive reconnect
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [url, paused])
+
+  return { messages, connectionState, send, disconnect }
+}

--- a/ui/src/layouts/Header.tsx
+++ b/ui/src/layouts/Header.tsx
@@ -1,6 +1,6 @@
 /**
  * Header — fixed top bar with sidebar toggle, logo, search, theme toggle,
- * notifications, and settings.
+ * connection status, notifications, and settings.
  *
  * The search button opens the global SearchPalette (managed by AppShell).
  * Ctrl+K / Cmd+K is handled at the AppShell level.
@@ -10,6 +10,8 @@ import { Link } from 'react-router-dom'
 import { Bell, Menu, Search, Settings } from 'lucide-react'
 import { useLayout } from './context'
 import { ThemeToggle } from '@/components/common/ThemeToggle'
+import { ConnectionStatus } from '@/components/common/ConnectionStatus'
+import { useAllAgentsStream } from '@/hooks/useAllAgentsStream'
 
 // ---------------------------------------------------------------------------
 // Notification badge
@@ -66,6 +68,7 @@ export interface HeaderProps {
 
 export function Header({ unreadCount = 0 }: HeaderProps) {
   const { toggleSidebar } = useLayout()
+  const { connectionState } = useAllAgentsStream()
 
   return (
     <header className="fixed inset-x-0 top-0 z-50 flex h-16 items-center gap-3 border-b border-gray-700 bg-gray-900 px-4 transition-colors duration-150">
@@ -94,6 +97,13 @@ export function Header({ unreadCount = 0 }: HeaderProps) {
 
       {/* Search trigger */}
       <SearchTrigger />
+
+      {/* Global stream connection status (icon only on small screens) */}
+      <ConnectionStatus
+        connectionState={connectionState}
+        iconOnly
+        className="hidden sm:flex"
+      />
 
       {/* Theme toggle */}
       <ThemeToggle />

--- a/ui/src/services/eventBus.ts
+++ b/ui/src/services/eventBus.ts
@@ -1,0 +1,47 @@
+/**
+ * agentEventBus — central pub/sub bus for WebSocket-sourced agent events.
+ *
+ * Components and hooks can subscribe to specific event types without
+ * knowing which WebSocket connection produced them.
+ *
+ * Events are published by useAllAgentsStream as it parses messages
+ * from the /stream endpoint.
+ */
+
+import type { AgentEvent } from '@/types/orchestrator'
+
+type AnyHandler = (event: AgentEvent) => void
+
+class EventBus {
+  private readonly listeners = new Map<string, Set<AnyHandler>>()
+
+  /**
+   * Publish an event to all registered handlers for its type.
+   */
+  emit<T extends AgentEvent>(event: T): void {
+    const handlers = this.listeners.get(event.type)
+    if (!handlers) return
+    for (const handler of handlers) {
+      handler(event)
+    }
+  }
+
+  /**
+   * Subscribe to events of a specific type.
+   * @returns Cleanup function that removes the handler.
+   */
+  on<T extends AgentEvent>(type: T['type'], handler: (event: T) => void): () => void {
+    let handlers = this.listeners.get(type)
+    if (!handlers) {
+      handlers = new Set()
+      this.listeners.set(type, handlers)
+    }
+    handlers.add(handler as AnyHandler)
+    return () => {
+      handlers!.delete(handler as AnyHandler)
+    }
+  }
+}
+
+/** Singleton event bus — import and use this directly */
+export const agentEventBus = new EventBus()

--- a/ui/src/services/websocket.ts
+++ b/ui/src/services/websocket.ts
@@ -1,0 +1,251 @@
+/**
+ * WebSocketManager — full lifecycle management for WebSocket connections.
+ *
+ * Features:
+ * - Connection states: Connecting | Connected | Disconnected | Reconnecting
+ * - Auto-reconnect with exponential backoff (min 1 s, max 30 s)
+ * - Heartbeat/ping to detect stale connections
+ * - Message buffering during reconnection (up to bufferSize messages)
+ * - Typed message and state change handler registration
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type ConnectionState = 'Connecting' | 'Connected' | 'Disconnected' | 'Reconnecting'
+
+type MessageHandler = (event: MessageEvent) => void
+type StateHandler = (state: ConnectionState) => void
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const DEFAULT_MIN_DELAY = 1_000
+const DEFAULT_MAX_DELAY = 30_000
+const DEFAULT_HEARTBEAT_INTERVAL = 15_000
+const DEFAULT_BUFFER_SIZE = 256
+
+// ---------------------------------------------------------------------------
+// Options
+// ---------------------------------------------------------------------------
+
+export interface WebSocketManagerOptions {
+  /** Minimum reconnect delay in ms (default 1 000) */
+  minReconnectDelay?: number
+  /** Maximum reconnect delay in ms (default 30 000) */
+  maxReconnectDelay?: number
+  /**
+   * Heartbeat interval in ms. Set to 0 to disable.
+   * When enabled a "ping" text frame is sent at the given interval to keep
+   * the connection alive and detect stale sockets. (default 15 000)
+   */
+  heartbeatInterval?: number
+  /** Max messages to buffer while reconnecting (default 256) */
+  messageBufferSize?: number
+}
+
+// ---------------------------------------------------------------------------
+// WebSocketManager
+// ---------------------------------------------------------------------------
+
+export class WebSocketManager {
+  private ws: WebSocket | null = null
+  private _state: ConnectionState = 'Disconnected'
+  private readonly messageHandlers = new Set<MessageHandler>()
+  private readonly stateHandlers = new Set<StateHandler>()
+  /** Messages buffered while the socket is not open */
+  private readonly pendingBuffer: string[] = []
+
+  private reconnectTimer: ReturnType<typeof setTimeout> | null = null
+  private heartbeatTimer: ReturnType<typeof setInterval> | null = null
+  private reconnectDelay: number
+  private intentionalClose = false
+
+  private readonly minDelay: number
+  private readonly maxDelay: number
+  private readonly heartbeatInterval: number
+  private readonly bufferSize: number
+
+  constructor(
+    private readonly url: string,
+    options: WebSocketManagerOptions = {},
+  ) {
+    this.minDelay = options.minReconnectDelay ?? DEFAULT_MIN_DELAY
+    this.maxDelay = options.maxReconnectDelay ?? DEFAULT_MAX_DELAY
+    this.heartbeatInterval = options.heartbeatInterval ?? DEFAULT_HEARTBEAT_INTERVAL
+    this.bufferSize = options.messageBufferSize ?? DEFAULT_BUFFER_SIZE
+    this.reconnectDelay = this.minDelay
+  }
+
+  // -------------------------------------------------------------------------
+  // Public API
+  // -------------------------------------------------------------------------
+
+  /** Current connection state */
+  get state(): ConnectionState {
+    return this._state
+  }
+
+  /**
+   * Start the connection. Idempotent — calling while already Connecting or
+   * Connected is a no-op.
+   */
+  connect(): void {
+    if (
+      this.ws &&
+      (this.ws.readyState === WebSocket.CONNECTING ||
+        this.ws.readyState === WebSocket.OPEN)
+    ) {
+      return
+    }
+    this.intentionalClose = false
+    this._open()
+  }
+
+  /** Close the connection and stop any pending reconnect attempts. */
+  disconnect(): void {
+    this.intentionalClose = true
+    this._clearTimers()
+    if (this.ws) {
+      this.ws.onclose = null
+      this.ws.onerror = null
+      this.ws.onmessage = null
+      this.ws.onopen = null
+      this.ws.close()
+      this.ws = null
+    }
+    this._setState('Disconnected')
+  }
+
+  /**
+   * Send a message. If the socket is not currently open the message is
+   * buffered (up to messageBufferSize) and flushed once reconnected.
+   */
+  send(message: string): void {
+    if (this.ws?.readyState === WebSocket.OPEN) {
+      this.ws.send(message)
+    } else {
+      if (this.pendingBuffer.length < this.bufferSize) {
+        this.pendingBuffer.push(message)
+      }
+    }
+  }
+
+  /**
+   * Register a message handler.
+   * @returns Cleanup function that removes the handler.
+   */
+  onMessage(handler: MessageHandler): () => void {
+    this.messageHandlers.add(handler)
+    return () => { this.messageHandlers.delete(handler) }
+  }
+
+  /**
+   * Register a connection-state change handler.
+   * @returns Cleanup function that removes the handler.
+   */
+  onStateChange(handler: StateHandler): () => void {
+    this.stateHandlers.add(handler)
+    return () => { this.stateHandlers.delete(handler) }
+  }
+
+  // -------------------------------------------------------------------------
+  // Private helpers
+  // -------------------------------------------------------------------------
+
+  private _open(): void {
+    this._setState(
+      this._state === 'Disconnected' ? 'Connecting' : 'Reconnecting',
+    )
+
+    try {
+      this.ws = new WebSocket(this.url)
+    } catch {
+      this._scheduleReconnect()
+      return
+    }
+
+    this.ws.onopen = () => {
+      this.reconnectDelay = this.minDelay
+      this._setState('Connected')
+      this._flushBuffer()
+      this._startHeartbeat()
+    }
+
+    this.ws.onmessage = (event: MessageEvent) => {
+      for (const handler of this.messageHandlers) {
+        handler(event)
+      }
+    }
+
+    // onerror is always followed by onclose; let onclose handle reconnect
+    this.ws.onerror = () => {}
+
+    this.ws.onclose = () => {
+      this._clearHeartbeat()
+      if (this.intentionalClose) {
+        this._setState('Disconnected')
+      } else {
+        this._setState('Reconnecting')
+        this._scheduleReconnect()
+      }
+    }
+  }
+
+  private _setState(state: ConnectionState): void {
+    if (this._state === state) return
+    this._state = state
+    for (const handler of this.stateHandlers) {
+      handler(state)
+    }
+  }
+
+  private _scheduleReconnect(): void {
+    this._clearReconnectTimer()
+    this.reconnectTimer = setTimeout(() => {
+      this.reconnectTimer = null
+      if (!this.intentionalClose) {
+        this._open()
+      }
+    }, this.reconnectDelay)
+    this.reconnectDelay = Math.min(this.reconnectDelay * 2, this.maxDelay)
+  }
+
+  private _flushBuffer(): void {
+    const pending = this.pendingBuffer.splice(0)
+    for (const msg of pending) {
+      this.ws?.send(msg)
+    }
+  }
+
+  private _startHeartbeat(): void {
+    if (this.heartbeatInterval <= 0) return
+    this._clearHeartbeat()
+    this.heartbeatTimer = setInterval(() => {
+      if (this.ws?.readyState === WebSocket.OPEN) {
+        this.ws.send('ping')
+      }
+    }, this.heartbeatInterval)
+  }
+
+  private _clearHeartbeat(): void {
+    if (this.heartbeatTimer !== null) {
+      clearInterval(this.heartbeatTimer)
+      this.heartbeatTimer = null
+    }
+  }
+
+  private _clearReconnectTimer(): void {
+    if (this.reconnectTimer !== null) {
+      clearTimeout(this.reconnectTimer)
+      this.reconnectTimer = null
+    }
+  }
+
+  private _clearTimers(): void {
+    this._clearReconnectTimer()
+    this._clearHeartbeat()
+  }
+}

--- a/ui/src/test/components/common/ConnectionStatus.test.tsx
+++ b/ui/src/test/components/common/ConnectionStatus.test.tsx
@@ -1,0 +1,62 @@
+/**
+ * Tests for ConnectionStatus component.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { ConnectionStatus } from '@/components/common/ConnectionStatus'
+import type { ConnectionState } from '@/services/websocket'
+
+describe('ConnectionStatus', () => {
+  const states: ConnectionState[] = [
+    'Connected',
+    'Connecting',
+    'Reconnecting',
+    'Disconnected',
+  ]
+
+  it.each(states)('renders a status element for %s', state => {
+    render(<ConnectionStatus connectionState={state} />)
+    expect(screen.getByRole('status')).toBeInTheDocument()
+  })
+
+  it('has aria-label reflecting the connection state', () => {
+    render(<ConnectionStatus connectionState="Connected" />)
+    expect(screen.getByRole('status')).toHaveAttribute(
+      'aria-label',
+      'Stream: Connected',
+    )
+  })
+
+  it('uses custom label when provided', () => {
+    render(<ConnectionStatus connectionState="Disconnected" label="Offline" />)
+    expect(screen.getByRole('status')).toHaveAttribute(
+      'aria-label',
+      'Stream: Offline',
+    )
+  })
+
+  it('shows text label by default', () => {
+    render(<ConnectionStatus connectionState="Connecting" />)
+    expect(screen.getByText('Connecting')).toBeInTheDocument()
+  })
+
+  it('hides text label when iconOnly=true', () => {
+    render(<ConnectionStatus connectionState="Connected" iconOnly />)
+    expect(screen.queryByText('Connected')).not.toBeInTheDocument()
+  })
+
+  it.each([
+    ['Connected', 'bg-green-500'],
+    ['Connecting', 'animate-pulse'],
+    ['Reconnecting', 'animate-pulse'],
+    ['Disconnected', 'bg-red-500'],
+  ] as [ConnectionState, string][])(
+    '%s state has expected dot class',
+    (state, expectedClass) => {
+      const { container } = render(<ConnectionStatus connectionState={state} />)
+      const dot = container.querySelector('[aria-hidden="true"]')
+      expect(dot?.className).toContain(expectedClass)
+    },
+  )
+})

--- a/ui/src/test/hooks/useAgentEvents.test.ts
+++ b/ui/src/test/hooks/useAgentEvents.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Tests for useAgentEvents hook.
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import { renderHook, act } from '@testing-library/react'
+import { useAgentEvents } from '@/hooks/useAgentEvents'
+import { agentEventBus } from '@/services/eventBus'
+import type { AgentStatusChangeEvent } from '@/types/orchestrator'
+
+describe('useAgentEvents', () => {
+  it('returns a subscribe function', () => {
+    const { result } = renderHook(() => useAgentEvents())
+    expect(typeof result.current.subscribe).toBe('function')
+  })
+
+  it('receives events of the subscribed type', () => {
+    const received: string[] = []
+
+    const { result } = renderHook(() => useAgentEvents())
+
+    act(() => {
+      result.current.subscribe('agent:status_change', event => {
+        received.push(event.agentId)
+      })
+    })
+
+    act(() => {
+      agentEventBus.emit<AgentStatusChangeEvent>({
+        type: 'agent:status_change',
+        agentId: 'test-agent',
+        status: 'Running',
+        timestamp: new Date().toISOString(),
+      })
+    })
+
+    expect(received).toContain('test-agent')
+  })
+
+  it('does not receive events of a different type', () => {
+    const received: unknown[] = []
+
+    const { result } = renderHook(() => useAgentEvents())
+
+    act(() => {
+      result.current.subscribe('approval:requested', event => {
+        received.push(event)
+      })
+    })
+
+    act(() => {
+      agentEventBus.emit<AgentStatusChangeEvent>({
+        type: 'agent:status_change',
+        agentId: 'irrelevant',
+        status: 'Stopped',
+        timestamp: new Date().toISOString(),
+      })
+    })
+
+    expect(received).toHaveLength(0)
+  })
+
+  it('subscribe cleanup function removes the handler', () => {
+    const received: string[] = []
+
+    const { result } = renderHook(() => useAgentEvents())
+
+    let cleanup: (() => void) | undefined
+    act(() => {
+      cleanup = result.current.subscribe('agent:status_change', event => {
+        received.push(event.agentId)
+      })
+    })
+
+    // Emit once — should receive
+    act(() => {
+      agentEventBus.emit<AgentStatusChangeEvent>({
+        type: 'agent:status_change',
+        agentId: 'first',
+        status: 'Running',
+        timestamp: new Date().toISOString(),
+      })
+    })
+
+    // Remove subscription
+    act(() => { cleanup?.() })
+
+    // Emit again — should not receive
+    act(() => {
+      agentEventBus.emit<AgentStatusChangeEvent>({
+        type: 'agent:status_change',
+        agentId: 'second',
+        status: 'Failed',
+        timestamp: new Date().toISOString(),
+      })
+    })
+
+    expect(received).toEqual(['first'])
+  })
+
+  it('unsubscribes all handlers on unmount', () => {
+    const handler = vi.fn()
+
+    const { result, unmount } = renderHook(() => useAgentEvents())
+
+    act(() => {
+      result.current.subscribe('agent:status_change', handler)
+    })
+
+    unmount()
+
+    act(() => {
+      agentEventBus.emit<AgentStatusChangeEvent>({
+        type: 'agent:status_change',
+        agentId: 'after-unmount',
+        status: 'Stopped',
+        timestamp: new Date().toISOString(),
+      })
+    })
+
+    expect(handler).not.toHaveBeenCalled()
+  })
+})

--- a/ui/src/test/hooks/useAllAgentsStream.test.ts
+++ b/ui/src/test/hooks/useAllAgentsStream.test.ts
@@ -1,0 +1,121 @@
+/**
+ * Tests for useAllAgentsStream hook.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act, waitFor } from '@testing-library/react'
+import { useAllAgentsStream } from '@/hooks/useAllAgentsStream'
+import { MockWebSocket, installMockWebSocket } from '@/test/mocks/mockWebSocket'
+import { agentEventBus } from '@/services/eventBus'
+
+let lastWs: MockWebSocket | undefined
+let cleanup: () => void
+
+beforeEach(() => {
+  lastWs = undefined
+  cleanup = installMockWebSocket(ws => { lastWs = ws })
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+  cleanup()
+})
+
+describe('useAllAgentsStream', () => {
+  it('starts connecting on mount (not yet open)', () => {
+    // useAllAgentsStream connects immediately on mount so by the time
+    // renderHook returns (after flushing effects in act) the state is
+    // 'Connecting' — the mock socket hasn't opened yet.
+    const { result } = renderHook(() => useAllAgentsStream())
+    expect(result.current.connectionState).toBe('Connecting')
+    expect(lastWs).toBeDefined()
+  })
+
+  it('becomes Connected after WebSocket opens', async () => {
+    const { result } = renderHook(() => useAllAgentsStream())
+    await waitFor(() => expect(lastWs).toBeDefined())
+
+    await act(async () => {
+      lastWs!.simulateOpen()
+    })
+
+    expect(result.current.connectionState).toBe('Connected')
+  })
+
+  it('parses agent:output events and adds lines to agentMessages', async () => {
+    const { result } = renderHook(() => useAllAgentsStream())
+    await waitFor(() => expect(lastWs).toBeDefined())
+    await act(async () => { lastWs!.simulateOpen() })
+
+    await act(async () => {
+      lastWs!.simulateMessage(
+        JSON.stringify({
+          type: 'agent:output',
+          agentId: 'agent-abc',
+          line: 'hello from agent',
+          timestamp: new Date().toISOString(),
+        }),
+      )
+    })
+
+    expect(result.current.agentMessages.get('agent-abc')).toHaveLength(1)
+    expect(result.current.agentMessages.get('agent-abc')![0].text).toBe(
+      'hello from agent',
+    )
+  })
+
+  it('demultiplexes messages to different agents', async () => {
+    const { result } = renderHook(() => useAllAgentsStream())
+    await waitFor(() => expect(lastWs).toBeDefined())
+    await act(async () => { lastWs!.simulateOpen() })
+
+    await act(async () => {
+      lastWs!.simulateMessage(JSON.stringify({ type: 'agent:output', agentId: 'agent-1', line: 'line-a', timestamp: new Date().toISOString() }))
+      lastWs!.simulateMessage(JSON.stringify({ type: 'agent:output', agentId: 'agent-2', line: 'line-b', timestamp: new Date().toISOString() }))
+    })
+
+    expect(result.current.agentMessages.get('agent-1')).toHaveLength(1)
+    expect(result.current.agentMessages.get('agent-2')).toHaveLength(1)
+  })
+
+  it('emits events to the agentEventBus', async () => {
+    const received: string[] = []
+    const unsub = agentEventBus.on('agent:status_change', event => {
+      received.push(event.agentId)
+    })
+
+    const { result } = renderHook(() => useAllAgentsStream())
+    await waitFor(() => expect(lastWs).toBeDefined())
+    await act(async () => { lastWs!.simulateOpen() })
+
+    await act(async () => {
+      lastWs!.simulateMessage(
+        JSON.stringify({
+          type: 'agent:status_change',
+          agentId: 'agent-xyz',
+          status: 'Running',
+          timestamp: new Date().toISOString(),
+        }),
+      )
+    })
+
+    expect(received).toContain('agent-xyz')
+    unsub()
+    result.current // suppress unused warning
+  })
+
+  it('handles non-JSON messages gracefully (stored under "unknown")', async () => {
+    const { result } = renderHook(() => useAllAgentsStream())
+    await waitFor(() => expect(lastWs).toBeDefined())
+    await act(async () => { lastWs!.simulateOpen() })
+
+    await act(async () => {
+      lastWs!.simulateMessage('plain text line')
+    })
+
+    expect(result.current.agentMessages.get('unknown')).toHaveLength(1)
+    expect(result.current.agentMessages.get('unknown')![0].text).toBe(
+      'plain text line',
+    )
+  })
+})

--- a/ui/src/test/hooks/useWebSocket.test.ts
+++ b/ui/src/test/hooks/useWebSocket.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Tests for useWebSocket hook.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act, waitFor } from '@testing-library/react'
+import { useWebSocket } from '@/hooks/useWebSocket'
+import { MockWebSocket, installMockWebSocket } from '@/test/mocks/mockWebSocket'
+
+let lastWs: MockWebSocket | undefined
+let cleanup: () => void
+
+beforeEach(() => {
+  lastWs = undefined
+  cleanup = installMockWebSocket(ws => { lastWs = ws })
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+  cleanup()
+})
+
+describe('useWebSocket', () => {
+  it('starts in Disconnected state', () => {
+    const { result } = renderHook(() =>
+      useWebSocket('ws://localhost/test', { paused: true }),
+    )
+    expect(result.current.connectionState).toBe('Disconnected')
+  })
+
+  it('transitions to Connecting on mount when not paused', async () => {
+    const { result } = renderHook(() =>
+      useWebSocket('ws://localhost/test'),
+    )
+    await waitFor(() => expect(result.current.connectionState).toBe('Connecting'))
+  })
+
+  it('transitions to Connected when WebSocket opens', async () => {
+    const { result } = renderHook(() => useWebSocket('ws://localhost/test'))
+
+    await waitFor(() => expect(lastWs).toBeDefined())
+
+    await act(async () => {
+      lastWs!.simulateOpen()
+    })
+
+    expect(result.current.connectionState).toBe('Connected')
+  })
+
+  it('receives messages and accumulates them', async () => {
+    const { result } = renderHook(() => useWebSocket('ws://localhost/test'))
+    await waitFor(() => expect(lastWs).toBeDefined())
+
+    await act(async () => {
+      lastWs!.simulateOpen()
+      lastWs!.simulateMessage('msg-1')
+      lastWs!.simulateMessage('msg-2')
+    })
+
+    expect(result.current.messages).toHaveLength(2)
+    expect(result.current.messages[0].data).toBe('msg-1')
+    expect(result.current.messages[1].data).toBe('msg-2')
+  })
+
+  it('caps messages at maxMessages', async () => {
+    const { result } = renderHook(() =>
+      useWebSocket('ws://localhost/test', { maxMessages: 3 }),
+    )
+    await waitFor(() => expect(lastWs).toBeDefined())
+
+    await act(async () => {
+      lastWs!.simulateOpen()
+      for (let i = 0; i < 5; i++) {
+        lastWs!.simulateMessage(`msg-${i}`)
+      }
+    })
+
+    expect(result.current.messages).toHaveLength(3)
+    expect(result.current.messages[0].data).toBe('msg-2')
+  })
+
+  it('send() transmits when connected', async () => {
+    const { result } = renderHook(() => useWebSocket('ws://localhost/test'))
+    await waitFor(() => expect(lastWs).toBeDefined())
+
+    await act(async () => {
+      lastWs!.simulateOpen()
+    })
+
+    act(() => {
+      result.current.send('hello')
+    })
+
+    expect(lastWs!.sentMessages).toContain('hello')
+  })
+
+  it('disconnect() closes the connection', async () => {
+    const { result } = renderHook(() => useWebSocket('ws://localhost/test'))
+    await waitFor(() => expect(lastWs).toBeDefined())
+
+    await act(async () => {
+      lastWs!.simulateOpen()
+    })
+
+    await act(async () => {
+      result.current.disconnect()
+    })
+
+    expect(result.current.connectionState).toBe('Disconnected')
+  })
+
+  it('does not auto-connect when paused=true', async () => {
+    let wsCreated = false
+    cleanup()
+    cleanup = installMockWebSocket(() => { wsCreated = true })
+
+    renderHook(() => useWebSocket('ws://localhost/test', { paused: true }))
+
+    // Give React time to run effects
+    await new Promise(r => setTimeout(r, 10))
+    expect(wsCreated).toBe(false)
+  })
+})

--- a/ui/src/test/mocks/mockWebSocket.ts
+++ b/ui/src/test/mocks/mockWebSocket.ts
@@ -1,0 +1,133 @@
+/**
+ * MockWebSocket — a controllable WebSocket replacement for unit tests.
+ *
+ * Usage:
+ *   import { MockWebSocket, installMockWebSocket } from '@/test/mocks/mockWebSocket'
+ *
+ *   let lastSocket: MockWebSocket
+ *   installMockWebSocket(ws => { lastSocket = ws })
+ *
+ *   // ... render component / hook ...
+ *   lastSocket.simulateOpen()
+ *   lastSocket.simulateMessage('hello')
+ *   lastSocket.simulateClose()
+ */
+
+import { vi } from 'vitest'
+
+export type MockWebSocketFactory = (ws: MockWebSocket) => void
+
+export class MockWebSocket {
+  static CONNECTING = 0
+  static OPEN = 1
+  static CLOSING = 2
+  static CLOSED = 3
+
+  readonly CONNECTING = 0
+  readonly OPEN = 1
+  readonly CLOSING = 2
+  readonly CLOSED = 3
+
+  readyState: number = MockWebSocket.CONNECTING
+
+  onopen: ((event: Event) => void) | null = null
+  onclose: ((event: CloseEvent) => void) | null = null
+  onerror: ((event: Event) => void) | null = null
+  onmessage: ((event: MessageEvent) => void) | null = null
+
+  sentMessages: string[] = []
+  readonly url: string
+
+  constructor(url: string) {
+    this.url = url
+  }
+
+  send(data: string): void {
+    this.sentMessages.push(data)
+  }
+
+  close(code = 1000, reason = ''): void {
+    if (this.readyState === MockWebSocket.CLOSED) return
+    this.readyState = MockWebSocket.CLOSED
+    if (this.onclose) {
+      this.onclose(new CloseEvent('close', { code, reason, wasClean: code === 1000 }))
+    }
+  }
+
+  addEventListener(): void {}
+  removeEventListener(): void {}
+  dispatchEvent(_event: Event): boolean { return true }
+
+  // -------------------------------------------------------------------------
+  // Test helpers — call these from test code to simulate server behaviour
+  // -------------------------------------------------------------------------
+
+  /** Simulate the WebSocket connection being established */
+  simulateOpen(): void {
+    this.readyState = MockWebSocket.OPEN
+    if (this.onopen) {
+      this.onopen(new Event('open'))
+    }
+  }
+
+  /** Simulate the server sending a text message */
+  simulateMessage(data: string): void {
+    if (this.onmessage) {
+      this.onmessage(new MessageEvent('message', { data }))
+    }
+  }
+
+  /** Simulate an error event (followed by close) */
+  simulateError(): void {
+    if (this.onerror) {
+      this.onerror(new Event('error'))
+    }
+    this.simulateClose(1006, 'Abnormal closure')
+  }
+
+  /** Simulate the connection being closed by the server */
+  simulateClose(code = 1006, reason = ''): void {
+    this.readyState = MockWebSocket.CLOSED
+    if (this.onclose) {
+      this.onclose(new CloseEvent('close', { code, reason, wasClean: false }))
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Installation helper
+// ---------------------------------------------------------------------------
+
+/**
+ * Replace the global WebSocket with MockWebSocket and call `onCreate`
+ * each time a new socket is constructed. Returns a cleanup function that
+ * restores the original WebSocket.
+ */
+export function installMockWebSocket(
+  onCreate?: MockWebSocketFactory,
+): () => void {
+  const instances: MockWebSocket[] = []
+
+  function MockWebSocketConstructor(url: string) {
+    const ws = new MockWebSocket(url)
+    instances.push(ws)
+    onCreate?.(ws)
+    return ws
+  }
+
+  MockWebSocketConstructor.CONNECTING = 0
+  MockWebSocketConstructor.OPEN = 1
+  MockWebSocketConstructor.CLOSING = 2
+  MockWebSocketConstructor.CLOSED = 3
+
+  vi.stubGlobal('WebSocket', MockWebSocketConstructor)
+
+  return () => {
+    vi.unstubAllGlobals()
+  }
+}
+
+/** Returns all MockWebSocket instances created since installMockWebSocket was called */
+export function getLastMockWebSocket(instances: MockWebSocket[]): MockWebSocket | undefined {
+  return instances[instances.length - 1]
+}

--- a/ui/src/test/services/websocket.test.ts
+++ b/ui/src/test/services/websocket.test.ts
@@ -1,0 +1,189 @@
+/**
+ * Tests for WebSocketManager.
+ *
+ * The global WebSocket stub in setup.ts stays in CONNECTING state.
+ * These tests install a fully controllable MockWebSocket per test.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { WebSocketManager } from '@/services/websocket'
+import { MockWebSocket, installMockWebSocket } from '@/test/mocks/mockWebSocket'
+import type { ConnectionState } from '@/services/websocket'
+
+let lastWs: MockWebSocket | undefined
+let cleanup: () => void
+
+beforeEach(() => {
+  lastWs = undefined
+  cleanup = installMockWebSocket(ws => { lastWs = ws })
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+  cleanup()
+})
+
+describe('WebSocketManager', () => {
+  it('starts in Disconnected state', () => {
+    const manager = new WebSocketManager('ws://localhost/test')
+    expect(manager.state).toBe('Disconnected')
+  })
+
+  it('transitions to Connecting on connect()', () => {
+    const manager = new WebSocketManager('ws://localhost/test')
+    manager.connect()
+    expect(manager.state).toBe('Connecting')
+  })
+
+  it('transitions to Connected when WebSocket opens', () => {
+    const states: ConnectionState[] = []
+    const manager = new WebSocketManager('ws://localhost/test')
+    manager.onStateChange(s => states.push(s))
+    manager.connect()
+
+    lastWs!.simulateOpen()
+
+    expect(manager.state).toBe('Connected')
+    expect(states).toContain('Connecting')
+    expect(states).toContain('Connected')
+  })
+
+  it('transitions to Reconnecting when WebSocket closes unexpectedly', () => {
+    vi.useFakeTimers()
+    const states: ConnectionState[] = []
+    const manager = new WebSocketManager('ws://localhost/test', { minReconnectDelay: 100 })
+    manager.onStateChange(s => states.push(s))
+    manager.connect()
+    lastWs!.simulateOpen()
+    lastWs!.simulateClose()
+
+    expect(states).toContain('Reconnecting')
+  })
+
+  it('disconnects cleanly and transitions to Disconnected', () => {
+    const states: ConnectionState[] = []
+    const manager = new WebSocketManager('ws://localhost/test')
+    manager.onStateChange(s => states.push(s))
+    manager.connect()
+    lastWs!.simulateOpen()
+    manager.disconnect()
+
+    expect(manager.state).toBe('Disconnected')
+    expect(states[states.length - 1]).toBe('Disconnected')
+  })
+
+  it('delivers messages to registered handlers', () => {
+    const received: string[] = []
+    const manager = new WebSocketManager('ws://localhost/test')
+    manager.onMessage(event => received.push(String(event.data)))
+    manager.connect()
+    lastWs!.simulateOpen()
+    lastWs!.simulateMessage('hello')
+    lastWs!.simulateMessage('world')
+
+    expect(received).toEqual(['hello', 'world'])
+  })
+
+  it('removes message handler when cleanup is called', () => {
+    const received: string[] = []
+    const manager = new WebSocketManager('ws://localhost/test')
+    const remove = manager.onMessage(event => received.push(String(event.data)))
+    manager.connect()
+    lastWs!.simulateOpen()
+    lastWs!.simulateMessage('before')
+    remove()
+    lastWs!.simulateMessage('after')
+
+    expect(received).toEqual(['before'])
+  })
+
+  it('buffers messages sent while disconnected and flushes on reconnect', () => {
+    const manager = new WebSocketManager('ws://localhost/test')
+    manager.connect()
+    // Don't open — send while still connecting
+    manager.send('buffered-1')
+    manager.send('buffered-2')
+
+    lastWs!.simulateOpen()
+
+    expect(lastWs!.sentMessages).toEqual(['buffered-1', 'buffered-2'])
+  })
+
+  it('sends messages directly when connected', () => {
+    const manager = new WebSocketManager('ws://localhost/test')
+    manager.connect()
+    lastWs!.simulateOpen()
+    manager.send('direct')
+
+    expect(lastWs!.sentMessages).toEqual(['direct'])
+  })
+
+  it('does not reconnect after intentional disconnect', () => {
+    vi.useFakeTimers()
+    let wsCount = 0
+    cleanup()
+    cleanup = installMockWebSocket(ws => { lastWs = ws; wsCount++ })
+
+    const manager = new WebSocketManager('ws://localhost/test', { minReconnectDelay: 50 })
+    manager.connect()
+    lastWs!.simulateOpen()
+    manager.disconnect()
+
+    vi.advanceTimersByTime(200)
+
+    expect(wsCount).toBe(1) // no reconnect attempts
+  })
+
+  it('schedules reconnect with exponential backoff', () => {
+    vi.useFakeTimers()
+    const wsInstances: MockWebSocket[] = []
+    cleanup()
+    cleanup = installMockWebSocket(ws => { lastWs = ws; wsInstances.push(ws) })
+
+    const manager = new WebSocketManager('ws://localhost/test', { minReconnectDelay: 100, maxReconnectDelay: 400 })
+    manager.connect()
+    lastWs!.simulateOpen()
+    lastWs!.simulateClose() // triggers first reconnect at 100ms
+
+    vi.advanceTimersByTime(100)
+    expect(wsInstances.length).toBe(2)
+
+    lastWs!.simulateClose() // second reconnect at 200ms
+    vi.advanceTimersByTime(200)
+    expect(wsInstances.length).toBe(3)
+  })
+
+  it('sends heartbeat ping when connected and heartbeat is enabled', () => {
+    vi.useFakeTimers()
+    const manager = new WebSocketManager('ws://localhost/test', { heartbeatInterval: 500 })
+    manager.connect()
+    lastWs!.simulateOpen()
+
+    vi.advanceTimersByTime(600)
+
+    expect(lastWs!.sentMessages).toContain('ping')
+  })
+
+  it('does not send heartbeat when heartbeatInterval is 0', () => {
+    vi.useFakeTimers()
+    const manager = new WebSocketManager('ws://localhost/test', { heartbeatInterval: 0 })
+    manager.connect()
+    lastWs!.simulateOpen()
+
+    vi.advanceTimersByTime(30_000)
+
+    expect(lastWs!.sentMessages).not.toContain('ping')
+  })
+
+  it('connect() is idempotent when already connecting', () => {
+    let wsCount = 0
+    cleanup()
+    cleanup = installMockWebSocket(() => wsCount++)
+
+    const manager = new WebSocketManager('ws://localhost/test')
+    manager.connect()
+    manager.connect() // second call should be no-op
+
+    expect(wsCount).toBe(1)
+  })
+})

--- a/ui/src/test/setup.ts
+++ b/ui/src/test/setup.ts
@@ -13,6 +13,41 @@ import { expect, beforeAll, afterEach, afterAll, vi } from 'vitest'
 import { server } from './mocks/server'
 
 // ---------------------------------------------------------------------------
+// WebSocket — jsdom does not implement WebSocket.
+// Provide a stub that stays in CONNECTING state so hooks that open WebSocket
+// connections don't throw. Individual tests can replace this with a fully
+// functional mock (see src/test/mocks/mockWebSocket.ts) when needed.
+// ---------------------------------------------------------------------------
+
+class _StubWebSocket {
+  static CONNECTING = 0
+  static OPEN = 1
+  static CLOSING = 2
+  static CLOSED = 3
+
+  readonly CONNECTING = 0
+  readonly OPEN = 1
+  readonly CLOSING = 2
+  readonly CLOSED = 3
+
+  readyState = 0 // CONNECTING — never opens, simulates a pending connection
+  onopen: ((event: Event) => void) | null = null
+  onclose: ((event: CloseEvent) => void) | null = null
+  onerror: ((event: Event) => void) | null = null
+  onmessage: ((event: MessageEvent) => void) | null = null
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  constructor(_url: string, _protocols?: string | string[]) {}
+  send(_data: string | ArrayBuffer | Blob | ArrayBufferView): void {}
+  close(_code?: number, _reason?: string): void {}
+  addEventListener(): void {}
+  removeEventListener(): void {}
+  dispatchEvent(_event: Event): boolean { return true }
+}
+
+vi.stubGlobal('WebSocket', _StubWebSocket)
+
+// ---------------------------------------------------------------------------
 // window.matchMedia — jsdom does not implement matchMedia, so we provide a
 // functional stub that defaults to the light colour scheme. Individual tests
 // can override this with vi.fn() if they need to test dark-mode behaviour.

--- a/ui/src/types/orchestrator.ts
+++ b/ui/src/types/orchestrator.ts
@@ -147,6 +147,66 @@ export interface DispatchRecord {
 }
 
 // ---------------------------------------------------------------------------
+// WebSocket event types
+// ---------------------------------------------------------------------------
+
+/** Agent produced a line of output on its log stream */
+export interface AgentOutputEvent {
+  type: 'agent:output'
+  agentId: string
+  line: string
+  timestamp: string
+}
+
+/** Agent lifecycle state changed */
+export interface AgentStatusChangeEvent {
+  type: 'agent:status_change'
+  agentId: string
+  status: AgentStatus
+  previousStatus?: AgentStatus
+  timestamp: string
+}
+
+/** A new tool-use approval request arrived */
+export interface ApprovalRequestedEvent {
+  type: 'approval:requested'
+  approval: PendingApproval
+}
+
+/** An approval was resolved (approved or denied) */
+export interface ApprovalResolvedEvent {
+  type: 'approval:resolved'
+  approvalId: string
+  status: 'Approved' | 'Denied'
+  timestamp: string
+}
+
+/** A workflow task was dispatched to an agent */
+export interface WorkflowTaskDispatchedEvent {
+  type: 'workflow:task_dispatched'
+  taskId: string
+  agentId: string
+  timestamp: string
+}
+
+/** A workflow task completed */
+export interface WorkflowTaskCompletedEvent {
+  type: 'workflow:task_completed'
+  taskId: string
+  result?: unknown
+  timestamp: string
+}
+
+/** Union of all agent-related WebSocket events */
+export type AgentEvent =
+  | AgentOutputEvent
+  | AgentStatusChangeEvent
+  | ApprovalRequestedEvent
+  | ApprovalResolvedEvent
+  | WorkflowTaskDispatchedEvent
+  | WorkflowTaskCompletedEvent
+
+// ---------------------------------------------------------------------------
 // Query params
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Implements the full WebSocket infrastructure for real-time communication with the orchestrator service (closes #168).

- **`WebSocketManager`** (`src/services/websocket.ts`): connection lifecycle class with states `Connecting | Connected | Disconnected | Reconnecting`, exponential backoff reconnect (1 s → 30 s), configurable heartbeat/ping, message buffering during reconnection, and typed handler registration
- **`agentEventBus`** (`src/services/eventBus.ts`): central pub/sub event bus for typed WebSocket events (`agent:output`, `agent:status_change`, `approval:requested`, `approval:resolved`, `workflow:task_dispatched`, `workflow:task_completed`)
- **`AgentEvent` types** added to `src/types/orchestrator.ts`
- **`useWebSocket`**: low-level hook wrapping `WebSocketManager`; auto-connects on mount, disconnects on unmount, capped message buffer, optional `paused` mode
- **`useAgentStream`**: refactored to use `WebSocketManager` internally (same public API)
- **`useAllAgentsStream`**: connects to `/stream`, demultiplexes JSON events by `agentId`, emits to event bus, maintains per-agent log buffers (1 000 lines each)
- **`useAgentEvents`**: subscribes to event bus by event type with automatic cleanup on unmount
- **`ConnectionStatus`** component: coloured dot indicator (green=Connected, pulsing yellow=Connecting/Reconnecting, red=Disconnected)
- **`Header`**: global `/stream` connection indicator added (icon-only dot on small screens)

## Test plan

- [x] All 396 tests pass (`npx vitest run`)
- [x] 45 new tests across 5 files
- [x] `WebSocketManager` — 13 tests: states, reconnect backoff, heartbeat, buffer flush, idempotent connect
- [x] `useWebSocket` — 8 tests: auto-connect, message accumulation, cap, send, disconnect, paused
- [x] `useAllAgentsStream` — 5 tests: connecting state, JSON parsing, demux, event bus emit, fallback for non-JSON
- [x] `useAgentEvents` — 5 tests: subscribe, type filtering, cleanup function, unmount cleanup
- [x] `ConnectionStatus` — 9 tests: renders all states, aria-label, icon-only, dot CSS classes
- [x] `MockWebSocket` + `installMockWebSocket` helper added for controllable WS testing
- [x] Global `WebSocket` stub in `setup.ts` prevents errors in tests not using explicit mocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)