### PR TITLE
feat(ui): build questions view for ask service with trigger controls and answer submission

### DIFF
--- a/ui/src/components/questions/AnswerDialog.tsx
+++ b/ui/src/components/questions/AnswerDialog.tsx
@@ -1,0 +1,227 @@
+/**
+ * AnswerDialog — modal for submitting an answer to a pending question.
+ *
+ * Shows:
+ * - Question context (check type, what triggered it)
+ * - Text input for free-form answer
+ * - Quick-answer buttons for common responses
+ * - Submit via POST /answer
+ * - Success/error feedback
+ */
+
+import { useEffect, useRef, useState } from 'react'
+import { X, MessageSquare, Zap } from 'lucide-react'
+import type { QuestionInfo } from '@/types/ask'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface AnswerDialogProps {
+  open: boolean
+  question: QuestionInfo | null
+  answering: boolean
+  answerError?: string
+  onSubmit: (questionId: string, answer: string) => void
+  onClose: () => void
+}
+
+// ---------------------------------------------------------------------------
+// Quick answers
+// ---------------------------------------------------------------------------
+
+const QUICK_ANSWERS = [
+  { label: 'Yes, start sessions', value: 'yes' },
+  { label: 'No, ignore for now', value: 'no' },
+  { label: 'Acknowledged', value: 'acknowledged' },
+]
+
+// ---------------------------------------------------------------------------
+// AnswerDialog
+// ---------------------------------------------------------------------------
+
+export function AnswerDialog({
+  open,
+  question,
+  answering,
+  answerError,
+  onSubmit,
+  onClose,
+}: AnswerDialogProps) {
+  const [answer, setAnswer] = useState('')
+  const inputRef = useRef<HTMLTextAreaElement>(null)
+  const dialogRef = useRef<HTMLDivElement>(null)
+
+  // Reset answer text when dialog opens for a new question
+  useEffect(() => {
+    if (open) {
+      setAnswer('')
+      // Focus the textarea after the dialog opens
+      setTimeout(() => inputRef.current?.focus(), 50)
+    }
+  }, [open, question?.question_id])
+
+  // Close on Escape
+  useEffect(() => {
+    function onKeyDown(e: KeyboardEvent) {
+      if (e.key === 'Escape' && open) onClose()
+    }
+    document.addEventListener('keydown', onKeyDown)
+    return () => document.removeEventListener('keydown', onKeyDown)
+  }, [open, onClose])
+
+  if (!open || !question) return null
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault()
+    if (!answer.trim()) return
+    onSubmit(question.question_id, answer.trim())
+  }
+
+  const handleQuickAnswer = (value: string) => {
+    onSubmit(question.question_id, value)
+  }
+
+  const checkLabel =
+    question.check_type === 'TmuxSessions' ? 'tmux session check' : question.check_type
+
+  return (
+    <>
+      {/* Backdrop */}
+      <div
+        className="fixed inset-0 z-40 bg-black/40 backdrop-blur-sm"
+        aria-hidden="true"
+        onClick={onClose}
+      />
+
+      {/* Dialog */}
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="answer-dialog-title"
+        className="fixed inset-0 z-50 flex items-center justify-center p-4"
+      >
+        <div className="relative w-full max-w-md rounded-xl bg-white dark:bg-gray-800 shadow-xl border border-gray-200 dark:border-gray-700 p-6 space-y-4">
+          {/* Close button */}
+          <button
+            type="button"
+            onClick={onClose}
+            className="absolute right-4 top-4 text-gray-400 hover:text-gray-600 dark:hover:text-gray-200 transition-colors"
+            aria-label="Close answer dialog"
+          >
+            <X size={18} />
+          </button>
+
+          {/* Title */}
+          <div className="flex items-center gap-2.5">
+            <div className="flex h-9 w-9 items-center justify-center rounded-full bg-yellow-100 dark:bg-yellow-900/30">
+              <MessageSquare size={17} className="text-yellow-600 dark:text-yellow-400" />
+            </div>
+            <div>
+              <h2
+                id="answer-dialog-title"
+                className="text-base font-semibold text-gray-900 dark:text-white"
+              >
+                Answer Question
+              </h2>
+              <p className="text-xs text-gray-400 dark:text-gray-500">
+                From {checkLabel}
+              </p>
+            </div>
+          </div>
+
+          {/* Context */}
+          <div className="rounded-md bg-gray-50 dark:bg-gray-900/50 border border-gray-100 dark:border-gray-700 p-3 space-y-1.5 text-xs">
+            <div className="flex justify-between">
+              <span className="text-gray-400 dark:text-gray-500">Check type</span>
+              <span className="font-medium text-gray-700 dark:text-gray-300">
+                {question.check_type}
+              </span>
+            </div>
+            <div className="flex justify-between">
+              <span className="text-gray-400 dark:text-gray-500">Asked at</span>
+              <span className="font-medium text-gray-700 dark:text-gray-300">
+                {new Date(question.asked_at).toLocaleString()}
+              </span>
+            </div>
+            <div className="flex justify-between">
+              <span className="text-gray-400 dark:text-gray-500">Notification</span>
+              <span className="font-mono font-medium text-gray-700 dark:text-gray-300 truncate max-w-[180px]">
+                {question.notification_id}
+              </span>
+            </div>
+          </div>
+
+          {/* Quick answers */}
+          <div className="space-y-1.5">
+            <p className="text-xs font-medium text-gray-500 dark:text-gray-400 flex items-center gap-1">
+              <Zap size={11} /> Quick answers
+            </p>
+            <div className="flex flex-wrap gap-2">
+              {QUICK_ANSWERS.map((qa) => (
+                <button
+                  key={qa.value}
+                  type="button"
+                  disabled={answering}
+                  onClick={() => handleQuickAnswer(qa.value)}
+                  className="rounded-full border border-gray-200 dark:border-gray-600 px-3 py-1 text-xs text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-50 transition-colors"
+                >
+                  {qa.label}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          {/* Free-form answer */}
+          <form onSubmit={handleSubmit} className="space-y-3">
+            <div>
+              <label
+                htmlFor="answer-input"
+                className="block text-xs font-medium text-gray-700 dark:text-gray-300 mb-1"
+              >
+                Custom answer
+              </label>
+              <textarea
+                id="answer-input"
+                ref={inputRef}
+                rows={3}
+                value={answer}
+                onChange={(e) => setAnswer(e.target.value)}
+                placeholder="Type your answer…"
+                disabled={answering}
+                className="w-full rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 px-3 py-2 text-sm text-gray-900 dark:text-white placeholder:text-gray-400 focus:outline-none focus:ring-2 focus:ring-primary-500 disabled:opacity-50 resize-none"
+              />
+            </div>
+
+            {/* Error */}
+            {answerError && (
+              <p className="text-xs text-red-600 dark:text-red-400">{answerError}</p>
+            )}
+
+            {/* Actions */}
+            <div className="flex justify-end gap-2">
+              <button
+                type="button"
+                onClick={onClose}
+                disabled={answering}
+                className="rounded-md border border-gray-200 dark:border-gray-700 px-4 py-2 text-sm text-gray-600 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-700 disabled:opacity-50 transition-colors"
+              >
+                Cancel
+              </button>
+              <button
+                type="submit"
+                disabled={!answer.trim() || answering}
+                className="rounded-md bg-primary-600 hover:bg-primary-700 disabled:opacity-50 px-4 py-2 text-sm font-medium text-white transition-colors"
+              >
+                {answering ? 'Submitting…' : 'Submit Answer'}
+              </button>
+            </div>
+          </form>
+        </div>
+      </div>
+    </>
+  )
+}
+
+export default AnswerDialog

--- a/ui/src/components/questions/CheckControls.tsx
+++ b/ui/src/components/questions/CheckControls.tsx
@@ -1,0 +1,222 @@
+/**
+ * CheckControls — run environment checks manually or on a schedule.
+ *
+ * Shows:
+ * - "Run Checks" button with loading state
+ * - Last trigger timestamp
+ * - Results after a successful trigger (checks run, notifications, tmux details)
+ * - Auto-trigger toggle with interval picker
+ */
+
+import { Play, RefreshCw, Clock, Bell, ToggleLeft, ToggleRight } from 'lucide-react'
+import type { TriggerResponse } from '@/types/ask'
+import type { AutoTriggerInterval } from '@/hooks/useAskService'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface CheckControlsProps {
+  triggering: boolean
+  lastTriggerResult?: TriggerResponse
+  lastTriggerAt?: Date
+  triggerError?: string
+  autoTrigger: boolean
+  autoTriggerInterval: AutoTriggerInterval
+  onRunTrigger: () => void
+  onSetAutoTrigger: (enabled: boolean) => void
+  onSetAutoTriggerInterval: (ms: AutoTriggerInterval) => void
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const INTERVAL_LABELS: Record<number, string> = {
+  30_000: '30s',
+  60_000: '1m',
+  300_000: '5m',
+  600_000: '10m',
+}
+
+function formatTimestamp(date: Date): string {
+  return date.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit' })
+}
+
+// ---------------------------------------------------------------------------
+// CheckControls
+// ---------------------------------------------------------------------------
+
+export function CheckControls({
+  triggering,
+  lastTriggerResult,
+  lastTriggerAt,
+  triggerError,
+  autoTrigger,
+  autoTriggerInterval,
+  onRunTrigger,
+  onSetAutoTrigger,
+  onSetAutoTriggerInterval,
+}: CheckControlsProps) {
+  const tmux = lastTriggerResult?.results?.tmux_sessions
+
+  return (
+    <div className="rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-5 space-y-4">
+      {/* Header */}
+      <div className="flex items-center justify-between gap-3 flex-wrap">
+        <div>
+          <h3 className="text-sm font-semibold text-gray-900 dark:text-white">
+            Environment Checks
+          </h3>
+          {lastTriggerAt && (
+            <p className="mt-0.5 flex items-center gap-1 text-xs text-gray-400 dark:text-gray-500">
+              <Clock size={11} />
+              Last run at {formatTimestamp(lastTriggerAt)}
+            </p>
+          )}
+        </div>
+
+        {/* Run button */}
+        <button
+          type="button"
+          onClick={onRunTrigger}
+          disabled={triggering}
+          aria-label="Run environment checks"
+          className="flex items-center gap-2 rounded-md bg-primary-600 hover:bg-primary-700 disabled:opacity-60 px-4 py-2 text-sm font-medium text-white transition-colors"
+        >
+          {triggering ? (
+            <RefreshCw size={14} className="animate-spin" />
+          ) : (
+            <Play size={14} />
+          )}
+          {triggering ? 'Running…' : 'Run Checks'}
+        </button>
+      </div>
+
+      {/* Error */}
+      {triggerError && (
+        <div className="rounded-md border border-red-200 dark:border-red-900/40 bg-red-50 dark:bg-red-900/10 px-3 py-2 text-sm text-red-600 dark:text-red-400">
+          {triggerError}
+        </div>
+      )}
+
+      {/* Last trigger results */}
+      {lastTriggerResult && (
+        <div className="space-y-3">
+          {/* Checks performed */}
+          <div className="flex items-start gap-2">
+            <RefreshCw size={13} className="mt-0.5 text-gray-400 flex-shrink-0" />
+            <div>
+              <p className="text-xs font-medium text-gray-600 dark:text-gray-400">Checks run</p>
+              <div className="mt-1 flex flex-wrap gap-1">
+                {lastTriggerResult.checks_run.map((check) => (
+                  <span
+                    key={check}
+                    className="rounded-full bg-blue-100 dark:bg-blue-900/30 px-2 py-0.5 text-xs text-blue-700 dark:text-blue-300"
+                  >
+                    {check}
+                  </span>
+                ))}
+              </div>
+            </div>
+          </div>
+
+          {/* Notifications sent */}
+          <div className="flex items-start gap-2">
+            <Bell size={13} className="mt-0.5 text-gray-400 flex-shrink-0" />
+            <div>
+              <p className="text-xs font-medium text-gray-600 dark:text-gray-400">
+                Notifications sent
+              </p>
+              {lastTriggerResult.notifications_sent.length === 0 ? (
+                <p className="mt-0.5 text-xs text-gray-400 dark:text-gray-500">None</p>
+              ) : (
+                <ul className="mt-1 space-y-0.5">
+                  {lastTriggerResult.notifications_sent.map((id) => (
+                    <li key={id} className="font-mono text-xs text-gray-500 dark:text-gray-400">
+                      {id}
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+          </div>
+
+          {/* Tmux result detail */}
+          {tmux && (
+            <div className="rounded-md bg-gray-50 dark:bg-gray-900/50 border border-gray-100 dark:border-gray-700 px-3 py-2 space-y-1">
+              <p className="text-xs font-medium text-gray-600 dark:text-gray-400">
+                tmux_sessions result
+              </p>
+              <div className="flex items-center gap-2">
+                <span
+                  className={[
+                    'h-2 w-2 rounded-full flex-shrink-0',
+                    tmux.running ? 'bg-green-500' : 'bg-red-500',
+                  ].join(' ')}
+                />
+                <span className="text-xs text-gray-600 dark:text-gray-300">
+                  {tmux.running
+                    ? `Running — ${tmux.session_count} session${tmux.session_count !== 1 ? 's' : ''}`
+                    : 'Not running'}
+                </span>
+              </div>
+              {tmux.sessions && tmux.sessions.length > 0 && (
+                <p className="text-xs text-gray-400 dark:text-gray-500 pl-4">
+                  {tmux.sessions.join(', ')}
+                </p>
+              )}
+            </div>
+          )}
+        </div>
+      )}
+
+      {/* Auto-trigger controls */}
+      <div className="border-t border-gray-100 dark:border-gray-700 pt-4 flex items-center justify-between gap-3 flex-wrap">
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            role="switch"
+            aria-checked={autoTrigger}
+            onClick={() => onSetAutoTrigger(!autoTrigger)}
+            className="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300 hover:text-gray-900 dark:hover:text-white transition-colors"
+          >
+            {autoTrigger ? (
+              <ToggleRight size={20} className="text-primary-600 dark:text-primary-400" />
+            ) : (
+              <ToggleLeft size={20} className="text-gray-400" />
+            )}
+            Auto-trigger
+          </button>
+        </div>
+
+        {autoTrigger && (
+          <div
+            className="flex items-center rounded-md border border-gray-200 dark:border-gray-700 overflow-hidden text-xs"
+            role="group"
+            aria-label="Auto-trigger interval"
+          >
+            {Object.entries(INTERVAL_LABELS).map(([ms, label]) => (
+              <button
+                key={ms}
+                type="button"
+                onClick={() => onSetAutoTriggerInterval(Number(ms) as AutoTriggerInterval)}
+                aria-pressed={autoTriggerInterval === Number(ms)}
+                className={[
+                  'px-2.5 py-1 transition-colors',
+                  autoTriggerInterval === Number(ms)
+                    ? 'bg-primary-100 text-primary-700 dark:bg-primary-900/30 dark:text-primary-400 font-medium'
+                    : 'text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200',
+                ].join(' ')}
+              >
+                {label}
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export default CheckControls

--- a/ui/src/components/questions/EnvironmentStatus.tsx
+++ b/ui/src/components/questions/EnvironmentStatus.tsx
@@ -1,0 +1,145 @@
+/**
+ * EnvironmentStatus — displays the current tmux environment status.
+ *
+ * Shows:
+ * - Running indicator (green/red dot)
+ * - Session count and names
+ * - Last checked timestamp
+ * - Expandable raw JSON view
+ */
+
+import { useState } from 'react'
+import { Terminal, ChevronDown, ChevronRight, Clock } from 'lucide-react'
+import type { TmuxCheckResult } from '@/types/ask'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface EnvironmentStatusProps {
+  tmux?: TmuxCheckResult
+  lastCheckedAt?: Date
+  loading?: boolean
+}
+
+// ---------------------------------------------------------------------------
+// EnvironmentStatus
+// ---------------------------------------------------------------------------
+
+export function EnvironmentStatus({ tmux, lastCheckedAt, loading }: EnvironmentStatusProps) {
+  const [expanded, setExpanded] = useState(false)
+
+  return (
+    <div className="rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-5 space-y-3">
+      {/* Header */}
+      <div className="flex items-center gap-2">
+        <Terminal size={15} className="text-gray-400" />
+        <h3 className="text-sm font-semibold text-gray-900 dark:text-white">Environment Status</h3>
+      </div>
+
+      {loading ? (
+        <div className="space-y-2">
+          <div className="h-4 w-2/3 rounded bg-gray-100 dark:bg-gray-700 animate-pulse" />
+          <div className="h-4 w-1/2 rounded bg-gray-100 dark:bg-gray-700 animate-pulse" />
+        </div>
+      ) : tmux ? (
+        <div className="space-y-3">
+          {/* Tmux status card */}
+          <div
+            className={[
+              'rounded-md border p-3 space-y-2',
+              tmux.running
+                ? 'border-green-100 dark:border-green-900/30 bg-green-50/50 dark:bg-green-900/10'
+                : 'border-red-100 dark:border-red-900/30 bg-red-50/30 dark:bg-red-900/5',
+            ].join(' ')}
+          >
+            {/* Running indicator */}
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-2">
+                <span
+                  className={[
+                    'h-2.5 w-2.5 rounded-full flex-shrink-0',
+                    tmux.running ? 'bg-green-500' : 'bg-red-500',
+                  ].join(' ')}
+                  role="status"
+                  aria-label={tmux.running ? 'tmux running' : 'tmux not running'}
+                />
+                <span className="text-sm font-medium text-gray-900 dark:text-white">
+                  tmux
+                </span>
+              </div>
+              <span
+                className={[
+                  'text-xs font-medium',
+                  tmux.running
+                    ? 'text-green-600 dark:text-green-400'
+                    : 'text-red-600 dark:text-red-400',
+                ].join(' ')}
+              >
+                {tmux.running ? 'Running' : 'Not running'}
+              </span>
+            </div>
+
+            {/* Session count */}
+            <p className="text-xs text-gray-500 dark:text-gray-400">
+              {tmux.session_count === 0
+                ? 'No active sessions'
+                : `${tmux.session_count} active session${tmux.session_count !== 1 ? 's' : ''}`}
+            </p>
+
+            {/* Session names */}
+            {tmux.sessions && tmux.sessions.length > 0 && (
+              <div className="flex flex-wrap gap-1">
+                {tmux.sessions.map((session) => (
+                  <span
+                    key={session}
+                    className="rounded bg-gray-100 dark:bg-gray-700 px-1.5 py-0.5 font-mono text-xs text-gray-600 dark:text-gray-300"
+                  >
+                    {session}
+                  </span>
+                ))}
+              </div>
+            )}
+          </div>
+
+          {/* Last checked timestamp */}
+          {lastCheckedAt && (
+            <p className="flex items-center gap-1 text-xs text-gray-400 dark:text-gray-500">
+              <Clock size={11} />
+              Checked at{' '}
+              {lastCheckedAt.toLocaleTimeString([], {
+                hour: '2-digit',
+                minute: '2-digit',
+                second: '2-digit',
+              })}
+            </p>
+          )}
+
+          {/* Expandable raw JSON */}
+          <div>
+            <button
+              type="button"
+              onClick={() => setExpanded((e) => !e)}
+              className="flex items-center gap-1 text-xs text-gray-400 dark:text-gray-500 hover:text-gray-600 dark:hover:text-gray-300 transition-colors"
+              aria-expanded={expanded}
+            >
+              {expanded ? <ChevronDown size={12} /> : <ChevronRight size={12} />}
+              {expanded ? 'Hide' : 'Show'} raw result
+            </button>
+            {expanded && (
+              <pre className="mt-2 overflow-auto rounded-md bg-gray-50 dark:bg-gray-900/50 border border-gray-100 dark:border-gray-700 p-2 text-xs text-gray-600 dark:text-gray-300">
+                {JSON.stringify(tmux, null, 2)}
+              </pre>
+            )}
+          </div>
+        </div>
+      ) : (
+        <p className="text-sm text-gray-400 dark:text-gray-500">
+          No check results yet. Run checks to see environment status.
+        </p>
+      )}
+    </div>
+  )
+}
+
+export default EnvironmentStatus

--- a/ui/src/components/questions/QuestionCard.tsx
+++ b/ui/src/components/questions/QuestionCard.tsx
@@ -1,0 +1,103 @@
+/**
+ * QuestionCard — displays a single question with status and answer controls.
+ *
+ * Shows:
+ * - Check type, asked timestamp, notification ID (linked)
+ * - Status badge: Pending (yellow) / Answered (green) / Expired (gray)
+ * - "Answer" button for Pending questions
+ * - Submitted answer for Answered questions
+ */
+
+import { Clock, Link } from 'lucide-react'
+import { StatusBadge } from '@/components/common/StatusBadge'
+import type { QuestionInfo } from '@/types/ask'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface QuestionCardProps {
+  question: QuestionInfo
+  onAnswer: (question: QuestionInfo) => void
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function formatAsked(isoString: string): string {
+  try {
+    return new Date(isoString).toLocaleString()
+  } catch {
+    return isoString
+  }
+}
+
+const CHECK_TYPE_LABELS: Record<string, string> = {
+  TmuxSessions: 'Tmux Sessions',
+}
+
+// ---------------------------------------------------------------------------
+// QuestionCard
+// ---------------------------------------------------------------------------
+
+export function QuestionCard({ question, onAnswer }: QuestionCardProps) {
+  const isPending = question.status === 'Pending'
+
+  return (
+    <div
+      className={[
+        'rounded-lg border bg-white dark:bg-gray-800 p-4 space-y-3',
+        isPending
+          ? 'border-yellow-200 dark:border-yellow-900/40'
+          : 'border-gray-200 dark:border-gray-700',
+      ].join(' ')}
+    >
+      {/* Header: check type + status */}
+      <div className="flex items-start justify-between gap-2">
+        <div>
+          <p className="text-sm font-medium text-gray-900 dark:text-white">
+            {CHECK_TYPE_LABELS[question.check_type] ?? question.check_type}
+          </p>
+          <p className="mt-0.5 flex items-center gap-1 text-xs text-gray-400 dark:text-gray-500">
+            <Clock size={11} />
+            {formatAsked(question.asked_at)}
+          </p>
+        </div>
+        <StatusBadge status={question.status} />
+      </div>
+
+      {/* Notification ID */}
+      <div className="flex items-center gap-1.5">
+        <Link size={11} className="text-gray-400 flex-shrink-0" />
+        <span className="text-xs text-gray-400 dark:text-gray-500">Notification</span>
+        <span className="font-mono text-xs text-gray-600 dark:text-gray-300 truncate">
+          {question.notification_id}
+        </span>
+      </div>
+
+      {/* Submitted answer (if answered) */}
+      {question.answer && (
+        <div className="rounded-md bg-green-50 dark:bg-green-900/10 border border-green-100 dark:border-green-900/30 px-3 py-2">
+          <p className="text-xs font-medium text-green-700 dark:text-green-400">
+            Answer submitted
+          </p>
+          <p className="mt-0.5 text-xs text-green-600 dark:text-green-300">{question.answer}</p>
+        </div>
+      )}
+
+      {/* Answer button for pending questions */}
+      {isPending && (
+        <button
+          type="button"
+          onClick={() => onAnswer(question)}
+          className="w-full rounded-md border border-yellow-300 dark:border-yellow-700 bg-yellow-50 dark:bg-yellow-900/20 px-3 py-1.5 text-xs font-medium text-yellow-800 dark:text-yellow-300 hover:bg-yellow-100 dark:hover:bg-yellow-900/30 transition-colors"
+        >
+          Answer
+        </button>
+      )}
+    </div>
+  )
+}
+
+export default QuestionCard

--- a/ui/src/hooks/useAskService.ts
+++ b/ui/src/hooks/useAskService.ts
@@ -1,0 +1,212 @@
+/**
+ * useAskService — state management for the Ask service.
+ *
+ * Provides:
+ * - Service health (reachability, connected notify URL)
+ * - Trigger: run environment checks, track results and history
+ * - Auto-trigger: optional interval-based triggering
+ * - Questions: the list of QuestionInfo items from recent triggers
+ * - Answer: submit answers to pending questions
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { askClient } from '@/services/ask'
+import type { QuestionInfo, TriggerResponse } from '@/types/ask'
+import type { HealthResponse } from '@/types/common'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface AskServiceHealth {
+  reachable: boolean
+  checking: boolean
+  /** URL the ask service uses to reach notify (from /health response) */
+  notifyUrl?: string
+  version?: string
+}
+
+export type AutoTriggerInterval = 30_000 | 60_000 | 300_000 | 600_000
+
+export interface UseAskServiceResult {
+  // Health
+  health: AskServiceHealth
+  recheckHealth: () => void
+
+  // Triggering
+  triggering: boolean
+  lastTriggerResult?: TriggerResponse
+  lastTriggerAt?: Date
+  triggerError?: string
+  runTrigger: () => Promise<void>
+
+  // Auto-trigger
+  autoTrigger: boolean
+  autoTriggerInterval: AutoTriggerInterval
+  setAutoTrigger: (enabled: boolean) => void
+  setAutoTriggerInterval: (ms: AutoTriggerInterval) => void
+
+  // Questions (derived from triggers + manual additions)
+  questions: QuestionInfo[]
+  addQuestion: (q: QuestionInfo) => void
+
+  // Answering
+  answering: boolean
+  answerError?: string
+  submitAnswer: (questionId: string, answer: string) => Promise<boolean>
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+const AUTO_TRIGGER_OPTIONS: AutoTriggerInterval[] = [30_000, 60_000, 300_000, 600_000]
+export { AUTO_TRIGGER_OPTIONS }
+
+export function useAskService(): UseAskServiceResult {
+  const [health, setHealth] = useState<AskServiceHealth>({ reachable: false, checking: true })
+  const [triggering, setTriggering] = useState(false)
+  const [lastTriggerResult, setLastTriggerResult] = useState<TriggerResponse | undefined>()
+  const [lastTriggerAt, setLastTriggerAt] = useState<Date | undefined>()
+  const [triggerError, setTriggerError] = useState<string | undefined>()
+  const [autoTrigger, setAutoTrigger] = useState(false)
+  const [autoTriggerInterval, setAutoTriggerInterval] = useState<AutoTriggerInterval>(60_000)
+  const [questions, setQuestions] = useState<QuestionInfo[]>([])
+  const [answering, setAnswering] = useState(false)
+  const [answerError, setAnswerError] = useState<string | undefined>()
+
+  const autoTimerRef = useRef<ReturnType<typeof setInterval> | null>(null)
+
+  // -------------------------------------------------------------------------
+  // Health check
+  // -------------------------------------------------------------------------
+
+  const recheckHealth = useCallback(async () => {
+    setHealth((prev) => ({ ...prev, checking: true }))
+    try {
+      const res = await askClient.getHealth() as HealthResponse & { notify_url?: string }
+      setHealth({
+        reachable: true,
+        checking: false,
+        notifyUrl: res.notify_url,
+        version: res.version,
+      })
+    } catch {
+      setHealth({ reachable: false, checking: false })
+    }
+  }, [])
+
+  useEffect(() => {
+    void recheckHealth()
+  }, [recheckHealth])
+
+  // -------------------------------------------------------------------------
+  // Trigger
+  // -------------------------------------------------------------------------
+
+  const runTrigger = useCallback(async () => {
+    setTriggering(true)
+    setTriggerError(undefined)
+    try {
+      const result = await askClient.trigger()
+      setLastTriggerResult(result)
+      setLastTriggerAt(new Date())
+
+      // Extract question info from trigger results if notifications were sent.
+      // The ask service creates questions client-side based on notifications_sent
+      // since the trigger endpoint doesn't return QuestionInfo directly.
+      if (result.notifications_sent.length > 0) {
+        const newQuestions: QuestionInfo[] = result.notifications_sent.map((notifId) => ({
+          question_id: crypto.randomUUID(),
+          notification_id: notifId,
+          check_type: 'TmuxSessions',
+          asked_at: new Date().toISOString(),
+          status: 'Pending' as const,
+        }))
+        setQuestions((prev) => {
+          // Deduplicate by notification_id
+          const existingNotifIds = new Set(prev.map((q) => q.notification_id))
+          const deduped = newQuestions.filter((q) => !existingNotifIds.has(q.notification_id))
+          return [...deduped, ...prev]
+        })
+      }
+    } catch (err) {
+      setTriggerError(err instanceof Error ? err.message : 'Failed to run checks')
+    } finally {
+      setTriggering(false)
+    }
+  }, [])
+
+  // -------------------------------------------------------------------------
+  // Auto-trigger timer
+  // -------------------------------------------------------------------------
+
+  useEffect(() => {
+    if (autoTimerRef.current) clearInterval(autoTimerRef.current)
+    if (!autoTrigger) return
+    autoTimerRef.current = setInterval(() => void runTrigger(), autoTriggerInterval)
+    return () => {
+      if (autoTimerRef.current) clearInterval(autoTimerRef.current)
+    }
+  }, [autoTrigger, autoTriggerInterval, runTrigger])
+
+  // -------------------------------------------------------------------------
+  // Questions
+  // -------------------------------------------------------------------------
+
+  const addQuestion = useCallback((q: QuestionInfo) => {
+    setQuestions((prev) => {
+      if (prev.some((existing) => existing.question_id === q.question_id)) return prev
+      return [q, ...prev]
+    })
+  }, [])
+
+  // -------------------------------------------------------------------------
+  // Answer
+  // -------------------------------------------------------------------------
+
+  const submitAnswer = useCallback(async (questionId: string, answer: string): Promise<boolean> => {
+    setAnswering(true)
+    setAnswerError(undefined)
+    try {
+      const res = await askClient.answer({ question_id: questionId, answer })
+      if (res.success) {
+        setQuestions((prev) =>
+          prev.map((q) =>
+            q.question_id === questionId
+              ? { ...q, status: 'Answered' as const, answer }
+              : q,
+          ),
+        )
+        return true
+      } else {
+        setAnswerError(res.message)
+        return false
+      }
+    } catch (err) {
+      setAnswerError(err instanceof Error ? err.message : 'Failed to submit answer')
+      return false
+    } finally {
+      setAnswering(false)
+    }
+  }, [])
+
+  return {
+    health,
+    recheckHealth,
+    triggering,
+    lastTriggerResult,
+    lastTriggerAt,
+    triggerError,
+    runTrigger,
+    autoTrigger,
+    autoTriggerInterval,
+    setAutoTrigger,
+    setAutoTriggerInterval,
+    questions,
+    addQuestion,
+    answering,
+    answerError,
+    submitAnswer,
+  }
+}

--- a/ui/src/pages/QuestionsPage.tsx
+++ b/ui/src/pages/QuestionsPage.tsx
@@ -1,12 +1,7 @@
+import { QuestionList } from './questions/QuestionList'
+
 export function QuestionsPage() {
-  return (
-    <div>
-      <h1 className="text-2xl font-semibold text-gray-900 dark:text-white">Questions</h1>
-      <p className="mt-2 text-gray-500 dark:text-gray-400">
-        Pending questions waiting for your response.
-      </p>
-    </div>
-  )
+  return <QuestionList />
 }
 
 export default QuestionsPage

--- a/ui/src/pages/questions/QuestionList.tsx
+++ b/ui/src/pages/questions/QuestionList.tsx
@@ -1,0 +1,237 @@
+/**
+ * QuestionList — main questions page assembling all ask-service components.
+ *
+ * Layout:
+ * - Page header with service health indicator
+ * - Service connection info (ask health + notify URL)
+ * - Check controls (run trigger, auto-trigger toggle)
+ * - Environment status (tmux card)
+ * - Questions list with status filters
+ * - AnswerDialog (modal)
+ */
+
+import { useState } from 'react'
+import { HelpCircle, Wifi, WifiOff, AlertTriangle, RefreshCw } from 'lucide-react'
+import { useAskService } from '@/hooks/useAskService'
+import { CheckControls } from '@/components/questions/CheckControls'
+import { EnvironmentStatus } from '@/components/questions/EnvironmentStatus'
+import { QuestionCard } from '@/components/questions/QuestionCard'
+import { AnswerDialog } from '@/components/questions/AnswerDialog'
+import type { QuestionInfo, QuestionStatus } from '@/types/ask'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+type StatusFilter = QuestionStatus | 'All'
+
+const STATUS_FILTERS: StatusFilter[] = ['All', 'Pending', 'Answered', 'Expired']
+
+// ---------------------------------------------------------------------------
+// QuestionList
+// ---------------------------------------------------------------------------
+
+export function QuestionList() {
+  const {
+    health,
+    recheckHealth,
+    triggering,
+    lastTriggerResult,
+    lastTriggerAt,
+    triggerError,
+    runTrigger,
+    autoTrigger,
+    autoTriggerInterval,
+    setAutoTrigger,
+    setAutoTriggerInterval,
+    questions,
+    answering,
+    answerError,
+    submitAnswer,
+  } = useAskService()
+
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>('All')
+  const [answerTarget, setAnswerTarget] = useState<QuestionInfo | null>(null)
+  const [answerSuccess, setAnswerSuccess] = useState(false)
+
+  const filteredQuestions =
+    statusFilter === 'All'
+      ? questions
+      : questions.filter((q) => q.status === statusFilter)
+
+  const pendingCount = questions.filter((q) => q.status === 'Pending').length
+
+  const handleAnswer = (question: QuestionInfo) => {
+    setAnswerTarget(question)
+    setAnswerSuccess(false)
+  }
+
+  const handleSubmitAnswer = async (questionId: string, answer: string) => {
+    const ok = await submitAnswer(questionId, answer)
+    if (ok) {
+      setAnswerSuccess(true)
+      setTimeout(() => {
+        setAnswerTarget(null)
+        setAnswerSuccess(false)
+      }, 1200)
+    }
+  }
+
+  const tmux = lastTriggerResult?.results?.tmux_sessions
+
+  return (
+    <div className="space-y-6">
+      {/* Page header */}
+      <div className="flex items-start justify-between gap-4 flex-wrap">
+        <div className="flex items-center gap-3">
+          <div className="flex h-10 w-10 items-center justify-center rounded-lg bg-purple-100 dark:bg-purple-900/30">
+            <HelpCircle size={20} className="text-purple-600 dark:text-purple-400" />
+          </div>
+          <div>
+            <h1 className="text-2xl font-semibold text-gray-900 dark:text-white">Questions</h1>
+            <p className="text-sm text-gray-500 dark:text-gray-400">
+              Pending questions waiting for your response.
+            </p>
+          </div>
+        </div>
+
+        {/* Service health indicator */}
+        <div className="flex items-center gap-2">
+          {health.checking ? (
+            <div className="flex items-center gap-1.5 text-xs text-gray-400">
+              <RefreshCw size={12} className="animate-spin" />
+              Checking…
+            </div>
+          ) : health.reachable ? (
+            <div className="flex items-center gap-1.5 text-xs text-green-600 dark:text-green-400">
+              <Wifi size={13} />
+              Ask service · port 17001
+              {health.version && (
+                <span className="text-gray-400">v{health.version}</span>
+              )}
+            </div>
+          ) : (
+            <button
+              type="button"
+              onClick={recheckHealth}
+              className="flex items-center gap-1.5 text-xs text-red-500 dark:text-red-400 hover:underline"
+            >
+              <WifiOff size={13} />
+              Ask service unreachable — retry
+            </button>
+          )}
+        </div>
+      </div>
+
+      {/* Notify service warning */}
+      {health.reachable && !health.notifyUrl && (
+        <div className="flex items-center gap-2 rounded-md border border-yellow-200 dark:border-yellow-900/40 bg-yellow-50 dark:bg-yellow-900/10 px-4 py-3 text-sm text-yellow-700 dark:text-yellow-400">
+          <AlertTriangle size={14} className="flex-shrink-0" />
+          <span>
+            Could not determine the connected notify service URL. Answers may not be delivered.
+          </span>
+        </div>
+      )}
+      {health.reachable && health.notifyUrl && (
+        <div className="flex items-center gap-2 text-xs text-gray-400 dark:text-gray-500">
+          <span>Connected notify service:</span>
+          <code className="font-mono text-gray-600 dark:text-gray-300">{health.notifyUrl}</code>
+        </div>
+      )}
+
+      {/* Main grid: controls + environment status */}
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+        <CheckControls
+          triggering={triggering}
+          lastTriggerResult={lastTriggerResult}
+          lastTriggerAt={lastTriggerAt}
+          triggerError={triggerError}
+          autoTrigger={autoTrigger}
+          autoTriggerInterval={autoTriggerInterval}
+          onRunTrigger={runTrigger}
+          onSetAutoTrigger={setAutoTrigger}
+          onSetAutoTriggerInterval={setAutoTriggerInterval}
+        />
+        <EnvironmentStatus tmux={tmux} lastCheckedAt={lastTriggerAt} />
+      </div>
+
+      {/* Answer success toast */}
+      {answerSuccess && (
+        <div className="rounded-md border border-green-200 dark:border-green-900/40 bg-green-50 dark:bg-green-900/10 px-4 py-3 text-sm text-green-700 dark:text-green-400">
+          Answer submitted successfully.
+        </div>
+      )}
+
+      {/* Questions section */}
+      <section aria-label="Questions">
+        <div className="mb-3 flex items-center justify-between gap-3 flex-wrap">
+          <h2 className="text-base font-semibold text-gray-900 dark:text-white">
+            Questions
+            {pendingCount > 0 && (
+              <span className="ml-2 rounded-full bg-yellow-100 dark:bg-yellow-900/30 px-2 py-0.5 text-xs font-medium text-yellow-700 dark:text-yellow-400">
+                {pendingCount} pending
+              </span>
+            )}
+          </h2>
+
+          {/* Status filter */}
+          <div
+            className="flex items-center rounded-md border border-gray-200 dark:border-gray-700 overflow-hidden text-xs"
+            role="group"
+            aria-label="Filter by status"
+          >
+            {STATUS_FILTERS.map((filter) => (
+              <button
+                key={filter}
+                type="button"
+                onClick={() => setStatusFilter(filter)}
+                aria-pressed={statusFilter === filter}
+                className={[
+                  'px-3 py-1.5 transition-colors',
+                  statusFilter === filter
+                    ? 'bg-primary-100 text-primary-700 dark:bg-primary-900/30 dark:text-primary-400 font-medium'
+                    : 'text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-gray-200',
+                ].join(' ')}
+              >
+                {filter}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {filteredQuestions.length === 0 ? (
+          <div className="rounded-lg border border-dashed border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800/50 py-12 text-center">
+            <HelpCircle size={32} className="mx-auto mb-3 text-gray-300 dark:text-gray-600" />
+            <p className="text-sm text-gray-500 dark:text-gray-400">
+              {statusFilter === 'All'
+                ? 'No questions yet. Run checks to see if any action is needed.'
+                : `No ${statusFilter.toLowerCase()} questions.`}
+            </p>
+          </div>
+        ) : (
+          <div className="grid grid-cols-1 gap-3 sm:grid-cols-2 xl:grid-cols-3">
+            {filteredQuestions.map((question) => (
+              <QuestionCard
+                key={question.question_id}
+                question={question}
+                onAnswer={handleAnswer}
+              />
+            ))}
+          </div>
+        )}
+      </section>
+
+      {/* Answer dialog */}
+      <AnswerDialog
+        open={answerTarget !== null}
+        question={answerTarget}
+        answering={answering}
+        answerError={answerError}
+        onSubmit={(id, answer) => void handleSubmitAnswer(id, answer)}
+        onClose={() => setAnswerTarget(null)}
+      />
+    </div>
+  )
+}
+
+export default QuestionList

--- a/ui/src/test/components/questions/AnswerDialog.test.tsx
+++ b/ui/src/test/components/questions/AnswerDialog.test.tsx
@@ -1,0 +1,136 @@
+/**
+ * Tests for AnswerDialog component.
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { AnswerDialog } from '@/components/questions/AnswerDialog'
+import type { QuestionInfo } from '@/types/ask'
+
+const QUESTION: QuestionInfo = {
+  question_id: 'q-1',
+  notification_id: 'notif-abc',
+  check_type: 'TmuxSessions',
+  asked_at: '2024-06-01T12:00:00Z',
+  status: 'Pending',
+}
+
+describe('AnswerDialog', () => {
+  it('does not render when open=false', () => {
+    render(
+      <AnswerDialog
+        open={false}
+        question={QUESTION}
+        answering={false}
+        onSubmit={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    )
+    expect(screen.queryByRole('dialog')).toBeNull()
+  })
+
+  it('renders dialog when open=true', () => {
+    render(
+      <AnswerDialog
+        open
+        question={QUESTION}
+        answering={false}
+        onSubmit={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    )
+    expect(screen.getByRole('dialog')).toBeTruthy()
+  })
+
+  it('shows "Answer Question" title', () => {
+    render(
+      <AnswerDialog open question={QUESTION} answering={false} onSubmit={vi.fn()} onClose={vi.fn()} />,
+    )
+    expect(screen.getByText('Answer Question')).toBeTruthy()
+  })
+
+  it('shows notification ID in context', () => {
+    render(
+      <AnswerDialog open question={QUESTION} answering={false} onSubmit={vi.fn()} onClose={vi.fn()} />,
+    )
+    expect(screen.getByText('notif-abc')).toBeTruthy()
+  })
+
+  it('shows quick answer buttons', () => {
+    render(
+      <AnswerDialog open question={QUESTION} answering={false} onSubmit={vi.fn()} onClose={vi.fn()} />,
+    )
+    expect(screen.getByText('Yes, start sessions')).toBeTruthy()
+    expect(screen.getByText('No, ignore for now')).toBeTruthy()
+    expect(screen.getByText('Acknowledged')).toBeTruthy()
+  })
+
+  it('calls onSubmit with quick answer value when clicked', () => {
+    const onSubmit = vi.fn()
+    render(
+      <AnswerDialog open question={QUESTION} answering={false} onSubmit={onSubmit} onClose={vi.fn()} />,
+    )
+    fireEvent.click(screen.getByText('Yes, start sessions'))
+    expect(onSubmit).toHaveBeenCalledWith('q-1', 'yes')
+  })
+
+  it('enables submit button only when textarea has content', () => {
+    render(
+      <AnswerDialog open question={QUESTION} answering={false} onSubmit={vi.fn()} onClose={vi.fn()} />,
+    )
+    const submitBtn = screen.getByText('Submit Answer')
+    expect((submitBtn as HTMLButtonElement).disabled).toBe(true)
+
+    fireEvent.change(screen.getByLabelText('Custom answer'), { target: { value: 'my answer' } })
+    expect((submitBtn as HTMLButtonElement).disabled).toBe(false)
+  })
+
+  it('calls onSubmit with typed answer on form submit', () => {
+    const onSubmit = vi.fn()
+    render(
+      <AnswerDialog open question={QUESTION} answering={false} onSubmit={onSubmit} onClose={vi.fn()} />,
+    )
+    fireEvent.change(screen.getByLabelText('Custom answer'), { target: { value: 'my answer' } })
+    fireEvent.click(screen.getByText('Submit Answer'))
+    expect(onSubmit).toHaveBeenCalledWith('q-1', 'my answer')
+  })
+
+  it('calls onClose when Cancel is clicked', () => {
+    const onClose = vi.fn()
+    render(
+      <AnswerDialog open question={QUESTION} answering={false} onSubmit={vi.fn()} onClose={onClose} />,
+    )
+    fireEvent.click(screen.getByText('Cancel'))
+    expect(onClose).toHaveBeenCalledOnce()
+  })
+
+  it('closes when close button (×) is clicked', () => {
+    const onClose = vi.fn()
+    render(
+      <AnswerDialog open question={QUESTION} answering={false} onSubmit={vi.fn()} onClose={onClose} />,
+    )
+    fireEvent.click(screen.getByLabelText('Close answer dialog'))
+    expect(onClose).toHaveBeenCalledOnce()
+  })
+
+  it('shows error when answerError is set', () => {
+    render(
+      <AnswerDialog
+        open
+        question={QUESTION}
+        answering={false}
+        answerError="Network error"
+        onSubmit={vi.fn()}
+        onClose={vi.fn()}
+      />,
+    )
+    expect(screen.getByText('Network error')).toBeTruthy()
+  })
+
+  it('shows "Submitting…" when answering=true', () => {
+    render(
+      <AnswerDialog open question={QUESTION} answering onSubmit={vi.fn()} onClose={vi.fn()} />,
+    )
+    expect(screen.getByText('Submitting…')).toBeTruthy()
+  })
+})

--- a/ui/src/test/components/questions/CheckControls.test.tsx
+++ b/ui/src/test/components/questions/CheckControls.test.tsx
@@ -1,0 +1,102 @@
+/**
+ * Tests for CheckControls component.
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { CheckControls } from '@/components/questions/CheckControls'
+import { makeTriggerResponse } from '@/test/mocks/factories'
+import type { AutoTriggerInterval } from '@/hooks/useAskService'
+
+const DEFAULT_PROPS = {
+  triggering: false,
+  triggerError: undefined,
+  autoTrigger: false,
+  autoTriggerInterval: 60_000 as AutoTriggerInterval,
+  onRunTrigger: vi.fn(),
+  onSetAutoTrigger: vi.fn(),
+  onSetAutoTriggerInterval: vi.fn(),
+}
+
+describe('CheckControls', () => {
+  it('renders the "Run Checks" button', () => {
+    render(<CheckControls {...DEFAULT_PROPS} />)
+    expect(screen.getByText('Run Checks')).toBeTruthy()
+  })
+
+  it('shows "Running…" label while triggering', () => {
+    render(<CheckControls {...DEFAULT_PROPS} triggering />)
+    expect(screen.getByText('Running…')).toBeTruthy()
+  })
+
+  it('disables the button while triggering', () => {
+    render(<CheckControls {...DEFAULT_PROPS} triggering />)
+    const btn = screen.getByLabelText('Run environment checks')
+    expect((btn as HTMLButtonElement).disabled).toBe(true)
+  })
+
+  it('calls onRunTrigger when button clicked', () => {
+    const onRunTrigger = vi.fn()
+    render(<CheckControls {...DEFAULT_PROPS} onRunTrigger={onRunTrigger} />)
+    fireEvent.click(screen.getByText('Run Checks'))
+    expect(onRunTrigger).toHaveBeenCalledOnce()
+  })
+
+  it('shows error message when triggerError is set', () => {
+    render(<CheckControls {...DEFAULT_PROPS} triggerError="Connection refused" />)
+    expect(screen.getByText('Connection refused')).toBeTruthy()
+  })
+
+  it('shows trigger results after successful check', () => {
+    const result = makeTriggerResponse({ checks_run: ['TmuxSessions'] })
+    render(<CheckControls {...DEFAULT_PROPS} lastTriggerResult={result} lastTriggerAt={new Date()} />)
+    expect(screen.getByText('TmuxSessions')).toBeTruthy()
+    expect(screen.getByText('Checks run')).toBeTruthy()
+  })
+
+  it('shows "None" when no notifications were sent', () => {
+    const result = makeTriggerResponse({ notifications_sent: [] })
+    render(<CheckControls {...DEFAULT_PROPS} lastTriggerResult={result} lastTriggerAt={new Date()} />)
+    expect(screen.getByText('None')).toBeTruthy()
+  })
+
+  it('shows notification IDs when sent', () => {
+    const result = makeTriggerResponse({ notifications_sent: ['notif-abc'] })
+    render(<CheckControls {...DEFAULT_PROPS} lastTriggerResult={result} lastTriggerAt={new Date()} />)
+    expect(screen.getByText('notif-abc')).toBeTruthy()
+  })
+
+  it('shows the auto-trigger toggle', () => {
+    render(<CheckControls {...DEFAULT_PROPS} />)
+    expect(screen.getByText('Auto-trigger')).toBeTruthy()
+  })
+
+  it('calls onSetAutoTrigger when toggle clicked', () => {
+    const onSetAutoTrigger = vi.fn()
+    render(<CheckControls {...DEFAULT_PROPS} onSetAutoTrigger={onSetAutoTrigger} />)
+    const toggle = screen.getByRole('switch', { name: /auto-trigger/i })
+    fireEvent.click(toggle)
+    expect(onSetAutoTrigger).toHaveBeenCalledWith(true)
+  })
+
+  it('shows interval picker when auto-trigger is on', () => {
+    render(<CheckControls {...DEFAULT_PROPS} autoTrigger />)
+    expect(screen.getByRole('group', { name: 'Auto-trigger interval' })).toBeTruthy()
+  })
+
+  it('does not show interval picker when auto-trigger is off', () => {
+    render(<CheckControls {...DEFAULT_PROPS} autoTrigger={false} />)
+    expect(screen.queryByRole('group', { name: 'Auto-trigger interval' })).toBeNull()
+  })
+
+  it('shows tmux result when available', () => {
+    const result = makeTriggerResponse({
+      results: {
+        tmux_sessions: { running: true, session_count: 2, sessions: ['main', 'dev'] },
+      },
+    })
+    render(<CheckControls {...DEFAULT_PROPS} lastTriggerResult={result} lastTriggerAt={new Date()} />)
+    expect(screen.getByText('tmux_sessions result')).toBeTruthy()
+    expect(screen.getByText(/Running — 2 sessions/)).toBeTruthy()
+  })
+})

--- a/ui/src/test/components/questions/EnvironmentStatus.test.tsx
+++ b/ui/src/test/components/questions/EnvironmentStatus.test.tsx
@@ -1,0 +1,78 @@
+/**
+ * Tests for EnvironmentStatus component.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { EnvironmentStatus } from '@/components/questions/EnvironmentStatus'
+import type { TmuxCheckResult } from '@/types/ask'
+
+const TMUX_RUNNING: TmuxCheckResult = {
+  running: true,
+  session_count: 2,
+  sessions: ['main', 'dev'],
+}
+
+const TMUX_STOPPED: TmuxCheckResult = {
+  running: false,
+  session_count: 0,
+  sessions: [],
+}
+
+describe('EnvironmentStatus', () => {
+  it('renders "Environment Status" heading', () => {
+    render(<EnvironmentStatus />)
+    expect(screen.getByText('Environment Status')).toBeTruthy()
+  })
+
+  it('shows placeholder message when no tmux data', () => {
+    render(<EnvironmentStatus />)
+    expect(screen.getByText(/No check results yet/)).toBeTruthy()
+  })
+
+  it('shows "Running" when tmux is running', () => {
+    render(<EnvironmentStatus tmux={TMUX_RUNNING} />)
+    expect(screen.getByText('Running')).toBeTruthy()
+  })
+
+  it('shows "Not running" when tmux is stopped', () => {
+    render(<EnvironmentStatus tmux={TMUX_STOPPED} />)
+    expect(screen.getByText('Not running')).toBeTruthy()
+  })
+
+  it('shows session count', () => {
+    render(<EnvironmentStatus tmux={TMUX_RUNNING} />)
+    expect(screen.getByText('2 active sessions')).toBeTruthy()
+  })
+
+  it('shows "No active sessions" when count is zero', () => {
+    render(<EnvironmentStatus tmux={TMUX_STOPPED} />)
+    expect(screen.getByText('No active sessions')).toBeTruthy()
+  })
+
+  it('shows session names as badges', () => {
+    render(<EnvironmentStatus tmux={TMUX_RUNNING} />)
+    expect(screen.getByText('main')).toBeTruthy()
+    expect(screen.getByText('dev')).toBeTruthy()
+  })
+
+  it('shows loading skeletons when loading=true', () => {
+    const { container } = render(<EnvironmentStatus loading />)
+    expect(container.querySelector('.animate-pulse')).toBeTruthy()
+  })
+
+  it('toggles raw JSON view on button click', () => {
+    render(<EnvironmentStatus tmux={TMUX_RUNNING} />)
+    expect(screen.queryByText(/"running": true/)).toBeNull()
+    fireEvent.click(screen.getByText('Show raw result'))
+    expect(screen.getByText(/"running": true/)).toBeTruthy()
+    fireEvent.click(screen.getByText('Hide raw result'))
+    expect(screen.queryByText(/"running": true/)).toBeNull()
+  })
+
+  it('shows last checked timestamp when provided', () => {
+    const ts = new Date('2024-06-01T14:30:00Z')
+    render(<EnvironmentStatus tmux={TMUX_RUNNING} lastCheckedAt={ts} />)
+    expect(screen.getByText(/Checked at/)).toBeTruthy()
+  })
+})

--- a/ui/src/test/components/questions/QuestionCard.test.tsx
+++ b/ui/src/test/components/questions/QuestionCard.test.tsx
@@ -1,0 +1,80 @@
+/**
+ * Tests for QuestionCard component.
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { QuestionCard } from '@/components/questions/QuestionCard'
+import type { QuestionInfo } from '@/types/ask'
+
+function makeQuestion(overrides: Partial<QuestionInfo> = {}): QuestionInfo {
+  return {
+    question_id: 'q-1',
+    notification_id: 'notif-abc-123',
+    check_type: 'TmuxSessions',
+    asked_at: '2024-06-01T12:00:00Z',
+    status: 'Pending',
+    ...overrides,
+  }
+}
+
+describe('QuestionCard', () => {
+  it('renders the check type label', () => {
+    render(<QuestionCard question={makeQuestion()} onAnswer={vi.fn()} />)
+    expect(screen.getByText('Tmux Sessions')).toBeTruthy()
+  })
+
+  it('renders the notification ID', () => {
+    render(<QuestionCard question={makeQuestion()} onAnswer={vi.fn()} />)
+    expect(screen.getByText('notif-abc-123')).toBeTruthy()
+  })
+
+  it('shows "Pending" status badge', () => {
+    render(<QuestionCard question={makeQuestion({ status: 'Pending' })} onAnswer={vi.fn()} />)
+    expect(screen.getByText('Pending')).toBeTruthy()
+  })
+
+  it('shows "Answered" status badge', () => {
+    render(<QuestionCard question={makeQuestion({ status: 'Answered' })} onAnswer={vi.fn()} />)
+    expect(screen.getByText('Answered')).toBeTruthy()
+  })
+
+  it('shows "Expired" status badge', () => {
+    render(<QuestionCard question={makeQuestion({ status: 'Expired' })} onAnswer={vi.fn()} />)
+    expect(screen.getByText('Expired')).toBeTruthy()
+  })
+
+  it('shows Answer button for Pending questions', () => {
+    render(<QuestionCard question={makeQuestion({ status: 'Pending' })} onAnswer={vi.fn()} />)
+    expect(screen.getByText('Answer')).toBeTruthy()
+  })
+
+  it('does not show Answer button for Answered questions', () => {
+    render(<QuestionCard question={makeQuestion({ status: 'Answered' })} onAnswer={vi.fn()} />)
+    expect(screen.queryByText('Answer')).toBeNull()
+  })
+
+  it('does not show Answer button for Expired questions', () => {
+    render(<QuestionCard question={makeQuestion({ status: 'Expired' })} onAnswer={vi.fn()} />)
+    expect(screen.queryByText('Answer')).toBeNull()
+  })
+
+  it('calls onAnswer with the question when Answer is clicked', () => {
+    const onAnswer = vi.fn()
+    const question = makeQuestion()
+    render(<QuestionCard question={question} onAnswer={onAnswer} />)
+    fireEvent.click(screen.getByText('Answer'))
+    expect(onAnswer).toHaveBeenCalledWith(question)
+  })
+
+  it('shows submitted answer text', () => {
+    render(
+      <QuestionCard
+        question={makeQuestion({ status: 'Answered', answer: 'yes' })}
+        onAnswer={vi.fn()}
+      />,
+    )
+    expect(screen.getByText('Answer submitted')).toBeTruthy()
+    expect(screen.getByText('yes')).toBeTruthy()
+  })
+})

--- a/ui/src/test/hooks/useAskService.test.ts
+++ b/ui/src/test/hooks/useAskService.test.ts
@@ -1,0 +1,217 @@
+/**
+ * Tests for useAskService hook.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act, waitFor } from '@testing-library/react'
+import { http, HttpResponse } from 'msw'
+import { useAskService } from '@/hooks/useAskService'
+import { server } from '@/test/mocks/server'
+import { makeTriggerResponse, makeAnswerResponse, resetQuestionSeq } from '@/test/mocks/factories'
+
+const BASE = 'http://localhost:17001'
+
+beforeEach(() => {
+  resetQuestionSeq()
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('useAskService', () => {
+  describe('health', () => {
+    it('reports reachable when health check succeeds', async () => {
+      const { result } = renderHook(() => useAskService())
+      await waitFor(() => expect(result.current.health.reachable).toBe(true))
+      expect(result.current.health.checking).toBe(false)
+    })
+
+    it('reports unreachable when health check fails', async () => {
+      server.use(http.get(`${BASE}/health`, () => HttpResponse.error()))
+      const { result } = renderHook(() => useAskService())
+      await waitFor(() => expect(result.current.health.checking).toBe(false))
+      expect(result.current.health.reachable).toBe(false)
+    })
+
+    it('recheckHealth re-runs the health check', async () => {
+      const { result } = renderHook(() => useAskService())
+      await waitFor(() => expect(result.current.health.reachable).toBe(true))
+
+      server.use(http.get(`${BASE}/health`, () => HttpResponse.error()))
+      act(() => { result.current.recheckHealth() })
+      await waitFor(() => expect(result.current.health.reachable).toBe(false))
+    })
+  })
+
+  describe('runTrigger', () => {
+    it('calls POST /trigger and sets result', async () => {
+      const triggerData = makeTriggerResponse({
+        checks_run: ['TmuxSessions'],
+        notifications_sent: [],
+      })
+      server.use(http.post(`${BASE}/trigger`, () => HttpResponse.json(triggerData)))
+
+      const { result } = renderHook(() => useAskService())
+      await waitFor(() => expect(result.current.health.checking).toBe(false))
+
+      await act(async () => { await result.current.runTrigger() })
+
+      expect(result.current.lastTriggerResult).toEqual(triggerData)
+      expect(result.current.lastTriggerAt).toBeDefined()
+      expect(result.current.triggering).toBe(false)
+    })
+
+    it('sets triggerError when trigger fails', async () => {
+      server.use(http.post(`${BASE}/trigger`, () => HttpResponse.error()))
+
+      const { result } = renderHook(() => useAskService())
+      await waitFor(() => expect(result.current.health.checking).toBe(false))
+
+      await act(async () => { await result.current.runTrigger() })
+
+      expect(result.current.triggerError).toBeDefined()
+    })
+
+    it('adds pending questions when notifications are sent', async () => {
+      const triggerData = makeTriggerResponse({ notifications_sent: ['notif-abc'] })
+      server.use(http.post(`${BASE}/trigger`, () => HttpResponse.json(triggerData)))
+
+      const { result } = renderHook(() => useAskService())
+      await waitFor(() => expect(result.current.health.checking).toBe(false))
+
+      await act(async () => { await result.current.runTrigger() })
+
+      await waitFor(() => expect(result.current.questions).toHaveLength(1))
+      expect(result.current.questions[0].status).toBe('Pending')
+      expect(result.current.questions[0].notification_id).toBe('notif-abc')
+    })
+
+    it('deduplicates questions by notification_id', async () => {
+      const triggerData = makeTriggerResponse({ notifications_sent: ['notif-abc'] })
+      server.use(http.post(`${BASE}/trigger`, () => HttpResponse.json(triggerData)))
+
+      const { result } = renderHook(() => useAskService())
+      await waitFor(() => expect(result.current.health.checking).toBe(false))
+
+      await act(async () => { await result.current.runTrigger() })
+      await act(async () => { await result.current.runTrigger() })
+
+      await waitFor(() => expect(result.current.questions).toHaveLength(1))
+    })
+  })
+
+  describe('submitAnswer', () => {
+    it('marks question as Answered on success', async () => {
+      const triggerData = makeTriggerResponse({ notifications_sent: ['notif-1'] })
+      server.use(http.post(`${BASE}/trigger`, () => HttpResponse.json(triggerData)))
+      server.use(
+        http.post(`${BASE}/answer`, () =>
+          HttpResponse.json(makeAnswerResponse({ success: true })),
+        ),
+      )
+
+      const { result } = renderHook(() => useAskService())
+      await waitFor(() => expect(result.current.health.checking).toBe(false))
+
+      await act(async () => { await result.current.runTrigger() })
+      await waitFor(() => expect(result.current.questions).toHaveLength(1))
+
+      const questionId = result.current.questions[0].question_id
+      let success = false
+      await act(async () => {
+        success = await result.current.submitAnswer(questionId, 'yes')
+      })
+
+      expect(success).toBe(true)
+      await waitFor(() => expect(result.current.questions[0].status).toBe('Answered'))
+    })
+
+    it('sets answerError on failure', async () => {
+      server.use(http.post(`${BASE}/answer`, () => HttpResponse.error()))
+
+      const { result } = renderHook(() => useAskService())
+      await waitFor(() => expect(result.current.health.checking).toBe(false))
+
+      act(() => {
+        result.current.addQuestion({
+          question_id: 'q-1',
+          notification_id: 'n-1',
+          check_type: 'TmuxSessions',
+          asked_at: '2024-01-01T00:00:00Z',
+          status: 'Pending',
+        })
+      })
+
+      let success = true
+      await act(async () => {
+        success = await result.current.submitAnswer('q-1', 'yes')
+      })
+
+      expect(success).toBe(false)
+      expect(result.current.answerError).toBeDefined()
+    })
+  })
+
+  describe('addQuestion', () => {
+    it('adds a question to the list', async () => {
+      const { result } = renderHook(() => useAskService())
+      await waitFor(() => expect(result.current.health.checking).toBe(false))
+
+      act(() => {
+        result.current.addQuestion({
+          question_id: 'q-1',
+          notification_id: 'n-1',
+          check_type: 'TmuxSessions',
+          asked_at: '2024-01-01T00:00:00Z',
+          status: 'Pending',
+        })
+      })
+      await waitFor(() => expect(result.current.questions).toHaveLength(1))
+    })
+
+    it('does not add duplicate questions', async () => {
+      const { result } = renderHook(() => useAskService())
+      await waitFor(() => expect(result.current.health.checking).toBe(false))
+
+      const q = {
+        question_id: 'q-1',
+        notification_id: 'n-1',
+        check_type: 'TmuxSessions' as const,
+        asked_at: '2024-01-01T00:00:00Z',
+        status: 'Pending' as const,
+      }
+      act(() => {
+        result.current.addQuestion(q)
+        result.current.addQuestion(q)
+      })
+      await waitFor(() => expect(result.current.questions).toHaveLength(1))
+    })
+  })
+
+  describe('auto-trigger', () => {
+    it('starts with auto-trigger disabled', async () => {
+      const { result } = renderHook(() => useAskService())
+      await waitFor(() => expect(result.current.health.checking).toBe(false))
+      expect(result.current.autoTrigger).toBe(false)
+    })
+
+    it('toggles auto-trigger on and off', async () => {
+      const { result } = renderHook(() => useAskService())
+      await waitFor(() => expect(result.current.health.checking).toBe(false))
+
+      act(() => result.current.setAutoTrigger(true))
+      expect(result.current.autoTrigger).toBe(true)
+      act(() => result.current.setAutoTrigger(false))
+      expect(result.current.autoTrigger).toBe(false)
+    })
+
+    it('updates interval', async () => {
+      const { result } = renderHook(() => useAskService())
+      await waitFor(() => expect(result.current.health.checking).toBe(false))
+
+      act(() => result.current.setAutoTriggerInterval(300_000))
+      expect(result.current.autoTriggerInterval).toBe(300_000)
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Implements `useAskService` hook with health checking, manual/auto-trigger scheduling, question list management (with notification-ID deduplication), and answer submission
- Adds `CheckControls` component with "Run Checks" button, last-trigger timestamp, results breakdown (checks run, notifications sent, tmux detail), and auto-trigger toggle with interval picker (30s/1m/5m/10m)
- Adds `EnvironmentStatus` showing the tmux session card: running indicator, session count and names, last-checked timestamp, and expandable raw JSON view
- Adds `QuestionCard` showing status badges (Pending/Answered/Expired), notification ID, submitted answer preview, and context-sensitive "Answer" button
- Adds `AnswerDialog` modal with question context, quick-answer buttons, free-form textarea, Escape/backdrop close, and loading/error states
- Assembles everything in `QuestionList` page with service health indicator, notify-URL connection info, status filter tabs, and empty-state placeholder
- Updates `QuestionsPage` to render the new `QuestionList`

Closes #170

## Test plan

- [x] `bunx tsc --noEmit` — clean
- [x] `bunx vitest run` — 578 tests pass (0 failures)
- [x] Hook tests cover health, trigger, deduplication, answer success/failure, addQuestion, auto-trigger toggle
- [x] Component tests cover all states: loading, empty, running/stopped tmux, pending/answered/expired questions, dialog open/close/submit/quick-answer

🤖 Generated with [Claude Code](https://claude.com/claude-code)