### PR TITLE
Add usage and clear-context client methods

### DIFF
--- a/crates/orchestrator/src/client.rs
+++ b/crates/orchestrator/src/client.rs
@@ -32,8 +32,9 @@ use crate::scheduler::types::{
     CreateWorkflowRequest, DispatchResponse, UpdateWorkflowRequest, WorkflowResponse,
 };
 use crate::types::{
-    AgentResponse, ApprovalActionRequest, CreateAgentRequest, HealthResponse, PaginatedResponse,
-    PendingApproval, SendMessageRequest, SendMessageResponse, SetModelRequest, ToolPolicy,
+    AgentResponse, AgentUsageStats, ApprovalActionRequest, ClearContextRequest,
+    ClearContextResponse, CreateAgentRequest, HealthResponse, PaginatedResponse, PendingApproval,
+    SendMessageRequest, SendMessageResponse, SetModelRequest, ToolPolicy,
 };
 
 /// Typed HTTP client for the orchestrator service.
@@ -133,6 +134,18 @@ impl OrchestratorClient {
     ) -> Result<AgentResponse> {
         let request = SetModelRequest { model, restart };
         self.put(&format!("/agents/{}/model", id), &request).await
+    }
+
+    // -- Usage & context operations --
+
+    /// Get usage statistics for an agent.
+    pub async fn get_agent_usage(&self, id: &Uuid) -> Result<AgentUsageStats> {
+        self.get(&format!("/agents/{}/usage", id)).await
+    }
+
+    /// Clear an agent's context and start a fresh session.
+    pub async fn clear_context(&self, id: &Uuid) -> Result<ClearContextResponse> {
+        self.post(&format!("/agents/{}/clear-context", id), &ClearContextRequest {}).await
     }
 
     // -- Approval operations --


### PR DESCRIPTION
## Summary

- Add `get_agent_usage(id)` client method — calls `GET /agents/{id}/usage`, returns `AgentUsageStats`
- Add `clear_context(id)` client method — calls `POST /agents/{id}/clear-context`, returns `ClearContextResponse`
- Both follow existing `OrchestratorClient` patterns with typed deserialization and anyhow error handling

Closes #153

## Test plan

- [x] Compiles without errors (`cargo check -p orchestrator`)
- [x] Existing tests pass (86 passed; 3 pre-existing failures unrelated to this change)
- [ ] Integration test: `get_agent_usage` returns stats for existing agent
- [ ] Integration test: `get_agent_usage` returns error for unknown agent
- [ ] Integration test: `clear_context` returns response with new session number
- [ ] Integration test: `clear_context` returns error for unknown agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)