### PR TITLE
Add usage and clear-context API endpoints

### DIFF
--- a/crates/orchestrator/src/api.rs
+++ b/crates/orchestrator/src/api.rs
@@ -46,6 +46,8 @@ pub fn create_router(state: ApiState) -> Router {
         .route("/agents/{id}/message", post(send_message))
         .route("/agents/{id}/model", axum::routing::put(set_agent_model))
         .route("/agents/{id}/policy", get(get_agent_policy).put(update_agent_policy))
+        .route("/agents/{id}/usage", get(get_agent_usage))
+        .route("/agents/{id}/clear-context", post(clear_agent_context))
         .route("/agents/{id}/approvals", get(list_agent_approvals))
         .route("/approvals", get(list_all_approvals))
         .route("/approvals/{id}", get(get_approval))
@@ -204,6 +206,36 @@ async fn set_agent_model(
     info!(agent_id = %id, model = ?agent.config.model, restart = req.restart, "Agent model changed via API");
 
     Ok(Json(AgentResponse::from(agent)))
+}
+
+// -- Usage & context endpoints --
+
+/// Get usage statistics for an agent.
+async fn get_agent_usage(
+    State(state): State<ApiState>,
+    Path(id): Path<Uuid>,
+) -> Result<impl IntoResponse, ApiError> {
+    // Verify agent exists; 404 if not.
+    state.manager.get_agent(&id).await?.ok_or(ApiError::NotFound)?;
+
+    let stats = state.manager.get_usage_stats(&id).await?;
+
+    Ok(Json(stats))
+}
+
+/// Clear an agent's context and start a fresh session.
+async fn clear_agent_context(
+    State(state): State<ApiState>,
+    Path(id): Path<Uuid>,
+) -> Result<impl IntoResponse, ApiError> {
+    // Verify agent exists; 404 if not.
+    state.manager.get_agent(&id).await?.ok_or(ApiError::NotFound)?;
+
+    let response = state.manager.clear_context(&id).await?;
+
+    info!(agent_id = %id, new_session = response.new_session_number, "Agent context cleared via API");
+
+    Ok(Json(response))
 }
 
 // -- Tool approval endpoints --


### PR DESCRIPTION
## Summary

- Add `GET /agents/{id}/usage` endpoint returning `AgentUsageStats` as JSON (current session, cumulative stats, session count)
- Add `POST /agents/{id}/clear-context` endpoint that clears agent context via `manager.clear_context()` and returns `ClearContextResponse`
- Both endpoints return 404 if agent not found, 500 on internal errors
- Follows existing `ApiState` patterns and route registration conventions

Closes #152

## Test plan

- [x] Compiles without errors (`cargo check -p orchestrator`)
- [x] Existing tests pass (86 passed; 3 pre-existing failures unrelated to this change)
- [ ] Manual test: `GET /agents/{id}/usage` returns stats for existing agent
- [ ] Manual test: `GET /agents/{id}/usage` returns 404 for unknown agent
- [ ] Manual test: `POST /agents/{id}/clear-context` clears context and returns response
- [ ] Manual test: `POST /agents/{id}/clear-context` returns 404 for unknown agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)