### PR TITLE
feat: define SeaORM entities for orchestrator crate agent and scheduler models

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1976,6 +1976,8 @@ dependencies = [
  "metrics",
  "metrics-exporter-prometheus",
  "reqwest",
+ "sea-orm",
+ "sea-orm-migration",
  "serde",
  "serde_json",
  "sqlx",

--- a/crates/orchestrator/Cargo.toml
+++ b/crates/orchestrator/Cargo.toml
@@ -30,6 +30,8 @@ sqlx = { version = "0.8", features = [
     "chrono",
     "uuid",
 ] }
+sea-orm = { workspace = true }
+sea-orm-migration = { workspace = true }
 
 # Async trait support
 async-trait = "0.1"

--- a/crates/orchestrator/src/entity/agent.rs
+++ b/crates/orchestrator/src/entity/agent.rs
@@ -1,0 +1,38 @@
+//! SeaORM entity for the `agents` table.
+
+use sea_orm::entity::prelude::*;
+
+/// SeaORM model for the `agents` table.
+///
+/// JSON columns (`tool_policy`, `env`) are stored as TEXT and deserialized
+/// manually in the storage layer to preserve the existing serde representations.
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+#[sea_orm(table_name = "agents")]
+pub struct Model {
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub id: String,
+    pub name: String,
+    pub status: String,
+    pub working_dir: String,
+    pub user: Option<String>,
+    pub shell: String,
+    /// Stored as INTEGER (0/1); mapped to `bool` in the domain layer.
+    pub interactive: i32,
+    pub prompt: Option<String>,
+    /// Stored as INTEGER (0/1); mapped to `bool` in the domain layer.
+    pub worktree: i32,
+    pub system_prompt: Option<String>,
+    pub tmux_session: Option<String>,
+    /// JSON-serialized [`crate::types::ToolPolicy`].
+    pub tool_policy: String,
+    pub model: Option<String>,
+    /// JSON-serialized `HashMap<String, String>`.
+    pub env: String,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/crates/orchestrator/src/entity/dispatch.rs
+++ b/crates/orchestrator/src/entity/dispatch.rs
@@ -1,0 +1,39 @@
+//! SeaORM entity for the `dispatch_log` table.
+
+use sea_orm::entity::prelude::*;
+
+/// SeaORM model for the `dispatch_log` table.
+///
+/// The composite unique constraint `(workflow_id, source_id)` is enforced by
+/// the migration but not represented in the entity model itself.
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+#[sea_orm(table_name = "dispatch_log")]
+pub struct Model {
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub id: String,
+    pub workflow_id: String,
+    pub source_id: String,
+    pub agent_id: String,
+    pub prompt_sent: String,
+    pub status: String,
+    pub dispatched_at: String,
+    pub completed_at: Option<String>,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {
+    #[sea_orm(
+        belongs_to = "super::workflow::Entity",
+        from = "Column::WorkflowId",
+        to = "super::workflow::Column::Id"
+    )]
+    Workflow,
+}
+
+impl Related<super::workflow::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::Workflow.def()
+    }
+}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/crates/orchestrator/src/entity/mod.rs
+++ b/crates/orchestrator/src/entity/mod.rs
@@ -1,0 +1,11 @@
+//! SeaORM entity definitions for the orchestrator crate.
+//!
+//! Three entities map to the three SQLite tables:
+//!
+//! - [`agent`] → `agents` table
+//! - [`workflow`] → `workflows` table
+//! - [`dispatch`] → `dispatch_log` table
+
+pub mod agent;
+pub mod dispatch;
+pub mod workflow;

