### PR TITLE
Add usage persistence and auto-clear callback

### DIFF
--- a/crates/orchestrator/src/main.rs
+++ b/crates/orchestrator/src/main.rs
@@ -101,9 +101,7 @@ async fn main() -> anyhow::Result<()> {
                     };
 
                     // 1. Persist usage to DB.
-                    if let Err(e) =
-                        storage.record_session_usage(&info.agent_id, &usage).await
-                    {
+                    if let Err(e) = storage.record_session_usage(&info.agent_id, &usage).await {
                         error!(
                             agent_id = %info.agent_id,
                             %e,
@@ -144,11 +142,8 @@ async fn main() -> anyhow::Result<()> {
                         }
                     };
 
-                    let current_input = stats
-                        .current_session
-                        .as_ref()
-                        .map(|s| s.input_tokens)
-                        .unwrap_or(0);
+                    let current_input =
+                        stats.current_session.as_ref().map(|s| s.input_tokens).unwrap_or(0);
 
                     if current_input < threshold {
                         return;


### PR DESCRIPTION
## Summary

- Register an `on_result` callback in the orchestrator that persists usage data from every result message via `storage.record_session_usage`
- Check the agent's `auto_clear_threshold` config after each usage record; trigger `manager.clear_context` when accumulated `input_tokens >= threshold`
- Use `Arc<RwLock<HashSet<Uuid>>>` re-entrancy guard to prevent concurrent auto-clears for the same agent
- Results without usage data (`None`) are silently skipped
- Auto-clear failures are logged but don't crash the orchestrator

## Test plan

- [x] Existing orchestrator tests pass (86/86, 3 pre-existing client failures unrelated)
- [ ] Manual: spawn agent with `auto_clear_threshold` set, verify usage is persisted after each result
- [ ] Manual: verify auto-clear triggers when input_tokens exceed threshold
- [ ] Manual: verify results without usage data are silently skipped

Closes #151

🤖 Generated with [Claude Code](https://claude.com/claude-code)