### PR TITLE
fix: terminate_agent should delete record from storage

### DIFF
--- a/crates/orchestrator/src/manager.rs
+++ b/crates/orchestrator/src/manager.rs
@@ -113,7 +113,11 @@ impl AgentManager {
         Ok(agent)
     }
 
-    /// Terminate a running agent: kill tmux session, update DB.
+    /// Terminate a running agent: kill tmux session and delete DB record.
+    ///
+    /// The record is deleted (not just updated to Stopped) so that `agent apply`
+    /// can recreate an agent with the same name and `agent teardown` + `agent apply`
+    /// forms a clean cycle without stale records accumulating in the database.
     pub async fn terminate_agent(&self, id: &Uuid) -> anyhow::Result<Agent> {
         let mut agent =
             self.storage.get(id).await?.ok_or_else(|| anyhow::anyhow!("Agent not found"))?;
@@ -124,11 +128,14 @@ impl AgentManager {
             }
         }
 
+        // Remove the record from storage entirely so the name can be reused.
+        self.storage.delete(id).await?;
+
+        // Set status on the returned value for callers that inspect it.
         agent.status = AgentStatus::Stopped;
         agent.updated_at = Utc::now();
-        self.storage.update(&agent).await?;
 
-        info!(agent_id = %id, "Agent terminated");
+        info!(agent_id = %id, "Agent terminated and record deleted");
 
         Ok(agent)
     }


### PR DESCRIPTION
## Summary

- `terminate_agent` now calls `storage.delete()` after killing the tmux session instead of `storage.update()` with `status=Stopped`
- The returned `Agent` still carries `status=Stopped` and updated `updated_at` for callers that inspect the return value
- Stale stopped records no longer accumulate in the SQLite database

## Root Cause

`terminate_agent` was calling `storage.update()` to set status to `Stopped`, but never removing the record. This caused:
- `agent apply` to fail with "Agent exists but is stopped — use delete-agent first"
- `agent teardown` + `agent apply` to not work as a clean cycle
- `list-agents` showing stale stopped records indefinitely

## Test plan

- [x] All 18 manager unit tests pass (`cargo test -p orchestrator manager`)
- [x] The `storage.delete()` method already exists and has its own tests
- [x] Verified pre-existing client test failures are unrelated (macOS system config sandbox issue)

Fixes #197

🤖 Generated with [Claude Code](https://claude.com/claude-code)