### PR TITLE
feat(ui): build hooks management page with placeholder for hook service integration

### DIFF
--- a/ui/src/components/hooks/HookPlaceholder.tsx
+++ b/ui/src/components/hooks/HookPlaceholder.tsx
@@ -1,0 +1,193 @@
+/**
+ * HookPlaceholder — coming-soon placeholder for the hooks management page.
+ *
+ * Renders a wireframe preview of the planned hooks feature set:
+ *   - Service health indicator for the hook service (port 17002)
+ *   - Feature cards for git hooks, system hooks, event log, configuration,
+ *     and notification triggers
+ *   - Link to the GitHub issue tracking implementation progress
+ */
+
+import { Activity, Bell, Code2, GitBranch, Info, Settings, Zap } from 'lucide-react'
+import { StatusBadge } from '@/components/common/StatusBadge'
+import { HOOK_SERVICE_PORT } from '@/hooks/useHooks'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface PlannedFeatureCardProps {
+  icon: React.ReactNode
+  title: string
+  description: string
+  items: string[]
+}
+
+// ---------------------------------------------------------------------------
+// Sub-components
+// ---------------------------------------------------------------------------
+
+function PlannedFeatureCard({ icon, title, description, items }: PlannedFeatureCardProps) {
+  return (
+    <div className="rounded-lg border border-dashed border-gray-200 bg-gray-50/50 p-5 dark:border-gray-700 dark:bg-gray-800/50">
+      <div className="flex items-center gap-3 mb-3">
+        <div className="flex h-9 w-9 items-center justify-center rounded-md bg-primary-100 dark:bg-primary-900/30">
+          {icon}
+        </div>
+        <h3 className="font-medium text-gray-900 dark:text-white">{title}</h3>
+      </div>
+      <p className="text-sm text-gray-500 dark:text-gray-400 mb-3">{description}</p>
+      <ul className="space-y-1">
+        {items.map((item) => (
+          <li key={item} className="flex items-center gap-2 text-xs text-gray-400 dark:text-gray-500">
+            <span className="h-1 w-1 rounded-full bg-gray-300 dark:bg-gray-600 flex-shrink-0" />
+            {item}
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}
+
+function ServiceStatusBanner({ port }: { port: number }) {
+  return (
+    <div className="flex items-center gap-3 rounded-lg border border-gray-200 bg-white p-4 shadow-sm dark:border-gray-700 dark:bg-gray-800">
+      <div className="flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-full bg-gray-100 dark:bg-gray-700">
+        <Activity size={18} className="text-gray-500 dark:text-gray-400" />
+      </div>
+      <div className="flex-1 min-w-0">
+        <p className="text-sm font-medium text-gray-900 dark:text-white">Hook Service</p>
+        <p className="text-xs text-gray-500 dark:text-gray-400">Port {port}</p>
+      </div>
+      <StatusBadge status="unknown" />
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Main export
+// ---------------------------------------------------------------------------
+
+export function HookPlaceholder() {
+  return (
+    <div className="space-y-8">
+      {/* Coming Soon header */}
+      <div className="text-center py-8">
+        <div className="flex justify-center mb-4">
+          <div className="flex h-16 w-16 items-center justify-center rounded-2xl bg-primary-100 dark:bg-primary-900/30">
+            <Zap size={32} className="text-primary-600 dark:text-primary-400" />
+          </div>
+        </div>
+        <h2 className="text-xl font-semibold text-gray-900 dark:text-white mb-2">
+          Hooks — Coming Soon
+        </h2>
+        <p className="text-gray-500 dark:text-gray-400 max-w-xl mx-auto">
+          The hook service will monitor git hooks and system hooks, automatically creating
+          notifications when hook events fire. Configure triggers, view execution logs, and
+          connect hook events to your notification workflows.
+        </p>
+      </div>
+
+      {/* Service health indicator */}
+      <div>
+        <h3 className="text-sm font-medium text-gray-700 dark:text-gray-300 uppercase tracking-wide mb-3">
+          Service Status
+        </h3>
+        <ServiceStatusBanner port={HOOK_SERVICE_PORT} />
+        <p className="mt-2 flex items-center gap-1.5 text-xs text-gray-400 dark:text-gray-500">
+          <Info size={12} />
+          The hook service is not yet implemented. Status will update automatically once the
+          service is running.
+        </p>
+      </div>
+
+      {/* Planned feature preview */}
+      <div>
+        <h3 className="text-sm font-medium text-gray-700 dark:text-gray-300 uppercase tracking-wide mb-4">
+          Planned Features
+        </h3>
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+          <PlannedFeatureCard
+            icon={<GitBranch size={18} className="text-primary-600 dark:text-primary-400" />}
+            title="Git Hooks"
+            description="Monitor git lifecycle events in your repositories."
+            items={[
+              'pre-commit — validate before commit',
+              'post-commit — trigger after commit',
+              'pre-push — gate pushes',
+              'post-merge — react to merges',
+              'post-checkout — respond to checkouts',
+            ]}
+          />
+          <PlannedFeatureCard
+            icon={<Code2 size={18} className="text-primary-600 dark:text-primary-400" />}
+            title="System Hooks"
+            description="React to system-level and process events."
+            items={[
+              'File system changes',
+              'Process start / stop events',
+              'Scheduled cron triggers',
+              'Custom shell script hooks',
+              'Environment variable changes',
+            ]}
+          />
+          <PlannedFeatureCard
+            icon={<Activity size={18} className="text-primary-600 dark:text-primary-400" />}
+            title="Event Log"
+            description="Full audit trail of every hook execution."
+            items={[
+              'Timestamp and duration per event',
+              'Success / failure status',
+              'Payload inspection',
+              'Error details for failures',
+              'Filterable by hook or event type',
+            ]}
+          />
+          <PlannedFeatureCard
+            icon={<Settings size={18} className="text-primary-600 dark:text-primary-400" />}
+            title="Hook Configuration"
+            description="Enable, disable, and tune individual hooks."
+            items={[
+              'Toggle hooks on / off',
+              'Edit hook event bindings',
+              'Set per-hook retry policy',
+              'Configure timeout thresholds',
+              'Import / export hook definitions',
+            ]}
+          />
+          <PlannedFeatureCard
+            icon={<Bell size={18} className="text-primary-600 dark:text-primary-400" />}
+            title="Notification Triggers"
+            description="Automatically create notifications when hooks fire."
+            items={[
+              'Trigger on success, failure, or both',
+              'Customisable message templates',
+              'Set notification priority per hook',
+              'Route to specific notification channels',
+              'Suppress duplicate notifications',
+            ]}
+          />
+        </div>
+      </div>
+
+      {/* Track progress link */}
+      <div className="rounded-lg border border-blue-100 bg-blue-50 p-4 dark:border-blue-900/40 dark:bg-blue-900/10">
+        <p className="text-sm text-blue-700 dark:text-blue-300">
+          <span className="font-medium">Track progress:</span>{' '}
+          Follow the hook service implementation on the{' '}
+          <a
+            href="https://github.com/geoffjay/agentd/issues/179"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="underline hover:text-blue-900 dark:hover:text-blue-100 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 rounded"
+          >
+            GitHub issue #179
+          </a>
+          .
+        </p>
+      </div>
+    </div>
+  )
+}
+
+export default HookPlaceholder

--- a/ui/src/components/hooks/index.ts
+++ b/ui/src/components/hooks/index.ts
@@ -1,0 +1,1 @@
+export { HookPlaceholder } from './HookPlaceholder'

--- a/ui/src/hooks/useHooks.ts
+++ b/ui/src/hooks/useHooks.ts
@@ -1,0 +1,113 @@
+/**
+ * useHooks — stub hook returning empty data for the hooks management page.
+ *
+ * This is a placeholder for when the hook service (port 17002) is fully
+ * implemented. The hook service will monitor git hooks and system hooks
+ * and create notifications based on hook events.
+ *
+ * Replace the stub implementations below with real API calls once the
+ * hook service is available.
+ */
+
+import { useState } from 'react'
+import type { Hook, HookEvent } from '@/types/hook'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface UseHooksResult {
+  hooks: Hook[]
+  total: number
+  loading: boolean
+  error?: string
+  refetch: () => void
+}
+
+export interface UseHookEventsResult {
+  events: HookEvent[]
+  total: number
+  loading: boolean
+  error?: string
+  refetch: () => void
+}
+
+export interface UseHookServiceStatusResult {
+  /** Whether the hook service is reachable */
+  reachable: boolean
+  checking: boolean
+  /** Port the hook service listens on */
+  port: number
+}
+
+// ---------------------------------------------------------------------------
+// Hook service port constant
+// ---------------------------------------------------------------------------
+
+/** The hook service listens on port 17002 (not yet implemented) */
+export const HOOK_SERVICE_PORT = 17002
+
+// ---------------------------------------------------------------------------
+// useHooks — list all registered hooks
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns the list of registered hooks from the hook service.
+ *
+ * Currently returns empty data since the service is not yet implemented.
+ * Replace with a real API call when the hook service is available.
+ */
+export function useHooks(): UseHooksResult {
+  const [loading] = useState(false)
+
+  return {
+    hooks: [],
+    total: 0,
+    loading,
+    error: undefined,
+    refetch: () => {
+      // TODO: fetch from hook service when implemented
+    },
+  }
+}
+
+// ---------------------------------------------------------------------------
+// useHookEvents — list recent hook execution events
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns recent hook execution events from the hook service.
+ *
+ * Currently returns empty data since the service is not yet implemented.
+ */
+export function useHookEvents(): UseHookEventsResult {
+  const [loading] = useState(false)
+
+  return {
+    events: [],
+    total: 0,
+    loading,
+    error: undefined,
+    refetch: () => {
+      // TODO: fetch from hook service when implemented
+    },
+  }
+}
+
+// ---------------------------------------------------------------------------
+// useHookServiceStatus — check if the hook service is reachable
+// ---------------------------------------------------------------------------
+
+/**
+ * Checks whether the hook service is reachable.
+ *
+ * Always returns unreachable since the service is not yet implemented.
+ * Replace with a real health-check call when the hook service is available.
+ */
+export function useHookServiceStatus(): UseHookServiceStatusResult {
+  return {
+    reachable: false,
+    checking: false,
+    port: HOOK_SERVICE_PORT,
+  }
+}

--- a/ui/src/pages/HooksPage.tsx
+++ b/ui/src/pages/HooksPage.tsx
@@ -1,12 +1,7 @@
+import { HookList } from './hooks/HookList'
+
 export function HooksPage() {
-  return (
-    <div>
-      <h1 className="text-2xl font-semibold text-gray-900 dark:text-white">Hooks</h1>
-      <p className="mt-2 text-gray-500 dark:text-gray-400">
-        Manage webhook integrations and event hooks.
-      </p>
-    </div>
-  )
+  return <HookList />
 }
 
 export default HooksPage

--- a/ui/src/pages/hooks/HookDetail.tsx
+++ b/ui/src/pages/hooks/HookDetail.tsx
@@ -1,0 +1,52 @@
+/**
+ * HookDetail — placeholder for the individual hook detail page.
+ *
+ * This component will display the full configuration and event log for a
+ * single hook once the hook service (port 17002) is implemented. For now
+ * it renders a minimal placeholder that is ready to be wired up.
+ */
+
+import { useParams } from 'react-router-dom'
+import { ArrowLeft, Zap } from 'lucide-react'
+import { Link } from 'react-router-dom'
+
+export function HookDetail() {
+  const { id } = useParams<{ id: string }>()
+
+  return (
+    <div id="main-content" className="space-y-6">
+      {/* Back nav */}
+      <Link
+        to="/hooks"
+        className="inline-flex items-center gap-2 text-sm text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 rounded"
+      >
+        <ArrowLeft size={16} />
+        Back to Hooks
+      </Link>
+
+      {/* Header */}
+      <div className="flex items-center gap-3">
+        <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary-100 dark:bg-primary-900/30">
+          <Zap size={22} className="text-primary-600 dark:text-primary-400" />
+        </div>
+        <div>
+          <h1 className="text-2xl font-semibold text-gray-900 dark:text-white">
+            Hook {id ?? '—'}
+          </h1>
+          <p className="text-sm text-gray-500 dark:text-gray-400">
+            Hook detail — coming soon
+          </p>
+        </div>
+      </div>
+
+      {/* Placeholder body */}
+      <div className="rounded-lg border border-dashed border-gray-200 bg-gray-50/50 p-10 text-center dark:border-gray-700 dark:bg-gray-800/50">
+        <p className="text-gray-400 dark:text-gray-500">
+          Hook detail view will be available once the hook service is implemented.
+        </p>
+      </div>
+    </div>
+  )
+}
+
+export default HookDetail

--- a/ui/src/pages/hooks/HookList.tsx
+++ b/ui/src/pages/hooks/HookList.tsx
@@ -1,0 +1,42 @@
+/**
+ * HookList — hooks management page.
+ *
+ * Renders a "coming soon" placeholder while the hook service (port 17002)
+ * is being implemented. The component structure is ready for real data
+ * once the service is available — replace the HookPlaceholder with a
+ * proper list table and connect the useHooks() hook.
+ */
+
+import { Zap } from 'lucide-react'
+import { HookPlaceholder } from '@/components/hooks/HookPlaceholder'
+import { useHooks } from '@/hooks/useHooks'
+
+export function HookList() {
+  // Stub hook — returns empty data until the hook service is implemented.
+  // Replace with real data-fetching logic once the service is available.
+  const { hooks: _hooks, loading: _loading } = useHooks()
+
+  return (
+    <div id="main-content" className="space-y-6">
+      {/* Page header */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-3">
+          <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-primary-100 dark:bg-primary-900/30">
+            <Zap size={22} className="text-primary-600 dark:text-primary-400" />
+          </div>
+          <div>
+            <h1 className="text-2xl font-semibold text-gray-900 dark:text-white">Hooks</h1>
+            <p className="text-sm text-gray-500 dark:text-gray-400">
+              Monitor git and system hook events
+            </p>
+          </div>
+        </div>
+      </div>
+
+      {/* Coming-soon placeholder / planned feature preview */}
+      <HookPlaceholder />
+    </div>
+  )
+}
+
+export default HookList

--- a/ui/src/test/components/hooks/HookPlaceholder.test.tsx
+++ b/ui/src/test/components/hooks/HookPlaceholder.test.tsx
@@ -1,0 +1,78 @@
+/**
+ * Tests for HookPlaceholder coming-soon component.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { HookPlaceholder } from '@/components/hooks/HookPlaceholder'
+
+function renderWithRouter(ui: React.ReactNode) {
+  return render(<MemoryRouter>{ui}</MemoryRouter>)
+}
+
+describe('HookPlaceholder', () => {
+  it('renders the "Hooks — Coming Soon" heading', () => {
+    renderWithRouter(<HookPlaceholder />)
+    expect(screen.getByText('Hooks — Coming Soon')).toBeInTheDocument()
+  })
+
+  it('shows the service status section', () => {
+    renderWithRouter(<HookPlaceholder />)
+    expect(screen.getByText('Service Status')).toBeInTheDocument()
+    expect(screen.getByText('Hook Service')).toBeInTheDocument()
+  })
+
+  it('displays the hook service port 17002', () => {
+    renderWithRouter(<HookPlaceholder />)
+    expect(screen.getByText('Port 17002')).toBeInTheDocument()
+  })
+
+  it('shows an "unknown" service status badge', () => {
+    renderWithRouter(<HookPlaceholder />)
+    expect(screen.getByText('unknown')).toBeInTheDocument()
+  })
+
+  it('renders the Planned Features section', () => {
+    renderWithRouter(<HookPlaceholder />)
+    expect(screen.getByText('Planned Features')).toBeInTheDocument()
+  })
+
+  it('renders Git Hooks feature card', () => {
+    renderWithRouter(<HookPlaceholder />)
+    expect(screen.getByText('Git Hooks')).toBeInTheDocument()
+    expect(screen.getByText(/Monitor git lifecycle events/)).toBeInTheDocument()
+  })
+
+  it('renders System Hooks feature card', () => {
+    renderWithRouter(<HookPlaceholder />)
+    expect(screen.getByText('System Hooks')).toBeInTheDocument()
+  })
+
+  it('renders Event Log feature card', () => {
+    renderWithRouter(<HookPlaceholder />)
+    expect(screen.getByText('Event Log')).toBeInTheDocument()
+  })
+
+  it('renders Hook Configuration feature card', () => {
+    renderWithRouter(<HookPlaceholder />)
+    expect(screen.getByText('Hook Configuration')).toBeInTheDocument()
+  })
+
+  it('renders Notification Triggers feature card', () => {
+    renderWithRouter(<HookPlaceholder />)
+    expect(screen.getByText('Notification Triggers')).toBeInTheDocument()
+  })
+
+  it('shows GitHub issue link', () => {
+    renderWithRouter(<HookPlaceholder />)
+    const link = screen.getByRole('link', { name: /GitHub issue #179/i })
+    expect(link).toBeInTheDocument()
+    expect(link).toHaveAttribute('href', 'https://github.com/geoffjay/agentd/issues/179')
+  })
+
+  it('includes explanation of what hooks will do', () => {
+    renderWithRouter(<HookPlaceholder />)
+    expect(screen.getByText(/monitor git hooks and system hooks/i)).toBeInTheDocument()
+  })
+})

--- a/ui/src/test/hooks/useHooks.test.ts
+++ b/ui/src/test/hooks/useHooks.test.ts
@@ -1,0 +1,94 @@
+/**
+ * Tests for useHooks, useHookEvents, and useHookServiceStatus stubs.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import {
+  useHooks,
+  useHookEvents,
+  useHookServiceStatus,
+  HOOK_SERVICE_PORT,
+} from '@/hooks/useHooks'
+
+describe('HOOK_SERVICE_PORT', () => {
+  it('is 17002', () => {
+    expect(HOOK_SERVICE_PORT).toBe(17002)
+  })
+})
+
+describe('useHooks', () => {
+  it('returns empty hooks list', () => {
+    const { result } = renderHook(() => useHooks())
+    expect(result.current.hooks).toEqual([])
+  })
+
+  it('returns total of 0', () => {
+    const { result } = renderHook(() => useHooks())
+    expect(result.current.total).toBe(0)
+  })
+
+  it('is not loading', () => {
+    const { result } = renderHook(() => useHooks())
+    expect(result.current.loading).toBe(false)
+  })
+
+  it('has no error', () => {
+    const { result } = renderHook(() => useHooks())
+    expect(result.current.error).toBeUndefined()
+  })
+
+  it('exposes a refetch function', () => {
+    const { result } = renderHook(() => useHooks())
+    expect(typeof result.current.refetch).toBe('function')
+  })
+
+  it('refetch does not throw', () => {
+    const { result } = renderHook(() => useHooks())
+    expect(() => result.current.refetch()).not.toThrow()
+  })
+})
+
+describe('useHookEvents', () => {
+  it('returns empty events list', () => {
+    const { result } = renderHook(() => useHookEvents())
+    expect(result.current.events).toEqual([])
+  })
+
+  it('returns total of 0', () => {
+    const { result } = renderHook(() => useHookEvents())
+    expect(result.current.total).toBe(0)
+  })
+
+  it('is not loading', () => {
+    const { result } = renderHook(() => useHookEvents())
+    expect(result.current.loading).toBe(false)
+  })
+
+  it('has no error', () => {
+    const { result } = renderHook(() => useHookEvents())
+    expect(result.current.error).toBeUndefined()
+  })
+
+  it('exposes a refetch function', () => {
+    const { result } = renderHook(() => useHookEvents())
+    expect(typeof result.current.refetch).toBe('function')
+  })
+})
+
+describe('useHookServiceStatus', () => {
+  it('reports service as unreachable', () => {
+    const { result } = renderHook(() => useHookServiceStatus())
+    expect(result.current.reachable).toBe(false)
+  })
+
+  it('is not checking', () => {
+    const { result } = renderHook(() => useHookServiceStatus())
+    expect(result.current.checking).toBe(false)
+  })
+
+  it('reports correct port', () => {
+    const { result } = renderHook(() => useHookServiceStatus())
+    expect(result.current.port).toBe(HOOK_SERVICE_PORT)
+  })
+})

--- a/ui/src/types/hook.ts
+++ b/ui/src/types/hook.ts
@@ -1,0 +1,80 @@
+/**
+ * TypeScript types for the Hook service.
+ *
+ * The hook service (port 17002) monitors git hooks and system hooks and
+ * creates notifications based on hook events. These types define the
+ * anticipated data model for when the service is fully implemented.
+ */
+
+// ---------------------------------------------------------------------------
+// Hook type / event model
+// ---------------------------------------------------------------------------
+
+/** Category of hook source */
+export type HookType = 'git' | 'system'
+
+/** Status of an individual hook definition */
+export type HookStatus = 'active' | 'inactive' | 'error'
+
+/**
+ * A registered hook that the hook service monitors.
+ *
+ * Git hooks: pre-commit, post-commit, pre-push, post-merge, etc.
+ * System hooks: file-change, process-event, cron-trigger, etc.
+ */
+export interface Hook {
+  id: string
+  name: string
+  type: HookType
+  /** Specific event that triggers this hook (e.g. "pre-commit", "file-change") */
+  event: string
+  enabled: boolean
+  created_at: string
+  updated_at?: string
+  /** Human-readable description of what this hook does */
+  description?: string
+  /** Notification message template rendered when the hook fires */
+  notification_template?: string
+}
+
+/**
+ * A log entry representing a single hook execution event.
+ */
+export interface HookEvent {
+  id: string
+  hook_id: string
+  hook_name: string
+  hook_type: HookType
+  event: string
+  status: 'success' | 'failure' | 'skipped'
+  triggered_at: string
+  duration_ms?: number
+  payload?: Record<string, unknown>
+  error?: string
+}
+
+/**
+ * Configuration for a hook's notification trigger.
+ */
+export interface HookNotificationTrigger {
+  hook_id: string
+  /** Which hook events produce notifications: "all" | "failure" | "success" */
+  on: 'all' | 'failure' | 'success'
+  title_template: string
+  message_template: string
+  priority: 'Low' | 'Normal' | 'High' | 'Urgent'
+}
+
+// ---------------------------------------------------------------------------
+// API response shapes (anticipated)
+// ---------------------------------------------------------------------------
+
+export interface HookListResponse {
+  hooks: Hook[]
+  total: number
+}
+
+export interface HookEventListResponse {
+  events: HookEvent[]
+  total: number
+}


### PR DESCRIPTION
## Summary

- **Types** (`src/types/hook.ts`): Full anticipated data model for the hook service — `Hook`, `HookEvent`, `HookNotificationTrigger`, list response shapes
- **Stub hooks** (`src/hooks/useHooks.ts`): `useHooks`, `useHookEvents`, `useHookServiceStatus` — return empty/unreachable data until the hook service (port 17002) is implemented; exports `HOOK_SERVICE_PORT = 17002`
- **HookPlaceholder** (`src/components/hooks/HookPlaceholder.tsx`): Coming-soon state with:
  - Service health indicator showing port 17002 with `unknown` status badge
  - Explanation of what hooks will do (git events, system events, notification creation)
  - Five planned feature preview cards: Git Hooks, System Hooks, Event Log, Hook Configuration, Notification Triggers
  - Link to GitHub issue #179 for progress tracking
- **HookList** (`src/pages/hooks/HookList.tsx`): Page component wired to `useHooks()` stub; ready for real implementation
- **HookDetail** (`src/pages/hooks/HookDetail.tsx`): Placeholder detail page with back navigation
- **HooksPage.tsx**: Updated to delegate to `HookList`
- Route `/hooks` was already registered in `App.tsx`

## Test plan

- [x] `bunx tsc --noEmit` — TypeScript clean
- [x] `bunx vitest run` — 496 tests passing across 54 test files
- [x] 9 unit tests for `useHooks`, `useHookEvents`, `useHookServiceStatus` stubs
- [x] 12 component tests for `HookPlaceholder` covering all rendered sections, service port, status badge, feature cards, and GitHub link

Closes #179

🤖 Generated with [Claude Code](https://claude.com/claude-code)