### PR TITLE
Add usage and cache efficiency charts to monitoring dashboard

### DIFF
--- a/ui/src/components/monitoring/CacheEfficiencyChart.tsx
+++ b/ui/src/components/monitoring/CacheEfficiencyChart.tsx
@@ -1,0 +1,221 @@
+/**
+ * CacheEfficiencyChart — Nivo donut chart showing aggregate prompt cache
+ * efficiency across all agents.
+ *
+ * Segments:
+ * - Cache read tokens (hits) — green
+ * - Cache creation tokens (misses) — amber
+ * - Non-cached input tokens — gray
+ *
+ * Center label shows overall cache hit percentage.
+ * Optional per-agent breakdown via a dropdown toggle.
+ */
+
+import { useState, useMemo } from 'react'
+import { ResponsivePie } from '@nivo/pie'
+import { ChevronDown } from 'lucide-react'
+import { ChartSkeleton } from '@/components/common/LoadingSkeleton'
+import { useNivoTheme } from '@/hooks/useNivoTheme'
+import type { AgentUsageEntry, AggregateUsage } from '@/hooks/useUsageMetrics'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface CacheEfficiencyChartProps {
+  entries: AgentUsageEntry[]
+  aggregate: AggregateUsage
+  loading?: boolean
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const SEGMENT_COLORS = {
+  cacheRead: '#22c55e',      // green — cache hits
+  cacheCreation: '#f59e0b',  // amber — cache misses
+  nonCached: '#94a3b8',      // gray  — non-cached input
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function pct(ratio: number): string {
+  return `${(ratio * 100).toFixed(1)}%`
+}
+
+function formatTokenCount(value: number): string {
+  if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(1)}M`
+  if (value >= 1_000) return `${(value / 1_000).toFixed(1)}k`
+  return String(value)
+}
+
+interface PieSegment {
+  id: string
+  label: string
+  value: number
+  color: string
+}
+
+function buildSegments(
+  cacheRead: number,
+  cacheCreation: number,
+  nonCached: number,
+): PieSegment[] {
+  return [
+    { id: 'cache_read', label: 'Cache Hits', value: cacheRead, color: SEGMENT_COLORS.cacheRead },
+    { id: 'cache_creation', label: 'Cache Misses', value: cacheCreation, color: SEGMENT_COLORS.cacheCreation },
+    { id: 'non_cached', label: 'Non-Cached', value: nonCached, color: SEGMENT_COLORS.nonCached },
+  ].filter((s) => s.value > 0)
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function CacheEfficiencyChart({ entries, aggregate, loading }: CacheEfficiencyChartProps) {
+  const nivoTheme = useNivoTheme()
+  const [selectedAgent, setSelectedAgent] = useState<string>('all')
+
+  // Build segment data for the selected view
+  const { segments, hitRatio } = useMemo(() => {
+    if (selectedAgent === 'all') {
+      const segs = buildSegments(
+        aggregate.totalCacheReadTokens,
+        aggregate.totalCacheCreationTokens,
+        aggregate.totalInputTokens,
+      )
+      return { segments: segs, hitRatio: aggregate.cacheHitRatio }
+    }
+
+    const entry = entries.find((e) => e.agentId === selectedAgent)
+    if (!entry) return { segments: [] as PieSegment[], hitRatio: 0 }
+
+    const c = entry.stats.cumulative
+    const total = c.cache_read_input_tokens + c.cache_creation_input_tokens + c.input_tokens
+    const ratio = total > 0 ? c.cache_read_input_tokens / total : 0
+
+    return {
+      segments: buildSegments(
+        c.cache_read_input_tokens,
+        c.cache_creation_input_tokens,
+        c.input_tokens,
+      ),
+      hitRatio: ratio,
+    }
+  }, [selectedAgent, entries, aggregate])
+
+  const hasData = segments.length > 0
+
+  return (
+    <div
+      className="rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-5"
+      aria-label="Cache efficiency donut chart"
+    >
+      <div className="flex items-center justify-between mb-4">
+        <h3 className="text-sm font-semibold text-gray-900 dark:text-white">
+          Cache Efficiency
+        </h3>
+
+        {/* Agent dropdown */}
+        {entries.length > 0 && (
+          <div className="relative">
+            <select
+              value={selectedAgent}
+              onChange={(e) => setSelectedAgent(e.target.value)}
+              aria-label="Select agent for cache breakdown"
+              className="appearance-none rounded-md border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 pl-2.5 pr-7 py-1 text-xs text-gray-600 dark:text-gray-400 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors cursor-pointer"
+            >
+              <option value="all">All Agents</option>
+              {entries.map((entry) => (
+                <option key={entry.agentId} value={entry.agentId}>
+                  {entry.name || entry.agentId.slice(0, 12)}
+                </option>
+              ))}
+            </select>
+            <ChevronDown
+              size={12}
+              className="absolute right-2 top-1/2 -translate-y-1/2 pointer-events-none text-gray-400"
+            />
+          </div>
+        )}
+      </div>
+
+      {loading ? (
+        <ChartSkeleton height={240} />
+      ) : !hasData ? (
+        <div className="flex items-center justify-center h-60 text-sm text-gray-400 dark:text-gray-500">
+          No cache data available
+        </div>
+      ) : (
+        <>
+          <div style={{ height: 240 }} className="relative" role="img" aria-label="Donut chart showing cache hit ratio">
+            <ResponsivePie
+              data={segments}
+              theme={nivoTheme}
+              colors={({ data }) => data.color}
+              margin={{ top: 8, right: 60, bottom: 8, left: 60 }}
+              innerRadius={0.6}
+              padAngle={2}
+              cornerRadius={3}
+              arcLinkLabel="label"
+              arcLinkLabelsSkipAngle={10}
+              arcLinkLabelsThickness={1}
+              arcLinkLabelsColor={{ from: 'color' }}
+              enableArcLabels={false}
+              tooltip={({ datum }) => (
+                <div className="rounded-md border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-2 text-xs shadow-lg">
+                  <div className="flex items-center gap-1.5">
+                    <span
+                      className="h-2 w-2 rounded-full flex-shrink-0"
+                      style={{ background: datum.color }}
+                    />
+                    <span className="text-gray-600 dark:text-gray-300">{datum.label}:</span>
+                    <span className="font-medium text-gray-900 dark:text-white">
+                      {formatTokenCount(datum.value)}
+                    </span>
+                  </div>
+                </div>
+              )}
+              role="img"
+            />
+
+            {/* Center label — cache hit percentage */}
+            <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
+              <div className="text-center">
+                <div className="text-2xl font-bold text-gray-900 dark:text-white">
+                  {pct(hitRatio)}
+                </div>
+                <div className="text-xs text-gray-500 dark:text-gray-400">Cache Hit</div>
+              </div>
+            </div>
+          </div>
+
+          {/* Legend */}
+          <div className="mt-3 flex flex-wrap gap-3">
+            {[
+              { label: 'Cache Hits', color: SEGMENT_COLORS.cacheRead },
+              { label: 'Cache Misses', color: SEGMENT_COLORS.cacheCreation },
+              { label: 'Non-Cached', color: SEGMENT_COLORS.nonCached },
+            ].map((item) => (
+              <span
+                key={item.label}
+                className="flex items-center gap-1 text-xs text-gray-500 dark:text-gray-400"
+              >
+                <span
+                  className="h-2 w-2 rounded-full flex-shrink-0"
+                  style={{ background: item.color }}
+                />
+                {item.label}
+              </span>
+            ))}
+          </div>
+        </>
+      )}
+    </div>
+  )
+}
+
+export default CacheEfficiencyChart

--- a/ui/src/components/monitoring/CostOverviewChart.tsx
+++ b/ui/src/components/monitoring/CostOverviewChart.tsx
@@ -1,0 +1,171 @@
+/**
+ * CostOverviewChart — Nivo bar chart showing cumulative cost per agent.
+ *
+ * Y-axis formatted as USD currency.
+ * Custom tooltip with cost breakdown.
+ */
+
+import { ResponsiveBar } from '@nivo/bar'
+import { ChartSkeleton } from '@/components/common/LoadingSkeleton'
+import { useNivoTheme } from '@/hooks/useNivoTheme'
+import type { AgentUsageEntry, AggregateUsage } from '@/hooks/useUsageMetrics'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface CostOverviewChartProps {
+  entries: AgentUsageEntry[]
+  aggregate: AggregateUsage
+  loading?: boolean
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const BAR_COLOR = '#3b82f6' // blue-500
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function truncateLabel(name: string, maxLen = 12): string {
+  return name.length > maxLen ? `${name.slice(0, maxLen)}…` : name
+}
+
+function formatUsd(value: number): string {
+  if (value < 0.01 && value > 0) return `$${value.toFixed(4)}`
+  return `$${value.toFixed(2)}`
+}
+
+function formatTokenCount(value: number): string {
+  if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(1)}M`
+  if (value >= 1_000) return `${(value / 1_000).toFixed(1)}k`
+  return String(value)
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function CostOverviewChart({ entries, aggregate, loading }: CostOverviewChartProps) {
+  const nivoTheme = useNivoTheme()
+
+  const barData = entries
+    .filter((entry) => entry.stats.cumulative.total_cost_usd > 0)
+    .map((entry) => ({
+      agent: truncateLabel(entry.name || entry.agentId),
+      agentFull: entry.name || entry.agentId,
+      cost: entry.stats.cumulative.total_cost_usd,
+      input_tokens: entry.stats.cumulative.input_tokens,
+      output_tokens: entry.stats.cumulative.output_tokens,
+      sessions: entry.stats.session_count,
+    }))
+    .sort((a, b) => b.cost - a.cost)
+
+  const hasData = barData.length > 0
+
+  return (
+    <div
+      className="rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-5"
+      aria-label="Cost overview bar chart"
+    >
+      <div className="flex items-center justify-between mb-4">
+        <h3 className="text-sm font-semibold text-gray-900 dark:text-white">
+          Cost per Agent
+        </h3>
+        {hasData && (
+          <span className="text-xs text-gray-500 dark:text-gray-400">
+            Total: <span className="font-medium text-gray-900 dark:text-white">{formatUsd(aggregate.totalCostUsd)}</span>
+          </span>
+        )}
+      </div>
+
+      {loading ? (
+        <ChartSkeleton height={240} />
+      ) : !hasData ? (
+        <div className="flex items-center justify-center h-60 text-sm text-gray-400 dark:text-gray-500">
+          No cost data available
+        </div>
+      ) : (
+        <>
+          <div style={{ height: 240 }} role="img" aria-label="Bar chart of cost per agent in USD">
+            <ResponsiveBar
+              data={barData}
+              keys={['cost']}
+              indexBy="agent"
+              theme={nivoTheme}
+              colors={[BAR_COLOR]}
+              margin={{ top: 8, right: 8, bottom: 40, left: 56 }}
+              padding={0.3}
+              borderRadius={3}
+              enableLabel={false}
+              axisLeft={{
+                tickSize: 0,
+                tickPadding: 4,
+                tickValues: 5,
+                format: (v) => formatUsd(Number(v)),
+              }}
+              axisBottom={{
+                tickSize: 0,
+                tickPadding: 6,
+                tickRotation: entries.length > 6 ? -35 : 0,
+              }}
+              tooltip={({ data: rowData }) => {
+                const row = rowData as Record<string, unknown>
+                return (
+                  <div className="rounded-md border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-2 text-xs shadow-lg">
+                    <div className="font-medium text-gray-900 dark:text-white mb-1.5">
+                      {row.agentFull as string}
+                    </div>
+                    <div className="space-y-0.5">
+                      <div className="flex justify-between gap-4">
+                        <span className="text-gray-500 dark:text-gray-400">Cost:</span>
+                        <span className="font-medium text-gray-900 dark:text-white">
+                          {formatUsd(row.cost as number)}
+                        </span>
+                      </div>
+                      <div className="flex justify-between gap-4">
+                        <span className="text-gray-500 dark:text-gray-400">Input tokens:</span>
+                        <span className="text-gray-700 dark:text-gray-300">
+                          {formatTokenCount(row.input_tokens as number)}
+                        </span>
+                      </div>
+                      <div className="flex justify-between gap-4">
+                        <span className="text-gray-500 dark:text-gray-400">Output tokens:</span>
+                        <span className="text-gray-700 dark:text-gray-300">
+                          {formatTokenCount(row.output_tokens as number)}
+                        </span>
+                      </div>
+                      <div className="flex justify-between gap-4">
+                        <span className="text-gray-500 dark:text-gray-400">Sessions:</span>
+                        <span className="text-gray-700 dark:text-gray-300">
+                          {row.sessions as number}
+                        </span>
+                      </div>
+                    </div>
+                  </div>
+                )
+              }}
+              role="img"
+              ariaLabel="Cost per agent bar chart"
+            />
+          </div>
+
+          {/* Summary footer */}
+          <div className="mt-3 flex flex-wrap gap-4 text-xs text-gray-500 dark:text-gray-400">
+            <span>
+              Agents: <span className="font-medium text-gray-700 dark:text-gray-300">{barData.length}</span>
+            </span>
+            <span>
+              Total tokens: <span className="font-medium text-gray-700 dark:text-gray-300">{formatTokenCount(aggregate.totalTokens)}</span>
+            </span>
+          </div>
+        </>
+      )}
+    </div>
+  )
+}
+
+export default CostOverviewChart

--- a/ui/src/components/monitoring/TokenUsageChart.tsx
+++ b/ui/src/components/monitoring/TokenUsageChart.tsx
@@ -1,0 +1,166 @@
+/**
+ * TokenUsageChart — Nivo stacked bar chart showing per-agent token usage.
+ *
+ * X-axis: agent names (truncated IDs as fallback)
+ * Y-axis: token count
+ * Stacked series: input tokens, output tokens, cache read tokens, cache creation tokens
+ */
+
+import { ResponsiveBar } from '@nivo/bar'
+import { ChartSkeleton } from '@/components/common/LoadingSkeleton'
+import { useNivoTheme } from '@/hooks/useNivoTheme'
+import type { AgentUsageEntry } from '@/hooks/useUsageMetrics'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface TokenUsageChartProps {
+  entries: AgentUsageEntry[]
+  loading?: boolean
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const TOKEN_KEYS = [
+  'input_tokens',
+  'output_tokens',
+  'cache_read_tokens',
+  'cache_creation_tokens',
+] as const
+
+const TOKEN_LABELS: Record<string, string> = {
+  input_tokens: 'Input Tokens',
+  output_tokens: 'Output Tokens',
+  cache_read_tokens: 'Cache Read',
+  cache_creation_tokens: 'Cache Creation',
+}
+
+const TOKEN_COLORS: Record<string, string> = {
+  input_tokens: '#3b82f6',      // blue
+  output_tokens: '#8b5cf6',     // violet
+  cache_read_tokens: '#22c55e', // green
+  cache_creation_tokens: '#f59e0b', // amber
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function truncateLabel(name: string, maxLen = 12): string {
+  return name.length > maxLen ? `${name.slice(0, maxLen)}…` : name
+}
+
+function formatTokenCount(value: number): string {
+  if (value >= 1_000_000) return `${(value / 1_000_000).toFixed(1)}M`
+  if (value >= 1_000) return `${(value / 1_000).toFixed(1)}k`
+  return String(value)
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function TokenUsageChart({ entries, loading }: TokenUsageChartProps) {
+  const nivoTheme = useNivoTheme()
+
+  const barData = entries.map((entry) => ({
+    agent: truncateLabel(entry.name || entry.agentId),
+    agentFull: entry.name || entry.agentId,
+    input_tokens: entry.stats.cumulative.input_tokens,
+    output_tokens: entry.stats.cumulative.output_tokens,
+    cache_read_tokens: entry.stats.cumulative.cache_read_input_tokens,
+    cache_creation_tokens: entry.stats.cumulative.cache_creation_input_tokens,
+  }))
+
+  const hasData = barData.some(
+    (d) => d.input_tokens + d.output_tokens + d.cache_read_tokens + d.cache_creation_tokens > 0,
+  )
+
+  return (
+    <div
+      className="rounded-lg border border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-800 p-5"
+      aria-label="Token usage stacked bar chart"
+    >
+      <h3 className="mb-4 text-sm font-semibold text-gray-900 dark:text-white">
+        Token Usage by Agent
+      </h3>
+
+      {loading ? (
+        <ChartSkeleton height={240} />
+      ) : !hasData ? (
+        <div className="flex items-center justify-center h-60 text-sm text-gray-400 dark:text-gray-500">
+          No usage data available
+        </div>
+      ) : (
+        <>
+          <div style={{ height: 240 }} role="img" aria-label="Stacked bar chart of token usage per agent">
+            <ResponsiveBar
+              data={barData}
+              keys={[...TOKEN_KEYS]}
+              indexBy="agent"
+              theme={nivoTheme}
+              colors={({ id }) => TOKEN_COLORS[id as string] ?? '#94a3b8'}
+              margin={{ top: 8, right: 8, bottom: 40, left: 56 }}
+              padding={0.3}
+              borderRadius={2}
+              enableLabel={false}
+              axisLeft={{
+                tickSize: 0,
+                tickPadding: 4,
+                tickValues: 5,
+                format: formatTokenCount,
+              }}
+              axisBottom={{
+                tickSize: 0,
+                tickPadding: 6,
+                tickRotation: entries.length > 6 ? -35 : 0,
+              }}
+              tooltip={({ id, value, indexValue, data: rowData }) => (
+                <div className="rounded-md border border-gray-200 dark:border-gray-600 bg-white dark:bg-gray-800 px-3 py-2 text-xs shadow-lg">
+                  <div className="font-medium text-gray-900 dark:text-white mb-1">
+                    {(rowData as Record<string, unknown>).agentFull as string}
+                  </div>
+                  <div className="flex items-center gap-1.5">
+                    <span
+                      className="h-2 w-2 rounded-full flex-shrink-0"
+                      style={{ background: TOKEN_COLORS[id as string] }}
+                    />
+                    <span className="text-gray-600 dark:text-gray-300">
+                      {TOKEN_LABELS[id as string] ?? String(id)}:
+                    </span>
+                    <span className="font-medium text-gray-900 dark:text-white">
+                      {formatTokenCount(value)}
+                    </span>
+                  </div>
+                </div>
+              )}
+              role="img"
+              ariaLabel="Token usage stacked bar chart"
+            />
+          </div>
+
+          {/* Legend */}
+          <div className="mt-3 flex flex-wrap gap-3">
+            {TOKEN_KEYS.map((key) => (
+              <span
+                key={key}
+                className="flex items-center gap-1 text-xs text-gray-500 dark:text-gray-400"
+              >
+                <span
+                  className="h-2 w-2 rounded-full flex-shrink-0"
+                  style={{ background: TOKEN_COLORS[key] }}
+                />
+                {TOKEN_LABELS[key]}
+              </span>
+            ))}
+          </div>
+        </>
+      )}
+    </div>
+  )
+}
+
+export default TokenUsageChart

--- a/ui/src/components/monitoring/index.ts
+++ b/ui/src/components/monitoring/index.ts
@@ -12,3 +12,12 @@ export type { ServiceMetricsCardProps } from './ServiceMetricsCard'
 
 export { SystemHealthPanel } from './SystemHealthPanel'
 export type { SystemHealthPanelProps } from './SystemHealthPanel'
+
+export { TokenUsageChart } from './TokenUsageChart'
+export type { TokenUsageChartProps } from './TokenUsageChart'
+
+export { CacheEfficiencyChart } from './CacheEfficiencyChart'
+export type { CacheEfficiencyChartProps } from './CacheEfficiencyChart'
+
+export { CostOverviewChart } from './CostOverviewChart'
+export type { CostOverviewChartProps } from './CostOverviewChart'

--- a/ui/src/hooks/index.ts
+++ b/ui/src/hooks/index.ts
@@ -46,3 +46,10 @@ export type { UseAgentEventsResult } from './useAgentEvents'
 
 export { useAgentUsage } from './useAgentUsage'
 export type { UseAgentUsageReturn } from './useAgentUsage'
+
+export { useUsageMetrics } from './useUsageMetrics'
+export type {
+  AgentUsageEntry,
+  AggregateUsage,
+  UseUsageMetricsResult,
+} from './useUsageMetrics'

--- a/ui/src/hooks/useUsageMetrics.ts
+++ b/ui/src/hooks/useUsageMetrics.ts
@@ -1,0 +1,204 @@
+/**
+ * useUsageMetrics — fetches and aggregates token usage, cache efficiency,
+ * and cost metrics across all running agents.
+ *
+ * Iterates `GET /agents/{id}/usage` for each agent discovered via
+ * `GET /agents` and provides dashboard-level computed values:
+ * - Per-agent usage breakdowns (for bar/pie charts)
+ * - Aggregate totals: total cost, total tokens, cache hit ratio
+ * - Auto-refresh on a configurable interval (same options as useMetrics)
+ * - Pauses when the tab is hidden
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { orchestratorClient } from '@/services/orchestrator'
+import type { Agent, AgentUsageStats } from '@/types/orchestrator'
+import type { RefreshInterval } from './useMetrics'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface AgentUsageEntry {
+  /** Agent ID */
+  agentId: string
+  /** Agent name (for chart labels) */
+  name: string
+  /** Raw usage stats from the API */
+  stats: AgentUsageStats
+}
+
+export interface AggregateUsage {
+  totalInputTokens: number
+  totalOutputTokens: number
+  totalCacheReadTokens: number
+  totalCacheCreationTokens: number
+  totalCostUsd: number
+  totalTokens: number
+  /** Cache hit ratio as a fraction 0–1 */
+  cacheHitRatio: number
+}
+
+export interface UseUsageMetricsResult {
+  /** Per-agent usage entries */
+  entries: AgentUsageEntry[]
+  /** Aggregate computed values */
+  aggregate: AggregateUsage
+  /** Loading state */
+  loading: boolean
+  /** Error message, if any */
+  error?: string
+  /** Trigger a manual refresh */
+  refetch: () => void
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const EMPTY_AGGREGATE: AggregateUsage = {
+  totalInputTokens: 0,
+  totalOutputTokens: 0,
+  totalCacheReadTokens: 0,
+  totalCacheCreationTokens: 0,
+  totalCostUsd: 0,
+  totalTokens: 0,
+  cacheHitRatio: 0,
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function computeAggregate(entries: AgentUsageEntry[]): AggregateUsage {
+  let totalInputTokens = 0
+  let totalOutputTokens = 0
+  let totalCacheReadTokens = 0
+  let totalCacheCreationTokens = 0
+  let totalCostUsd = 0
+
+  for (const entry of entries) {
+    const c = entry.stats.cumulative
+    totalInputTokens += c.input_tokens
+    totalOutputTokens += c.output_tokens
+    totalCacheReadTokens += c.cache_read_input_tokens
+    totalCacheCreationTokens += c.cache_creation_input_tokens
+    totalCostUsd += c.total_cost_usd
+  }
+
+  const totalTokens =
+    totalInputTokens + totalOutputTokens + totalCacheReadTokens + totalCacheCreationTokens
+
+  // Cache hit ratio: cache reads / (cache reads + cache creation + non-cached input)
+  const cacheTotal = totalCacheReadTokens + totalCacheCreationTokens + totalInputTokens
+  const cacheHitRatio = cacheTotal > 0 ? totalCacheReadTokens / cacheTotal : 0
+
+  return {
+    totalInputTokens,
+    totalOutputTokens,
+    totalCacheReadTokens,
+    totalCacheCreationTokens,
+    totalCostUsd,
+    totalTokens,
+    cacheHitRatio,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+export function useUsageMetrics(refreshInterval: RefreshInterval = 30_000): UseUsageMetricsResult {
+  const [entries, setEntries] = useState<AgentUsageEntry[]>([])
+  const [aggregate, setAggregate] = useState<AggregateUsage>(EMPTY_AGGREGATE)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | undefined>()
+
+  const timerRef = useRef<ReturnType<typeof setInterval> | null>(null)
+  const mountedRef = useRef(true)
+
+  useEffect(() => {
+    mountedRef.current = true
+    return () => {
+      mountedRef.current = false
+    }
+  }, [])
+
+  const fetchAll = useCallback(async () => {
+    try {
+      // 1. List all agents
+      const agentsResp = await orchestratorClient.listAgents({ limit: 200 })
+      const agents: Agent[] = agentsResp.items
+
+      // 2. Fetch usage for each agent in parallel
+      const usageResults = await Promise.allSettled(
+        agents.map((agent) => orchestratorClient.getAgentUsage(agent.id)),
+      )
+
+      // 3. Build entries (skip agents where usage fetch failed)
+      const newEntries: AgentUsageEntry[] = []
+      for (let i = 0; i < agents.length; i++) {
+        const result = usageResults[i]
+        if (result.status === 'fulfilled') {
+          newEntries.push({
+            agentId: agents[i].id,
+            name: agents[i].name,
+            stats: result.value,
+          })
+        }
+      }
+
+      if (mountedRef.current) {
+        setEntries(newEntries)
+        setAggregate(computeAggregate(newEntries))
+        setError(undefined)
+      }
+    } catch (err) {
+      if (mountedRef.current) {
+        setError(err instanceof Error ? err.message : 'Failed to fetch usage metrics')
+      }
+    } finally {
+      if (mountedRef.current) {
+        setLoading(false)
+      }
+    }
+  }, [])
+
+  // Initial fetch
+  useEffect(() => {
+    void fetchAll()
+  }, [fetchAll])
+
+  // Auto-refresh
+  useEffect(() => {
+    if (timerRef.current) clearInterval(timerRef.current)
+    timerRef.current = setInterval(() => void fetchAll(), refreshInterval)
+    return () => {
+      if (timerRef.current) clearInterval(timerRef.current)
+    }
+  }, [refreshInterval, fetchAll])
+
+  // Pause on tab blur, resume on focus
+  useEffect(() => {
+    function handleVisibility() {
+      if (document.hidden) {
+        if (timerRef.current) clearInterval(timerRef.current)
+      } else {
+        void fetchAll()
+        timerRef.current = setInterval(() => void fetchAll(), refreshInterval)
+      }
+    }
+    document.addEventListener('visibilitychange', handleVisibility)
+    return () => {
+      document.removeEventListener('visibilitychange', handleVisibility)
+    }
+  }, [refreshInterval, fetchAll])
+
+  return {
+    entries,
+    aggregate,
+    loading,
+    error,
+    refetch: () => void fetchAll(),
+  }
+}

--- a/ui/src/pages/monitoring/MonitoringDashboard.tsx
+++ b/ui/src/pages/monitoring/MonitoringDashboard.tsx
@@ -12,11 +12,15 @@
 
 import { RefreshCw, Clock } from 'lucide-react'
 import { useMetrics } from '@/hooks/useMetrics'
+import { useUsageMetrics } from '@/hooks/useUsageMetrics'
 import { AgentActivityChart } from '@/components/monitoring/AgentActivityChart'
 import { NotificationMetricsChart } from '@/components/monitoring/NotificationMetricsChart'
 import { ServiceMetricsCard } from '@/components/monitoring/ServiceMetricsCard'
 import { SystemHealthPanel } from '@/components/monitoring/SystemHealthPanel'
 import { PlaceholderChart } from '@/components/monitoring/PlaceholderChart'
+import { TokenUsageChart } from '@/components/monitoring/TokenUsageChart'
+import { CacheEfficiencyChart } from '@/components/monitoring/CacheEfficiencyChart'
+import { CostOverviewChart } from '@/components/monitoring/CostOverviewChart'
 import type { RefreshInterval } from '@/hooks/useMetrics'
 
 // ---------------------------------------------------------------------------
@@ -51,6 +55,12 @@ export function MonitoringDashboard() {
     refreshInterval,
     setRefreshInterval,
   } = useMetrics(30_000)
+
+  const {
+    entries: usageEntries,
+    aggregate: usageAggregate,
+    loading: usageLoading,
+  } = useUsageMetrics(refreshInterval)
 
   // Map response times from serviceMetrics — they come from Prometheus
   // latency data when available, otherwise undefined (SystemHealthPanel
@@ -160,6 +170,28 @@ export function MonitoringDashboard() {
       <section aria-label="System health">
         <h2 className="sr-only">System Health</h2>
         <SystemHealthPanel serviceMetrics={serviceMetrics} loading={loading} />
+      </section>
+
+      {/* Token Usage & Prompt Cache section */}
+      <section aria-label="Token usage and prompt cache metrics">
+        <h2 className="mb-3 text-sm font-semibold text-gray-700 dark:text-gray-300">
+          Token Usage &amp; Prompt Cache
+        </h2>
+        <div className="grid grid-cols-1 gap-4 lg:grid-cols-2">
+          <TokenUsageChart entries={usageEntries} loading={usageLoading} />
+          <CacheEfficiencyChart
+            entries={usageEntries}
+            aggregate={usageAggregate}
+            loading={usageLoading}
+          />
+        </div>
+        <div className="mt-4">
+          <CostOverviewChart
+            entries={usageEntries}
+            aggregate={usageAggregate}
+            loading={usageLoading}
+          />
+        </div>
       </section>
 
       {/* Placeholder charts for future monitor service */}

--- a/ui/src/test/components/monitoring/CacheEfficiencyChart.test.tsx
+++ b/ui/src/test/components/monitoring/CacheEfficiencyChart.test.tsx
@@ -1,0 +1,114 @@
+/**
+ * Tests for CacheEfficiencyChart component.
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { CacheEfficiencyChart } from '@/components/monitoring/CacheEfficiencyChart'
+import type { AgentUsageEntry, AggregateUsage } from '@/hooks/useUsageMetrics'
+
+// Mock useNivoTheme to avoid ThemeProvider dependency in unit tests
+vi.mock('@/hooks/useNivoTheme', () => ({ useNivoTheme: () => ({}) }))
+
+// Mock Nivo charts
+vi.mock('@nivo/pie', () => ({
+  ResponsivePie: () => <div role="img" aria-label="mock-pie" />,
+}))
+
+const AGGREGATE: AggregateUsage = {
+  totalInputTokens: 1000,
+  totalOutputTokens: 500,
+  totalCacheReadTokens: 800,
+  totalCacheCreationTokens: 200,
+  totalCostUsd: 0.10,
+  totalTokens: 2500,
+  cacheHitRatio: 0.4,
+}
+
+const ENTRIES: AgentUsageEntry[] = [
+  {
+    agentId: 'agent-1',
+    name: 'Agent Alpha',
+    stats: {
+      agent_id: 'agent-1',
+      cumulative: {
+        input_tokens: 1000,
+        output_tokens: 500,
+        cache_read_input_tokens: 800,
+        cache_creation_input_tokens: 200,
+        total_cost_usd: 0.10,
+        num_turns: 10,
+        duration_ms: 5000,
+        duration_api_ms: 3000,
+        result_count: 5,
+        started_at: '2024-01-01T00:00:00Z',
+      },
+      session_count: 2,
+    },
+  },
+]
+
+const EMPTY_AGGREGATE: AggregateUsage = {
+  totalInputTokens: 0,
+  totalOutputTokens: 0,
+  totalCacheReadTokens: 0,
+  totalCacheCreationTokens: 0,
+  totalCostUsd: 0,
+  totalTokens: 0,
+  cacheHitRatio: 0,
+}
+
+describe('CacheEfficiencyChart', () => {
+  it('renders heading', () => {
+    render(<CacheEfficiencyChart entries={ENTRIES} aggregate={AGGREGATE} />)
+    expect(screen.getByText('Cache Efficiency')).toBeTruthy()
+  })
+
+  it('shows cache hit percentage in center', () => {
+    render(<CacheEfficiencyChart entries={ENTRIES} aggregate={AGGREGATE} />)
+    expect(screen.getByText('40.0%')).toBeTruthy()
+    expect(screen.getByText('Cache Hit')).toBeTruthy()
+  })
+
+  it('shows loading skeleton when loading=true', () => {
+    const { container } = render(
+      <CacheEfficiencyChart entries={[]} aggregate={EMPTY_AGGREGATE} loading />,
+    )
+    expect(container.querySelector('.animate-pulse')).toBeTruthy()
+  })
+
+  it('shows empty message when no data', () => {
+    render(<CacheEfficiencyChart entries={[]} aggregate={EMPTY_AGGREGATE} />)
+    expect(screen.getByText('No cache data available')).toBeTruthy()
+  })
+
+  it('renders agent dropdown when entries exist', () => {
+    render(<CacheEfficiencyChart entries={ENTRIES} aggregate={AGGREGATE} />)
+    expect(screen.getByLabelText('Select agent for cache breakdown')).toBeTruthy()
+  })
+
+  it('shows All Agents as default option', () => {
+    render(<CacheEfficiencyChart entries={ENTRIES} aggregate={AGGREGATE} />)
+    const select = screen.getByLabelText('Select agent for cache breakdown') as HTMLSelectElement
+    expect(select.value).toBe('all')
+  })
+
+  it('can switch to per-agent view', () => {
+    render(<CacheEfficiencyChart entries={ENTRIES} aggregate={AGGREGATE} />)
+    const select = screen.getByLabelText('Select agent for cache breakdown')
+    fireEvent.change(select, { target: { value: 'agent-1' } })
+    expect((select as HTMLSelectElement).value).toBe('agent-1')
+  })
+
+  it('renders legend items', () => {
+    render(<CacheEfficiencyChart entries={ENTRIES} aggregate={AGGREGATE} />)
+    expect(screen.getByText('Cache Hits')).toBeTruthy()
+    expect(screen.getByText('Cache Misses')).toBeTruthy()
+    expect(screen.getByText('Non-Cached')).toBeTruthy()
+  })
+
+  it('has aria-label on outer container', () => {
+    render(<CacheEfficiencyChart entries={ENTRIES} aggregate={AGGREGATE} />)
+    expect(screen.getByLabelText('Cache efficiency donut chart')).toBeTruthy()
+  })
+})

--- a/ui/src/test/components/monitoring/CostOverviewChart.test.tsx
+++ b/ui/src/test/components/monitoring/CostOverviewChart.test.tsx
@@ -1,0 +1,118 @@
+/**
+ * Tests for CostOverviewChart component.
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { CostOverviewChart } from '@/components/monitoring/CostOverviewChart'
+import type { AgentUsageEntry, AggregateUsage } from '@/hooks/useUsageMetrics'
+
+// Mock useNivoTheme to avoid ThemeProvider dependency in unit tests
+vi.mock('@/hooks/useNivoTheme', () => ({ useNivoTheme: () => ({}) }))
+
+// Mock Nivo charts
+vi.mock('@nivo/bar', () => ({
+  ResponsiveBar: ({ ariaLabel }: { ariaLabel: string }) => <div role="img" aria-label={ariaLabel} />,
+}))
+
+const AGGREGATE: AggregateUsage = {
+  totalInputTokens: 2000,
+  totalOutputTokens: 1000,
+  totalCacheReadTokens: 500,
+  totalCacheCreationTokens: 100,
+  totalCostUsd: 0.25,
+  totalTokens: 3600,
+  cacheHitRatio: 0.19,
+}
+
+const ENTRIES: AgentUsageEntry[] = [
+  {
+    agentId: 'agent-1',
+    name: 'Agent Alpha',
+    stats: {
+      agent_id: 'agent-1',
+      cumulative: {
+        input_tokens: 1200,
+        output_tokens: 600,
+        cache_read_input_tokens: 300,
+        cache_creation_input_tokens: 50,
+        total_cost_usd: 0.15,
+        num_turns: 8,
+        duration_ms: 4000,
+        duration_api_ms: 2500,
+        result_count: 4,
+        started_at: '2024-01-01T00:00:00Z',
+      },
+      session_count: 1,
+    },
+  },
+  {
+    agentId: 'agent-2',
+    name: 'Agent Beta',
+    stats: {
+      agent_id: 'agent-2',
+      cumulative: {
+        input_tokens: 800,
+        output_tokens: 400,
+        cache_read_input_tokens: 200,
+        cache_creation_input_tokens: 50,
+        total_cost_usd: 0.10,
+        num_turns: 5,
+        duration_ms: 3000,
+        duration_api_ms: 2000,
+        result_count: 3,
+        started_at: '2024-01-01T00:00:00Z',
+      },
+      session_count: 1,
+    },
+  },
+]
+
+const EMPTY_AGGREGATE: AggregateUsage = {
+  totalInputTokens: 0,
+  totalOutputTokens: 0,
+  totalCacheReadTokens: 0,
+  totalCacheCreationTokens: 0,
+  totalCostUsd: 0,
+  totalTokens: 0,
+  cacheHitRatio: 0,
+}
+
+describe('CostOverviewChart', () => {
+  it('renders heading', () => {
+    render(<CostOverviewChart entries={ENTRIES} aggregate={AGGREGATE} />)
+    expect(screen.getByText('Cost per Agent')).toBeTruthy()
+  })
+
+  it('displays total cost', () => {
+    render(<CostOverviewChart entries={ENTRIES} aggregate={AGGREGATE} />)
+    expect(screen.getByText('$0.25')).toBeTruthy()
+  })
+
+  it('renders bar chart when data is present', () => {
+    render(<CostOverviewChart entries={ENTRIES} aggregate={AGGREGATE} />)
+    expect(screen.getByLabelText('Cost per agent bar chart')).toBeTruthy()
+  })
+
+  it('shows loading skeleton when loading=true', () => {
+    const { container } = render(
+      <CostOverviewChart entries={[]} aggregate={EMPTY_AGGREGATE} loading />,
+    )
+    expect(container.querySelector('.animate-pulse')).toBeTruthy()
+  })
+
+  it('shows empty message when no data', () => {
+    render(<CostOverviewChart entries={[]} aggregate={EMPTY_AGGREGATE} />)
+    expect(screen.getByText('No cost data available')).toBeTruthy()
+  })
+
+  it('shows agent count in footer', () => {
+    render(<CostOverviewChart entries={ENTRIES} aggregate={AGGREGATE} />)
+    expect(screen.getByText('2')).toBeTruthy()
+  })
+
+  it('has aria-label on outer container', () => {
+    render(<CostOverviewChart entries={ENTRIES} aggregate={AGGREGATE} />)
+    expect(screen.getByLabelText('Cost overview bar chart')).toBeTruthy()
+  })
+})

--- a/ui/src/test/components/monitoring/TokenUsageChart.test.tsx
+++ b/ui/src/test/components/monitoring/TokenUsageChart.test.tsx
@@ -1,0 +1,76 @@
+/**
+ * Tests for TokenUsageChart component.
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { TokenUsageChart } from '@/components/monitoring/TokenUsageChart'
+import type { AgentUsageEntry } from '@/hooks/useUsageMetrics'
+
+// Mock useNivoTheme to avoid ThemeProvider dependency in unit tests
+vi.mock('@/hooks/useNivoTheme', () => ({ useNivoTheme: () => ({}) }))
+
+// Mock Nivo charts
+vi.mock('@nivo/bar', () => ({
+  ResponsiveBar: ({ ariaLabel }: { ariaLabel: string }) => <div role="img" aria-label={ariaLabel} />,
+}))
+
+const ENTRIES: AgentUsageEntry[] = [
+  {
+    agentId: 'agent-1',
+    name: 'Test Agent',
+    stats: {
+      agent_id: 'agent-1',
+      cumulative: {
+        input_tokens: 1000,
+        output_tokens: 500,
+        cache_read_input_tokens: 200,
+        cache_creation_input_tokens: 100,
+        total_cost_usd: 0.05,
+        num_turns: 10,
+        duration_ms: 5000,
+        duration_api_ms: 3000,
+        result_count: 5,
+        started_at: '2024-01-01T00:00:00Z',
+      },
+      session_count: 2,
+    },
+  },
+]
+
+const EMPTY_ENTRIES: AgentUsageEntry[] = []
+
+describe('TokenUsageChart', () => {
+  it('renders heading', () => {
+    render(<TokenUsageChart entries={ENTRIES} />)
+    expect(screen.getByText('Token Usage by Agent')).toBeTruthy()
+  })
+
+  it('renders bar chart when data is present', () => {
+    render(<TokenUsageChart entries={ENTRIES} />)
+    expect(screen.getByLabelText('Stacked bar chart of token usage per agent')).toBeTruthy()
+  })
+
+  it('shows loading skeleton when loading=true', () => {
+    const { container } = render(<TokenUsageChart entries={[]} loading />)
+    expect(container.querySelector('.animate-pulse')).toBeTruthy()
+  })
+
+  it('shows empty message when no data', () => {
+    render(<TokenUsageChart entries={EMPTY_ENTRIES} />)
+    expect(screen.getByText('No usage data available')).toBeTruthy()
+  })
+
+  it('renders legend with all token types', () => {
+    render(<TokenUsageChart entries={ENTRIES} />)
+    expect(screen.getByText('Input Tokens')).toBeTruthy()
+    expect(screen.getByText('Output Tokens')).toBeTruthy()
+    expect(screen.getByText('Cache Read')).toBeTruthy()
+    expect(screen.getByText('Cache Creation')).toBeTruthy()
+  })
+
+  it('has aria-label on outer container', () => {
+    render(<TokenUsageChart entries={ENTRIES} />)
+    expect(screen.getAllByLabelText('Token usage stacked bar chart').length).toBeGreaterThanOrEqual(1)
+  })
+})


### PR DESCRIPTION
## Summary

- Add **TokenUsageChart** (stacked bar) showing per-agent breakdown of input, output, cache read, and cache creation tokens
- Add **CacheEfficiencyChart** (donut) showing aggregate cache hit ratio with per-agent dropdown toggle
- Add **CostOverviewChart** (bar) displaying cumulative cost per agent formatted as USD
- Add **useUsageMetrics** hook that fetches usage stats for all agents, computes aggregates (total cost, total tokens, cache hit ratio), and auto-refreshes on the dashboard interval
- Integrate all three charts into the monitoring dashboard in a new "Token Usage & Prompt Cache" section
- 22 new tests covering all three chart components (rendering, loading states, empty states, accessibility)

## Test plan

- [x] All 22 new component tests pass (`vitest run`)
- [x] All 37 existing monitoring tests still pass
- [ ] Verify charts render correctly with real agent data in light and dark mode
- [ ] Verify responsive layout: side-by-side on desktop, stacked on mobile
- [ ] Verify charts respect the dashboard refresh interval selector
- [ ] Verify cache efficiency dropdown switches between all-agents and per-agent views

Closes #269

🤖 Generated with [Claude Code](https://claude.com/claude-code)