### PR TITLE
feat(ui): build monitoring dashboard with Nivo charts and placeholder metrics

### DIFF
--- a/ui/src/components/monitoring/AgentActivityChart.tsx
+++ b/ui/src/components/monitoring/AgentActivityChart.tsx
@@ -1,0 +1,197 @@
+/**
+ * AgentActivityChart — Nivo charts for agent activity.
+ *
+ * Shows:
+ * - Bar chart: agent status distribution (Running / Pending / Stopped / Failed)
+ * - Pie chart: same data as a donut
+ * - Line chart: running agent count over time (from time-series snapshots)
+ */
+
+import { useState } from 'react'
+import { ResponsiveBar } from '@nivo/bar'
+import { ResponsivePie } from '@nivo/pie'
+import { ResponsiveLine } from '@nivo/line'
+import { BarChart2, Clock, PieChart } from 'lucide-react'
+import { ChartSkeleton } from '@/components/common/LoadingSkeleton'
+import { useNivoTheme } from '@/hooks/useNivoTheme'
+import type { AgentStatusCounts, AgentTimePoint } from '@/hooks/useMetrics'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface AgentActivityChartProps {
+  counts: AgentStatusCounts
+  timeSeries: AgentTimePoint[]
+  loading?: boolean
+}
+
+type ChartView = 'bar' | 'pie' | 'line'
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const STATUS_COLORS: Record<string, string> = {
+  Running: '#22c55e',
+  Pending: '#f59e0b',
+  Stopped: '#94a3b8',
+  Failed: '#ef4444',
+}
+
+// ---------------------------------------------------------------------------
+// AgentActivityChart
+// ---------------------------------------------------------------------------
+
+export function AgentActivityChart({ counts, timeSeries, loading }: AgentActivityChartProps) {
+  const [view, setView] = useState<ChartView>('bar')
+  const nivoTheme = useNivoTheme()
+
+  const barData = Object.entries(counts).map(([status, count]) => ({
+    status,
+    count,
+    color: STATUS_COLORS[status] ?? '#94a3b8',
+  }))
+
+  const pieData = Object.entries(counts)
+    .filter(([, count]) => count > 0)
+    .map(([status, count]) => ({
+      id: status,
+      label: status,
+      value: count,
+      color: STATUS_COLORS[status] ?? '#94a3b8',
+    }))
+
+  const lineData = [
+    {
+      id: 'Running',
+      color: STATUS_COLORS.Running,
+      data: timeSeries.length > 0
+        ? timeSeries.map((pt, i) => ({ x: i, y: pt.y }))
+        : [{ x: 0, y: 0 }],
+    },
+  ]
+
+  const views: Array<{ value: ChartView; icon: React.ReactNode; label: string }> = [
+    { value: 'bar', icon: <BarChart2 size={14} />, label: 'Bar' },
+    { value: 'pie', icon: <PieChart size={14} />, label: 'Pie' },
+    { value: 'line', icon: <Clock size={14} />, label: 'Over time' },
+  ]
+
+  return (
+    <div
+      className="rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-5"
+      aria-label="Agent activity charts"
+    >
+      <div className="flex items-center justify-between mb-4">
+        <h3 className="text-sm font-semibold text-gray-900 dark:text-white">Agent Activity</h3>
+        <div
+          className="flex items-center rounded-md border border-gray-200 dark:border-gray-700 overflow-hidden"
+          role="group"
+          aria-label="Chart view"
+        >
+          {views.map((v) => (
+            <button
+              key={v.value}
+              type="button"
+              onClick={() => setView(v.value)}
+              aria-pressed={view === v.value}
+              className={[
+                'flex items-center gap-1 px-2.5 py-1 text-xs transition-colors',
+                view === v.value
+                  ? 'bg-primary-100 text-primary-700 dark:bg-primary-900/30 dark:text-primary-400 font-medium'
+                  : 'text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200',
+              ].join(' ')}
+            >
+              {v.icon}
+              {v.label}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {loading ? (
+        <ChartSkeleton />
+      ) : (
+        <div style={{ height: 200 }} aria-label={`Agent ${view} chart`}>
+          {view === 'bar' && (
+            <ResponsiveBar
+              data={barData}
+              keys={['count']}
+              indexBy="status"
+              theme={nivoTheme}
+              colors={({ data }) => STATUS_COLORS[data.status as string] ?? '#94a3b8'}
+              enableLabel={true}
+              labelSkipHeight={14}
+              axisLeft={{ tickSize: 0, tickPadding: 4, tickValues: 5 }}
+              axisBottom={{ tickSize: 0, tickPadding: 4 }}
+              margin={{ top: 8, right: 8, bottom: 30, left: 32 }}
+              borderRadius={3}
+              padding={0.3}
+              role="img"
+              ariaLabel="Agent status distribution bar chart"
+            />
+          )}
+
+          {view === 'pie' && (
+            <ResponsivePie
+              data={pieData.length > 0 ? pieData : [{ id: 'none', label: 'No agents', value: 1, color: '#e2e8f0' }]}
+              theme={nivoTheme}
+              colors={({ data }) => data.color}
+              margin={{ top: 8, right: 60, bottom: 8, left: 60 }}
+              innerRadius={0.55}
+              padAngle={2}
+              cornerRadius={3}
+              arcLinkLabel="label"
+              arcLinkLabelsSkipAngle={10}
+              arcLinkLabelsThickness={1}
+              role="img"
+              ariaLabel="Agent status distribution pie chart"
+            />
+          )}
+
+          {view === 'line' && (
+            <ResponsiveLine
+              data={lineData}
+              theme={nivoTheme}
+              colors={[STATUS_COLORS.Running]}
+              margin={{ top: 8, right: 8, bottom: 30, left: 36 }}
+              xScale={{ type: 'linear' }}
+              yScale={{ type: 'linear', min: 0, stacked: false }}
+              axisLeft={{ tickSize: 0, tickPadding: 4, tickValues: 5 }}
+              axisBottom={{
+                tickSize: 0,
+                tickPadding: 4,
+                legend: 'Samples (most recent →)',
+                legendOffset: 26,
+                legendPosition: 'middle',
+              }}
+              enablePoints={timeSeries.length < 20}
+              pointSize={4}
+              curve="monotoneX"
+              enableGridX={false}
+              areaOpacity={0.15}
+              enableArea
+              role="img"
+              ariaLabel="Running agent count over time"
+            />
+          )}
+        </div>
+      )}
+
+      {/* Legend */}
+      {!loading && view !== 'line' && (
+        <div className="mt-3 flex flex-wrap gap-3">
+          {Object.entries(STATUS_COLORS).map(([status, color]) => (
+            <span key={status} className="flex items-center gap-1 text-xs text-gray-500 dark:text-gray-400">
+              <span className="h-2 w-2 rounded-full flex-shrink-0" style={{ background: color }} />
+              {counts[status as keyof AgentStatusCounts]} {status}
+            </span>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default AgentActivityChart

--- a/ui/src/components/monitoring/NotificationMetricsChart.tsx
+++ b/ui/src/components/monitoring/NotificationMetricsChart.tsx
@@ -1,0 +1,113 @@
+/**
+ * NotificationMetricsChart — Nivo charts for notification metrics.
+ *
+ * Shows:
+ * - Bar chart: notifications by priority level
+ * - Total count summary
+ */
+
+import { ResponsiveBar } from '@nivo/bar'
+import { ChartSkeleton } from '@/components/common/LoadingSkeleton'
+import { useNivoTheme } from '@/hooks/useNivoTheme'
+import type { NotificationCounts } from '@/hooks/useMetrics'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface NotificationMetricsChartProps {
+  counts: NotificationCounts
+  loading?: boolean
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const PRIORITY_COLORS: Record<string, string> = {
+  Low: '#94a3b8',
+  Normal: '#60a5fa',
+  High: '#f59e0b',
+  Urgent: '#ef4444',
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function NotificationMetricsChart({ counts, loading }: NotificationMetricsChartProps) {
+  const nivoTheme = useNivoTheme()
+
+  const barData = [
+    { priority: 'Low', count: counts.Low, color: PRIORITY_COLORS.Low },
+    { priority: 'Normal', count: counts.Normal, color: PRIORITY_COLORS.Normal },
+    { priority: 'High', count: counts.High, color: PRIORITY_COLORS.High },
+    { priority: 'Urgent', count: counts.Urgent, color: PRIORITY_COLORS.Urgent },
+  ]
+
+  const activeCount = counts.Low + counts.Normal + counts.High + counts.Urgent
+
+  return (
+    <div
+      className="rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-5"
+      aria-label="Notification metrics"
+    >
+      <div className="flex items-center justify-between mb-4">
+        <h3 className="text-sm font-semibold text-gray-900 dark:text-white">
+          Notification Breakdown
+        </h3>
+        <div className="text-right">
+          <p className="text-lg font-semibold tabular-nums text-gray-900 dark:text-white">
+            {counts.total}
+          </p>
+          <p className="text-xs text-gray-400 dark:text-gray-500">total</p>
+        </div>
+      </div>
+
+      {loading ? (
+        <ChartSkeleton />
+      ) : (
+        <div style={{ height: 160 }} aria-label="Notifications by priority bar chart">
+          <ResponsiveBar
+            data={barData}
+            keys={['count']}
+            indexBy="priority"
+            theme={nivoTheme}
+            colors={({ data }) => PRIORITY_COLORS[data.priority as string] ?? '#94a3b8'}
+            enableLabel={true}
+            labelSkipHeight={12}
+            axisLeft={null}
+            axisBottom={{ tickSize: 0, tickPadding: 4 }}
+            margin={{ top: 8, right: 8, bottom: 28, left: 8 }}
+            borderRadius={3}
+            padding={0.3}
+            role="img"
+            ariaLabel="Notification count by priority"
+          />
+        </div>
+      )}
+
+      {/* Summary counts */}
+      {!loading && (
+        <div className="mt-3 flex gap-4">
+          {Object.entries(PRIORITY_COLORS).map(([priority, color]) => (
+            <div key={priority} className="flex items-center gap-1.5">
+              <span className="h-2 w-2 rounded-full flex-shrink-0" style={{ background: color }} />
+              <span className="text-xs text-gray-500 dark:text-gray-400">
+                {counts[priority as keyof Omit<NotificationCounts, 'total'>]} {priority}
+              </span>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {!loading && activeCount === 0 && (
+        <p className="mt-2 text-xs text-gray-400 dark:text-gray-500">
+          No active notifications
+        </p>
+      )}
+    </div>
+  )
+}
+
+export default NotificationMetricsChart

--- a/ui/src/components/monitoring/PlaceholderChart.tsx
+++ b/ui/src/components/monitoring/PlaceholderChart.tsx
@@ -1,0 +1,177 @@
+/**
+ * PlaceholderChart — a chart placeholder with a "Coming Soon" overlay.
+ *
+ * Shows a Nivo chart rendered with sample/synthetic data, overlaid with a
+ * translucent "Coming Soon" message indicating the chart will show real data
+ * once the monitor service is fully implemented.
+ */
+
+import { Info } from 'lucide-react'
+import { ResponsiveBar } from '@nivo/bar'
+import { ResponsiveLine } from '@nivo/line'
+import { useNivoTheme } from '@/hooks/useNivoTheme'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type PlaceholderChartVariant = 'cpu' | 'memory' | 'disk' | 'network'
+
+export interface PlaceholderChartProps {
+  variant: PlaceholderChartVariant
+  title: string
+  description?: string
+  /** Height of the chart area in pixels (default 140) */
+  height?: number
+}
+
+// ---------------------------------------------------------------------------
+// Sample data generators
+// ---------------------------------------------------------------------------
+
+function makeSineData(base: number, amplitude: number, points = 20) {
+  return Array.from({ length: points }, (_, i) => ({
+    x: i,
+    y: Math.max(0, Math.min(100, base + amplitude * Math.sin(i * 0.5) + Math.random() * 5)),
+  }))
+}
+
+const SAMPLE_DATA: Record<
+  PlaceholderChartVariant,
+  {
+    color: string
+    lineData: Array<{ x: number; y: number }>
+    barData: Array<{ label: string; value: number }>
+    unit: string
+  }
+> = {
+  cpu: {
+    color: '#3b82f6',
+    lineData: makeSineData(45, 20),
+    barData: [
+      { label: 'User', value: 32 },
+      { label: 'System', value: 14 },
+      { label: 'IO', value: 8 },
+      { label: 'Idle', value: 46 },
+    ],
+    unit: '%',
+  },
+  memory: {
+    color: '#8b5cf6',
+    lineData: makeSineData(62, 10),
+    barData: [
+      { label: 'Used', value: 62 },
+      { label: 'Cache', value: 18 },
+      { label: 'Free', value: 20 },
+    ],
+    unit: '%',
+  },
+  disk: {
+    color: '#f59e0b',
+    lineData: makeSineData(38, 5),
+    barData: [
+      { label: '/', value: 38 },
+      { label: '/data', value: 55 },
+      { label: '/tmp', value: 12 },
+    ],
+    unit: '%',
+  },
+  network: {
+    color: '#22c55e',
+    lineData: makeSineData(30, 25),
+    barData: [
+      { label: 'In', value: 42 },
+      { label: 'Out', value: 28 },
+    ],
+    unit: 'MB/s',
+  },
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function PlaceholderChart({ variant, title, description, height = 140 }: PlaceholderChartProps) {
+  const nivoTheme = useNivoTheme()
+  const data = SAMPLE_DATA[variant]
+
+  const lineChartData = [
+    {
+      id: title,
+      color: data.color,
+      data: data.lineData,
+    },
+  ]
+
+  return (
+    <div className="rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 overflow-hidden">
+      {/* Header */}
+      <div className="px-4 pt-4 pb-2">
+        <div className="flex items-center justify-between">
+          <h3 className="text-sm font-semibold text-gray-900 dark:text-white">{title}</h3>
+          <span className="rounded-full bg-amber-100 dark:bg-amber-900/30 px-2 py-0.5 text-xs font-medium text-amber-700 dark:text-amber-400">
+            Coming Soon
+          </span>
+        </div>
+        {description && (
+          <p className="mt-0.5 text-xs text-gray-400 dark:text-gray-500">{description}</p>
+        )}
+      </div>
+
+      {/* Chart with overlay */}
+      <div className="relative px-2" style={{ height }}>
+        {/* Sample chart — blurred */}
+        <div className="absolute inset-0 blur-sm opacity-60 pointer-events-none" aria-hidden="true">
+          <ResponsiveLine
+            data={lineChartData}
+            theme={nivoTheme}
+            margin={{ top: 8, right: 8, bottom: 24, left: 32 }}
+            xScale={{ type: 'linear' }}
+            yScale={{ type: 'linear', min: 0, max: 100 }}
+            colors={[data.color]}
+            enablePoints={false}
+            enableGridX={false}
+            curve="monotoneX"
+            axisBottom={null}
+            axisLeft={{ tickSize: 0, tickPadding: 4, tickValues: 3 }}
+            isInteractive={false}
+          />
+        </div>
+
+        {/* Coming Soon overlay */}
+        <div className="absolute inset-0 flex flex-col items-center justify-center gap-1">
+          <div className="flex h-8 w-8 items-center justify-center rounded-full bg-amber-100 dark:bg-amber-900/30">
+            <Info size={16} className="text-amber-600 dark:text-amber-400" />
+          </div>
+          <p className="text-xs font-medium text-gray-600 dark:text-gray-400">
+            Monitor service not yet available
+          </p>
+          <p className="text-xs text-gray-400 dark:text-gray-500">
+            Port 17003 · Planned feature
+          </p>
+        </div>
+      </div>
+
+      {/* Sample bar chart */}
+      <div className="px-4 pb-3">
+        <div className="h-12 opacity-30 pointer-events-none" aria-hidden="true">
+          <ResponsiveBar
+            data={data.barData}
+            keys={['value']}
+            indexBy="label"
+            theme={nivoTheme}
+            colors={[data.color]}
+            enableLabel={false}
+            axisLeft={null}
+            axisBottom={{ tickSize: 0, tickPadding: 2 }}
+            margin={{ top: 0, right: 0, bottom: 20, left: 0 }}
+            isInteractive={false}
+            borderRadius={2}
+          />
+        </div>
+      </div>
+    </div>
+  )
+}
+
+export default PlaceholderChart

--- a/ui/src/components/monitoring/ServiceMetricsCard.tsx
+++ b/ui/src/components/monitoring/ServiceMetricsCard.tsx
@@ -1,0 +1,167 @@
+/**
+ * ServiceMetricsCard — shows key metrics for a single service.
+ *
+ * Displays:
+ * - Service name + port + reachability status
+ * - Total requests
+ * - Error rate (percentage)
+ * - Response time (measured from health check)
+ */
+
+import { Activity, AlertCircle, CheckCircle2, XCircle } from 'lucide-react'
+import { CardSkeleton } from '@/components/common/LoadingSkeleton'
+import type { ServiceMetricsData } from '@/hooks/useMetrics'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface ServiceMetricsCardProps {
+  data: ServiceMetricsData
+  responseTimeMs?: number
+  loading?: boolean
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function formatNumber(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`
+  return String(Math.round(n))
+}
+
+function errorRateClass(rate: number): string {
+  if (rate > 0.1) return 'text-red-500 dark:text-red-400'
+  if (rate > 0.01) return 'text-yellow-500 dark:text-yellow-400'
+  return 'text-green-500 dark:text-green-400'
+}
+
+// ---------------------------------------------------------------------------
+// Metric stat
+// ---------------------------------------------------------------------------
+
+function Stat({
+  label,
+  value,
+  valueClass = '',
+  sub,
+}: {
+  label: string
+  value: string
+  valueClass?: string
+  sub?: string
+}) {
+  return (
+    <div>
+      <p className="text-xs text-gray-400 dark:text-gray-500">{label}</p>
+      <p className={`text-lg font-semibold tabular-nums ${valueClass || 'text-gray-900 dark:text-white'}`}>
+        {value}
+      </p>
+      {sub && <p className="text-xs text-gray-400 dark:text-gray-500">{sub}</p>}
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// ServiceMetricsCard
+// ---------------------------------------------------------------------------
+
+export function ServiceMetricsCard({ data, responseTimeMs, loading }: ServiceMetricsCardProps) {
+  if (loading) return <CardSkeleton />
+
+  const { name, port, reachable, http } = data
+  const errorPct = (http.errorRate * 100).toFixed(1)
+
+  return (
+    <div
+      className={[
+        'rounded-lg border bg-white dark:bg-gray-800 p-5 space-y-4',
+        reachable
+          ? 'border-gray-200 dark:border-gray-700'
+          : 'border-red-200 dark:border-red-900/40',
+      ].join(' ')}
+    >
+      {/* Header */}
+      <div className="flex items-start justify-between">
+        <div className="flex items-center gap-2.5">
+          <div
+            className={[
+              'flex h-9 w-9 items-center justify-center rounded-full',
+              reachable
+                ? 'bg-green-100 dark:bg-green-900/30'
+                : 'bg-red-100 dark:bg-red-900/30',
+            ].join(' ')}
+          >
+            <Activity
+              size={18}
+              className={
+                reachable
+                  ? 'text-green-600 dark:text-green-400'
+                  : 'text-red-500 dark:text-red-400'
+              }
+            />
+          </div>
+          <div>
+            <p className="font-semibold text-gray-900 dark:text-white">{name}</p>
+            <p className="text-xs text-gray-400 dark:text-gray-500">Port {port}</p>
+          </div>
+        </div>
+
+        {reachable ? (
+          <div className="flex items-center gap-1 text-xs text-green-600 dark:text-green-400">
+            <CheckCircle2 size={14} />
+            <span>Up</span>
+          </div>
+        ) : (
+          <div className="flex items-center gap-1 text-xs text-red-500 dark:text-red-400">
+            <XCircle size={14} />
+            <span>Down</span>
+          </div>
+        )}
+      </div>
+
+      {/* Metrics grid */}
+      {reachable ? (
+        <div className="grid grid-cols-3 gap-3">
+          <Stat
+            label="Requests"
+            value={formatNumber(http.requestsTotal)}
+          />
+          <Stat
+            label="Error rate"
+            value={`${errorPct}%`}
+            valueClass={errorRateClass(http.errorRate)}
+          />
+          <Stat
+            label="Response"
+            value={responseTimeMs !== undefined ? `${responseTimeMs}ms` : '—'}
+            sub={responseTimeMs !== undefined
+              ? responseTimeMs < 100
+                ? 'Fast'
+                : responseTimeMs < 500
+                  ? 'OK'
+                  : 'Slow'
+              : undefined
+            }
+          />
+        </div>
+      ) : (
+        <div className="flex items-center gap-2 text-sm text-red-500 dark:text-red-400">
+          <AlertCircle size={14} />
+          <span>Service unreachable</span>
+        </div>
+      )}
+
+      {/* Error count detail */}
+      {reachable && http.errorsTotal > 0 && (
+        <p className="text-xs text-yellow-600 dark:text-yellow-400">
+          {formatNumber(http.errorsTotal)} error{http.errorsTotal !== 1 ? 's' : ''} logged
+        </p>
+      )}
+    </div>
+  )
+}
+
+export default ServiceMetricsCard

--- a/ui/src/components/monitoring/SystemHealthPanel.tsx
+++ b/ui/src/components/monitoring/SystemHealthPanel.tsx
@@ -1,0 +1,164 @@
+/**
+ * SystemHealthPanel — grid of service health indicators with response times.
+ *
+ * Shows per-service:
+ * - Status dot + name
+ * - Port
+ * - Response time (measured client-side from /health check)
+ * - Uptime calculation from repeated successful checks
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { Activity, CheckCircle2, Clock, XCircle } from 'lucide-react'
+import { orchestratorClient } from '@/services/orchestrator'
+import { notifyClient } from '@/services/notify'
+import { askClient } from '@/services/ask'
+import type { ServiceMetricsData } from '@/hooks/useMetrics'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface SystemHealthPanelProps {
+  serviceMetrics: ServiceMetricsData[]
+  loading?: boolean
+}
+
+interface ResponseTimeStat {
+  key: string
+  latestMs?: number
+  successCount: number
+  totalChecks: number
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const HEALTH_FETCHERS = {
+  orchestrator: () => orchestratorClient.getHealth(),
+  notify: () => notifyClient.getHealth(),
+  ask: () => askClient.getHealth(),
+}
+
+function uptimePct(stat: ResponseTimeStat): number {
+  if (stat.totalChecks === 0) return 0
+  return Math.round((stat.successCount / stat.totalChecks) * 100)
+}
+
+function responseClass(ms?: number): string {
+  if (ms === undefined) return 'text-gray-400 dark:text-gray-500'
+  if (ms < 100) return 'text-green-500 dark:text-green-400'
+  if (ms < 500) return 'text-yellow-500 dark:text-yellow-400'
+  return 'text-red-500 dark:text-red-400'
+}
+
+// ---------------------------------------------------------------------------
+// SystemHealthPanel
+// ---------------------------------------------------------------------------
+
+export function SystemHealthPanel({ serviceMetrics, loading }: SystemHealthPanelProps) {
+  const [responseStats, setResponseStats] = useState<Record<string, ResponseTimeStat>>({})
+  const statsRef = useRef<Record<string, ResponseTimeStat>>({})
+
+  const measureResponseTimes = useCallback(async () => {
+    const entries = Object.entries(HEALTH_FETCHERS)
+    await Promise.allSettled(
+      entries.map(async ([key, fetcher]) => {
+        const start = performance.now()
+        let success = false
+        try {
+          await fetcher()
+          success = true
+        } catch {
+          // reachability failure
+        }
+        const ms = success ? Math.round(performance.now() - start) : undefined
+
+        const prev = statsRef.current[key] ?? { key, successCount: 0, totalChecks: 0 }
+        const next: ResponseTimeStat = {
+          key,
+          latestMs: success ? ms : undefined,
+          successCount: prev.successCount + (success ? 1 : 0),
+          totalChecks: prev.totalChecks + 1,
+        }
+        statsRef.current = { ...statsRef.current, [key]: next }
+      }),
+    )
+    setResponseStats({ ...statsRef.current })
+  }, [])
+
+  useEffect(() => {
+    void measureResponseTimes()
+    const timer = setInterval(() => void measureResponseTimes(), 30_000)
+    return () => clearInterval(timer)
+  }, [measureResponseTimes])
+
+  return (
+    <div className="rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-5">
+      <div className="flex items-center gap-2 mb-4">
+        <Activity size={16} className="text-primary-500" />
+        <h3 className="text-sm font-semibold text-gray-900 dark:text-white">System Health</h3>
+      </div>
+
+      {loading ? (
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+          {[1, 2, 3].map((i) => (
+            <div key={i} className="h-20 rounded-lg bg-gray-100 dark:bg-gray-700 animate-pulse" />
+          ))}
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+          {serviceMetrics.map((svc) => {
+            const stat = responseStats[svc.key]
+            const uptime = stat ? uptimePct(stat) : null
+
+            return (
+              <div
+                key={svc.key}
+                className={[
+                  'rounded-lg border p-3 space-y-2',
+                  svc.reachable
+                    ? 'border-gray-100 dark:border-gray-700 bg-gray-50 dark:bg-gray-800/50'
+                    : 'border-red-100 dark:border-red-900/30 bg-red-50/30 dark:bg-red-900/5',
+                ].join(' ')}
+              >
+                {/* Service name + status */}
+                <div className="flex items-center justify-between">
+                  <span className="text-sm font-medium text-gray-900 dark:text-white">
+                    {svc.name}
+                  </span>
+                  {svc.reachable ? (
+                    <CheckCircle2 size={15} className="text-green-500 dark:text-green-400" />
+                  ) : (
+                    <XCircle size={15} className="text-red-500 dark:text-red-400" />
+                  )}
+                </div>
+
+                {/* Port */}
+                <p className="text-xs text-gray-400 dark:text-gray-500">Port {svc.port}</p>
+
+                {/* Response time + uptime */}
+                <div className="flex items-center justify-between">
+                  <div className="flex items-center gap-1">
+                    <Clock size={12} className="text-gray-400 dark:text-gray-500" />
+                    <span className={`text-xs tabular-nums font-medium ${responseClass(stat?.latestMs)}`}>
+                      {stat?.latestMs !== undefined ? `${stat.latestMs}ms` : '—'}
+                    </span>
+                  </div>
+                  {uptime !== null && (
+                    <span className={`text-xs tabular-nums ${uptime === 100 ? 'text-green-500 dark:text-green-400' : uptime > 90 ? 'text-yellow-500' : 'text-red-500'}`}>
+                      {uptime}% up
+                    </span>
+                  )}
+                </div>
+              </div>
+            )
+          })}
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default SystemHealthPanel

--- a/ui/src/components/monitoring/index.ts
+++ b/ui/src/components/monitoring/index.ts
@@ -1,0 +1,14 @@
+export { AgentActivityChart } from './AgentActivityChart'
+export type { AgentActivityChartProps } from './AgentActivityChart'
+
+export { NotificationMetricsChart } from './NotificationMetricsChart'
+export type { NotificationMetricsChartProps } from './NotificationMetricsChart'
+
+export { PlaceholderChart } from './PlaceholderChart'
+export type { PlaceholderChartProps, PlaceholderChartVariant } from './PlaceholderChart'
+
+export { ServiceMetricsCard } from './ServiceMetricsCard'
+export type { ServiceMetricsCardProps } from './ServiceMetricsCard'
+
+export { SystemHealthPanel } from './SystemHealthPanel'
+export type { SystemHealthPanelProps } from './SystemHealthPanel'

--- a/ui/src/hooks/useMetrics.ts
+++ b/ui/src/hooks/useMetrics.ts
@@ -1,0 +1,240 @@
+/**
+ * useMetrics — fetches and aggregates monitoring metrics from all services.
+ *
+ * Sources:
+ * - Agent status counts from orchestrator (real-time)
+ * - Notification priority counts from notify service (real-time)
+ * - Prometheus /metrics text from each service (request/error rates)
+ * - Synthetic time-series derived from snapshots (for chart history)
+ *
+ * Auto-refreshes on a configurable interval. Pauses when the tab is hidden.
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { orchestratorClient } from '@/services/orchestrator'
+import { notifyClient } from '@/services/notify'
+import { serviceConfig } from '@/services/config'
+import { parsePrometheusText, extractHttpMetrics } from './usePrometheusParser'
+import type { ParsedMetrics, HttpMetricsSummary } from './usePrometheusParser'
+import type { AgentStatus } from '@/types/orchestrator'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type RefreshInterval = 10_000 | 30_000 | 60_000 | 300_000
+
+export interface AgentStatusCounts {
+  Running: number
+  Pending: number
+  Stopped: number
+  Failed: number
+}
+
+export interface NotificationCounts {
+  Low: number
+  Normal: number
+  High: number
+  Urgent: number
+  total: number
+}
+
+export interface ServiceMetricsData {
+  key: string
+  name: string
+  port: number
+  http: HttpMetricsSummary
+  raw?: ParsedMetrics
+  reachable: boolean
+}
+
+/** Single time-series point for agent activity chart */
+export interface AgentTimePoint {
+  x: string // ISO timestamp
+  y: number
+}
+
+export interface UseMetricsResult {
+  /** Current agent status counts */
+  agentCounts: AgentStatusCounts
+  /** Current notification priority counts */
+  notifCounts: NotificationCounts
+  /** Per-service Prometheus metrics */
+  serviceMetrics: ServiceMetricsData[]
+  /** Synthetic agent time-series (running count over last N snapshots) */
+  agentTimeSeries: AgentTimePoint[]
+  /** Overall loading state */
+  loading: boolean
+  /** Last successful refresh time */
+  lastRefresh?: Date
+  /** Any error during fetch */
+  error?: string
+  /** Trigger a manual refresh */
+  refetch: () => void
+  refreshInterval: RefreshInterval
+  setRefreshInterval: (interval: RefreshInterval) => void
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const SERVICE_ENDPOINTS = [
+  { key: 'orchestrator', name: 'Orchestrator', port: 17006, url: () => serviceConfig.orchestratorServiceUrl },
+  { key: 'notify', name: 'Notify', port: 17004, url: () => serviceConfig.notifyServiceUrl },
+  { key: 'ask', name: 'Ask', port: 17001, url: () => serviceConfig.askServiceUrl },
+]
+
+const EMPTY_AGENT_COUNTS: AgentStatusCounts = { Running: 0, Pending: 0, Stopped: 0, Failed: 0 }
+const EMPTY_NOTIF_COUNTS: NotificationCounts = { Low: 0, Normal: 0, High: 0, Urgent: 0, total: 0 }
+
+// How many data points to keep for time-series (one per refresh)
+const MAX_HISTORY_POINTS = 60
+
+// ---------------------------------------------------------------------------
+// Prometheus fetch helper
+// ---------------------------------------------------------------------------
+
+async function fetchPrometheusMetrics(baseUrl: string): Promise<ParsedMetrics | undefined> {
+  try {
+    const resp = await fetch(`${baseUrl}/metrics`, {
+      signal: AbortSignal.timeout(5000),
+    })
+    if (!resp.ok) return undefined
+    const text = await resp.text()
+    return parsePrometheusText(text)
+  } catch {
+    return undefined
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+export function useMetrics(initialInterval: RefreshInterval = 30_000): UseMetricsResult {
+  const [agentCounts, setAgentCounts] = useState<AgentStatusCounts>(EMPTY_AGENT_COUNTS)
+  const [notifCounts, setNotifCounts] = useState<NotificationCounts>(EMPTY_NOTIF_COUNTS)
+  const [serviceMetrics, setServiceMetrics] = useState<ServiceMetricsData[]>([])
+  const [agentTimeSeries, setAgentTimeSeries] = useState<AgentTimePoint[]>([])
+  const [loading, setLoading] = useState(true)
+  const [lastRefresh, setLastRefresh] = useState<Date | undefined>()
+  const [error, setError] = useState<string | undefined>()
+  const [refreshInterval, setRefreshInterval] = useState<RefreshInterval>(initialInterval)
+
+  const timerRef = useRef<ReturnType<typeof setInterval> | null>(null)
+  const historyRef = useRef<AgentTimePoint[]>([])
+
+  const fetchAll = useCallback(async () => {
+    try {
+      // Fetch all data in parallel
+      const [agentResult, notifActionable, notifCount, ...prometheusResults] =
+        await Promise.allSettled([
+          orchestratorClient.listAgents({ limit: 200 }),
+          notifyClient.listActionable({ limit: 200 }),
+          notifyClient.getCount(),
+          ...SERVICE_ENDPOINTS.map((svc) => fetchPrometheusMetrics(svc.url())),
+        ])
+
+      // Agent counts
+      if (agentResult.status === 'fulfilled') {
+        const agents = agentResult.value.items
+        const counts: AgentStatusCounts = { Running: 0, Pending: 0, Stopped: 0, Failed: 0 }
+        for (const agent of agents) {
+          const s = agent.status as AgentStatus
+          if (s in counts) counts[s]++
+        }
+        setAgentCounts(counts)
+
+        // Append to time series
+        const point: AgentTimePoint = {
+          x: new Date().toISOString(),
+          y: counts.Running,
+        }
+        historyRef.current = [...historyRef.current, point].slice(-MAX_HISTORY_POINTS)
+        setAgentTimeSeries([...historyRef.current])
+      }
+
+      // Notification counts
+      if (
+        notifActionable.status === 'fulfilled' &&
+        notifCount.status === 'fulfilled'
+      ) {
+        const nCounts: NotificationCounts = { Low: 0, Normal: 0, High: 0, Urgent: 0, total: 0 }
+        for (const n of notifActionable.value.items) {
+          const p = n.priority as keyof Omit<NotificationCounts, 'total'>
+          if (p in nCounts) nCounts[p]++
+        }
+        nCounts.total = notifCount.value.total
+        setNotifCounts(nCounts)
+      }
+
+      // Service Prometheus metrics
+      const svcData: ServiceMetricsData[] = SERVICE_ENDPOINTS.map((svc, i) => {
+        const promResult = prometheusResults[i]
+        const raw = promResult?.status === 'fulfilled' ? promResult.value : undefined
+        return {
+          key: svc.key,
+          name: svc.name,
+          port: svc.port,
+          http: raw ? extractHttpMetrics(raw) : { requestsTotal: 0, errorsTotal: 0, errorRate: 0 },
+          raw,
+          reachable: raw !== undefined,
+        }
+      })
+      setServiceMetrics(svcData)
+
+      setLastRefresh(new Date())
+      setError(undefined)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to fetch metrics')
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  // Initial fetch + auto-refresh
+  useEffect(() => {
+    void fetchAll()
+  }, [fetchAll])
+
+  useEffect(() => {
+    if (timerRef.current) clearInterval(timerRef.current)
+    timerRef.current = setInterval(() => void fetchAll(), refreshInterval)
+    return () => {
+      if (timerRef.current) clearInterval(timerRef.current)
+    }
+  }, [refreshInterval, fetchAll])
+
+  // Pause on tab blur, resume on focus
+  useEffect(() => {
+    function onHide() {
+      if (timerRef.current) clearInterval(timerRef.current)
+    }
+    function onShow() {
+      void fetchAll()
+      timerRef.current = setInterval(() => void fetchAll(), refreshInterval)
+    }
+    document.addEventListener('visibilitychange', () => {
+      if (document.hidden) onHide()
+      else onShow()
+    })
+    return () => {
+      document.removeEventListener('visibilitychange', onHide)
+      document.removeEventListener('visibilitychange', onShow)
+    }
+  }, [refreshInterval, fetchAll])
+
+  return {
+    agentCounts,
+    notifCounts,
+    serviceMetrics,
+    agentTimeSeries,
+    loading,
+    lastRefresh,
+    error,
+    refetch: () => void fetchAll(),
+    refreshInterval,
+    setRefreshInterval,
+  }
+}

--- a/ui/src/hooks/usePrometheusParser.ts
+++ b/ui/src/hooks/usePrometheusParser.ts
@@ -1,0 +1,140 @@
+/**
+ * usePrometheusParser — utilities for parsing Prometheus text format metrics.
+ *
+ * Prometheus text format lines look like:
+ *   # HELP metric_name Description of metric.
+ *   # TYPE metric_name counter
+ *   metric_name{label="value"} 42.0 1234567890000
+ *   metric_name 7
+ */
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface PrometheusMetric {
+  name: string
+  labels: Record<string, string>
+  value: number
+  timestamp?: number
+}
+
+export interface ParsedMetrics {
+  /** All individual metric samples */
+  samples: PrometheusMetric[]
+  /** Look up a metric by name (returns first match) */
+  get: (name: string) => PrometheusMetric | undefined
+  /** Look up all samples for a metric name */
+  getAll: (name: string) => PrometheusMetric[]
+  /** Sum all values for a given metric name */
+  sum: (name: string) => number
+}
+
+// ---------------------------------------------------------------------------
+// Parser
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse a Prometheus text exposition format string into structured samples.
+ *
+ * Handles:
+ * - Comment lines (# HELP / # TYPE)
+ * - Label sets ({key="value", ...})
+ * - Float/NaN/+Inf/-Inf values
+ * - Optional timestamps
+ */
+export function parsePrometheusText(text: string): ParsedMetrics {
+  const samples: PrometheusMetric[] = []
+
+  for (const rawLine of text.split('\n')) {
+    const line = rawLine.trim()
+    if (!line || line.startsWith('#')) continue
+
+    // Match: name{labels} value [timestamp]
+    // or:   name value [timestamp]
+    const braceIdx = line.indexOf('{')
+    const spaceIdx = line.indexOf(' ')
+
+    let name: string
+    let labelsStr: string = ''
+    let rest: string
+
+    if (braceIdx !== -1 && braceIdx < spaceIdx) {
+      name = line.slice(0, braceIdx)
+      const closeBrace = line.indexOf('}', braceIdx)
+      labelsStr = line.slice(braceIdx + 1, closeBrace)
+      rest = line.slice(closeBrace + 1).trim()
+    } else {
+      name = line.slice(0, spaceIdx)
+      rest = line.slice(spaceIdx + 1).trim()
+    }
+
+    if (!name) continue
+
+    const parts = rest.split(/\s+/)
+    const rawValue = parts[0]
+    const timestamp = parts[1] ? parseInt(parts[1], 10) : undefined
+
+    const value = parseFloat(rawValue)
+    if (isNaN(value) && rawValue !== 'NaN') continue // skip unparseable
+
+    const labels = parseLabels(labelsStr)
+    samples.push({ name, labels, value: isNaN(value) ? 0 : value, timestamp })
+  }
+
+  return makeParsedMetrics(samples)
+}
+
+function parseLabels(labelsStr: string): Record<string, string> {
+  if (!labelsStr.trim()) return {}
+  const labels: Record<string, string> = {}
+  // Match key="value" pairs
+  const re = /(\w+)="([^"]*)"/g
+  let m
+  while ((m = re.exec(labelsStr)) !== null) {
+    labels[m[1]] = m[2]
+  }
+  return labels
+}
+
+function makeParsedMetrics(samples: PrometheusMetric[]): ParsedMetrics {
+  return {
+    samples,
+    get: (name) => samples.find((s) => s.name === name),
+    getAll: (name) => samples.filter((s) => s.name === name),
+    sum: (name) =>
+      samples.filter((s) => s.name === name).reduce((acc, s) => acc + s.value, 0),
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Convenience: extract common HTTP metrics
+// ---------------------------------------------------------------------------
+
+export interface HttpMetricsSummary {
+  /** Total requests (sum of http_requests_total) */
+  requestsTotal: number
+  /** Total errors (5xx + 4xx) */
+  errorsTotal: number
+  /** Error rate 0–1 */
+  errorRate: number
+  /** P50/P95/P99 latency ms (if histogram available) */
+  latencyP50?: number
+  latencyP99?: number
+}
+
+export function extractHttpMetrics(metrics: ParsedMetrics): HttpMetricsSummary {
+  const requestsTotal = metrics.sum('http_requests_total')
+
+  // Count errors: status codes 4xx and 5xx
+  const errorSamples = metrics
+    .getAll('http_requests_total')
+    .filter((s) => {
+      const code = parseInt(s.labels.status ?? s.labels.code ?? '0', 10)
+      return code >= 400
+    })
+  const errorsTotal = errorSamples.reduce((acc, s) => acc + s.value, 0)
+  const errorRate = requestsTotal > 0 ? errorsTotal / requestsTotal : 0
+
+  return { requestsTotal, errorsTotal, errorRate }
+}

--- a/ui/src/pages/MonitoringPage.tsx
+++ b/ui/src/pages/MonitoringPage.tsx
@@ -1,10 +1,7 @@
+import { MonitoringDashboard } from './monitoring/MonitoringDashboard'
+
 export function MonitoringPage() {
-  return (
-    <div>
-      <h1 className="text-2xl font-semibold text-gray-900 dark:text-white">Monitoring</h1>
-      <p className="mt-2 text-gray-500 dark:text-gray-400">Real-time agent and service metrics.</p>
-    </div>
-  )
+  return <MonitoringDashboard />
 }
 
 export default MonitoringPage

--- a/ui/src/pages/monitoring/MonitoringDashboard.tsx
+++ b/ui/src/pages/monitoring/MonitoringDashboard.tsx
@@ -1,0 +1,200 @@
+/**
+ * MonitoringDashboard — main monitoring page that assembles all monitoring
+ * components into a cohesive dashboard.
+ *
+ * Layout:
+ * - Header with refresh controls and last-refresh timestamp
+ * - Service metrics cards (one per service: orchestrator, notify, ask)
+ * - Agent activity chart + notification metrics chart (side-by-side)
+ * - System health panel
+ * - Placeholder charts for future monitor service (cpu, memory, disk, network)
+ */
+
+import { RefreshCw, Clock } from 'lucide-react'
+import { useMetrics } from '@/hooks/useMetrics'
+import { AgentActivityChart } from '@/components/monitoring/AgentActivityChart'
+import { NotificationMetricsChart } from '@/components/monitoring/NotificationMetricsChart'
+import { ServiceMetricsCard } from '@/components/monitoring/ServiceMetricsCard'
+import { SystemHealthPanel } from '@/components/monitoring/SystemHealthPanel'
+import { PlaceholderChart } from '@/components/monitoring/PlaceholderChart'
+import type { RefreshInterval } from '@/hooks/useMetrics'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const REFRESH_OPTIONS: Array<{ label: string; value: RefreshInterval }> = [
+  { label: '10s', value: 10_000 },
+  { label: '30s', value: 30_000 },
+  { label: '1m', value: 60_000 },
+  { label: '5m', value: 300_000 },
+]
+
+function formatRefreshTime(date: Date): string {
+  return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' })
+}
+
+// ---------------------------------------------------------------------------
+// MonitoringDashboard
+// ---------------------------------------------------------------------------
+
+export function MonitoringDashboard() {
+  const {
+    agentCounts,
+    notifCounts,
+    serviceMetrics,
+    agentTimeSeries,
+    loading,
+    lastRefresh,
+    error,
+    refetch,
+    refreshInterval,
+    setRefreshInterval,
+  } = useMetrics(30_000)
+
+  // Map response times from serviceMetrics — they come from Prometheus
+  // latency data when available, otherwise undefined (SystemHealthPanel
+  // measures separately via /health).
+  const responseTimeMap: Record<string, number | undefined> = {}
+  for (const svc of serviceMetrics) {
+    responseTimeMap[svc.key] = svc.http.latencyP50
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Page header */}
+      <div className="flex items-start justify-between gap-4 flex-wrap">
+        <div>
+          <h1 className="text-2xl font-semibold text-gray-900 dark:text-white">Monitoring</h1>
+          <p className="mt-1 text-sm text-gray-500 dark:text-gray-400">
+            Real-time agent and service metrics.
+          </p>
+        </div>
+
+        <div className="flex items-center gap-3">
+          {/* Last refresh indicator */}
+          {lastRefresh && (
+            <div className="flex items-center gap-1.5 text-xs text-gray-400 dark:text-gray-500">
+              <Clock size={12} />
+              <span>Updated {formatRefreshTime(lastRefresh)}</span>
+            </div>
+          )}
+
+          {/* Interval picker */}
+          <div
+            className="flex items-center rounded-md border border-gray-200 dark:border-gray-700 overflow-hidden text-xs"
+            role="group"
+            aria-label="Refresh interval"
+          >
+            {REFRESH_OPTIONS.map((opt) => (
+              <button
+                key={opt.value}
+                type="button"
+                onClick={() => setRefreshInterval(opt.value)}
+                aria-pressed={refreshInterval === opt.value}
+                className={[
+                  'px-2.5 py-1 transition-colors',
+                  refreshInterval === opt.value
+                    ? 'bg-primary-100 text-primary-700 dark:bg-primary-900/30 dark:text-primary-400 font-medium'
+                    : 'text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200',
+                ].join(' ')}
+              >
+                {opt.label}
+              </button>
+            ))}
+          </div>
+
+          {/* Manual refresh */}
+          <button
+            type="button"
+            onClick={refetch}
+            disabled={loading}
+            aria-label="Refresh metrics"
+            className="flex items-center gap-1.5 rounded-md border border-gray-200 dark:border-gray-700 px-3 py-1.5 text-xs text-gray-600 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors disabled:opacity-50"
+          >
+            <RefreshCw size={12} className={loading ? 'animate-spin' : ''} />
+            Refresh
+          </button>
+        </div>
+      </div>
+
+      {/* Error banner */}
+      {error && (
+        <div className="rounded-md border border-red-200 dark:border-red-900/40 bg-red-50 dark:bg-red-900/10 px-4 py-3 text-sm text-red-600 dark:text-red-400">
+          Failed to fetch metrics: {error}
+        </div>
+      )}
+
+      {/* Service metrics cards */}
+      <section aria-label="Service metrics">
+        <h2 className="sr-only">Service Metrics</h2>
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
+          {loading
+            ? [0, 1, 2].map((i) => (
+                <ServiceMetricsCard key={i} data={{ key: '', name: '', port: 0, http: { requestsTotal: 0, errorsTotal: 0, errorRate: 0 }, reachable: false }} loading />
+              ))
+            : serviceMetrics.map((svc) => (
+                <ServiceMetricsCard
+                  key={svc.key}
+                  data={svc}
+                  responseTimeMs={responseTimeMap[svc.key]}
+                />
+              ))}
+        </div>
+      </section>
+
+      {/* Charts row: agent activity + notification breakdown */}
+      <section aria-label="Activity charts">
+        <h2 className="sr-only">Activity Charts</h2>
+        <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+          <AgentActivityChart
+            counts={agentCounts}
+            timeSeries={agentTimeSeries}
+            loading={loading}
+          />
+          <NotificationMetricsChart counts={notifCounts} loading={loading} />
+        </div>
+      </section>
+
+      {/* System health grid */}
+      <section aria-label="System health">
+        <h2 className="sr-only">System Health</h2>
+        <SystemHealthPanel serviceMetrics={serviceMetrics} loading={loading} />
+      </section>
+
+      {/* Placeholder charts for future monitor service */}
+      <section aria-label="System resource charts (coming soon)">
+        <h2 className="mb-3 text-sm font-semibold text-gray-700 dark:text-gray-300">
+          System Resources
+          <span className="ml-2 text-xs font-normal text-gray-400 dark:text-gray-500">
+            — requires monitor service (port 17003)
+          </span>
+        </h2>
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-4">
+          <PlaceholderChart
+            variant="cpu"
+            title="CPU Usage"
+            description="User, system, and idle time"
+          />
+          <PlaceholderChart
+            variant="memory"
+            title="Memory Usage"
+            description="Used, cached, and free"
+          />
+          <PlaceholderChart
+            variant="disk"
+            title="Disk Usage"
+            description="Per-mount utilisation"
+          />
+          <PlaceholderChart
+            variant="network"
+            title="Network I/O"
+            description="Inbound and outbound traffic"
+          />
+        </div>
+      </section>
+    </div>
+  )
+}
+
+export default MonitoringDashboard

--- a/ui/src/test/components/monitoring/AgentActivityChart.test.tsx
+++ b/ui/src/test/components/monitoring/AgentActivityChart.test.tsx
@@ -1,0 +1,77 @@
+/**
+ * Tests for AgentActivityChart component.
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { AgentActivityChart } from '@/components/monitoring/AgentActivityChart'
+import type { AgentStatusCounts, AgentTimePoint } from '@/hooks/useMetrics'
+
+// Mock useNivoTheme to avoid ThemeProvider dependency in unit tests
+vi.mock('@/hooks/useNivoTheme', () => ({ useNivoTheme: () => ({}) }))
+
+// Mock Nivo charts
+vi.mock('@nivo/bar', () => ({
+  ResponsiveBar: ({ ariaLabel }: { ariaLabel: string }) => <div role="img" aria-label={ariaLabel} />,
+}))
+vi.mock('@nivo/pie', () => ({
+  ResponsivePie: ({ ariaLabel }: { ariaLabel: string }) => <div role="img" aria-label={ariaLabel} />,
+}))
+vi.mock('@nivo/line', () => ({
+  ResponsiveLine: ({ ariaLabel }: { ariaLabel: string }) => <div role="img" aria-label={ariaLabel} />,
+}))
+
+const COUNTS: AgentStatusCounts = { Running: 3, Pending: 1, Stopped: 2, Failed: 0 }
+const TIME_SERIES: AgentTimePoint[] = [
+  { x: '2024-01-01T00:00:00Z', y: 2 },
+  { x: '2024-01-01T00:00:30Z', y: 3 },
+]
+
+describe('AgentActivityChart', () => {
+  it('renders "Agent Activity" heading', () => {
+    render(<AgentActivityChart counts={COUNTS} timeSeries={TIME_SERIES} />)
+    expect(screen.getByText('Agent Activity')).toBeTruthy()
+  })
+
+  it('defaults to bar chart view', () => {
+    render(<AgentActivityChart counts={COUNTS} timeSeries={TIME_SERIES} />)
+    expect(screen.getByLabelText('Agent status distribution bar chart')).toBeTruthy()
+  })
+
+  it('switches to pie chart when Pie button clicked', () => {
+    render(<AgentActivityChart counts={COUNTS} timeSeries={TIME_SERIES} />)
+    fireEvent.click(screen.getByText('Pie'))
+    expect(screen.getByLabelText('Agent status distribution pie chart')).toBeTruthy()
+  })
+
+  it('switches to line chart when "Over time" button clicked', () => {
+    render(<AgentActivityChart counts={COUNTS} timeSeries={TIME_SERIES} />)
+    fireEvent.click(screen.getByText('Over time'))
+    expect(screen.getByLabelText('Running agent count over time')).toBeTruthy()
+  })
+
+  it('shows loading skeleton when loading=true', () => {
+    const { container } = render(<AgentActivityChart counts={COUNTS} timeSeries={[]} loading />)
+    // ChartSkeleton renders with animate-pulse
+    expect(container.querySelector('.animate-pulse')).toBeTruthy()
+  })
+
+  it('shows status legend with counts', () => {
+    render(<AgentActivityChart counts={COUNTS} timeSeries={TIME_SERIES} />)
+    expect(screen.getByText(/3 Running/)).toBeTruthy()
+    expect(screen.getByText(/1 Pending/)).toBeTruthy()
+  })
+
+  it('has aria-label on chart container', () => {
+    render(<AgentActivityChart counts={COUNTS} timeSeries={TIME_SERIES} />)
+    expect(screen.getByLabelText('Agent activity charts')).toBeTruthy()
+  })
+
+  it('view buttons have aria-pressed attributes', () => {
+    render(<AgentActivityChart counts={COUNTS} timeSeries={TIME_SERIES} />)
+    const barButton = screen.getByText('Bar').closest('button')
+    expect(barButton?.getAttribute('aria-pressed')).toBe('true')
+    const pieButton = screen.getByText('Pie').closest('button')
+    expect(pieButton?.getAttribute('aria-pressed')).toBe('false')
+  })
+})

--- a/ui/src/test/components/monitoring/NotificationMetricsChart.test.tsx
+++ b/ui/src/test/components/monitoring/NotificationMetricsChart.test.tsx
@@ -1,0 +1,72 @@
+/**
+ * Tests for NotificationMetricsChart component.
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { NotificationMetricsChart } from '@/components/monitoring/NotificationMetricsChart'
+import type { NotificationCounts } from '@/hooks/useMetrics'
+
+// Mock useNivoTheme to avoid ThemeProvider dependency in unit tests
+vi.mock('@/hooks/useNivoTheme', () => ({ useNivoTheme: () => ({}) }))
+
+// Mock Nivo chart
+vi.mock('@nivo/bar', () => ({
+  ResponsiveBar: ({ ariaLabel }: { ariaLabel: string }) => <div role="img" aria-label={ariaLabel} />,
+}))
+
+const FULL_COUNTS: NotificationCounts = {
+  Low: 5,
+  Normal: 12,
+  High: 3,
+  Urgent: 1,
+  total: 100,
+}
+
+const EMPTY_COUNTS: NotificationCounts = {
+  Low: 0,
+  Normal: 0,
+  High: 0,
+  Urgent: 0,
+  total: 0,
+}
+
+describe('NotificationMetricsChart', () => {
+  it('renders "Notification Breakdown" heading', () => {
+    render(<NotificationMetricsChart counts={FULL_COUNTS} />)
+    expect(screen.getByText('Notification Breakdown')).toBeTruthy()
+  })
+
+  it('shows total count', () => {
+    render(<NotificationMetricsChart counts={FULL_COUNTS} />)
+    expect(screen.getByText('100')).toBeTruthy()
+  })
+
+  it('renders the bar chart with aria label', () => {
+    render(<NotificationMetricsChart counts={FULL_COUNTS} />)
+    expect(screen.getByLabelText('Notification count by priority')).toBeTruthy()
+  })
+
+  it('shows priority labels in legend', () => {
+    render(<NotificationMetricsChart counts={FULL_COUNTS} />)
+    expect(screen.getByText(/5 Low/)).toBeTruthy()
+    expect(screen.getByText(/12 Normal/)).toBeTruthy()
+    expect(screen.getByText(/3 High/)).toBeTruthy()
+    expect(screen.getByText(/1 Urgent/)).toBeTruthy()
+  })
+
+  it('shows "No active notifications" when all counts are zero', () => {
+    render(<NotificationMetricsChart counts={EMPTY_COUNTS} />)
+    expect(screen.getByText('No active notifications')).toBeTruthy()
+  })
+
+  it('does not show "No active notifications" when counts exist', () => {
+    render(<NotificationMetricsChart counts={FULL_COUNTS} />)
+    expect(screen.queryByText('No active notifications')).toBeNull()
+  })
+
+  it('shows loading skeleton when loading=true', () => {
+    const { container } = render(<NotificationMetricsChart counts={EMPTY_COUNTS} loading />)
+    expect(container.querySelector('.animate-pulse')).toBeTruthy()
+  })
+})

--- a/ui/src/test/components/monitoring/PlaceholderChart.test.tsx
+++ b/ui/src/test/components/monitoring/PlaceholderChart.test.tsx
@@ -1,0 +1,53 @@
+/**
+ * Tests for PlaceholderChart component.
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { PlaceholderChart } from '@/components/monitoring/PlaceholderChart'
+
+// Mock useNivoTheme to avoid ThemeProvider dependency in unit tests
+vi.mock('@/hooks/useNivoTheme', () => ({ useNivoTheme: () => ({}) }))
+
+// Nivo charts use canvas/SVG; mock them to avoid heavy rendering
+vi.mock('@nivo/line', () => ({
+  ResponsiveLine: () => <div data-testid="responsive-line" />,
+}))
+vi.mock('@nivo/bar', () => ({
+  ResponsiveBar: () => <div data-testid="responsive-bar" />,
+}))
+
+describe('PlaceholderChart', () => {
+  it('renders the chart title', () => {
+    render(<PlaceholderChart variant="cpu" title="CPU Usage" />)
+    expect(screen.getByText('CPU Usage')).toBeTruthy()
+  })
+
+  it('renders "Coming Soon" badge', () => {
+    render(<PlaceholderChart variant="memory" title="Memory" />)
+    expect(screen.getByText('Coming Soon')).toBeTruthy()
+  })
+
+  it('renders description when provided', () => {
+    render(<PlaceholderChart variant="disk" title="Disk" description="Per-mount utilisation" />)
+    expect(screen.getByText('Per-mount utilisation')).toBeTruthy()
+  })
+
+  it('does not render description when not provided', () => {
+    render(<PlaceholderChart variant="network" title="Network" />)
+    expect(screen.queryByText('Per-mount utilisation')).toBeNull()
+  })
+
+  it('shows "Monitor service not yet available" overlay', () => {
+    render(<PlaceholderChart variant="cpu" title="CPU" />)
+    expect(screen.getByText('Monitor service not yet available')).toBeTruthy()
+  })
+
+  it('renders for all variants without crashing', () => {
+    const variants = ['cpu', 'memory', 'disk', 'network'] as const
+    for (const variant of variants) {
+      const { unmount } = render(<PlaceholderChart variant={variant} title={variant} />)
+      unmount()
+    }
+  })
+})

--- a/ui/src/test/components/monitoring/ServiceMetricsCard.test.tsx
+++ b/ui/src/test/components/monitoring/ServiceMetricsCard.test.tsx
@@ -1,0 +1,78 @@
+/**
+ * Tests for ServiceMetricsCard component.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { ServiceMetricsCard } from '@/components/monitoring/ServiceMetricsCard'
+import type { ServiceMetricsData } from '@/hooks/useMetrics'
+
+function makeServiceData(overrides: Partial<ServiceMetricsData> = {}): ServiceMetricsData {
+  return {
+    key: 'orchestrator',
+    name: 'Orchestrator',
+    port: 17006,
+    http: { requestsTotal: 500, errorsTotal: 5, errorRate: 0.01 },
+    reachable: true,
+    ...overrides,
+  }
+}
+
+describe('ServiceMetricsCard', () => {
+  it('renders service name and port', () => {
+    render(<ServiceMetricsCard data={makeServiceData()} />)
+    expect(screen.getByText('Orchestrator')).toBeTruthy()
+    expect(screen.getByText('Port 17006')).toBeTruthy()
+  })
+
+  it('shows "Up" badge when reachable', () => {
+    render(<ServiceMetricsCard data={makeServiceData({ reachable: true })} />)
+    expect(screen.getByText('Up')).toBeTruthy()
+  })
+
+  it('shows "Down" badge when not reachable', () => {
+    render(<ServiceMetricsCard data={makeServiceData({ reachable: false })} />)
+    expect(screen.getByText('Down')).toBeTruthy()
+  })
+
+  it('shows "Service unreachable" message when down', () => {
+    render(<ServiceMetricsCard data={makeServiceData({ reachable: false })} />)
+    expect(screen.getByText('Service unreachable')).toBeTruthy()
+  })
+
+  it('shows request count when reachable', () => {
+    render(<ServiceMetricsCard data={makeServiceData({ http: { requestsTotal: 1500, errorsTotal: 0, errorRate: 0 } })} />)
+    expect(screen.getByText('1.5k')).toBeTruthy()
+  })
+
+  it('shows response time when provided', () => {
+    render(<ServiceMetricsCard data={makeServiceData()} responseTimeMs={42} />)
+    expect(screen.getByText('42ms')).toBeTruthy()
+    expect(screen.getByText('Fast')).toBeTruthy()
+  })
+
+  it('shows dash when no response time', () => {
+    render(<ServiceMetricsCard data={makeServiceData()} />)
+    expect(screen.getByText('—')).toBeTruthy()
+  })
+
+  it('shows error count when there are errors', () => {
+    render(<ServiceMetricsCard data={makeServiceData({ http: { requestsTotal: 100, errorsTotal: 3, errorRate: 0.03 } })} />)
+    expect(screen.getByText(/3 errors? logged/)).toBeTruthy()
+  })
+
+  it('renders loading skeleton when loading=true', () => {
+    const { container } = render(<ServiceMetricsCard data={makeServiceData()} loading />)
+    expect(container.querySelector('[aria-busy="true"]')).toBeTruthy()
+  })
+
+  it('labels slow response correctly', () => {
+    render(<ServiceMetricsCard data={makeServiceData()} responseTimeMs={600} />)
+    expect(screen.getByText('Slow')).toBeTruthy()
+  })
+
+  it('labels OK response correctly', () => {
+    render(<ServiceMetricsCard data={makeServiceData()} responseTimeMs={200} />)
+    expect(screen.getByText('OK')).toBeTruthy()
+  })
+})

--- a/ui/src/test/components/monitoring/SystemHealthPanel.test.tsx
+++ b/ui/src/test/components/monitoring/SystemHealthPanel.test.tsx
@@ -1,0 +1,70 @@
+/**
+ * Tests for SystemHealthPanel component.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { SystemHealthPanel } from '@/components/monitoring/SystemHealthPanel'
+import type { ServiceMetricsData } from '@/hooks/useMetrics'
+
+// Mock the service clients used for health checks
+vi.mock('@/services/orchestrator', () => ({
+  orchestratorClient: { getHealth: vi.fn().mockResolvedValue({ status: 'ok' }) },
+}))
+vi.mock('@/services/notify', () => ({
+  notifyClient: { getHealth: vi.fn().mockResolvedValue({ status: 'ok' }) },
+}))
+vi.mock('@/services/ask', () => ({
+  askClient: { getHealth: vi.fn().mockResolvedValue({ status: 'ok' }) },
+}))
+
+function makeMetrics(overrides: Partial<ServiceMetricsData>[] = []): ServiceMetricsData[] {
+  const defaults: ServiceMetricsData[] = [
+    { key: 'orchestrator', name: 'Orchestrator', port: 17006, http: { requestsTotal: 100, errorsTotal: 0, errorRate: 0 }, reachable: true },
+    { key: 'notify', name: 'Notify', port: 17004, http: { requestsTotal: 50, errorsTotal: 0, errorRate: 0 }, reachable: true },
+    { key: 'ask', name: 'Ask', port: 17001, http: { requestsTotal: 20, errorsTotal: 0, errorRate: 0 }, reachable: false },
+  ]
+  return defaults.map((d, i) => ({ ...d, ...overrides[i] }))
+}
+
+describe('SystemHealthPanel', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('renders "System Health" heading', () => {
+    render(<SystemHealthPanel serviceMetrics={makeMetrics()} />)
+    expect(screen.getByText('System Health')).toBeTruthy()
+  })
+
+  it('renders a card for each service', () => {
+    render(<SystemHealthPanel serviceMetrics={makeMetrics()} />)
+    expect(screen.getByText('Orchestrator')).toBeTruthy()
+    expect(screen.getByText('Notify')).toBeTruthy()
+    expect(screen.getByText('Ask')).toBeTruthy()
+  })
+
+  it('shows port for each service', () => {
+    render(<SystemHealthPanel serviceMetrics={makeMetrics()} />)
+    expect(screen.getByText('Port 17006')).toBeTruthy()
+    expect(screen.getByText('Port 17004')).toBeTruthy()
+    expect(screen.getByText('Port 17001')).toBeTruthy()
+  })
+
+  it('shows loading skeletons when loading=true', () => {
+    const { container } = render(<SystemHealthPanel serviceMetrics={[]} loading />)
+    const pulses = container.querySelectorAll('.animate-pulse')
+    expect(pulses.length).toBeGreaterThanOrEqual(3)
+  })
+
+  it('shows response time dash before first check', () => {
+    render(<SystemHealthPanel serviceMetrics={makeMetrics()} />)
+    // Before timers resolve, all show '—'
+    const dashes = screen.getAllByText('—')
+    expect(dashes.length).toBeGreaterThanOrEqual(1)
+  })
+})

--- a/ui/src/test/hooks/usePrometheusParser.test.ts
+++ b/ui/src/test/hooks/usePrometheusParser.test.ts
@@ -1,0 +1,175 @@
+/**
+ * Tests for the Prometheus text format parser.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { parsePrometheusText, extractHttpMetrics } from '@/hooks/usePrometheusParser'
+
+// ---------------------------------------------------------------------------
+// parsePrometheusText
+// ---------------------------------------------------------------------------
+
+describe('parsePrometheusText', () => {
+  it('parses a simple metric with no labels', () => {
+    const text = 'process_uptime_seconds 42.5\n'
+    const metrics = parsePrometheusText(text)
+    expect(metrics.samples).toHaveLength(1)
+    expect(metrics.samples[0].name).toBe('process_uptime_seconds')
+    expect(metrics.samples[0].value).toBe(42.5)
+    expect(metrics.samples[0].labels).toEqual({})
+  })
+
+  it('parses a metric with labels', () => {
+    const text = 'http_requests_total{method="GET",status="200"} 123\n'
+    const metrics = parsePrometheusText(text)
+    expect(metrics.samples).toHaveLength(1)
+    expect(metrics.samples[0].name).toBe('http_requests_total')
+    expect(metrics.samples[0].value).toBe(123)
+    expect(metrics.samples[0].labels).toEqual({ method: 'GET', status: '200' })
+  })
+
+  it('ignores comment lines (# HELP, # TYPE)', () => {
+    const text = [
+      '# HELP http_requests_total Total HTTP requests',
+      '# TYPE http_requests_total counter',
+      'http_requests_total 42',
+    ].join('\n')
+    const metrics = parsePrometheusText(text)
+    expect(metrics.samples).toHaveLength(1)
+  })
+
+  it('ignores empty lines', () => {
+    const text = '\nprocess_uptime_seconds 1\n\n'
+    const metrics = parsePrometheusText(text)
+    expect(metrics.samples).toHaveLength(1)
+  })
+
+  it('parses multiple metrics', () => {
+    const text = [
+      'http_requests_total{status="200"} 100',
+      'http_requests_total{status="500"} 5',
+      'http_request_duration_seconds 0.05',
+    ].join('\n')
+    const metrics = parsePrometheusText(text)
+    expect(metrics.samples).toHaveLength(3)
+  })
+
+  it('parses optional timestamps', () => {
+    const text = 'process_uptime_seconds 42 1700000000000\n'
+    const metrics = parsePrometheusText(text)
+    expect(metrics.samples[0].timestamp).toBe(1700000000000)
+  })
+
+  it('skips lines with unparseable values', () => {
+    const text = 'bad_metric notanumber\n'
+    const metrics = parsePrometheusText(text)
+    expect(metrics.samples).toHaveLength(0)
+  })
+
+  describe('.get()', () => {
+    it('returns first matching sample', () => {
+      const text = [
+        'http_requests_total{status="200"} 100',
+        'http_requests_total{status="500"} 5',
+      ].join('\n')
+      const metrics = parsePrometheusText(text)
+      const m = metrics.get('http_requests_total')
+      expect(m).toBeDefined()
+      expect(m?.labels.status).toBe('200')
+    })
+
+    it('returns undefined for unknown metric', () => {
+      const metrics = parsePrometheusText('process_uptime_seconds 1')
+      expect(metrics.get('nonexistent')).toBeUndefined()
+    })
+  })
+
+  describe('.getAll()', () => {
+    it('returns all matching samples', () => {
+      const text = [
+        'http_requests_total{status="200"} 100',
+        'http_requests_total{status="500"} 5',
+        'other_metric 1',
+      ].join('\n')
+      const metrics = parsePrometheusText(text)
+      const all = metrics.getAll('http_requests_total')
+      expect(all).toHaveLength(2)
+    })
+
+    it('returns empty array for unknown metric', () => {
+      const metrics = parsePrometheusText('process_uptime_seconds 1')
+      expect(metrics.getAll('nonexistent')).toHaveLength(0)
+    })
+  })
+
+  describe('.sum()', () => {
+    it('sums all values for a metric name', () => {
+      const text = [
+        'http_requests_total{status="200"} 100',
+        'http_requests_total{status="500"} 5',
+        'http_requests_total{status="404"} 3',
+      ].join('\n')
+      const metrics = parsePrometheusText(text)
+      expect(metrics.sum('http_requests_total')).toBe(108)
+    })
+
+    it('returns 0 for unknown metric', () => {
+      const metrics = parsePrometheusText('process_uptime_seconds 1')
+      expect(metrics.sum('nonexistent')).toBe(0)
+    })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// extractHttpMetrics
+// ---------------------------------------------------------------------------
+
+describe('extractHttpMetrics', () => {
+  it('extracts request totals', () => {
+    const text = [
+      'http_requests_total{status="200"} 100',
+      'http_requests_total{status="201"} 20',
+    ].join('\n')
+    const metrics = parsePrometheusText(text)
+    const http = extractHttpMetrics(metrics)
+    expect(http.requestsTotal).toBe(120)
+  })
+
+  it('extracts error count from 4xx and 5xx', () => {
+    const text = [
+      'http_requests_total{status="200"} 100',
+      'http_requests_total{status="404"} 10',
+      'http_requests_total{status="500"} 5',
+    ].join('\n')
+    const metrics = parsePrometheusText(text)
+    const http = extractHttpMetrics(metrics)
+    expect(http.errorsTotal).toBe(15)
+  })
+
+  it('calculates error rate', () => {
+    const text = [
+      'http_requests_total{status="200"} 90',
+      'http_requests_total{status="500"} 10',
+    ].join('\n')
+    const metrics = parsePrometheusText(text)
+    const http = extractHttpMetrics(metrics)
+    expect(http.errorRate).toBeCloseTo(0.1)
+  })
+
+  it('returns 0 error rate when no requests', () => {
+    const metrics = parsePrometheusText('process_uptime_seconds 1')
+    const http = extractHttpMetrics(metrics)
+    expect(http.requestsTotal).toBe(0)
+    expect(http.errorRate).toBe(0)
+  })
+
+  it('uses status label to identify errors', () => {
+    const text = [
+      'http_requests_total{status="200"} 80',
+      'http_requests_total{code="400"} 20',
+    ].join('\n')
+    const metrics = parsePrometheusText(text)
+    const http = extractHttpMetrics(metrics)
+    expect(http.errorsTotal).toBe(20)
+  })
+})


### PR DESCRIPTION
## Summary

- Implements `usePrometheusParser` hook for parsing Prometheus text format metrics with `.get()`, `.getAll()`, `.sum()` helpers and `extractHttpMetrics()` for HTTP request/error summaries
- Implements `useMetrics` hook that aggregates agent counts, notification counts, and per-service Prometheus `/metrics` in parallel; auto-refreshes on configurable intervals (10s/30s/1m/5m) and pauses on tab blur
- Adds five monitoring components: `AgentActivityChart` (bar/pie/line views with ARIA), `NotificationMetricsChart` (priority breakdown), `ServiceMetricsCard` (per-service stats), `SystemHealthPanel` (live health checks with uptime tracking), and `PlaceholderChart` ("Coming Soon" overlay for future monitor service)
- Assembles everything in `MonitoringDashboard` with a refresh-interval picker and updates `MonitoringPage` to render it
- 55 new tests across Prometheus parser and 5 component suites; 524 total passing

Closes #171

## Test plan

- [x] `bunx tsc --noEmit` reports no errors
- [x] `bunx vitest run` — 524 tests pass (0 failures)
- [x] All new monitoring component tests cover loading skeletons, ARIA attributes, and chart view toggles
- [x] Prometheus parser tests cover label parsing, `.get/.getAll/.sum`, timestamps, and HTTP metric extraction

🤖 Generated with [Claude Code](https://claude.com/claude-code)