### PR TITLE
Add CLI commands for usage and clear-context

### DIFF
--- a/crates/cli/src/commands/orchestrator.rs
+++ b/crates/cli/src/commands/orchestrator.rs
@@ -1275,10 +1275,8 @@ async fn usage_cmd(
         (None, None) => bail!("Either an agent ID or --name must be provided."),
     };
 
-    let stats = client
-        .get_agent_usage(&agent_id)
-        .await
-        .context("Failed to get agent usage stats")?;
+    let stats =
+        client.get_agent_usage(&agent_id).await.context("Failed to get agent usage stats")?;
 
     if json {
         println!("{}", serde_json::to_string_pretty(&stats)?);
@@ -1301,10 +1299,8 @@ async fn clear_context_cmd(
         (None, None) => bail!("Either an agent ID or --name must be provided."),
     };
 
-    let response = client
-        .clear_context(&agent_id)
-        .await
-        .context("Failed to clear agent context")?;
+    let response =
+        client.clear_context(&agent_id).await.context("Failed to clear agent context")?;
 
     if json {
         println!("{}", serde_json::to_string_pretty(&response)?);
@@ -1340,11 +1336,7 @@ fn display_usage_stats(stats: &AgentUsageStats) {
 fn display_session_usage(usage: &SessionUsage) {
     println!("  {}: {}", "Input Tokens".bold(), format_tokens(usage.input_tokens));
     println!("  {}: {}", "Output Tokens".bold(), format_tokens(usage.output_tokens));
-    println!(
-        "  {}: {}",
-        "Cache Read Tokens".bold(),
-        format_tokens(usage.cache_read_input_tokens)
-    );
+    println!("  {}: {}", "Cache Read Tokens".bold(), format_tokens(usage.cache_read_input_tokens));
     println!(
         "  {}: {}",
         "Cache Creation Tokens".bold(),


### PR DESCRIPTION
## Summary

- Add `agent orchestrator usage [ID] --name <name>` subcommand — displays current session and cumulative usage stats (tokens, cost, turns, duration, session count) in a readable table format
- Add `agent orchestrator clear-context [ID] --name <name>` subcommand — clears agent context, shows session usage at time of clear and new session number
- Add `--auto-clear-threshold <tokens>` flag to `create-agent` for configuring automatic context clearing
- Both new commands support `--name` resolution consistent with existing commands (attach, set-model)
- JSON output supported via `--json` flag

Closes #154

## Test plan

- [x] Compiles without errors (`cargo check -p cli`)
- [x] Unit tests pass (pre-existing failures only, unrelated to changes)
- [x] Manual test: `agent orchestrator usage --name <agent>` displays formatted stats
- [x] Manual test: `agent orchestrator usage <uuid>` displays formatted stats
- [x] Manual test: `agent orchestrator clear-context --name <agent>` clears and shows response
- [x] Manual test: `agent orchestrator usage --json` outputs raw JSON
- [ ] Manual test: `agent orchestrator create-agent --name test --auto-clear-threshold 100000` passes threshold
- [x] Manual test: `agent orchestrator usage` (no args) shows helpful error

🤖 Generated with [Claude Code](https://claude.com/claude-code)