--- a/crates/orchestrator/src/entity/workflow.rs
+++ b/crates/orchestrator/src/entity/workflow.rs
@@ -1,0 +1,42 @@
+//! SeaORM entity for the `workflows` table.
+
+use sea_orm::entity::prelude::*;
+
+/// SeaORM model for the `workflows` table.
+///
+/// JSON columns (`source_config`, `tool_policy`) are stored as TEXT and
+/// deserialized manually in the storage layer.
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+#[sea_orm(table_name = "workflows")]
+pub struct Model {
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub id: String,
+    #[sea_orm(unique)]
+    pub name: String,
+    pub agent_id: String,
+    pub source_type: String,
+    /// JSON-serialized [`crate::scheduler::types::TaskSourceConfig`].
+    pub source_config: String,
+    pub prompt_template: String,
+    pub poll_interval_secs: i64,
+    /// Stored as INTEGER (0/1); mapped to `bool` in the domain layer.
+    pub enabled: i32,
+    /// JSON-serialized [`crate::types::ToolPolicy`].
+    pub tool_policy: String,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {
+    #[sea_orm(has_many = "super::dispatch::Entity")]
+    Dispatch,
+}
+
+impl Related<super::dispatch::Entity> for Entity {
+    fn to() -> RelationDef {
+        Relation::Dispatch.def()
+    }
+}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/crates/orchestrator/src/lib.rs
+++ b/crates/orchestrator/src/lib.rs
@@ -24,6 +24,8 @@
 pub mod api;
 pub mod approvals;
 pub mod client;
+pub mod entity;
+pub(crate) mod migration;
 pub mod manager;
 pub mod scheduler;
 pub mod storage;

--- a/crates/orchestrator/src/main.rs
+++ b/crates/orchestrator/src/main.rs
@@ -1,5 +1,7 @@
 mod api;
 mod approvals;
+mod entity;
+mod migration;
 mod manager;
 mod scheduler;
 mod storage;
@@ -60,9 +62,9 @@ async fn main() -> anyhow::Result<()> {
 
     let manager = Arc::new(manager);
 
-    // Scheduler for autonomous workflows (shares the same SQLite pool).
-    let scheduler_storage = SchedulerStorage::new(storage.pool().clone());
-    scheduler_storage.init_schema().await?;
+    // Scheduler for autonomous workflows (shares the same SeaORM connection).
+    // Schema is already applied by AgentStorage::with_path() via Migrator::up().
+    let scheduler_storage = SchedulerStorage::new(storage.db().clone());
     let scheduler = Arc::new(Scheduler::new(scheduler_storage, registry.clone()));
 
     // Register scheduler as a result callback so it gets notified when agents finish.

--- a/crates/orchestrator/src/migration/m20250305_000001_create_tables.rs
+++ b/crates/orchestrator/src/migration/m20250305_000001_create_tables.rs
@@ -1,0 +1,256 @@
+//! Initial migration: create the `agents`, `workflows`, and `dispatch_log` tables.
+//!
+//! Matches the schema previously managed by `init_schema()` calls in both
+//! `AgentStorage` and `SchedulerStorage`, so existing installations can adopt
+//! the migration framework without data loss.
+
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        // -----------------------------------------------------------------
+        // agents table
+        // -----------------------------------------------------------------
+        manager
+            .create_table(
+                Table::create()
+                    .table(Agents::Table)
+                    .if_not_exists()
+                    .col(
+                        ColumnDef::new(Agents::Id)
+                            .string()
+                            .not_null()
+                            .primary_key(),
+                    )
+                    .col(ColumnDef::new(Agents::Name).string().not_null())
+                    .col(ColumnDef::new(Agents::Status).string().not_null())
+                    .col(ColumnDef::new(Agents::WorkingDir).string().not_null())
+                    .col(ColumnDef::new(Agents::User).string().null())
+                    .col(ColumnDef::new(Agents::Shell).string().not_null())
+                    .col(
+                        ColumnDef::new(Agents::Interactive)
+                            .integer()
+                            .not_null()
+                            .default(0),
+                    )
+                    .col(ColumnDef::new(Agents::Prompt).string().null())
+                    .col(
+                        ColumnDef::new(Agents::Worktree)
+                            .integer()
+                            .not_null()
+                            .default(0),
+                    )
+                    .col(ColumnDef::new(Agents::SystemPrompt).string().null())
+                    .col(ColumnDef::new(Agents::TmuxSession).string().null())
+                    .col(
+                        ColumnDef::new(Agents::ToolPolicy)
+                            .string()
+                            .not_null()
+                            .default("{\"mode\":\"allow_all\"}"),
+                    )
+                    .col(ColumnDef::new(Agents::Model).string().null())
+                    .col(
+                        ColumnDef::new(Agents::Env)
+                            .string()
+                            .not_null()
+                            .default("{}"),
+                    )
+                    .col(ColumnDef::new(Agents::CreatedAt).string().not_null())
+                    .col(ColumnDef::new(Agents::UpdatedAt).string().not_null())
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx_agents_status")
+                    .table(Agents::Table)
+                    .col(Agents::Status)
+                    .if_not_exists()
+                    .to_owned(),
+            )
+            .await?;
+
+        // -----------------------------------------------------------------
+        // workflows table
+        // -----------------------------------------------------------------
+        manager
+            .create_table(
+                Table::create()
+                    .table(Workflows::Table)
+                    .if_not_exists()
+                    .col(
+                        ColumnDef::new(Workflows::Id)
+                            .string()
+                            .not_null()
+                            .primary_key(),
+                    )
+                    .col(
+                        ColumnDef::new(Workflows::Name)
+                            .string()
+                            .not_null()
+                            .unique_key(),
+                    )
+                    .col(ColumnDef::new(Workflows::AgentId).string().not_null())
+                    .col(ColumnDef::new(Workflows::SourceType).string().not_null())
+                    .col(ColumnDef::new(Workflows::SourceConfig).string().not_null())
+                    .col(ColumnDef::new(Workflows::PromptTemplate).string().not_null())
+                    .col(
+                        ColumnDef::new(Workflows::PollIntervalSecs)
+                            .integer()
+                            .not_null()
+                            .default(60),
+                    )
+                    .col(
+                        ColumnDef::new(Workflows::Enabled)
+                            .integer()
+                            .not_null()
+                            .default(1),
+                    )
+                    .col(
+                        ColumnDef::new(Workflows::ToolPolicy)
+                            .string()
+                            .not_null()
+                            .default("{\"mode\":\"allow_all\"}"),
+                    )
+                    .col(ColumnDef::new(Workflows::CreatedAt).string().not_null())
+                    .col(ColumnDef::new(Workflows::UpdatedAt).string().not_null())
+                    .to_owned(),
+            )
+            .await?;
+
+        // -----------------------------------------------------------------
+        // dispatch_log table
+        // -----------------------------------------------------------------
+        manager
+            .create_table(
+                Table::create()
+                    .table(DispatchLog::Table)
+                    .if_not_exists()
+                    .col(
+                        ColumnDef::new(DispatchLog::Id)
+                            .string()
+                            .not_null()
+                            .primary_key(),
+                    )
+                    .col(ColumnDef::new(DispatchLog::WorkflowId).string().not_null())
+                    .col(ColumnDef::new(DispatchLog::SourceId).string().not_null())
+                    .col(ColumnDef::new(DispatchLog::AgentId).string().not_null())
+                    .col(ColumnDef::new(DispatchLog::PromptSent).string().not_null())
+                    .col(ColumnDef::new(DispatchLog::Status).string().not_null())
+                    .col(ColumnDef::new(DispatchLog::DispatchedAt).string().not_null())
+                    .col(ColumnDef::new(DispatchLog::CompletedAt).string().null())
+                    .to_owned(),
+            )
+            .await?;
+
+        // Composite unique constraint on (workflow_id, source_id)
+        manager
+            .create_index(
+                Index::create()
+                    .name("uq_dispatch_workflow_source")
+                    .table(DispatchLog::Table)
+                    .col(DispatchLog::WorkflowId)
+                    .col(DispatchLog::SourceId)
+                    .unique()
+                    .if_not_exists()
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx_dispatch_workflow")
+                    .table(DispatchLog::Table)
+                    .col(DispatchLog::WorkflowId)
+                    .if_not_exists()
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx_dispatch_status")
+                    .table(DispatchLog::Table)
+                    .col(DispatchLog::Status)
+                    .if_not_exists()
+                    .to_owned(),
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .drop_table(Table::drop().table(DispatchLog::Table).to_owned())
+            .await?;
+        manager
+            .drop_table(Table::drop().table(Workflows::Table).to_owned())
+            .await?;
+        manager
+            .drop_table(Table::drop().table(Agents::Table).to_owned())
+            .await?;
+        Ok(())
+    }
+}
+
+/// Iden enum for the `agents` table columns.
+#[derive(DeriveIden)]
+enum Agents {
+    Table,
+    Id,
+    Name,
+    Status,
+    WorkingDir,
+    User,
+    Shell,
+    Interactive,
+    Prompt,
+    Worktree,
+    SystemPrompt,
+    TmuxSession,
+    ToolPolicy,
+    Model,
+    Env,
+    CreatedAt,
+    UpdatedAt,
+}
+
+/// Iden enum for the `workflows` table columns.
+#[derive(DeriveIden)]
+enum Workflows {
+    Table,
+    Id,
+    Name,
+    AgentId,
+    SourceType,
+    SourceConfig,
+    PromptTemplate,
+    PollIntervalSecs,
+    Enabled,
+    ToolPolicy,
+    CreatedAt,
+    UpdatedAt,
+}
+
+/// Iden enum for the `dispatch_log` table columns.
+#[derive(DeriveIden)]
+enum DispatchLog {
+    Table,
+    Id,
+    WorkflowId,
+    SourceId,
+    AgentId,
+    PromptSent,
+    Status,
+    DispatchedAt,
+    CompletedAt,
+}

--- a/crates/orchestrator/src/migration/mod.rs
+++ b/crates/orchestrator/src/migration/mod.rs
@@ -1,0 +1,24 @@
+//! SeaORM migration runner for the orchestrator service.
+//!
+//! Run all pending migrations at service startup:
+//!
+//! ```rust,ignore
+//! use orchestrator::migration::Migrator;
+//! use sea_orm_migration::MigratorTrait;
+//!
+//! Migrator::up(&db, None).await?;
+//! ```
+
+pub use sea_orm_migration::prelude::*;
+
+mod m20250305_000001_create_tables;
+
+/// The migration runner — applies all known migrations in order.
+pub struct Migrator;
+
+#[async_trait::async_trait]
+impl MigratorTrait for Migrator {
+    fn migrations() -> Vec<Box<dyn MigrationTrait>> {
+        vec![Box::new(m20250305_000001_create_tables::Migration)]
+    }
+}

--- a/crates/orchestrator/src/scheduler/storage.rs
+++ b/crates/orchestrator/src/scheduler/storage.rs
@@ -1,154 +1,127 @@
+//! SeaORM-based persistent storage for workflows and dispatch logs.
+//!
+//! [`SchedulerStorage`] shares the same [`DatabaseConnection`] as
+//! [`crate::storage::AgentStorage`] — the database schema (including the
+//! `workflows` and `dispatch_log` tables) is managed by the single
+//! [`crate::migration::Migrator`] that runs at startup.
+
+use crate::{
+    entity::{dispatch as dispatch_entity, workflow as workflow_entity},
+    scheduler::types::{DispatchRecord, DispatchStatus, WorkflowConfig},
+};
 use anyhow::Result;
 use chrono::{DateTime, Utc};
-use sqlx::{sqlite::SqlitePool, Row};
+use sea_orm::{
+    ColumnTrait, Condition, DatabaseConnection, EntityTrait, Order, PaginatorTrait, QueryFilter,
+    QueryOrder, QuerySelect, Set,
+};
 use uuid::Uuid;
 
-use crate::scheduler::types::{DispatchRecord, DispatchStatus, WorkflowConfig};
-
 /// Persistent storage for workflows and dispatch logs.
+///
+/// Shares a [`DatabaseConnection`] with [`crate::storage::AgentStorage`];
+/// the caller is responsible for running migrations before constructing this.
 #[derive(Clone)]
 pub struct SchedulerStorage {
-    pool: SqlitePool,
+    db: DatabaseConnection,
 }
 
 impl SchedulerStorage {
-    pub fn new(pool: SqlitePool) -> Self {
-        Self { pool }
-    }
-
-    pub async fn init_schema(&self) -> Result<()> {
-        sqlx::query(
-            r#"
-            CREATE TABLE IF NOT EXISTS workflows (
-                id TEXT PRIMARY KEY,
-                name TEXT NOT NULL UNIQUE,
-                agent_id TEXT NOT NULL,
-                source_type TEXT NOT NULL,
-                source_config TEXT NOT NULL,
-                prompt_template TEXT NOT NULL,
-                poll_interval_secs INTEGER NOT NULL DEFAULT 60,
-                enabled INTEGER NOT NULL DEFAULT 1,
-                tool_policy TEXT NOT NULL DEFAULT '{"mode":"allow_all"}',
-                created_at TEXT NOT NULL,
-                updated_at TEXT NOT NULL
-            )
-            "#,
-        )
-        .execute(&self.pool)
-        .await?;
-
-        sqlx::query(
-            r#"
-            CREATE TABLE IF NOT EXISTS dispatch_log (
-                id TEXT PRIMARY KEY,
-                workflow_id TEXT NOT NULL,
-                source_id TEXT NOT NULL,
-                agent_id TEXT NOT NULL,
-                prompt_sent TEXT NOT NULL,
-                status TEXT NOT NULL,
-                dispatched_at TEXT NOT NULL,
-                completed_at TEXT,
-                UNIQUE(workflow_id, source_id)
-            )
-            "#,
-        )
-        .execute(&self.pool)
-        .await?;
-
-        sqlx::query(
-            "CREATE INDEX IF NOT EXISTS idx_dispatch_workflow ON dispatch_log(workflow_id)",
-        )
-        .execute(&self.pool)
-        .await?;
-
-        sqlx::query("CREATE INDEX IF NOT EXISTS idx_dispatch_status ON dispatch_log(status)")
-            .execute(&self.pool)
-            .await?;
-
-        Ok(())
+    /// Create a new [`SchedulerStorage`] backed by `db`.
+    ///
+    /// `db` is expected to already have the full schema applied (via
+    /// [`crate::migration::Migrator::up`]).
+    pub fn new(db: DatabaseConnection) -> Self {
+        Self { db }
     }
 
     // -- Workflow CRUD --
 
+    /// Inserts a workflow and returns its UUID.
     pub async fn add_workflow(&self, workflow: &WorkflowConfig) -> Result<Uuid> {
         let source_config_json = serde_json::to_string(&workflow.source_config)?;
         let tool_policy_json = serde_json::to_string(&workflow.tool_policy).unwrap_or_default();
-        sqlx::query(
-            r#"
-            INSERT INTO workflows (id, name, agent_id, source_type, source_config, prompt_template, poll_interval_secs, enabled, tool_policy, created_at, updated_at)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-            "#,
-        )
-        .bind(workflow.id.to_string())
-        .bind(&workflow.name)
-        .bind(workflow.agent_id.to_string())
-        .bind(workflow.source_config.source_type())
-        .bind(&source_config_json)
-        .bind(&workflow.prompt_template)
-        .bind(workflow.poll_interval_secs as i64)
-        .bind(workflow.enabled as i32)
-        .bind(&tool_policy_json)
-        .bind(workflow.created_at.to_rfc3339())
-        .bind(workflow.updated_at.to_rfc3339())
-        .execute(&self.pool)
-        .await?;
 
+        let model = workflow_entity::ActiveModel {
+            id: Set(workflow.id.to_string()),
+            name: Set(workflow.name.clone()),
+            agent_id: Set(workflow.agent_id.to_string()),
+            source_type: Set(workflow.source_config.source_type().to_string()),
+            source_config: Set(source_config_json),
+            prompt_template: Set(workflow.prompt_template.clone()),
+            poll_interval_secs: Set(workflow.poll_interval_secs as i64),
+            enabled: Set(if workflow.enabled { 1 } else { 0 }),
+            tool_policy: Set(tool_policy_json),
+            created_at: Set(workflow.created_at.to_rfc3339()),
+            updated_at: Set(workflow.updated_at.to_rfc3339()),
+        };
+
+        workflow_entity::Entity::insert(model).exec(&self.db).await?;
         Ok(workflow.id)
     }
 
+    /// Retrieves a workflow by its UUID.
     pub async fn get_workflow(&self, id: &Uuid) -> Result<Option<WorkflowConfig>> {
-        let row = sqlx::query("SELECT * FROM workflows WHERE id = ?")
-            .bind(id.to_string())
-            .fetch_optional(&self.pool)
-            .await?;
-
-        match row {
-            Some(row) => Ok(Some(row_to_workflow(&row)?)),
+        let model =
+            workflow_entity::Entity::find_by_id(id.to_string()).one(&self.db).await?;
+        match model {
+            Some(m) => Ok(Some(model_to_workflow(m)?)),
             None => Ok(None),
         }
     }
 
+    /// Lists all workflows ordered by creation time (newest first).
     pub async fn list_workflows(&self) -> Result<Vec<WorkflowConfig>> {
-        let rows = sqlx::query("SELECT * FROM workflows ORDER BY created_at DESC")
-            .fetch_all(&self.pool)
+        let models: Vec<workflow_entity::Model> = workflow_entity::Entity::find()
+            .order_by(workflow_entity::Column::CreatedAt, Order::Desc)
+            .all(&self.db)
             .await?;
-
-        rows.iter().map(row_to_workflow).collect()
+        models.into_iter().map(model_to_workflow).collect()
     }
 
+    /// Updates mutable workflow fields (name, prompt_template, poll_interval_secs, enabled, tool_policy, updated_at).
     pub async fn update_workflow(&self, workflow: &WorkflowConfig) -> Result<()> {
+        use sea_orm::sea_query::Expr;
         let tool_policy_json = serde_json::to_string(&workflow.tool_policy).unwrap_or_default();
-        let result = sqlx::query(
-            r#"
-            UPDATE workflows
-            SET name = ?, prompt_template = ?, poll_interval_secs = ?, enabled = ?, tool_policy = ?, updated_at = ?
-            WHERE id = ?
-            "#,
-        )
-        .bind(&workflow.name)
-        .bind(&workflow.prompt_template)
-        .bind(workflow.poll_interval_secs as i64)
-        .bind(workflow.enabled as i32)
-        .bind(&tool_policy_json)
-        .bind(workflow.updated_at.to_rfc3339())
-        .bind(workflow.id.to_string())
-        .execute(&self.pool)
-        .await?;
 
-        if result.rows_affected() == 0 {
+        let result = workflow_entity::Entity::update_many()
+            .col_expr(workflow_entity::Column::Name, Expr::value(workflow.name.clone()))
+            .col_expr(
+                workflow_entity::Column::PromptTemplate,
+                Expr::value(workflow.prompt_template.clone()),
+            )
+            .col_expr(
+                workflow_entity::Column::PollIntervalSecs,
+                Expr::value(workflow.poll_interval_secs as i64),
+            )
+            .col_expr(
+                workflow_entity::Column::Enabled,
+                Expr::value(if workflow.enabled { 1i32 } else { 0i32 }),
+            )
+            .col_expr(workflow_entity::Column::ToolPolicy, Expr::value(tool_policy_json))
+            .col_expr(
+                workflow_entity::Column::UpdatedAt,
+                Expr::value(workflow.updated_at.to_rfc3339()),
+            )
+            .filter(workflow_entity::Column::Id.eq(workflow.id.to_string()))
+            .exec(&self.db)
+            .await?;
+
+        if result.rows_affected == 0 {
             anyhow::bail!("Workflow not found");
         }
 
         Ok(())
     }
 
+    /// Permanently deletes a workflow by UUID.
     pub async fn delete_workflow(&self, id: &Uuid) -> Result<()> {
-        let result = sqlx::query("DELETE FROM workflows WHERE id = ?")
-            .bind(id.to_string())
-            .execute(&self.pool)
+        let result = workflow_entity::Entity::delete_many()
+            .filter(workflow_entity::Column::Id.eq(id.to_string()))
+            .exec(&self.db)
             .await?;
 
-        if result.rows_affected() == 0 {
+        if result.rows_affected == 0 {
             anyhow::bail!("Workflow not found");
         }
 
@@ -157,208 +130,212 @@ impl SchedulerStorage {
 
     // -- Dispatch log --
 
+    /// Inserts a dispatch record.
     pub async fn add_dispatch(&self, record: &DispatchRecord) -> Result<()> {
-        sqlx::query(
-            r#"
-            INSERT INTO dispatch_log (id, workflow_id, source_id, agent_id, prompt_sent, status, dispatched_at, completed_at)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-            "#,
-        )
-        .bind(record.id.to_string())
-        .bind(record.workflow_id.to_string())
-        .bind(&record.source_id)
-        .bind(record.agent_id.to_string())
-        .bind(&record.prompt_sent)
-        .bind(record.status.to_string())
-        .bind(record.dispatched_at.to_rfc3339())
-        .bind(record.completed_at.map(|dt| dt.to_rfc3339()))
-        .execute(&self.pool)
-        .await?;
+        let model = dispatch_entity::ActiveModel {
+            id: Set(record.id.to_string()),
+            workflow_id: Set(record.workflow_id.to_string()),
+            source_id: Set(record.source_id.clone()),
+            agent_id: Set(record.agent_id.to_string()),
+            prompt_sent: Set(record.prompt_sent.clone()),
+            status: Set(record.status.to_string()),
+            dispatched_at: Set(record.dispatched_at.to_rfc3339()),
+            completed_at: Set(record.completed_at.map(|dt| dt.to_rfc3339())),
+        };
 
+        dispatch_entity::Entity::insert(model).exec(&self.db).await?;
         Ok(())
     }
 
+    /// Updates the status and optional completion timestamp of a dispatch record.
     pub async fn update_dispatch_status(
         &self,
         id: &Uuid,
         status: DispatchStatus,
         completed_at: Option<DateTime<Utc>>,
     ) -> Result<()> {
-        let result =
-            sqlx::query("UPDATE dispatch_log SET status = ?, completed_at = ? WHERE id = ?")
-                .bind(status.to_string())
-                .bind(completed_at.map(|dt| dt.to_rfc3339()))
-                .bind(id.to_string())
-                .execute(&self.pool)
-                .await?;
+        use sea_orm::sea_query::Expr;
 
-        if result.rows_affected() == 0 {
+        let result = dispatch_entity::Entity::update_many()
+            .col_expr(dispatch_entity::Column::Status, Expr::value(status.to_string()))
+            .col_expr(
+                dispatch_entity::Column::CompletedAt,
+                Expr::value(completed_at.map(|dt| dt.to_rfc3339())),
+            )
+            .filter(dispatch_entity::Column::Id.eq(id.to_string()))
+            .exec(&self.db)
+            .await?;
+
+        if result.rows_affected == 0 {
             anyhow::bail!("Dispatch record not found");
         }
 
         Ok(())
     }
 
-    /// Check if a task has already been dispatched for a given workflow.
+    /// Returns `true` if the given `source_id` has already been dispatched for `workflow_id`.
     pub async fn is_dispatched(&self, workflow_id: &Uuid, source_id: &str) -> Result<bool> {
-        let row = sqlx::query(
-            "SELECT COUNT(*) as cnt FROM dispatch_log WHERE workflow_id = ? AND source_id = ?",
-        )
-        .bind(workflow_id.to_string())
-        .bind(source_id)
-        .fetch_one(&self.pool)
-        .await?;
-
-        let count: i32 = row.get("cnt");
+        let count = dispatch_entity::Entity::find()
+            .filter(
+                Condition::all()
+                    .add(dispatch_entity::Column::WorkflowId.eq(workflow_id.to_string()))
+                    .add(dispatch_entity::Column::SourceId.eq(source_id)),
+            )
+            .count(&self.db)
+            .await?;
         Ok(count > 0)
     }
 
+    /// Lists all dispatch records for a workflow, newest first.
     #[allow(dead_code)]
     pub async fn list_dispatches(&self, workflow_id: &Uuid) -> Result<Vec<DispatchRecord>> {
-        let rows = sqlx::query(
-            "SELECT * FROM dispatch_log WHERE workflow_id = ? ORDER BY dispatched_at DESC",
-        )
-        .bind(workflow_id.to_string())
-        .fetch_all(&self.pool)
-        .await?;
-
-        rows.iter().map(row_to_dispatch).collect()
+        let models: Vec<dispatch_entity::Model> = dispatch_entity::Entity::find()
+            .filter(dispatch_entity::Column::WorkflowId.eq(workflow_id.to_string()))
+            .order_by(dispatch_entity::Column::DispatchedAt, Order::Desc)
+            .all(&self.db)
+            .await?;
+        models.into_iter().map(model_to_dispatch).collect()
     }
 
-    /// List workflows with pagination.
+    /// Lists workflows with pagination; returns `(items, total_count)`.
     pub async fn list_workflows_paginated(
         &self,
         limit: usize,
         offset: usize,
     ) -> Result<(Vec<WorkflowConfig>, usize)> {
-        let count =
-            sqlx::query("SELECT COUNT(*) as total FROM workflows").fetch_one(&self.pool).await?;
-        let rows = sqlx::query("SELECT * FROM workflows ORDER BY created_at DESC LIMIT ? OFFSET ?")
-            .bind(limit as i64)
-            .bind(offset as i64)
-            .fetch_all(&self.pool)
+        let total = workflow_entity::Entity::find().count(&self.db).await? as usize;
+
+        let models: Vec<workflow_entity::Model> = workflow_entity::Entity::find()
+            .order_by(workflow_entity::Column::CreatedAt, Order::Desc)
+            .limit(limit as u64)
+            .offset(offset as u64)
+            .all(&self.db)
             .await?;
 
-        let total: i64 = count.get("total");
-        let workflows = rows.iter().map(row_to_workflow).collect::<Result<Vec<_>>>()?;
-        Ok((workflows, total as usize))
+        let workflows = models.into_iter().map(model_to_workflow).collect::<Result<Vec<_>>>()?;
+        Ok((workflows, total))
     }
 
-    /// List dispatch history with pagination.
+    /// Lists dispatch records for a workflow with pagination; returns `(items, total_count)`.
     pub async fn list_dispatches_paginated(
         &self,
         workflow_id: &Uuid,
         limit: usize,
         offset: usize,
     ) -> Result<(Vec<DispatchRecord>, usize)> {
-        let count = sqlx::query("SELECT COUNT(*) as total FROM dispatch_log WHERE workflow_id = ?")
-            .bind(workflow_id.to_string())
-            .fetch_one(&self.pool)
+        let condition =
+            Condition::all().add(dispatch_entity::Column::WorkflowId.eq(workflow_id.to_string()));
+
+        let total = dispatch_entity::Entity::find()
+            .filter(condition.clone())
+            .count(&self.db)
+            .await? as usize;
+
+        let models: Vec<dispatch_entity::Model> = dispatch_entity::Entity::find()
+            .filter(condition)
+            .order_by(dispatch_entity::Column::DispatchedAt, Order::Desc)
+            .limit(limit as u64)
+            .offset(offset as u64)
+            .all(&self.db)
             .await?;
 
-        let rows = sqlx::query(
-            "SELECT * FROM dispatch_log WHERE workflow_id = ? ORDER BY dispatched_at DESC LIMIT ? OFFSET ?",
-        )
-        .bind(workflow_id.to_string())
-        .bind(limit as i64)
-        .bind(offset as i64)
-        .fetch_all(&self.pool)
-        .await?;
-
-        let total: i64 = count.get("total");
-        let dispatches = rows.iter().map(row_to_dispatch).collect::<Result<Vec<_>>>()?;
-        Ok((dispatches, total as usize))
+        let dispatches =
+            models.into_iter().map(model_to_dispatch).collect::<Result<Vec<_>>>()?;
+        Ok((dispatches, total))
     }
 
-    /// Find the active (Dispatched) dispatch for a given agent.
+    /// Finds the active (`Dispatched`) dispatch record for an agent, if any.
     #[allow(dead_code)]
     pub async fn find_active_dispatch(&self, agent_id: &Uuid) -> Result<Option<DispatchRecord>> {
-        let row = sqlx::query(
-            "SELECT * FROM dispatch_log WHERE agent_id = ? AND status = 'dispatched' LIMIT 1",
-        )
-        .bind(agent_id.to_string())
-        .fetch_optional(&self.pool)
-        .await?;
+        let model = dispatch_entity::Entity::find()
+            .filter(
+                Condition::all()
+                    .add(dispatch_entity::Column::AgentId.eq(agent_id.to_string()))
+                    .add(dispatch_entity::Column::Status.eq("dispatched")),
+            )
+            .one(&self.db)
+            .await?;
 
-        match row {
-            Some(row) => Ok(Some(row_to_dispatch(&row)?)),
+        match model {
+            Some(m) => Ok(Some(model_to_dispatch(m)?)),
             None => Ok(None),
         }
     }
 
-    /// Mark all in-flight dispatches as failed (used during startup recovery).
+    /// Marks all in-flight (`dispatched`) dispatch records as `failed`.
+    ///
+    /// Used during startup recovery to handle records that were in-flight when
+    /// the service was last interrupted.
+    ///
+    /// Returns the number of rows updated.
     pub async fn fail_inflight_dispatches(&self) -> Result<u64> {
+        use sea_orm::sea_query::Expr;
         let now = Utc::now().to_rfc3339();
-        let result = sqlx::query(
-            "UPDATE dispatch_log SET status = 'failed', completed_at = ? WHERE status = 'dispatched'",
-        )
-        .bind(&now)
-        .execute(&self.pool)
-        .await?;
 
-        Ok(result.rows_affected())
+        let result = dispatch_entity::Entity::update_many()
+            .col_expr(dispatch_entity::Column::Status, Expr::value("failed"))
+            .col_expr(dispatch_entity::Column::CompletedAt, Expr::value(now))
+            .filter(dispatch_entity::Column::Status.eq("dispatched"))
+            .exec(&self.db)
+            .await?;
+
+        Ok(result.rows_affected)
     }
 }
 
-fn row_to_workflow(row: &sqlx::sqlite::SqliteRow) -> Result<WorkflowConfig> {
-    let id: String = row.get("id");
-    let agent_id: String = row.get("agent_id");
-    let source_config_json: String = row.get("source_config");
-    let tool_policy_json: String = row.get("tool_policy");
-    let enabled: bool = row.get::<i32, _>("enabled") != 0;
-    let poll_interval: i64 = row.get("poll_interval_secs");
-    let created_at: String = row.get("created_at");
-    let updated_at: String = row.get("updated_at");
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
 
+fn model_to_workflow(model: workflow_entity::Model) -> Result<WorkflowConfig> {
+    use crate::types::ToolPolicy;
     Ok(WorkflowConfig {
-        id: Uuid::parse_str(&id)?,
-        name: row.get("name"),
-        agent_id: Uuid::parse_str(&agent_id)?,
-        source_config: serde_json::from_str(&source_config_json)?,
-        prompt_template: row.get("prompt_template"),
-        poll_interval_secs: poll_interval as u64,
-        enabled,
-        tool_policy: serde_json::from_str(&tool_policy_json).unwrap_or_default(),
-        created_at: DateTime::parse_from_rfc3339(&created_at)?.with_timezone(&Utc),
-        updated_at: DateTime::parse_from_rfc3339(&updated_at)?.with_timezone(&Utc),
+        id: Uuid::parse_str(&model.id)?,
+        name: model.name,
+        agent_id: Uuid::parse_str(&model.agent_id)?,
+        source_config: serde_json::from_str(&model.source_config)?,
+        prompt_template: model.prompt_template,
+        poll_interval_secs: model.poll_interval_secs as u64,
+        enabled: model.enabled != 0,
+        tool_policy: serde_json::from_str::<ToolPolicy>(&model.tool_policy).unwrap_or_default(),
+        created_at: DateTime::parse_from_rfc3339(&model.created_at)?.with_timezone(&Utc),
+        updated_at: DateTime::parse_from_rfc3339(&model.updated_at)?.with_timezone(&Utc),
     })
 }
 
-fn row_to_dispatch(row: &sqlx::sqlite::SqliteRow) -> Result<DispatchRecord> {
-    let id: String = row.get("id");
-    let workflow_id: String = row.get("workflow_id");
-    let agent_id: String = row.get("agent_id");
-    let status_str: String = row.get("status");
-    let dispatched_at: String = row.get("dispatched_at");
-    let completed_at: Option<String> = row.get("completed_at");
-
+fn model_to_dispatch(model: dispatch_entity::Model) -> Result<DispatchRecord> {
     Ok(DispatchRecord {
-        id: Uuid::parse_str(&id)?,
-        workflow_id: Uuid::parse_str(&workflow_id)?,
-        source_id: row.get("source_id"),
-        agent_id: Uuid::parse_str(&agent_id)?,
-        prompt_sent: row.get("prompt_sent"),
-        status: status_str.parse()?,
-        dispatched_at: DateTime::parse_from_rfc3339(&dispatched_at)?.with_timezone(&Utc),
-        completed_at: completed_at
+        id: Uuid::parse_str(&model.id)?,
+        workflow_id: Uuid::parse_str(&model.workflow_id)?,
+        source_id: model.source_id,
+        agent_id: Uuid::parse_str(&model.agent_id)?,
+        prompt_sent: model.prompt_sent,
+        status: model.status.parse()?,
+        dispatched_at: DateTime::parse_from_rfc3339(&model.dispatched_at)?.with_timezone(&Utc),
+        completed_at: model
+            .completed_at
             .map(|s| DateTime::parse_from_rfc3339(&s).map(|dt| dt.with_timezone(&Utc)))
             .transpose()?,
     })
 }
 
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::scheduler::types::TaskSourceConfig;
+    use crate::storage::AgentStorage;
     use tempfile::TempDir;
 
     async fn create_test_storage() -> (SchedulerStorage, TempDir) {
         let temp_dir = TempDir::new().unwrap();
         let db_path = temp_dir.path().join("test.db");
-        let db_url = format!("sqlite://{}?mode=rwc", db_path.display());
-        let pool = SqlitePool::connect(&db_url).await.unwrap();
-        let storage = SchedulerStorage::new(pool);
-        storage.init_schema().await.unwrap();
+        // Run migrations via AgentStorage (which applies all three tables)
+        let agent_storage = AgentStorage::with_path(&db_path).await.unwrap();
+        let storage = SchedulerStorage::new(agent_storage.db().clone());
         (storage, temp_dir)
     }
 

--- a/crates/orchestrator/src/storage.rs
+++ b/crates/orchestrator/src/storage.rs
@@ -1,245 +1,233 @@
-use crate::types::{Agent, AgentConfig, AgentStatus, ToolPolicy};
+//! SeaORM-based persistent storage for agent records.
+//!
+//! Provides [`AgentStorage`], backed by a SQLite database via SeaORM.
+//! The shared [`DatabaseConnection`] is also exposed for [`crate::scheduler::storage::SchedulerStorage`].
+
+use crate::{
+    entity::agent as agent_entity,
+    migration::Migrator,
+    types::{Agent, AgentConfig, AgentStatus, ToolPolicy},
+};
 use anyhow::Result;
 use chrono::{DateTime, Utc};
-use sqlx::{sqlite::SqlitePool, Row};
+use sea_orm::{
+    ColumnTrait, Condition, DatabaseConnection, EntityTrait, Order, PaginatorTrait, QueryFilter,
+    QueryOrder, QuerySelect, Set,
+};
+use sea_orm_migration::prelude::MigratorTrait;
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
 use uuid::Uuid;
 
+/// Persistent storage backend for agent records using SeaORM + SQLite.
+///
+/// Holds a [`DatabaseConnection`] that is `Clone + Send + Sync`, so
+/// [`AgentStorage`] itself can be cheaply cloned and shared across tasks.
+///
+/// The underlying database is also shared with [`crate::scheduler::storage::SchedulerStorage`]
+/// via [`AgentStorage::db()`].
 #[derive(Clone)]
 pub struct AgentStorage {
-    pool: SqlitePool,
+    db: DatabaseConnection,
 }
 
 impl AgentStorage {
-    /// Access the underlying SQLite pool (used by SchedulerStorage).
-    pub fn pool(&self) -> &SqlitePool {
-        &self.pool
-    }
-
+    /// Returns the platform-specific database file path.
     pub fn get_db_path() -> Result<PathBuf> {
         agentd_common::storage::get_db_path("agentd-orchestrator", "orchestrator.db")
     }
 
+    /// Creates a new storage instance connected to the default path.
     pub async fn new() -> Result<Self> {
         let db_path = Self::get_db_path()?;
         Self::with_path(&db_path).await
     }
 
+    /// Creates a new storage instance connected to `db_path`.
+    ///
+    /// All pending SeaORM migrations (agents, workflows, dispatch_log) are
+    /// applied before returning.
     pub async fn with_path(db_path: &Path) -> Result<Self> {
-        let pool = agentd_common::storage::create_pool(db_path).await?;
-        let storage = Self { pool };
-        storage.init_schema().await?;
-        Ok(storage)
+        let db = agentd_common::storage::create_connection(db_path).await?;
+        Migrator::up(&db, None).await?;
+        Ok(Self { db })
     }
 
-    async fn init_schema(&self) -> Result<()> {
-        sqlx::query(
-            r#"
-            CREATE TABLE IF NOT EXISTS agents (
-                id TEXT PRIMARY KEY,
-                name TEXT NOT NULL,
-                status TEXT NOT NULL,
-                working_dir TEXT NOT NULL,
-                user TEXT,
-                shell TEXT NOT NULL,
-                interactive INTEGER NOT NULL DEFAULT 0,
-                prompt TEXT,
-                worktree INTEGER NOT NULL DEFAULT 0,
-                system_prompt TEXT,
-                tmux_session TEXT,
-                tool_policy TEXT NOT NULL DEFAULT '{"mode":"allow_all"}',
-                model TEXT,
-                env TEXT NOT NULL DEFAULT '{}',
-                created_at TEXT NOT NULL,
-                updated_at TEXT NOT NULL
-            )
-            "#,
-        )
-        .execute(&self.pool)
-        .await?;
-
-        sqlx::query("CREATE INDEX IF NOT EXISTS idx_agents_status ON agents(status)")
-            .execute(&self.pool)
-            .await?;
-
-        Ok(())
+    /// Exposes the underlying [`DatabaseConnection`] so that
+    /// [`crate::scheduler::storage::SchedulerStorage`] can share the same
+    /// connection without opening a second database file.
+    pub fn db(&self) -> &DatabaseConnection {
+        &self.db
     }
 
+    /// Inserts an agent and returns its UUID.
     pub async fn add(&self, agent: &Agent) -> Result<Uuid> {
-        sqlx::query(
-            r#"
-            INSERT INTO agents (id, name, status, working_dir, user, shell, interactive, prompt, worktree, system_prompt, tmux_session, tool_policy, model, env, created_at, updated_at)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-            "#,
-        )
-        .bind(agent.id.to_string())
-        .bind(&agent.name)
-        .bind(agent.status.to_string())
-        .bind(&agent.config.working_dir)
-        .bind(agent.config.user.as_deref())
-        .bind(&agent.config.shell)
-        .bind(agent.config.interactive)
-        .bind(agent.config.prompt.as_deref())
-        .bind(agent.config.worktree)
-        .bind(agent.config.system_prompt.as_deref())
-        .bind(agent.tmux_session.as_deref())
-        .bind(serde_json::to_string(&agent.config.tool_policy).unwrap_or_default())
-        .bind(agent.config.model.as_deref())
-        .bind(serde_json::to_string(&agent.config.env).unwrap_or_else(|_| "{}".to_string()))
-        .bind(agent.created_at.to_rfc3339())
-        .bind(agent.updated_at.to_rfc3339())
-        .execute(&self.pool)
-        .await?;
+        let model = agent_entity::ActiveModel {
+            id: Set(agent.id.to_string()),
+            name: Set(agent.name.clone()),
+            status: Set(agent.status.to_string()),
+            working_dir: Set(agent.config.working_dir.clone()),
+            user: Set(agent.config.user.clone()),
+            shell: Set(agent.config.shell.clone()),
+            interactive: Set(if agent.config.interactive { 1 } else { 0 }),
+            prompt: Set(agent.config.prompt.clone()),
+            worktree: Set(if agent.config.worktree { 1 } else { 0 }),
+            system_prompt: Set(agent.config.system_prompt.clone()),
+            tmux_session: Set(agent.tmux_session.clone()),
+            tool_policy: Set(
+                serde_json::to_string(&agent.config.tool_policy).unwrap_or_default(),
+            ),
+            model: Set(agent.config.model.clone()),
+            env: Set(
+                serde_json::to_string(&agent.config.env)
+                    .unwrap_or_else(|_| "{}".to_string()),
+            ),
+            created_at: Set(agent.created_at.to_rfc3339()),
+            updated_at: Set(agent.updated_at.to_rfc3339()),
+        };
 
+        agent_entity::Entity::insert(model).exec(&self.db).await?;
         Ok(agent.id)
     }
 
+    /// Retrieves an agent by its UUID.
     pub async fn get(&self, id: &Uuid) -> Result<Option<Agent>> {
-        let row = sqlx::query("SELECT * FROM agents WHERE id = ?")
-            .bind(id.to_string())
-            .fetch_optional(&self.pool)
-            .await?;
-
-        match row {
-            Some(row) => Ok(Some(row_to_agent(&row)?)),
+        let model = agent_entity::Entity::find_by_id(id.to_string()).one(&self.db).await?;
+        match model {
+            Some(m) => Ok(Some(model_to_agent(m)?)),
             None => Ok(None),
         }
     }
 
+    /// Updates the mutable fields of an agent (status, tmux_session, tool_policy, model, updated_at).
     pub async fn update(&self, agent: &Agent) -> Result<()> {
-        let result = sqlx::query(
-            r#"
-            UPDATE agents
-            SET status = ?, tmux_session = ?, tool_policy = ?, model = ?, updated_at = ?
-            WHERE id = ?
-            "#,
-        )
-        .bind(agent.status.to_string())
-        .bind(agent.tmux_session.as_deref())
-        .bind(serde_json::to_string(&agent.config.tool_policy).unwrap_or_default())
-        .bind(agent.config.model.as_deref())
-        .bind(agent.updated_at.to_rfc3339())
-        .bind(agent.id.to_string())
-        .execute(&self.pool)
-        .await?;
+        use sea_orm::sea_query::Expr;
 
-        if result.rows_affected() == 0 {
-            anyhow::bail!("Agent not found");
-        }
-
-        Ok(())
-    }
-
-    #[allow(dead_code)]
-    pub async fn delete(&self, id: &Uuid) -> Result<()> {
-        let result = sqlx::query("DELETE FROM agents WHERE id = ?")
-            .bind(id.to_string())
-            .execute(&self.pool)
+        let result = agent_entity::Entity::update_many()
+            .col_expr(
+                agent_entity::Column::Status,
+                Expr::value(agent.status.to_string()),
+            )
+            .col_expr(
+                agent_entity::Column::TmuxSession,
+                Expr::value(agent.tmux_session.clone()),
+            )
+            .col_expr(
+                agent_entity::Column::ToolPolicy,
+                Expr::value(
+                    serde_json::to_string(&agent.config.tool_policy).unwrap_or_default(),
+                ),
+            )
+            .col_expr(agent_entity::Column::Model, Expr::value(agent.config.model.clone()))
+            .col_expr(
+                agent_entity::Column::UpdatedAt,
+                Expr::value(agent.updated_at.to_rfc3339()),
+            )
+            .filter(agent_entity::Column::Id.eq(agent.id.to_string()))
+            .exec(&self.db)
             .await?;
 
-        if result.rows_affected() == 0 {
+        if result.rows_affected == 0 {
             anyhow::bail!("Agent not found");
         }
 
         Ok(())
     }
 
-    pub async fn list(&self, status_filter: Option<AgentStatus>) -> Result<Vec<Agent>> {
-        let rows = if let Some(status) = status_filter {
-            sqlx::query("SELECT * FROM agents WHERE status = ? ORDER BY created_at DESC")
-                .bind(status.to_string())
-                .fetch_all(&self.pool)
-                .await?
-        } else {
-            sqlx::query("SELECT * FROM agents ORDER BY created_at DESC")
-                .fetch_all(&self.pool)
-                .await?
-        };
+    /// Permanently deletes an agent by UUID.
+    #[allow(dead_code)]
+    pub async fn delete(&self, id: &Uuid) -> Result<()> {
+        let result = agent_entity::Entity::delete_many()
+            .filter(agent_entity::Column::Id.eq(id.to_string()))
+            .exec(&self.db)
+            .await?;
 
-        rows.iter().map(row_to_agent).collect()
+        if result.rows_affected == 0 {
+            anyhow::bail!("Agent not found");
+        }
+
+        Ok(())
     }
 
-    /// List agents with pagination.
+    /// Lists all agents, optionally filtered by status (newest first).
+    pub async fn list(&self, status_filter: Option<AgentStatus>) -> Result<Vec<Agent>> {
+        let mut query =
+            agent_entity::Entity::find().order_by(agent_entity::Column::CreatedAt, Order::Desc);
+
+        if let Some(status) = status_filter {
+            query = query.filter(agent_entity::Column::Status.eq(status.to_string()));
+        }
+
+        let models: Vec<agent_entity::Model> = query.all(&self.db).await?;
+        models.into_iter().map(model_to_agent).collect()
+    }
+
+    /// Lists agents with pagination; returns `(items, total_count)`.
     pub async fn list_paginated(
         &self,
         status_filter: Option<AgentStatus>,
         limit: usize,
         offset: usize,
     ) -> Result<(Vec<Agent>, usize)> {
-        let (count_row, data_rows) = if let Some(status) = status_filter {
-            let status_str = status.to_string();
-            let count = sqlx::query("SELECT COUNT(*) as total FROM agents WHERE status = ?")
-                .bind(&status_str)
-                .fetch_one(&self.pool)
-                .await?;
-            let rows = sqlx::query(
-                "SELECT * FROM agents WHERE status = ? ORDER BY created_at DESC LIMIT ? OFFSET ?",
-            )
-            .bind(&status_str)
-            .bind(limit as i64)
-            .bind(offset as i64)
-            .fetch_all(&self.pool)
-            .await?;
-            (count, rows)
-        } else {
-            let count =
-                sqlx::query("SELECT COUNT(*) as total FROM agents").fetch_one(&self.pool).await?;
-            let rows =
-                sqlx::query("SELECT * FROM agents ORDER BY created_at DESC LIMIT ? OFFSET ?")
-                    .bind(limit as i64)
-                    .bind(offset as i64)
-                    .fetch_all(&self.pool)
-                    .await?;
-            (count, rows)
+        let condition = match &status_filter {
+            Some(s) => Condition::all().add(agent_entity::Column::Status.eq(s.to_string())),
+            None => Condition::all(),
         };
 
-        let total: i64 = count_row.get("total");
-        let agents = data_rows.iter().map(row_to_agent).collect::<Result<Vec<_>>>()?;
+        let total = agent_entity::Entity::find()
+            .filter(condition.clone())
+            .count(&self.db)
+            .await? as usize;
 
-        Ok((agents, total as usize))
+        let models: Vec<agent_entity::Model> = agent_entity::Entity::find()
+            .filter(condition)
+            .order_by(agent_entity::Column::CreatedAt, Order::Desc)
+            .limit(limit as u64)
+            .offset(offset as u64)
+            .all(&self.db)
+            .await?;
+
+        let agents = models.into_iter().map(model_to_agent).collect::<Result<Vec<_>>>()?;
+        Ok((agents, total))
     }
 }
 
-fn row_to_agent(row: &sqlx::sqlite::SqliteRow) -> Result<Agent> {
-    let id: String = row.get("id");
-    let status_str: String = row.get("status");
-    let user: Option<String> = row.get("user");
-    let interactive: bool = row.get::<i32, _>("interactive") != 0;
-    let prompt: Option<String> = row.get("prompt");
-    let worktree: bool = row.get::<i32, _>("worktree") != 0;
-    let system_prompt: Option<String> = row.get("system_prompt");
-    let tmux_session: Option<String> = row.get("tmux_session");
-    let tool_policy_str: String = row.get("tool_policy");
-    let tool_policy: ToolPolicy = serde_json::from_str(&tool_policy_str).unwrap_or_default();
-    let model: Option<String> = row.get("model");
-    // env column may not exist in older databases (backward compatibility): default to empty map.
-    let env_str: String = row.try_get("env").unwrap_or_else(|_| "{}".to_string());
-    let env: HashMap<String, String> = serde_json::from_str(&env_str).unwrap_or_default();
-    let created_at: String = row.get("created_at");
-    let updated_at: String = row.get("updated_at");
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Convert a raw entity [`agent_entity::Model`] into the domain [`Agent`] type.
+fn model_to_agent(model: agent_entity::Model) -> Result<Agent> {
+    let tool_policy: ToolPolicy =
+        serde_json::from_str(&model.tool_policy).unwrap_or_default();
+    let env: HashMap<String, String> =
+        serde_json::from_str(&model.env).unwrap_or_default();
 
     Ok(Agent {
-        id: Uuid::parse_str(&id)?,
-        name: row.get("name"),
-        status: status_str.parse()?,
+        id: Uuid::parse_str(&model.id)?,
+        name: model.name,
+        status: model.status.parse()?,
         config: AgentConfig {
-            working_dir: row.get("working_dir"),
-            user,
-            shell: row.get("shell"),
-            interactive,
-            prompt,
-            worktree,
-            system_prompt,
+            working_dir: model.working_dir,
+            user: model.user,
+            shell: model.shell,
+            interactive: model.interactive != 0,
+            prompt: model.prompt,
+            worktree: model.worktree != 0,
+            system_prompt: model.system_prompt,
             tool_policy,
-            model,
+            model: model.model,
             env,
         },
-        tmux_session,
-        created_at: DateTime::parse_from_rfc3339(&created_at)?.with_timezone(&Utc),
-        updated_at: DateTime::parse_from_rfc3339(&updated_at)?.with_timezone(&Utc),
+        tmux_session: model.tmux_session,
+        created_at: DateTime::parse_from_rfc3339(&model.created_at)?.with_timezone(&Utc),
+        updated_at: DateTime::parse_from_rfc3339(&model.updated_at)?.with_timezone(&Utc),
     })
 }
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
 
 #[cfg(test)]
 mod tests {
@@ -337,7 +325,6 @@ mod tests {
 
         storage.add(&agent).await.unwrap();
 
-        // Set model and update
         agent.config.model = Some("opus".to_string());
         agent.updated_at = chrono::Utc::now();
         storage.update(&agent).await.unwrap();
@@ -345,7 +332,6 @@ mod tests {
         let retrieved = storage.get(&agent.id).await.unwrap().unwrap();
         assert_eq!(retrieved.config.model, Some("opus".to_string()));
 
-        // Change model
         agent.config.model = Some("sonnet".to_string());
         agent.updated_at = chrono::Utc::now();
         storage.update(&agent).await.unwrap();
@@ -353,7 +339,6 @@ mod tests {
         let retrieved = storage.get(&agent.id).await.unwrap().unwrap();
         assert_eq!(retrieved.config.model, Some("sonnet".to_string()));
 
-        // Clear model
         agent.config.model = None;
         agent.updated_at = chrono::Utc::now();
         storage.update(&agent).await.unwrap();


### PR DESCRIPTION
## Summary

- Add `sea-orm` and `sea-orm-migration` workspace dependencies to the orchestrator crate
- Implement `entity/agent.rs` — `DeriveEntityModel` for the `agents` table (15 columns), JSON columns for `tool_policy` and `env`
- Implement `entity/workflow.rs` — `DeriveEntityModel` for the `workflows` table (11 columns) with Workflow has-many Dispatch relation
- Implement `entity/dispatch.rs` — `DeriveEntityModel` for the `dispatch_log` table (8 columns) with Dispatch belongs-to Workflow relation
- Single initial migration (`m20250305_000001_create_tables.rs`) creates all three tables with all indexes including the composite unique constraint `(workflow_id, source_id)` on `dispatch_log`
- Rewrite `AgentStorage` from `SqlitePool` to `DatabaseConnection`; expose `db()` accessor for connection sharing
- Rewrite `SchedulerStorage` to accept `DatabaseConnection` instead of `SqlitePool`
- Remove `init_schema()` calls from both storage modules; all schema management runs via `Migrator::up()` at startup
- Update `main.rs` and `lib.rs` to declare `entity` and `migration` modules

## Test plan

- [x] `cargo build -p orchestrator` passes
- [x] All 73 storage, scheduler, manager, and types tests pass
- [x] `test_workflow_crud` confirms full CRUD on workflows
- [x] `test_dispatch_log` confirms dispatch lifecycle: add → find active → update status → list history
- [x] `test_fail_inflight` confirms bulk status update for startup recovery
- [x] `test_add_with_env` and `test_update_persists_model` confirm JSON serialization roundtrips

Closes #226

🤖 Generated with [Claude Code](https://claude.com/claude-code)