### PR TITLE
Add sea-orm and sea-orm-migration workspace dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,3 +36,5 @@ axum = "0.8"
 tower-http = { version = "0.6", features = ["trace", "cors"] }
 metrics = "0.24"
 metrics-exporter-prometheus = { version = "0.16", default-features = false }
+sea-orm = { version = "1.1", features = ["sqlx-sqlite", "runtime-tokio-rustls", "macros"] }
+sea-orm-migration = { version = "1.1" }

--- a/README.md
+++ b/README.md
@@ -268,6 +268,13 @@ All services communicate via REST APIs. The orchestrator additionally provides W
 
 ## Development
 
+### Prerequisites (Development Tools)
+
+```bash
+# Install sea-orm-cli for database migrations (required when working on DB migrations)
+cargo install sea-orm-cli
+```
+
 ### Building
 
 ```bash


### PR DESCRIPTION
## Summary

- Adds `sea-orm = { version = "1.1", features = ["sqlx-sqlite", "runtime-tokio-rustls", "macros"] }` to `[workspace.dependencies]`
- Adds `sea-orm-migration = { version = "1.1" }` to `[workspace.dependencies]`
- Documents `cargo install sea-orm-cli` in the README development prerequisites

## Compatibility Verification

Verified that sea-orm 1.1 and sqlx 0.8 coexist without conflicts by temporarily adding both deps to `agentd-common` and running `cargo check` successfully (68 new packages resolved cleanly).

## Test plan

- [x] `cargo check` passes with no errors
- [x] sea-orm 1.1 resolves alongside existing sqlx 0.8 (no version conflicts)
- [x] Workspace Cargo.toml syntax is valid

Closes #223

Generated with Claude Code