### PR TITLE
feat(ui): build workflow management view for automated task dispatching

### DIFF
--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -13,6 +13,7 @@ import {
   WorkflowsPage,
 } from '@/pages'
 import { AgentDetail } from '@/pages/agents/AgentDetail'
+import { WorkflowDetail } from '@/pages/workflows/WorkflowDetail'
 import { ErrorBoundary } from '@/components/common/ErrorBoundary'
 
 function App() {
@@ -28,6 +29,7 @@ function App() {
             <Route path="/notifications" element={<NotificationsPage />} />
             <Route path="/questions" element={<QuestionsPage />} />
             <Route path="/workflows" element={<WorkflowsPage />} />
+            <Route path="/workflows/:id" element={<WorkflowDetail />} />
             <Route path="/monitoring" element={<MonitoringPage />} />
             <Route path="/hooks" element={<HooksPage />} />
             <Route path="/settings" element={<SettingsPage />} />

--- a/ui/src/components/workflows/DispatchHistory.tsx
+++ b/ui/src/components/workflows/DispatchHistory.tsx
@@ -1,0 +1,222 @@
+/**
+ * DispatchHistory — paginated table of workflow dispatch records.
+ *
+ * Shows source ID, prompt excerpt, status badge, and timestamps.
+ * Supports filtering by status and pagination.
+ */
+
+import { useState } from 'react'
+import { ChevronDown, ChevronUp } from 'lucide-react'
+import { ListItemSkeleton } from '@/components/common/LoadingSkeleton'
+import { Pagination } from '@/components/common/Pagination'
+import { useDispatchHistory } from '@/hooks/useWorkflows'
+import type { DispatchRecord, DispatchStatus } from '@/types/orchestrator'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface DispatchHistoryProps {
+  workflowId: string
+  pageSize?: number
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const STATUS_STYLES: Record<DispatchStatus, string> = {
+  pending: 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400',
+  dispatched: 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400',
+  completed: 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400',
+  failed: 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400',
+  skipped: 'bg-gray-100 text-gray-600 dark:bg-gray-800 dark:text-gray-400',
+}
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleString(undefined, {
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+}
+
+function truncate(text: string, maxLen = 80): string {
+  return text.length > maxLen ? text.slice(0, maxLen) + '…' : text
+}
+
+// ---------------------------------------------------------------------------
+// Status filter
+// ---------------------------------------------------------------------------
+
+const STATUS_OPTIONS: Array<{ value: DispatchStatus | 'all'; label: string }> = [
+  { value: 'all', label: 'All' },
+  { value: 'dispatched', label: 'Dispatched' },
+  { value: 'completed', label: 'Completed' },
+  { value: 'failed', label: 'Failed' },
+  { value: 'skipped', label: 'Skipped' },
+  { value: 'pending', label: 'Pending' },
+]
+
+// ---------------------------------------------------------------------------
+// Row component
+// ---------------------------------------------------------------------------
+
+function DispatchRow({ record }: { record: DispatchRecord }) {
+  const [expanded, setExpanded] = useState(false)
+
+  return (
+    <>
+      <tr className="border-t border-gray-100 dark:border-gray-800 hover:bg-gray-50 dark:hover:bg-gray-800/50">
+        <td className="py-2 px-4 font-mono text-xs text-gray-500 dark:text-gray-400">
+          {record.source_id}
+        </td>
+        <td className="py-2 px-4 text-sm">
+          <div className="flex items-start gap-1">
+            <span className="text-gray-700 dark:text-gray-300 leading-relaxed">
+              {truncate(record.prompt_sent)}
+            </span>
+            {record.prompt_sent.length > 80 && (
+              <button
+                type="button"
+                onClick={() => setExpanded((v) => !v)}
+                className="flex-shrink-0 text-primary-500 hover:text-primary-700 focus-visible:outline-none"
+                aria-label={expanded ? 'Collapse prompt' : 'Expand prompt'}
+              >
+                {expanded ? <ChevronUp size={14} /> : <ChevronDown size={14} />}
+              </button>
+            )}
+          </div>
+        </td>
+        <td className="py-2 px-4">
+          <span
+            className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${STATUS_STYLES[record.status]}`}
+          >
+            {record.status}
+          </span>
+        </td>
+        <td className="py-2 px-4 text-xs text-gray-500 dark:text-gray-400 whitespace-nowrap">
+          {formatDate(record.dispatched_at)}
+        </td>
+        <td className="py-2 px-4 text-xs text-gray-400 dark:text-gray-500 whitespace-nowrap">
+          {record.completed_at ? formatDate(record.completed_at) : '—'}
+        </td>
+      </tr>
+
+      {expanded && (
+        <tr className="bg-gray-50 dark:bg-gray-800/50">
+          <td colSpan={5} className="px-4 py-2">
+            <pre className="text-xs font-mono text-gray-700 dark:text-gray-300 whitespace-pre-wrap">
+              {record.prompt_sent}
+            </pre>
+          </td>
+        </tr>
+      )}
+    </>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+export function DispatchHistory({ workflowId, pageSize = 20 }: DispatchHistoryProps) {
+  const [page, setPage] = useState(1)
+  const [statusFilter, setStatusFilter] = useState<DispatchStatus | 'all'>('all')
+
+  const { dispatches, total, loading, error } = useDispatchHistory({
+    workflowId,
+    page,
+    pageSize,
+    status: statusFilter === 'all' ? undefined : statusFilter,
+  })
+
+  return (
+    <div className="space-y-3">
+      {/* Filter bar */}
+      <div className="flex items-center gap-2">
+        <span className="text-xs text-gray-500 dark:text-gray-400">Filter:</span>
+        <div className="flex gap-1">
+          {STATUS_OPTIONS.map((opt) => (
+            <button
+              key={opt.value}
+              type="button"
+              onClick={() => { setStatusFilter(opt.value); setPage(1) }}
+              className={[
+                'rounded px-2 py-0.5 text-xs transition-colors',
+                statusFilter === opt.value
+                  ? 'bg-primary-100 text-primary-700 dark:bg-primary-900/30 dark:text-primary-400 font-medium'
+                  : 'text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200',
+              ].join(' ')}
+            >
+              {opt.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Table */}
+      <div className="overflow-x-auto rounded-lg border border-gray-200 dark:border-gray-700">
+        <table className="min-w-full text-sm">
+          <thead className="bg-gray-50 dark:bg-gray-800">
+            <tr>
+              <th className="py-2 px-4 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide">
+                Source ID
+              </th>
+              <th className="py-2 px-4 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide">
+                Prompt sent
+              </th>
+              <th className="py-2 px-4 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide">
+                Status
+              </th>
+              <th className="py-2 px-4 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide">
+                Dispatched
+              </th>
+              <th className="py-2 px-4 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide">
+                Completed
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {loading ? (
+              Array.from({ length: 3 }).map((_, i) => (
+                <tr key={i} className="border-t border-gray-100 dark:border-gray-800">
+                  <td colSpan={5} className="p-2">
+                    <ListItemSkeleton />
+                  </td>
+                </tr>
+              ))
+            ) : error ? (
+              <tr>
+                <td colSpan={5} className="py-8 text-center text-sm text-red-500">
+                  {error}
+                </td>
+              </tr>
+            ) : dispatches.length === 0 ? (
+              <tr>
+                <td colSpan={5} className="py-8 text-center text-sm text-gray-400 dark:text-gray-500">
+                  No dispatches found.
+                </td>
+              </tr>
+            ) : (
+              dispatches.map((record) => <DispatchRow key={record.id} record={record} />)
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      {/* Pagination */}
+      {total > pageSize && (
+        <Pagination
+          currentPage={page}
+          totalItems={total}
+          pageSize={pageSize}
+          onPageChange={setPage}
+        />
+      )}
+    </div>
+  )
+}
+
+export default DispatchHistory

--- a/ui/src/components/workflows/PromptTemplateEditor.tsx
+++ b/ui/src/components/workflows/PromptTemplateEditor.tsx
@@ -1,0 +1,159 @@
+/**
+ * PromptTemplateEditor — textarea with variable placeholder hints and live preview.
+ *
+ * Shows available template variables ({{title}}, {{body}}, etc.) and
+ * renders a preview substituting sample values so the user can see
+ * how the prompt will look when dispatched.
+ */
+
+import { useState } from 'react'
+import { ChevronDown, ChevronUp, Info } from 'lucide-react'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface PromptTemplateEditorProps {
+  value: string
+  onChange: (value: string) => void
+  disabled?: boolean
+  error?: string
+}
+
+// ---------------------------------------------------------------------------
+// Template variable definitions
+// ---------------------------------------------------------------------------
+
+const TEMPLATE_VARS: Array<{ name: string; description: string; sample: string }> = [
+  { name: '{{title}}', description: 'Task title', sample: 'Fix login bug' },
+  { name: '{{body}}', description: 'Task body / description', sample: 'Users cannot log in with SSO...' },
+  { name: '{{url}}', description: 'Source URL', sample: 'https://github.com/owner/repo/issues/42' },
+  { name: '{{labels}}', description: 'Comma-separated labels', sample: 'bug, high-priority' },
+  { name: '{{source_id}}', description: 'Source identifier (e.g. issue number)', sample: '42' },
+]
+
+const DEFAULT_TEMPLATE =
+  `You are working on the following task:\n\nTitle: {{title}}\n\nDescription:\n{{body}}\n\nSource: {{url}}\nLabels: {{labels}}\n\nPlease work on this task and report back when complete.`
+
+/** Render a template with sample values for preview */
+function renderPreview(template: string): string {
+  let result = template
+  for (const v of TEMPLATE_VARS) {
+    result = result.replaceAll(v.name, v.sample)
+  }
+  return result
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function PromptTemplateEditor({
+  value,
+  onChange,
+  disabled = false,
+  error,
+}: PromptTemplateEditorProps) {
+  const [showPreview, setShowPreview] = useState(false)
+  const [showVars, setShowVars] = useState(false)
+
+  function insertVariable(varName: string) {
+    // Append variable at cursor position. As a simple fallback, append at end.
+    onChange(value + varName)
+  }
+
+  const preview = renderPreview(value || DEFAULT_TEMPLATE)
+  const hasValue = value.trim().length > 0
+
+  return (
+    <div className="space-y-2">
+      {/* Textarea */}
+      <textarea
+        value={value}
+        onChange={(e) => onChange(e.target.value)}
+        disabled={disabled}
+        rows={6}
+        placeholder={DEFAULT_TEMPLATE}
+        className={[
+          'w-full rounded-md border px-3 py-2 text-sm font-mono',
+          'bg-white dark:bg-gray-900',
+          'text-gray-900 dark:text-white',
+          'placeholder:text-gray-400 dark:placeholder:text-gray-600',
+          'focus:outline-none focus:ring-2 focus:ring-primary-500',
+          'disabled:cursor-not-allowed disabled:opacity-50',
+          error
+            ? 'border-red-400 dark:border-red-500'
+            : 'border-gray-300 dark:border-gray-600',
+        ].join(' ')}
+      />
+      {error && <p className="text-xs text-red-500 dark:text-red-400">{error}</p>}
+
+      {/* Available variables */}
+      <div className="rounded-md border border-gray-200 dark:border-gray-700 overflow-hidden">
+        <button
+          type="button"
+          onClick={() => setShowVars((v) => !v)}
+          className="flex w-full items-center justify-between px-3 py-2 text-xs text-gray-600 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors"
+        >
+          <span className="flex items-center gap-1.5">
+            <Info size={12} />
+            Available variables
+          </span>
+          {showVars ? <ChevronUp size={12} /> : <ChevronDown size={12} />}
+        </button>
+
+        {showVars && (
+          <div className="border-t border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800/50 px-3 py-2">
+            <div className="flex flex-wrap gap-2">
+              {TEMPLATE_VARS.map((v) => (
+                <button
+                  key={v.name}
+                  type="button"
+                  onClick={() => insertVariable(v.name)}
+                  disabled={disabled}
+                  title={`${v.description} — click to insert`}
+                  className="inline-flex items-center gap-1 rounded border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-800 px-2 py-0.5 font-mono text-xs text-primary-600 dark:text-primary-400 hover:bg-primary-50 dark:hover:bg-primary-900/20 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                >
+                  {v.name}
+                </button>
+              ))}
+            </div>
+            <table className="mt-2 w-full text-xs">
+              <tbody>
+                {TEMPLATE_VARS.map((v) => (
+                  <tr key={v.name} className="border-t border-gray-100 dark:border-gray-700">
+                    <td className="py-1 pr-3 font-mono text-primary-600 dark:text-primary-400 whitespace-nowrap">{v.name}</td>
+                    <td className="py-1 pr-3 text-gray-600 dark:text-gray-400">{v.description}</td>
+                    <td className="py-1 text-gray-400 dark:text-gray-500 italic">{v.sample}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+
+      {/* Preview */}
+      {hasValue && (
+        <div className="rounded-md border border-gray-200 dark:border-gray-700 overflow-hidden">
+          <button
+            type="button"
+            onClick={() => setShowPreview((v) => !v)}
+            className="flex w-full items-center justify-between px-3 py-2 text-xs text-gray-600 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-800 transition-colors"
+          >
+            <span>Preview with sample data</span>
+            {showPreview ? <ChevronUp size={12} /> : <ChevronDown size={12} />}
+          </button>
+
+          {showPreview && (
+            <pre className="border-t border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-800/50 px-3 py-2 text-xs text-gray-700 dark:text-gray-300 whitespace-pre-wrap font-mono overflow-auto max-h-48">
+              {preview}
+            </pre>
+          )}
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default PromptTemplateEditor

--- a/ui/src/components/workflows/WorkflowForm.tsx
+++ b/ui/src/components/workflows/WorkflowForm.tsx
@@ -1,0 +1,448 @@
+/**
+ * WorkflowForm — create/edit workflow dialog.
+ *
+ * Fields:
+ * - Name
+ * - Agent (dropdown filtered to Running agents)
+ * - Task source type (GitHub Issues)
+ * - GitHub Issues config: owner, repo, labels, state
+ * - Prompt template (with PromptTemplateEditor)
+ * - Poll interval (in minutes)
+ * - Enabled toggle
+ *
+ * Validation: agent must be selected, GitHub fields required, interval ≥ 1m.
+ */
+
+import { useEffect, useRef, useState } from 'react'
+import { X } from 'lucide-react'
+import { PromptTemplateEditor } from './PromptTemplateEditor'
+import type { Agent } from '@/types/orchestrator'
+import type { CreateWorkflowRequest, Workflow } from '@/types/orchestrator'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface WorkflowFormProps {
+  open: boolean
+  /** Provided when editing; undefined when creating */
+  workflow?: Workflow
+  /** List of available agents */
+  agents: Agent[]
+  onSave: (request: CreateWorkflowRequest) => Promise<void>
+  onClose: () => void
+}
+
+interface FormErrors {
+  name?: string
+  agent_id?: string
+  owner?: string
+  repo?: string
+  prompt_template?: string
+  poll_interval?: string
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const DEFAULT_TEMPLATE =
+  `You are working on the following task:\n\nTitle: {{title}}\n\nDescription:\n{{body}}\n\nSource: {{url}}\nLabels: {{labels}}\n\nPlease work on this task and report back when complete.`
+
+function secsToMinutes(secs: number): string {
+  const mins = Math.round(secs / 60)
+  return String(mins)
+}
+
+function minutesToSecs(mins: string): number {
+  const n = parseInt(mins, 10)
+  return isNaN(n) ? 60 : Math.max(1, n) * 60
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function WorkflowForm({ open, workflow, agents, onSave, onClose }: WorkflowFormProps) {
+  const firstFieldRef = useRef<HTMLInputElement>(null)
+
+  // Form state
+  const [name, setName] = useState('')
+  const [agentId, setAgentId] = useState('')
+  const [owner, setOwner] = useState('')
+  const [repo, setRepo] = useState('')
+  const [labelsRaw, setLabelsRaw] = useState('')
+  const [issueState, setIssueState] = useState<'open' | 'closed' | 'all'>('open')
+  const [promptTemplate, setPromptTemplate] = useState(DEFAULT_TEMPLATE)
+  const [pollMinutes, setPollMinutes] = useState('15')
+  const [enabled, setEnabled] = useState(true)
+  const [errors, setErrors] = useState<FormErrors>({})
+  const [saving, setSaving] = useState(false)
+  const [saveError, setSaveError] = useState<string | undefined>()
+
+  // Populate form when editing
+  useEffect(() => {
+    if (!open) return
+    if (workflow) {
+      setName(workflow.name)
+      setAgentId(workflow.agent_id)
+      const src = workflow.source_config
+      if (src.type === 'github_issues') {
+        setOwner(src.owner)
+        setRepo(src.repo)
+        setLabelsRaw(src.labels.join(', '))
+        setIssueState(src.state as 'open' | 'closed' | 'all')
+      }
+      setPromptTemplate(workflow.prompt_template)
+      setPollMinutes(secsToMinutes(workflow.poll_interval_secs))
+      setEnabled(workflow.enabled)
+    } else {
+      setName('')
+      setAgentId('')
+      setOwner('')
+      setRepo('')
+      setLabelsRaw('')
+      setIssueState('open')
+      setPromptTemplate(DEFAULT_TEMPLATE)
+      setPollMinutes('15')
+      setEnabled(true)
+    }
+    setErrors({})
+    setSaveError(undefined)
+    // Focus first field after render
+    setTimeout(() => firstFieldRef.current?.focus(), 50)
+  }, [open, workflow])
+
+  // Close on Escape
+  useEffect(() => {
+    if (!open) return
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === 'Escape') onClose()
+    }
+    document.addEventListener('keydown', handleKeyDown)
+    return () => document.removeEventListener('keydown', handleKeyDown)
+  }, [open, onClose])
+
+  if (!open) return null
+
+  // Validation
+  function validate(): FormErrors {
+    const e: FormErrors = {}
+    if (!name.trim()) e.name = 'Name is required'
+    if (!agentId) e.agent_id = 'Select an agent'
+    if (!owner.trim()) e.owner = 'Owner is required'
+    if (!repo.trim()) e.repo = 'Repository is required'
+    if (!promptTemplate.trim()) e.prompt_template = 'Prompt template is required'
+    const mins = parseInt(pollMinutes, 10)
+    if (isNaN(mins) || mins < 1) e.poll_interval = 'Minimum poll interval is 1 minute'
+    return e
+  }
+
+  async function handleSave() {
+    const e = validate()
+    if (Object.keys(e).length > 0) {
+      setErrors(e)
+      return
+    }
+
+    setSaving(true)
+    setSaveError(undefined)
+    try {
+      const labels = labelsRaw
+        .split(',')
+        .map((l) => l.trim())
+        .filter(Boolean)
+
+      const request: CreateWorkflowRequest = {
+        name: name.trim(),
+        agent_id: agentId,
+        source_config: {
+          type: 'github_issues',
+          owner: owner.trim(),
+          repo: repo.trim(),
+          labels,
+          state: issueState,
+        },
+        prompt_template: promptTemplate.trim(),
+        poll_interval_secs: minutesToSecs(pollMinutes),
+        enabled,
+        tool_policy: { type: 'AllowAll' },
+      }
+
+      await onSave(request)
+      onClose()
+    } catch (err) {
+      setSaveError(err instanceof Error ? err.message : 'Failed to save workflow')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  const runningAgents = agents.filter((a) => a.status === 'Running')
+  const isEditing = Boolean(workflow)
+
+  return (
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center p-4"
+      role="dialog"
+      aria-modal="true"
+      aria-labelledby="workflow-form-title"
+    >
+      {/* Backdrop */}
+      <div
+        className="absolute inset-0 bg-black/50"
+        onClick={onClose}
+        aria-hidden="true"
+      />
+
+      {/* Panel */}
+      <div className="relative z-10 w-full max-w-2xl max-h-[90vh] overflow-y-auto rounded-xl bg-white dark:bg-gray-900 shadow-xl">
+        {/* Header */}
+        <div className="sticky top-0 z-10 flex items-center justify-between border-b border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 px-6 py-4">
+          <h2 id="workflow-form-title" className="text-lg font-semibold text-gray-900 dark:text-white">
+            {isEditing ? 'Edit Workflow' : 'Create Workflow'}
+          </h2>
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded p-1 text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500"
+            aria-label="Close dialog"
+          >
+            <X size={18} />
+          </button>
+        </div>
+
+        {/* Body */}
+        <div className="px-6 py-5 space-y-5">
+          {saveError && (
+            <p className="rounded-md bg-red-50 dark:bg-red-900/20 px-3 py-2 text-sm text-red-700 dark:text-red-400">
+              {saveError}
+            </p>
+          )}
+
+          {/* Name */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+              Workflow name <span className="text-red-500">*</span>
+            </label>
+            <input
+              ref={firstFieldRef}
+              type="text"
+              value={name}
+              onChange={(e) => setName(e.target.value)}
+              placeholder="e.g. Dispatch GitHub Issues"
+              className={fieldClass(errors.name)}
+            />
+            {errors.name && <p className="mt-1 text-xs text-red-500">{errors.name}</p>}
+          </div>
+
+          {/* Agent */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+              Agent <span className="text-red-500">*</span>
+            </label>
+            <select
+              value={agentId}
+              onChange={(e) => setAgentId(e.target.value)}
+              className={fieldClass(errors.agent_id)}
+            >
+              <option value="">Select a running agent…</option>
+              {runningAgents.map((a) => (
+                <option key={a.id} value={a.id}>
+                  {a.name}
+                </option>
+              ))}
+            </select>
+            {runningAgents.length === 0 && (
+              <p className="mt-1 text-xs text-yellow-600 dark:text-yellow-400">
+                No running agents found. Start an agent first.
+              </p>
+            )}
+            {errors.agent_id && <p className="mt-1 text-xs text-red-500">{errors.agent_id}</p>}
+          </div>
+
+          {/* Task source type */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+              Task source type
+            </label>
+            <select
+              value="github_issues"
+              disabled
+              className={fieldClass()}
+            >
+              <option value="github_issues">GitHub Issues</option>
+            </select>
+            <p className="mt-1 text-xs text-gray-400 dark:text-gray-500">
+              More source types planned for future releases.
+            </p>
+          </div>
+
+          {/* GitHub Issues config */}
+          <fieldset className="rounded-lg border border-gray-200 dark:border-gray-700 p-4 space-y-3">
+            <legend className="text-sm font-medium text-gray-700 dark:text-gray-300 px-1">
+              GitHub Issues configuration
+            </legend>
+
+            <div className="grid grid-cols-2 gap-3">
+              <div>
+                <label className="block text-xs font-medium text-gray-600 dark:text-gray-400 mb-1">
+                  Owner <span className="text-red-500">*</span>
+                </label>
+                <input
+                  type="text"
+                  value={owner}
+                  onChange={(e) => setOwner(e.target.value)}
+                  placeholder="e.g. geoffjay"
+                  className={fieldClass(errors.owner, 'text-sm')}
+                />
+                {errors.owner && <p className="mt-1 text-xs text-red-500">{errors.owner}</p>}
+              </div>
+              <div>
+                <label className="block text-xs font-medium text-gray-600 dark:text-gray-400 mb-1">
+                  Repository <span className="text-red-500">*</span>
+                </label>
+                <input
+                  type="text"
+                  value={repo}
+                  onChange={(e) => setRepo(e.target.value)}
+                  placeholder="e.g. agentd"
+                  className={fieldClass(errors.repo, 'text-sm')}
+                />
+                {errors.repo && <p className="mt-1 text-xs text-red-500">{errors.repo}</p>}
+              </div>
+            </div>
+
+            <div>
+              <label className="block text-xs font-medium text-gray-600 dark:text-gray-400 mb-1">
+                Labels <span className="text-gray-400">(comma-separated)</span>
+              </label>
+              <input
+                type="text"
+                value={labelsRaw}
+                onChange={(e) => setLabelsRaw(e.target.value)}
+                placeholder="e.g. bug, enhancement"
+                className={fieldClass(undefined, 'text-sm')}
+              />
+            </div>
+
+            <div>
+              <label className="block text-xs font-medium text-gray-600 dark:text-gray-400 mb-1">
+                Issue state
+              </label>
+              <select
+                value={issueState}
+                onChange={(e) => setIssueState(e.target.value as 'open' | 'closed' | 'all')}
+                className={fieldClass(undefined, 'text-sm')}
+              >
+                <option value="open">Open</option>
+                <option value="closed">Closed</option>
+                <option value="all">All</option>
+              </select>
+            </div>
+          </fieldset>
+
+          {/* Prompt template */}
+          <div>
+            <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+              Prompt template <span className="text-red-500">*</span>
+            </label>
+            <PromptTemplateEditor
+              value={promptTemplate}
+              onChange={setPromptTemplate}
+              disabled={saving}
+              error={errors.prompt_template}
+            />
+          </div>
+
+          {/* Poll interval + Enabled */}
+          <div className="grid grid-cols-2 gap-4">
+            <div>
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                Poll interval (minutes) <span className="text-red-500">*</span>
+              </label>
+              <input
+                type="number"
+                min={1}
+                value={pollMinutes}
+                onChange={(e) => setPollMinutes(e.target.value)}
+                className={fieldClass(errors.poll_interval)}
+              />
+              {errors.poll_interval && (
+                <p className="mt-1 text-xs text-red-500">{errors.poll_interval}</p>
+              )}
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-3">
+                Enabled
+              </label>
+              <button
+                type="button"
+                role="switch"
+                aria-checked={enabled}
+                onClick={() => setEnabled((v) => !v)}
+                className={[
+                  'relative inline-flex h-6 w-11 items-center rounded-full transition-colors',
+                  'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500',
+                  enabled
+                    ? 'bg-primary-500'
+                    : 'bg-gray-200 dark:bg-gray-700',
+                ].join(' ')}
+              >
+                <span
+                  className={[
+                    'inline-block h-4 w-4 rounded-full bg-white shadow transition-transform',
+                    enabled ? 'translate-x-6' : 'translate-x-1',
+                  ].join(' ')}
+                />
+              </button>
+            </div>
+          </div>
+        </div>
+
+        {/* Footer */}
+        <div className="sticky bottom-0 flex items-center justify-end gap-3 border-t border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 px-6 py-4">
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={saving}
+            className="rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors disabled:opacity-50"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={handleSave}
+            disabled={saving}
+            className="rounded-md bg-primary-600 px-4 py-2 text-sm font-medium text-white hover:bg-primary-700 transition-colors disabled:opacity-50"
+          >
+            {saving ? 'Saving…' : isEditing ? 'Save changes' : 'Create workflow'}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Style helpers
+// ---------------------------------------------------------------------------
+
+function fieldClass(error?: string, extra = ''): string {
+  return [
+    'w-full rounded-md border px-3 py-2 text-sm',
+    'bg-white dark:bg-gray-900',
+    'text-gray-900 dark:text-white',
+    'focus:outline-none focus:ring-2 focus:ring-primary-500',
+    'disabled:cursor-not-allowed disabled:opacity-50',
+    error
+      ? 'border-red-400 dark:border-red-500'
+      : 'border-gray-300 dark:border-gray-600',
+    extra,
+  ]
+    .filter(Boolean)
+    .join(' ')
+}
+
+export default WorkflowForm

--- a/ui/src/components/workflows/WorkflowTable.tsx
+++ b/ui/src/components/workflows/WorkflowTable.tsx
@@ -1,0 +1,280 @@
+/**
+ * WorkflowTable — paginated table of workflow configurations.
+ *
+ * Columns: name, agent, source summary, poll interval, enabled toggle,
+ *          dispatch count (from history), actions (edit, delete).
+ */
+
+import { useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { Edit2, Eye, Trash2 } from 'lucide-react'
+import { AgentStatusBadge } from '@/components/agents/AgentStatusBadge'
+import { ConfirmDialog } from '@/components/common/ConfirmDialog'
+import { ListItemSkeleton } from '@/components/common/LoadingSkeleton'
+import type { Agent, Workflow } from '@/types/orchestrator'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface WorkflowTableProps {
+  workflows: Workflow[]
+  agents: Agent[]
+  loading: boolean
+  onEdit: (workflow: Workflow) => void
+  onDelete: (id: string) => Promise<void>
+  onToggleEnabled: (id: string, enabled: boolean) => Promise<void>
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function sourceLabel(workflow: Workflow): string {
+  const src = workflow.source_config
+  if (src.type === 'github_issues') {
+    const parts = [`${src.owner}/${src.repo}`]
+    if (src.labels.length > 0) parts.push(`#${src.labels[0]}`)
+    if (src.labels.length > 1) parts.push(`+${src.labels.length - 1}`)
+    return `GitHub: ${parts.join(' ')}`
+  }
+  return src.type
+}
+
+function formatInterval(secs: number): string {
+  if (secs < 60) return `${secs}s`
+  const mins = Math.round(secs / 60)
+  if (mins < 60) return `${mins}m`
+  return `${Math.round(mins / 60)}h`
+}
+
+// ---------------------------------------------------------------------------
+// Empty state
+// ---------------------------------------------------------------------------
+
+function EmptyState() {
+  return (
+    <tr>
+      <td colSpan={7} className="py-12 text-center">
+        <p className="text-sm text-gray-500 dark:text-gray-400">
+          No workflows configured yet.
+        </p>
+        <p className="mt-1 text-xs text-gray-400 dark:text-gray-500">
+          Create a workflow to start dispatching tasks automatically.
+        </p>
+      </td>
+    </tr>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Toggle switch
+// ---------------------------------------------------------------------------
+
+function ToggleSwitch({
+  checked,
+  onChange,
+  disabled,
+  label,
+}: {
+  checked: boolean
+  onChange: (v: boolean) => void
+  disabled?: boolean
+  label: string
+}) {
+  return (
+    <button
+      type="button"
+      role="switch"
+      aria-checked={checked}
+      aria-label={label}
+      disabled={disabled}
+      onClick={() => onChange(!checked)}
+      className={[
+        'relative inline-flex h-5 w-9 items-center rounded-full transition-colors',
+        'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500',
+        'disabled:opacity-50 disabled:cursor-not-allowed',
+        checked ? 'bg-primary-500' : 'bg-gray-200 dark:bg-gray-700',
+      ].join(' ')}
+    >
+      <span
+        className={[
+          'inline-block h-3.5 w-3.5 rounded-full bg-white shadow transition-transform',
+          checked ? 'translate-x-4' : 'translate-x-0.5',
+        ].join(' ')}
+      />
+    </button>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// WorkflowTable
+// ---------------------------------------------------------------------------
+
+export function WorkflowTable({
+  workflows,
+  agents,
+  loading,
+  onEdit,
+  onDelete,
+  onToggleEnabled,
+}: WorkflowTableProps) {
+  const navigate = useNavigate()
+  const [deletingId, setDeletingId] = useState<string | null>(null)
+  const [togglingId, setTogglingId] = useState<string | null>(null)
+
+  const agentMap = new Map(agents.map((a) => [a.id, a]))
+
+  async function handleToggle(id: string, enabled: boolean) {
+    setTogglingId(id)
+    try {
+      await onToggleEnabled(id, enabled)
+    } finally {
+      setTogglingId(null)
+    }
+  }
+
+  async function handleDelete() {
+    if (!deletingId) return
+    await onDelete(deletingId)
+    setDeletingId(null)
+  }
+
+  return (
+    <>
+      <div className="overflow-x-auto rounded-lg border border-gray-200 dark:border-gray-700">
+        <table className="min-w-full text-sm">
+          <thead className="bg-gray-50 dark:bg-gray-800">
+            <tr>
+              {['Workflow', 'Agent', 'Source', 'Interval', 'Enabled', 'Updated', ''].map((h) => (
+                <th
+                  key={h}
+                  className="py-3 px-4 text-left text-xs font-medium text-gray-500 dark:text-gray-400 uppercase tracking-wide whitespace-nowrap"
+                >
+                  {h}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-100 dark:divide-gray-800">
+            {loading ? (
+              Array.from({ length: 3 }).map((_, i) => (
+                <tr key={i}>
+                  <td colSpan={7} className="p-2">
+                    <ListItemSkeleton />
+                  </td>
+                </tr>
+              ))
+            ) : workflows.length === 0 ? (
+              <EmptyState />
+            ) : (
+              workflows.map((wf) => {
+                const agent = agentMap.get(wf.agent_id)
+                return (
+                  <tr
+                    key={wf.id}
+                    className="hover:bg-gray-50 dark:hover:bg-gray-800/40 transition-colors"
+                  >
+                    {/* Name */}
+                    <td className="py-3 px-4">
+                      <button
+                        type="button"
+                        onClick={() => navigate(`/workflows/${wf.id}`)}
+                        className="font-medium text-primary-600 dark:text-primary-400 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 rounded"
+                      >
+                        {wf.name}
+                      </button>
+                    </td>
+
+                    {/* Agent */}
+                    <td className="py-3 px-4">
+                      {agent ? (
+                        <div className="flex items-center gap-2">
+                          <AgentStatusBadge status={agent.status} variant="dot" />
+                          <span className="text-gray-700 dark:text-gray-300 text-xs">
+                            {agent.name}
+                          </span>
+                        </div>
+                      ) : (
+                        <span className="text-xs text-gray-400 dark:text-gray-500">
+                          Unknown agent
+                        </span>
+                      )}
+                    </td>
+
+                    {/* Source */}
+                    <td className="py-3 px-4 text-xs text-gray-500 dark:text-gray-400">
+                      {sourceLabel(wf)}
+                    </td>
+
+                    {/* Poll interval */}
+                    <td className="py-3 px-4 text-xs text-gray-500 dark:text-gray-400">
+                      {formatInterval(wf.poll_interval_secs)}
+                    </td>
+
+                    {/* Enabled toggle */}
+                    <td className="py-3 px-4">
+                      <ToggleSwitch
+                        checked={wf.enabled}
+                        onChange={(v) => handleToggle(wf.id, v)}
+                        disabled={togglingId === wf.id}
+                        label={`${wf.enabled ? 'Disable' : 'Enable'} ${wf.name}`}
+                      />
+                    </td>
+
+                    {/* Updated */}
+                    <td className="py-3 px-4 text-xs text-gray-400 dark:text-gray-500 whitespace-nowrap">
+                      {new Date(wf.updated_at).toLocaleDateString()}
+                    </td>
+
+                    {/* Actions */}
+                    <td className="py-3 px-4">
+                      <div className="flex items-center gap-1">
+                        <button
+                          type="button"
+                          onClick={() => navigate(`/workflows/${wf.id}`)}
+                          className="rounded p-1 text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500"
+                          aria-label={`View ${wf.name}`}
+                        >
+                          <Eye size={15} />
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => onEdit(wf)}
+                          className="rounded p-1 text-gray-400 hover:text-primary-600 dark:hover:text-primary-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500"
+                          aria-label={`Edit ${wf.name}`}
+                        >
+                          <Edit2 size={15} />
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => setDeletingId(wf.id)}
+                          className="rounded p-1 text-gray-400 hover:text-red-600 dark:hover:text-red-400 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500"
+                          aria-label={`Delete ${wf.name}`}
+                        >
+                          <Trash2 size={15} />
+                        </button>
+                      </div>
+                    </td>
+                  </tr>
+                )
+              })
+            )}
+          </tbody>
+        </table>
+      </div>
+
+      <ConfirmDialog
+        open={deletingId !== null}
+        title="Delete workflow"
+        description="This will permanently delete the workflow and stop all scheduled polling. Existing dispatch records will be removed."
+        confirmLabel="Delete"
+        variant="danger"
+        onConfirm={handleDelete}
+        onCancel={() => setDeletingId(null)}
+      />
+    </>
+  )
+}
+
+export default WorkflowTable

--- a/ui/src/components/workflows/index.ts
+++ b/ui/src/components/workflows/index.ts
@@ -1,0 +1,8 @@
+export { WorkflowTable } from './WorkflowTable'
+export type { WorkflowTableProps } from './WorkflowTable'
+export { WorkflowForm } from './WorkflowForm'
+export type { WorkflowFormProps } from './WorkflowForm'
+export { DispatchHistory } from './DispatchHistory'
+export type { DispatchHistoryProps } from './DispatchHistory'
+export { PromptTemplateEditor } from './PromptTemplateEditor'
+export type { PromptTemplateEditorProps } from './PromptTemplateEditor'

--- a/ui/src/hooks/useWorkflows.ts
+++ b/ui/src/hooks/useWorkflows.ts
@@ -1,0 +1,315 @@
+/**
+ * useWorkflows — hook for the workflow management page.
+ *
+ * Provides:
+ * - Paginated workflow fetching with auto-refresh
+ * - create, update, delete, toggle-enabled actions
+ * - Per-workflow dispatch history
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { orchestratorClient } from '@/services/orchestrator'
+import type {
+  CreateWorkflowRequest,
+  DispatchRecord,
+  UpdateWorkflowRequest,
+  Workflow,
+} from '@/types/orchestrator'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type WorkflowSortField = 'name' | 'created_at' | 'poll_interval_secs'
+export type WorkflowSortDir = 'asc' | 'desc'
+
+export interface UseWorkflowsOptions {
+  /** Only include enabled/disabled workflows; undefined = all */
+  enabled?: boolean
+  /** Client-side name search */
+  search?: string
+  page?: number
+  pageSize?: number
+  sortBy?: WorkflowSortField
+  sortDir?: WorkflowSortDir
+  /** Pause auto-refresh */
+  paused?: boolean
+  refreshInterval?: number
+}
+
+export interface UseWorkflowsResult {
+  workflows: Workflow[]
+  total: number
+  allWorkflows: Workflow[]
+  loading: boolean
+  refreshing: boolean
+  error?: string
+  refetch: () => void
+  createWorkflow: (request: CreateWorkflowRequest) => Promise<Workflow>
+  updateWorkflow: (id: string, request: UpdateWorkflowRequest) => Promise<Workflow>
+  deleteWorkflow: (id: string) => Promise<void>
+  toggleEnabled: (id: string, enabled: boolean) => Promise<Workflow>
+}
+
+export interface UseWorkflowDetailResult {
+  workflow?: Workflow
+  loading: boolean
+  error?: string
+  refetch: () => void
+  updateWorkflow: (request: UpdateWorkflowRequest) => Promise<Workflow>
+  deleteWorkflow: () => Promise<void>
+}
+
+export interface UseDispatchHistoryOptions {
+  workflowId: string
+  page?: number
+  pageSize?: number
+  status?: DispatchRecord['status']
+}
+
+export interface UseDispatchHistoryResult {
+  dispatches: DispatchRecord[]
+  total: number
+  loading: boolean
+  error?: string
+  refetch: () => void
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const DEFAULT_PAGE_SIZE = 20
+const DEFAULT_REFRESH_INTERVAL = 30_000
+
+function compareWorkflows(
+  a: Workflow,
+  b: Workflow,
+  field: WorkflowSortField,
+  dir: WorkflowSortDir,
+): number {
+  let result = 0
+  if (field === 'name') {
+    result = a.name.localeCompare(b.name)
+  } else if (field === 'created_at') {
+    result = new Date(a.created_at).getTime() - new Date(b.created_at).getTime()
+  } else if (field === 'poll_interval_secs') {
+    result = a.poll_interval_secs - b.poll_interval_secs
+  }
+  return dir === 'asc' ? result : -result
+}
+
+// ---------------------------------------------------------------------------
+// useWorkflows — list hook
+// ---------------------------------------------------------------------------
+
+export function useWorkflows({
+  enabled,
+  search = '',
+  page = 1,
+  pageSize = DEFAULT_PAGE_SIZE,
+  sortBy = 'created_at',
+  sortDir = 'desc',
+  paused = false,
+  refreshInterval = DEFAULT_REFRESH_INTERVAL,
+}: UseWorkflowsOptions = {}): UseWorkflowsResult {
+  const [allWorkflows, setAllWorkflows] = useState<Workflow[]>([])
+  const [loading, setLoading] = useState(true)
+  const [refreshing, setRefreshing] = useState(false)
+  const [error, setError] = useState<string | undefined>()
+
+  const timerRef = useRef<ReturnType<typeof setInterval> | null>(null)
+
+  const fetchWorkflows = useCallback(async (isBackground = false) => {
+    if (isBackground) {
+      setRefreshing(true)
+    } else {
+      setLoading(true)
+      setError(undefined)
+    }
+
+    try {
+      const result = await orchestratorClient.listWorkflows({ limit: 200 })
+      setAllWorkflows(result.items)
+      setError(undefined)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load workflows')
+    } finally {
+      setLoading(false)
+      setRefreshing(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    fetchWorkflows(false)
+  }, [fetchWorkflows])
+
+  useEffect(() => {
+    if (paused) {
+      if (timerRef.current) clearInterval(timerRef.current)
+      return
+    }
+    timerRef.current = setInterval(() => fetchWorkflows(true), refreshInterval)
+    return () => {
+      if (timerRef.current) clearInterval(timerRef.current)
+    }
+  }, [paused, refreshInterval, fetchWorkflows])
+
+  // Client-side filter, sort, paginate
+  const filtered = allWorkflows.filter((w) => {
+    if (enabled !== undefined && w.enabled !== enabled) return false
+    if (search) return w.name.toLowerCase().includes(search.toLowerCase())
+    return true
+  })
+
+  const sorted = [...filtered].sort((a, b) => compareWorkflows(a, b, sortBy, sortDir))
+  const total = sorted.length
+  const start = (page - 1) * pageSize
+  const workflows = sorted.slice(start, start + pageSize)
+
+  // Actions
+  const refetch = useCallback(() => fetchWorkflows(false), [fetchWorkflows])
+
+  const createWorkflow = useCallback(
+    async (request: CreateWorkflowRequest): Promise<Workflow> => {
+      const created = await orchestratorClient.createWorkflow(request)
+      await fetchWorkflows(true)
+      return created
+    },
+    [fetchWorkflows],
+  )
+
+  const updateWorkflow = useCallback(
+    async (id: string, request: UpdateWorkflowRequest): Promise<Workflow> => {
+      const updated = await orchestratorClient.updateWorkflow(id, request)
+      setAllWorkflows((prev) => prev.map((w) => (w.id === id ? updated : w)))
+      return updated
+    },
+    [],
+  )
+
+  const deleteWorkflow = useCallback(async (id: string): Promise<void> => {
+    await orchestratorClient.deleteWorkflow(id)
+    setAllWorkflows((prev) => prev.filter((w) => w.id !== id))
+  }, [])
+
+  const toggleEnabled = useCallback(
+    async (id: string, newEnabled: boolean): Promise<Workflow> => {
+      return updateWorkflow(id, { enabled: newEnabled })
+    },
+    [updateWorkflow],
+  )
+
+  return {
+    workflows,
+    total,
+    allWorkflows,
+    loading,
+    refreshing,
+    error,
+    refetch,
+    createWorkflow,
+    updateWorkflow,
+    deleteWorkflow,
+    toggleEnabled,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// useWorkflowDetail — single workflow
+// ---------------------------------------------------------------------------
+
+export function useWorkflowDetail(id: string): UseWorkflowDetailResult {
+  const [workflow, setWorkflow] = useState<Workflow | undefined>()
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | undefined>()
+
+  const fetchWorkflow = useCallback(async () => {
+    setLoading(true)
+    setError(undefined)
+    try {
+      const result = await orchestratorClient.getWorkflow(id)
+      setWorkflow(result)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load workflow')
+    } finally {
+      setLoading(false)
+    }
+  }, [id])
+
+  useEffect(() => {
+    fetchWorkflow()
+  }, [fetchWorkflow])
+
+  const updateWorkflow = useCallback(
+    async (request: UpdateWorkflowRequest): Promise<Workflow> => {
+      const updated = await orchestratorClient.updateWorkflow(id, request)
+      setWorkflow(updated)
+      return updated
+    },
+    [id],
+  )
+
+  const deleteWorkflow = useCallback(async (): Promise<void> => {
+    await orchestratorClient.deleteWorkflow(id)
+  }, [id])
+
+  return {
+    workflow,
+    loading,
+    error,
+    refetch: fetchWorkflow,
+    updateWorkflow,
+    deleteWorkflow,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// useDispatchHistory — per-workflow dispatch history
+// ---------------------------------------------------------------------------
+
+export function useDispatchHistory({
+  workflowId,
+  page = 1,
+  pageSize = DEFAULT_PAGE_SIZE,
+  status,
+}: UseDispatchHistoryOptions): UseDispatchHistoryResult {
+  const [allDispatches, setAllDispatches] = useState<DispatchRecord[]>([])
+  const [total, setTotal] = useState(0)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | undefined>()
+
+  const fetchHistory = useCallback(async () => {
+    setLoading(true)
+    setError(undefined)
+    try {
+      const result = await orchestratorClient.getWorkflowHistory(workflowId, {
+        limit: 100,
+        offset: 0,
+      })
+      setAllDispatches(result.items)
+      setTotal(result.total)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load dispatch history')
+    } finally {
+      setLoading(false)
+    }
+  }, [workflowId])
+
+  useEffect(() => {
+    fetchHistory()
+  }, [fetchHistory])
+
+  // Client-side filter + paginate
+  const filtered = status ? allDispatches.filter((d) => d.status === status) : allDispatches
+  const start = (page - 1) * pageSize
+  const dispatches = filtered.slice(start, start + pageSize)
+
+  return {
+    dispatches,
+    total: status ? filtered.length : total,
+    loading,
+    error,
+    refetch: fetchHistory,
+  }
+}

--- a/ui/src/pages/WorkflowsPage.tsx
+++ b/ui/src/pages/WorkflowsPage.tsx
@@ -1,12 +1,7 @@
+import { WorkflowList } from './workflows/WorkflowList'
+
 export function WorkflowsPage() {
-  return (
-    <div>
-      <h1 className="text-2xl font-semibold text-gray-900 dark:text-white">Workflows</h1>
-      <p className="mt-2 text-gray-500 dark:text-gray-400">
-        Configure and monitor automated workflows.
-      </p>
-    </div>
-  )
+  return <WorkflowList />
 }
 
 export default WorkflowsPage

--- a/ui/src/pages/workflows/WorkflowDetail.tsx
+++ b/ui/src/pages/workflows/WorkflowDetail.tsx
@@ -1,0 +1,246 @@
+/**
+ * WorkflowDetail — detail view for a single workflow.
+ *
+ * Layout:
+ * - Header: name, enabled status, agent, created/updated timestamps, actions
+ * - Configuration card: source config, prompt template, poll interval
+ * - Dispatch history table
+ */
+
+import { useState } from 'react'
+import { Link, useNavigate, useParams } from 'react-router-dom'
+import { ArrowLeft, Edit2, RefreshCw, Trash2, Zap } from 'lucide-react'
+import { DispatchHistory } from '@/components/workflows/DispatchHistory'
+import { WorkflowForm } from '@/components/workflows/WorkflowForm'
+import { ConfirmDialog } from '@/components/common/ConfirmDialog'
+import { CardSkeleton } from '@/components/common/LoadingSkeleton'
+import { StatusBadge } from '@/components/common/StatusBadge'
+import { useWorkflowDetail } from '@/hooks/useWorkflows'
+import { useAgents } from '@/hooks/useAgents'
+import type { CreateWorkflowRequest } from '@/types/orchestrator'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function sourceDetail(
+  src: { type: string; owner?: string; repo?: string; labels?: string[]; state?: string },
+): string {
+  if (src.type === 'github_issues') {
+    const parts: string[] = []
+    if (src.owner && src.repo) parts.push(`${src.owner}/${src.repo}`)
+    if (src.labels && src.labels.length > 0) parts.push(`Labels: ${src.labels.join(', ')}`)
+    if (src.state) parts.push(`State: ${src.state}`)
+    return parts.join(' · ')
+  }
+  return src.type
+}
+
+function formatDateTime(iso: string): string {
+  return new Date(iso).toLocaleString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+    hour: '2-digit',
+    minute: '2-digit',
+  })
+}
+
+// ---------------------------------------------------------------------------
+// Config detail card
+// ---------------------------------------------------------------------------
+
+function ConfigRow({ label, value }: { label: string; value: React.ReactNode }) {
+  return (
+    <div className="grid grid-cols-3 gap-4 py-3 border-t border-gray-100 dark:border-gray-800 first:border-t-0">
+      <dt className="text-sm font-medium text-gray-500 dark:text-gray-400">{label}</dt>
+      <dd className="col-span-2 text-sm text-gray-900 dark:text-white">{value}</dd>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// WorkflowDetail
+// ---------------------------------------------------------------------------
+
+export function WorkflowDetail() {
+  const { id } = useParams<{ id: string }>()
+  const navigate = useNavigate()
+
+  const { workflow, loading, error, refetch, updateWorkflow, deleteWorkflow } =
+    useWorkflowDetail(id ?? '')
+
+  const { allAgents } = useAgents({ pageSize: 200 })
+  const [formOpen, setFormOpen] = useState(false)
+  const [confirmDelete, setConfirmDelete] = useState(false)
+  const [deleting, setDeleting] = useState(false)
+
+  async function handleSave(request: CreateWorkflowRequest) {
+    await updateWorkflow({
+      name: request.name,
+      prompt_template: request.prompt_template,
+      poll_interval_secs: request.poll_interval_secs,
+      enabled: request.enabled,
+      tool_policy: request.tool_policy,
+    })
+  }
+
+  async function handleDelete() {
+    setDeleting(true)
+    try {
+      await deleteWorkflow()
+      navigate('/workflows')
+    } finally {
+      setDeleting(false)
+      setConfirmDelete(false)
+    }
+  }
+
+  if (loading) {
+    return (
+      <div id="main-content" className="space-y-4">
+        <CardSkeleton />
+        <CardSkeleton />
+      </div>
+    )
+  }
+
+  if (error || !workflow) {
+    return (
+      <div id="main-content" className="space-y-4">
+        <Link
+          to="/workflows"
+          className="inline-flex items-center gap-2 text-sm text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white transition-colors"
+        >
+          <ArrowLeft size={16} />
+          Back to Workflows
+        </Link>
+        <p className="text-sm text-red-500 dark:text-red-400">
+          {error ?? 'Workflow not found.'}
+        </p>
+      </div>
+    )
+  }
+
+  const agent = allAgents.find((a) => a.id === workflow.agent_id)
+
+  return (
+    <div id="main-content" className="space-y-6">
+      {/* Back nav */}
+      <Link
+        to="/workflows"
+        className="inline-flex items-center gap-2 text-sm text-gray-500 hover:text-gray-900 dark:text-gray-400 dark:hover:text-white transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 rounded"
+      >
+        <ArrowLeft size={16} />
+        Back to Workflows
+      </Link>
+
+      {/* Header */}
+      <div className="flex items-start justify-between">
+        <div className="flex items-start gap-4">
+          <div className="flex h-12 w-12 flex-shrink-0 items-center justify-center rounded-xl bg-primary-100 dark:bg-primary-900/30">
+            <Zap size={24} className="text-primary-600 dark:text-primary-400" />
+          </div>
+          <div>
+            <div className="flex items-center gap-3">
+              <h1 className="text-2xl font-semibold text-gray-900 dark:text-white">
+                {workflow.name}
+              </h1>
+              <StatusBadge status={workflow.enabled ? 'healthy' : 'unknown'} />
+            </div>
+            <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+              Agent: {agent?.name ?? workflow.agent_id}
+            </p>
+          </div>
+        </div>
+
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={refetch}
+            className="rounded-md p-2 text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
+            aria-label="Refresh"
+          >
+            <RefreshCw size={18} />
+          </button>
+          <button
+            type="button"
+            onClick={() => setFormOpen(true)}
+            className="inline-flex items-center gap-2 rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500"
+          >
+            <Edit2 size={15} />
+            Edit
+          </button>
+          <button
+            type="button"
+            onClick={() => setConfirmDelete(true)}
+            className="inline-flex items-center gap-2 rounded-md border border-red-300 dark:border-red-700 bg-white dark:bg-gray-800 px-3 py-2 text-sm font-medium text-red-600 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-red-500"
+          >
+            <Trash2 size={15} />
+            Delete
+          </button>
+        </div>
+      </div>
+
+      {/* Configuration card */}
+      <div className="rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-6">
+        <h2 className="text-base font-semibold text-gray-900 dark:text-white mb-4">
+          Configuration
+        </h2>
+        <dl>
+          <ConfigRow label="Source" value={sourceDetail(workflow.source_config)} />
+          <ConfigRow
+            label="Poll interval"
+            value={
+              workflow.poll_interval_secs < 60
+                ? `${workflow.poll_interval_secs}s`
+                : `${Math.round(workflow.poll_interval_secs / 60)}m`
+            }
+          />
+          <ConfigRow label="Enabled" value={workflow.enabled ? 'Yes' : 'No'} />
+          <ConfigRow label="Created" value={formatDateTime(workflow.created_at)} />
+          <ConfigRow label="Updated" value={formatDateTime(workflow.updated_at)} />
+          <ConfigRow
+            label="Prompt template"
+            value={
+              <pre className="text-xs font-mono bg-gray-50 dark:bg-gray-900 rounded p-2 whitespace-pre-wrap max-h-32 overflow-auto">
+                {workflow.prompt_template}
+              </pre>
+            }
+          />
+        </dl>
+      </div>
+
+      {/* Dispatch history */}
+      <div className="rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-6">
+        <h2 className="text-base font-semibold text-gray-900 dark:text-white mb-4">
+          Dispatch history
+        </h2>
+        <DispatchHistory workflowId={workflow.id} />
+      </div>
+
+      {/* Edit dialog */}
+      <WorkflowForm
+        open={formOpen}
+        workflow={workflow}
+        agents={allAgents}
+        onSave={handleSave}
+        onClose={() => setFormOpen(false)}
+      />
+
+      {/* Delete confirmation */}
+      <ConfirmDialog
+        open={confirmDelete}
+        title="Delete workflow"
+        description={`Delete "${workflow.name}"? This cannot be undone.`}
+        confirmLabel="Delete"
+        variant="danger"
+        loading={deleting}
+        onConfirm={handleDelete}
+        onCancel={() => setConfirmDelete(false)}
+      />
+    </div>
+  )
+}
+
+export default WorkflowDetail

--- a/ui/src/pages/workflows/WorkflowList.tsx
+++ b/ui/src/pages/workflows/WorkflowList.tsx
@@ -1,0 +1,168 @@
+/**
+ * WorkflowList — workflow management page.
+ *
+ * Shows a table of all configured workflows with create, edit, delete,
+ * and enable/disable actions. Includes search and pagination.
+ */
+
+import { useState } from 'react'
+import { Plus, RefreshCw, Search } from 'lucide-react'
+import { WorkflowTable } from '@/components/workflows/WorkflowTable'
+import { WorkflowForm } from '@/components/workflows/WorkflowForm'
+import { useWorkflows } from '@/hooks/useWorkflows'
+import { useAgents } from '@/hooks/useAgents'
+import type { CreateWorkflowRequest, Workflow } from '@/types/orchestrator'
+
+export function WorkflowList() {
+  const [search, setSearch] = useState('')
+  const [page, setPage] = useState(1)
+  const [formOpen, setFormOpen] = useState(false)
+  const [editingWorkflow, setEditingWorkflow] = useState<Workflow | undefined>()
+
+  const {
+    workflows,
+    total,
+    loading,
+    refreshing,
+    error,
+    refetch,
+    createWorkflow,
+    updateWorkflow,
+    deleteWorkflow,
+    toggleEnabled,
+  } = useWorkflows({ search, page, pageSize: 20, paused: formOpen })
+
+  // We need the full agent list for the form dropdown
+  const { allAgents } = useAgents({ pageSize: 200 })
+
+  function openCreate() {
+    setEditingWorkflow(undefined)
+    setFormOpen(true)
+  }
+
+  function openEdit(workflow: Workflow) {
+    setEditingWorkflow(workflow)
+    setFormOpen(true)
+  }
+
+  async function handleSave(request: CreateWorkflowRequest) {
+    if (editingWorkflow) {
+      await updateWorkflow(editingWorkflow.id, {
+        name: request.name,
+        prompt_template: request.prompt_template,
+        poll_interval_secs: request.poll_interval_secs,
+        enabled: request.enabled,
+        tool_policy: request.tool_policy,
+      })
+    } else {
+      await createWorkflow(request)
+    }
+    setPage(1)
+  }
+
+  const pageCount = Math.ceil(total / 20)
+
+  return (
+    <div id="main-content" className="space-y-6">
+      {/* Page header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold text-gray-900 dark:text-white">Workflows</h1>
+          <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+            Automated task dispatch — poll external sources and dispatch tasks to agents.
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={refetch}
+            disabled={loading || refreshing}
+            className="rounded-md p-2 text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors disabled:opacity-50"
+            aria-label="Refresh workflows"
+          >
+            <RefreshCw size={18} className={refreshing ? 'animate-spin' : ''} />
+          </button>
+          <button
+            type="button"
+            onClick={openCreate}
+            className="inline-flex items-center gap-2 rounded-md bg-primary-600 px-4 py-2 text-sm font-medium text-white hover:bg-primary-700 transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500"
+          >
+            <Plus size={16} />
+            New workflow
+          </button>
+        </div>
+      </div>
+
+      {/* Error banner */}
+      {error && (
+        <div className="rounded-md bg-red-50 dark:bg-red-900/20 px-4 py-3 text-sm text-red-700 dark:text-red-400">
+          {error}
+        </div>
+      )}
+
+      {/* Search */}
+      <div className="relative max-w-xs">
+        <Search
+          size={14}
+          className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400 pointer-events-none"
+        />
+        <input
+          type="text"
+          value={search}
+          onChange={(e) => { setSearch(e.target.value); setPage(1) }}
+          placeholder="Search workflows…"
+          className="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 pl-8 pr-3 py-2 text-sm text-gray-900 dark:text-white placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-primary-500"
+        />
+      </div>
+
+      {/* Table */}
+      <WorkflowTable
+        workflows={workflows}
+        agents={allAgents}
+        loading={loading}
+        onEdit={openEdit}
+        onDelete={deleteWorkflow}
+        onToggleEnabled={toggleEnabled}
+      />
+
+      {/* Pagination */}
+      {pageCount > 1 && (
+        <div className="flex items-center justify-between text-sm text-gray-500 dark:text-gray-400">
+          <span>{total} workflow{total !== 1 ? 's' : ''}</span>
+          <div className="flex gap-2">
+            <button
+              type="button"
+              disabled={page <= 1}
+              onClick={() => setPage((p) => p - 1)}
+              className="rounded px-3 py-1 border border-gray-300 dark:border-gray-600 disabled:opacity-40 hover:bg-gray-50 dark:hover:bg-gray-800"
+            >
+              Previous
+            </button>
+            <span className="px-2 py-1">
+              Page {page} of {pageCount}
+            </span>
+            <button
+              type="button"
+              disabled={page >= pageCount}
+              onClick={() => setPage((p) => p + 1)}
+              className="rounded px-3 py-1 border border-gray-300 dark:border-gray-600 disabled:opacity-40 hover:bg-gray-50 dark:hover:bg-gray-800"
+            >
+              Next
+            </button>
+          </div>
+        </div>
+      )}
+
+      {/* Create/Edit form dialog */}
+      <WorkflowForm
+        open={formOpen}
+        workflow={editingWorkflow}
+        agents={allAgents}
+        onSave={handleSave}
+        onClose={() => setFormOpen(false)}
+      />
+    </div>
+  )
+}
+
+export default WorkflowList

--- a/ui/src/services/orchestrator.ts
+++ b/ui/src/services/orchestrator.ts
@@ -12,6 +12,8 @@ import type {
   Agent,
   ApprovalActionRequest,
   CreateAgentRequest,
+  CreateWorkflowRequest,
+  DispatchRecord,
   ListAgentsParams,
   ListApprovalsParams,
   PendingApproval,
@@ -20,6 +22,8 @@ import type {
   SetModelRequest,
   ToolPolicy,
   UpdatePolicyRequest,
+  UpdateWorkflowRequest,
+  Workflow,
 } from '@/types/orchestrator'
 
 export class OrchestratorClient extends ApiClient {
@@ -107,6 +111,40 @@ export class OrchestratorClient extends ApiClient {
 
   denyRequest(id: string, body?: ApprovalActionRequest): Promise<PendingApproval> {
     return this.post<PendingApproval>(`/approvals/${id}/deny`, body ?? {})
+  }
+
+  // -------------------------------------------------------------------------
+  // Workflows
+  // -------------------------------------------------------------------------
+
+  listWorkflows(params?: { limit?: number; offset?: number }): Promise<PaginatedResponse<Workflow>> {
+    return this.get<PaginatedResponse<Workflow>>('/workflows', params as Record<string, string>)
+  }
+
+  getWorkflow(id: string): Promise<Workflow> {
+    return this.get<Workflow>(`/workflows/${id}`)
+  }
+
+  createWorkflow(request: CreateWorkflowRequest): Promise<Workflow> {
+    return this.post<Workflow>('/workflows', request)
+  }
+
+  updateWorkflow(id: string, request: UpdateWorkflowRequest): Promise<Workflow> {
+    return this.put<Workflow>(`/workflows/${id}`, request)
+  }
+
+  deleteWorkflow(id: string): Promise<void> {
+    return this.delete<void>(`/workflows/${id}`)
+  }
+
+  getWorkflowHistory(
+    id: string,
+    params?: { limit?: number; offset?: number },
+  ): Promise<PaginatedResponse<DispatchRecord>> {
+    return this.get<PaginatedResponse<DispatchRecord>>(
+      `/workflows/${id}/history`,
+      params as Record<string, string>,
+    )
   }
 
   // -------------------------------------------------------------------------

--- a/ui/src/test/components/workflows/PromptTemplateEditor.test.tsx
+++ b/ui/src/test/components/workflows/PromptTemplateEditor.test.tsx
@@ -1,0 +1,72 @@
+/**
+ * Tests for PromptTemplateEditor component.
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { PromptTemplateEditor } from '@/components/workflows/PromptTemplateEditor'
+
+describe('PromptTemplateEditor', () => {
+  it('renders the textarea', () => {
+    render(<PromptTemplateEditor value="" onChange={() => {}} />)
+    expect(screen.getByRole('textbox')).toBeInTheDocument()
+  })
+
+  it('calls onChange when user types', () => {
+    const onChange = vi.fn()
+    render(<PromptTemplateEditor value="" onChange={onChange} />)
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'Hello {{title}}' } })
+    expect(onChange).toHaveBeenCalledWith('Hello {{title}}')
+  })
+
+  it('shows available variables section', () => {
+    render(<PromptTemplateEditor value="" onChange={() => {}} />)
+    expect(screen.getByText('Available variables')).toBeInTheDocument()
+  })
+
+  it('expands variables section when clicked', () => {
+    render(<PromptTemplateEditor value="" onChange={() => {}} />)
+    fireEvent.click(screen.getByText('Available variables'))
+    // {{title}} appears in both the variable buttons and the table — use getAllByText
+    expect(screen.getAllByText('{{title}}')).not.toHaveLength(0)
+    expect(screen.getAllByText('{{body}}')).not.toHaveLength(0)
+  })
+
+  it('shows preview button when value is provided', () => {
+    render(<PromptTemplateEditor value="Fix: {{title}}" onChange={() => {}} />)
+    expect(screen.getByText('Preview with sample data')).toBeInTheDocument()
+  })
+
+  it('does not show preview button when value is empty', () => {
+    render(<PromptTemplateEditor value="" onChange={() => {}} />)
+    expect(screen.queryByText('Preview with sample data')).not.toBeInTheDocument()
+  })
+
+  it('expands preview when clicked', () => {
+    render(<PromptTemplateEditor value="Fix: {{title}}" onChange={() => {}} />)
+    fireEvent.click(screen.getByText('Preview with sample data'))
+    // Preview should show sample substitution
+    expect(screen.getByText(/Fix: Fix login bug/)).toBeInTheDocument()
+  })
+
+  it('renders error message when provided', () => {
+    render(<PromptTemplateEditor value="" onChange={() => {}} error="Template is required" />)
+    expect(screen.getByText('Template is required')).toBeInTheDocument()
+  })
+
+  it('applies error border class when error is provided', () => {
+    render(<PromptTemplateEditor value="" onChange={() => {}} error="oops" />)
+    const textarea = screen.getByRole('textbox')
+    expect(textarea.className).toContain('border-red')
+  })
+
+  it('inserts variable when variable button is clicked', () => {
+    const onChange = vi.fn()
+    render(<PromptTemplateEditor value="Start " onChange={onChange} />)
+    fireEvent.click(screen.getByText('Available variables'))
+    // Click on the {{title}} variable button
+    const titleBtn = screen.getAllByText('{{title}}')[0]
+    fireEvent.click(titleBtn)
+    expect(onChange).toHaveBeenCalledWith('Start {{title}}')
+  })
+})

--- a/ui/src/test/hooks/useWorkflows.test.ts
+++ b/ui/src/test/hooks/useWorkflows.test.ts
@@ -1,0 +1,200 @@
+/**
+ * Tests for useWorkflows hook.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { useWorkflows, useDispatchHistory } from '@/hooks/useWorkflows'
+import { orchestratorClient } from '@/services/orchestrator'
+import type { Workflow, DispatchRecord } from '@/types/orchestrator'
+
+// ---------------------------------------------------------------------------
+// Test fixtures
+// ---------------------------------------------------------------------------
+
+function makeWorkflow(overrides: Partial<Workflow> = {}): Workflow {
+  return {
+    id: 'wf-1',
+    name: 'Test Workflow',
+    agent_id: 'agent-1',
+    source_config: {
+      type: 'github_issues',
+      owner: 'acme',
+      repo: 'myrepo',
+      labels: ['bug'],
+      state: 'open',
+    },
+    prompt_template: 'Fix: {{title}}',
+    poll_interval_secs: 900,
+    enabled: true,
+    tool_policy: { type: 'AllowAll' },
+    created_at: '2024-01-01T00:00:00Z',
+    updated_at: '2024-01-01T00:00:00Z',
+    ...overrides,
+  }
+}
+
+function makeDispatch(overrides: Partial<DispatchRecord> = {}): DispatchRecord {
+  return {
+    id: 'dr-1',
+    workflow_id: 'wf-1',
+    source_id: '42',
+    agent_id: 'agent-1',
+    prompt_sent: 'Fix: My bug',
+    status: 'dispatched',
+    dispatched_at: '2024-01-01T00:00:00Z',
+    completed_at: undefined,
+    ...overrides,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// useWorkflows
+// ---------------------------------------------------------------------------
+
+describe('useWorkflows', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('fetches and returns workflows', async () => {
+    const wf = makeWorkflow()
+    vi.spyOn(orchestratorClient, 'listWorkflows').mockResolvedValue({
+      items: [wf],
+      total: 1,
+      limit: 200,
+      offset: 0,
+    })
+
+    const { result } = renderHook(() => useWorkflows())
+    await waitFor(() => expect(result.current.loading).toBe(false))
+
+    expect(result.current.workflows).toHaveLength(1)
+    expect(result.current.workflows[0].name).toBe('Test Workflow')
+    expect(result.current.total).toBe(1)
+  })
+
+  it('sets error on fetch failure', async () => {
+    vi.spyOn(orchestratorClient, 'listWorkflows').mockRejectedValue(
+      new Error('Service unavailable'),
+    )
+
+    const { result } = renderHook(() => useWorkflows())
+    await waitFor(() => expect(result.current.loading).toBe(false))
+
+    expect(result.current.error).toBe('Service unavailable')
+    expect(result.current.workflows).toHaveLength(0)
+  })
+
+  it('filters by search term', async () => {
+    const wf1 = makeWorkflow({ id: '1', name: 'GitHub Dispatch' })
+    const wf2 = makeWorkflow({ id: '2', name: 'File Watch' })
+    vi.spyOn(orchestratorClient, 'listWorkflows').mockResolvedValue({
+      items: [wf1, wf2],
+      total: 2,
+      limit: 200,
+      offset: 0,
+    })
+
+    const { result } = renderHook(() => useWorkflows({ search: 'GitHub' }))
+    await waitFor(() => expect(result.current.loading).toBe(false))
+
+    expect(result.current.workflows).toHaveLength(1)
+    expect(result.current.workflows[0].name).toBe('GitHub Dispatch')
+  })
+
+  it('calls toggleEnabled with correct params', async () => {
+    const wf = makeWorkflow({ enabled: true })
+    vi.spyOn(orchestratorClient, 'listWorkflows').mockResolvedValue({
+      items: [wf],
+      total: 1,
+      limit: 200,
+      offset: 0,
+    })
+    const updatedWf = { ...wf, enabled: false }
+    const updateSpy = vi
+      .spyOn(orchestratorClient, 'updateWorkflow')
+      .mockResolvedValue(updatedWf)
+
+    const { result } = renderHook(() => useWorkflows())
+    await waitFor(() => expect(result.current.loading).toBe(false))
+
+    await result.current.toggleEnabled('wf-1', false)
+    expect(updateSpy).toHaveBeenCalledWith('wf-1', { enabled: false })
+  })
+
+  it('deleteWorkflow removes workflow from state', async () => {
+    const wf = makeWorkflow()
+    vi.spyOn(orchestratorClient, 'listWorkflows').mockResolvedValue({
+      items: [wf],
+      total: 1,
+      limit: 200,
+      offset: 0,
+    })
+    vi.spyOn(orchestratorClient, 'deleteWorkflow').mockResolvedValue(undefined)
+
+    const { result } = renderHook(() => useWorkflows())
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(result.current.workflows).toHaveLength(1)
+
+    await result.current.deleteWorkflow('wf-1')
+    await waitFor(() => expect(result.current.workflows).toHaveLength(0))
+  })
+})
+
+// ---------------------------------------------------------------------------
+// useDispatchHistory
+// ---------------------------------------------------------------------------
+
+describe('useDispatchHistory', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('fetches dispatch history', async () => {
+    const dispatch = makeDispatch()
+    vi.spyOn(orchestratorClient, 'getWorkflowHistory').mockResolvedValue({
+      items: [dispatch],
+      total: 1,
+      limit: 100,
+      offset: 0,
+    })
+
+    const { result } = renderHook(() => useDispatchHistory({ workflowId: 'wf-1' }))
+    await waitFor(() => expect(result.current.loading).toBe(false))
+
+    expect(result.current.dispatches).toHaveLength(1)
+    expect(result.current.dispatches[0].source_id).toBe('42')
+  })
+
+  it('filters by status', async () => {
+    const d1 = makeDispatch({ id: 'd1', status: 'dispatched' })
+    const d2 = makeDispatch({ id: 'd2', status: 'completed' })
+    vi.spyOn(orchestratorClient, 'getWorkflowHistory').mockResolvedValue({
+      items: [d1, d2],
+      total: 2,
+      limit: 100,
+      offset: 0,
+    })
+
+    const { result } = renderHook(() =>
+      useDispatchHistory({ workflowId: 'wf-1', status: 'dispatched' }),
+    )
+    await waitFor(() => expect(result.current.loading).toBe(false))
+
+    expect(result.current.dispatches).toHaveLength(1)
+    expect(result.current.dispatches[0].status).toBe('dispatched')
+  })
+
+  it('sets error on failure', async () => {
+    vi.spyOn(orchestratorClient, 'getWorkflowHistory').mockRejectedValue(
+      new Error('Not found'),
+    )
+
+    const { result } = renderHook(() => useDispatchHistory({ workflowId: 'wf-1' }))
+    await waitFor(() => expect(result.current.loading).toBe(false))
+
+    expect(result.current.error).toBe('Not found')
+    expect(result.current.dispatches).toHaveLength(0)
+  })
+})

--- a/ui/src/types/orchestrator.ts
+++ b/ui/src/types/orchestrator.ts
@@ -119,31 +119,92 @@ export interface ApprovalActionRequest {
 
 export type TaskStatus = 'Pending' | 'Running' | 'Completed' | 'Failed' | 'Cancelled'
 
-export interface TaskSourceConfig {
-  type: string
-  [key: string]: unknown
-}
+/** Status of a task dispatch record (mirrors Rust DispatchStatus) */
+export type DispatchStatus = 'pending' | 'dispatched' | 'completed' | 'failed' | 'skipped'
 
-export interface Task {
+/**
+ * Tagged union for different task source backends.
+ * Currently only GitHub Issues is supported.
+ */
+export type TaskSourceConfig =
+  | {
+      type: 'github_issues'
+      owner: string
+      repo: string
+      labels: string[]
+      state: 'open' | 'closed' | 'all'
+    }
+
+/**
+ * A workflow as returned by the API.
+ * Mirrors the Rust WorkflowResponse type.
+ */
+export interface Workflow {
   id: string
-  workflow_id: string
   name: string
-  status: TaskStatus
-  source: TaskSourceConfig
+  agent_id: string
+  source_config: TaskSourceConfig
+  prompt_template: string
+  poll_interval_secs: number
+  enabled: boolean
+  tool_policy: ToolPolicy
   created_at: string
   updated_at: string
 }
 
-export interface WorkflowConfig {
-  name: string
-  tasks: TaskSourceConfig[]
-}
-
+/**
+ * A task dispatch record as returned by the API.
+ * Mirrors the Rust DispatchResponse type.
+ */
 export interface DispatchRecord {
   id: string
   workflow_id: string
+  source_id: string
+  agent_id: string
+  prompt_sent: string
+  status: DispatchStatus
   dispatched_at: string
-  status: TaskStatus
+  completed_at?: string
+}
+
+/**
+ * An external task fetched from a task source.
+ * Mirrors the Rust Task type.
+ */
+export interface Task {
+  source_id: string
+  title: string
+  body: string
+  url: string
+  labels: string[]
+  assignee?: string
+  metadata: Record<string, string>
+}
+
+/** Request body for creating a workflow */
+export interface CreateWorkflowRequest {
+  name: string
+  agent_id: string
+  source_config: TaskSourceConfig
+  prompt_template: string
+  poll_interval_secs: number
+  enabled: boolean
+  tool_policy: ToolPolicy
+}
+
+/** Request body for updating a workflow (all fields optional) */
+export interface UpdateWorkflowRequest {
+  name?: string
+  prompt_template?: string
+  poll_interval_secs?: number
+  enabled?: boolean
+  tool_policy?: ToolPolicy
+}
+
+/** Legacy type alias kept for compatibility */
+export interface WorkflowConfig {
+  name: string
+  tasks: Array<{ type: string; [key: string]: unknown }>
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- **Accurate types** (`src/types/orchestrator.ts`): `Workflow`, `DispatchRecord`, `DispatchStatus`, `TaskSourceConfig` (github_issues tagged union), `CreateWorkflowRequest`, `UpdateWorkflowRequest` — mirrors the Rust scheduler types exactly
- **OrchestratorClient**: Added `listWorkflows`, `getWorkflow`, `createWorkflow`, `updateWorkflow`, `deleteWorkflow`, `getWorkflowHistory`
- **`useWorkflows` hook**: Paginated list + search filter + auto-refresh; `createWorkflow`, `updateWorkflow`, `deleteWorkflow`, `toggleEnabled` actions; `useWorkflowDetail` for single-workflow; `useDispatchHistory` with status filter
- **`PromptTemplateEditor`**: Variable hint table (`{{title}}`, `{{body}}`, `{{url}}`, `{{labels}}`, `{{source_id}}`), click-to-insert buttons, collapsible live preview with sample substitution
- **`WorkflowForm`**: Create/edit dialog — agent dropdown (Running only), GitHub Issues fieldset (owner, repo, labels, state), prompt template editor, poll interval in minutes, enabled toggle, full validation
- **`WorkflowTable`**: Name/agent/source/interval/enabled toggle/updated columns; navigate-to-detail, edit/delete per-row actions
- **`DispatchHistory`**: Status filter tabs, expandable prompt rows, status badges, pagination
- **`WorkflowList` page**: Search, create button, paginated table
- **`WorkflowDetail` page**: Config overview (dl/dd layout), dispatch history, edit/delete actions
- **`WorkflowsPage`**: Delegates to WorkflowList
- **App.tsx**: `/workflows/:id` route registered

## Test plan

- [x] `bunx tsc --noEmit` — TypeScript clean
- [x] `bunx vitest run` — 487 tests passing across 54 test files
- [x] 8 hook tests (`useWorkflows`, `useDispatchHistory`) covering fetch, error, search filter, toggle, delete, status filter
- [x] 10 component tests for `PromptTemplateEditor`

Closes #172

🤖 Generated with [Claude Code](https://claude.com/claude-code)