### PR TITLE
Add real-time usage update events to WebSocket stream

### DIFF
--- a/ui/src/hooks/index.ts
+++ b/ui/src/hooks/index.ts
@@ -30,7 +30,14 @@ export { useAgentDetail } from './useAgentDetail'
 export type { UseAgentDetailOptions, UseAgentDetailResult } from './useAgentDetail'
 
 export { useAgentStream } from './useAgentStream'
-export type { StreamStatus, LogLine, UseAgentStreamResult } from './useAgentStream'
+export type {
+  StreamStatus,
+  LogLine,
+  UseAgentStreamResult,
+  UseAgentStreamOptions,
+  UsageUpdateCallback,
+  ContextClearedCallback,
+} from './useAgentStream'
 
 export { useApprovals } from './useApprovals'
 export type { UseApprovalsOptions, UseApprovalsResult } from './useApprovals'

--- a/ui/src/hooks/useAgentStream.ts
+++ b/ui/src/hooks/useAgentStream.ts
@@ -12,6 +12,8 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { WebSocketManager } from '@/services/websocket'
 import { serviceConfig } from '@/services/config'
+import { agentEventBus } from '@/services/eventBus'
+import type { AgentEvent, UsageUpdateEvent, ContextClearedEvent } from '@/types/orchestrator'
 
 // ---------------------------------------------------------------------------
 // Types
@@ -24,6 +26,19 @@ export interface LogLine {
   /** Raw text (may contain ANSI escape sequences) */
   text: string
   timestamp: string
+}
+
+/** Callback invoked when a real-time usage update event arrives */
+export type UsageUpdateCallback = (event: UsageUpdateEvent) => void
+
+/** Callback invoked when a context cleared event arrives */
+export type ContextClearedCallback = (event: ContextClearedEvent) => void
+
+export interface UseAgentStreamOptions {
+  /** Called when an agent:usage_update event arrives on the stream */
+  onUsageUpdate?: UsageUpdateCallback
+  /** Called when an agent:context_cleared event arrives on the stream */
+  onContextCleared?: ContextClearedCallback
 }
 
 export interface UseAgentStreamResult {
@@ -68,9 +83,19 @@ function agentStreamUrl(agentId: string): string {
 // Hook
 // ---------------------------------------------------------------------------
 
-export function useAgentStream(agentId: string): UseAgentStreamResult {
+export function useAgentStream(
+  agentId: string,
+  options: UseAgentStreamOptions = {},
+): UseAgentStreamResult {
   const [lines, setLines] = useState<LogLine[]>([])
   const [status, setStatus] = useState<StreamStatus>('connecting')
+
+  // Store callbacks in refs so the WebSocket effect doesn't re-run when
+  // callbacks change.
+  const onUsageUpdateRef = useRef(options.onUsageUpdate)
+  const onContextClearedRef = useRef(options.onContextCleared)
+  onUsageUpdateRef.current = options.onUsageUpdate
+  onContextClearedRef.current = options.onContextCleared
 
   const managerRef = useRef<WebSocketManager | null>(null)
 
@@ -98,6 +123,42 @@ export function useAgentStream(agentId: string): UseAgentStreamResult {
 
     const unsubMsg = manager.onMessage((event: MessageEvent) => {
       const rawText = String(event.data)
+
+      // Try to parse as JSON event first
+      let parsed: AgentEvent | null = null
+      try {
+        parsed = JSON.parse(rawText) as AgentEvent
+      } catch {
+        // Not JSON — treat as plain log output
+      }
+
+      if (parsed) {
+        // Emit to the global event bus so other hooks can react
+        agentEventBus.emit(parsed)
+
+        if (parsed.type === 'agent:usage_update') {
+          onUsageUpdateRef.current?.(parsed)
+          return
+        }
+
+        if (parsed.type === 'agent:context_cleared') {
+          onContextClearedRef.current?.(parsed)
+          return
+        }
+
+        // For agent:output events, extract the line text
+        if (parsed.type === 'agent:output') {
+          const incoming = [makeLogLine(parsed.line)]
+          setLines((prev) => capLines(prev, incoming))
+          return
+        }
+
+        // Other structured events are emitted to the bus but not added
+        // to the log buffer.
+        return
+      }
+
+      // Plain text fallback
       const incoming = rawText.split('\n').filter(Boolean).map(makeLogLine)
       setLines((prev) => capLines(prev, incoming))
     })

--- a/ui/src/hooks/useAgentUsage.ts
+++ b/ui/src/hooks/useAgentUsage.ts
@@ -3,6 +3,7 @@
  *
  * Provides:
  * - Usage data fetching with configurable auto-refresh
+ * - Real-time optimistic updates via agentEventBus (usage_update / context_cleared)
  * - Loading / error state
  * - clearContext action that triggers API call, then refreshes usage data
  * - Auto-pauses refresh when agent is stopped/failed
@@ -10,7 +11,13 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { orchestratorClient } from '@/services/orchestrator'
-import type { AgentUsageStats, ClearContextResponse } from '@/types/orchestrator'
+import { agentEventBus } from '@/services/eventBus'
+import type {
+  AgentUsageStats,
+  ClearContextResponse,
+  UsageUpdateEvent,
+  ContextClearedEvent,
+} from '@/types/orchestrator'
 
 // ---------------------------------------------------------------------------
 // Types
@@ -23,6 +30,83 @@ export interface UseAgentUsageReturn {
   refresh: () => void
   clearContext: () => Promise<ClearContextResponse>
   clearing: boolean
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Optimistically apply a UsageSnapshot delta to existing AgentUsageStats.
+ * The snapshot from the event represents a single turn's usage, so we add
+ * it to both the current session and cumulative totals.
+ */
+function applyUsageUpdate(
+  prev: AgentUsageStats,
+  event: UsageUpdateEvent,
+): AgentUsageStats {
+  const snapshot = event.usage
+  const currentSession = prev.current_session
+    ? {
+        ...prev.current_session,
+        input_tokens: prev.current_session.input_tokens + snapshot.input_tokens,
+        output_tokens: prev.current_session.output_tokens + snapshot.output_tokens,
+        cache_read_input_tokens:
+          prev.current_session.cache_read_input_tokens + snapshot.cache_read_input_tokens,
+        cache_creation_input_tokens:
+          prev.current_session.cache_creation_input_tokens +
+          snapshot.cache_creation_input_tokens,
+        total_cost_usd: prev.current_session.total_cost_usd + snapshot.total_cost_usd,
+        num_turns: prev.current_session.num_turns + snapshot.num_turns,
+        duration_ms: prev.current_session.duration_ms + snapshot.duration_ms,
+        duration_api_ms: prev.current_session.duration_api_ms + snapshot.duration_api_ms,
+        result_count: prev.current_session.result_count + 1,
+      }
+    : undefined
+
+  return {
+    ...prev,
+    current_session: currentSession,
+    cumulative: {
+      ...prev.cumulative,
+      input_tokens: prev.cumulative.input_tokens + snapshot.input_tokens,
+      output_tokens: prev.cumulative.output_tokens + snapshot.output_tokens,
+      cache_read_input_tokens:
+        prev.cumulative.cache_read_input_tokens + snapshot.cache_read_input_tokens,
+      cache_creation_input_tokens:
+        prev.cumulative.cache_creation_input_tokens + snapshot.cache_creation_input_tokens,
+      total_cost_usd: prev.cumulative.total_cost_usd + snapshot.total_cost_usd,
+      num_turns: prev.cumulative.num_turns + snapshot.num_turns,
+      duration_ms: prev.cumulative.duration_ms + snapshot.duration_ms,
+      duration_api_ms: prev.cumulative.duration_api_ms + snapshot.duration_api_ms,
+      result_count: prev.cumulative.result_count + 1,
+    },
+  }
+}
+
+/**
+ * Handle a context_cleared event: reset the current session and bump count.
+ */
+function applyContextCleared(
+  prev: AgentUsageStats,
+  event: ContextClearedEvent,
+): AgentUsageStats {
+  return {
+    ...prev,
+    current_session: {
+      input_tokens: 0,
+      output_tokens: 0,
+      cache_read_input_tokens: 0,
+      cache_creation_input_tokens: 0,
+      total_cost_usd: 0,
+      num_turns: 0,
+      duration_ms: 0,
+      duration_api_ms: 0,
+      result_count: 0,
+      started_at: event.timestamp,
+    },
+    session_count: prev.session_count + 1,
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -101,6 +185,33 @@ export function useAgentUsage(
 
     return () => clearInterval(timer)
   }, [autoRefreshMs, fetchUsage])
+
+  // ---------------------------------------------------------------------------
+  // Real-time event bus subscriptions
+  // ---------------------------------------------------------------------------
+
+  useEffect(() => {
+    const unsubUsage = agentEventBus.on<UsageUpdateEvent>(
+      'agent:usage_update',
+      (event) => {
+        if (event.agentId !== agentId || !mountedRef.current) return
+        setUsage((prev) => (prev ? applyUsageUpdate(prev, event) : prev))
+      },
+    )
+
+    const unsubCleared = agentEventBus.on<ContextClearedEvent>(
+      'agent:context_cleared',
+      (event) => {
+        if (event.agentId !== agentId || !mountedRef.current) return
+        setUsage((prev) => (prev ? applyContextCleared(prev, event) : prev))
+      },
+    )
+
+    return () => {
+      unsubUsage()
+      unsubCleared()
+    }
+  }, [agentId])
 
   // ---------------------------------------------------------------------------
   // Clear context action

--- a/ui/src/hooks/useAllAgentsStream.ts
+++ b/ui/src/hooks/useAllAgentsStream.ts
@@ -18,7 +18,7 @@ import { WebSocketManager } from '@/services/websocket'
 import { serviceConfig } from '@/services/config'
 import { agentEventBus } from '@/services/eventBus'
 import type { ConnectionState } from '@/services/websocket'
-import type { AgentEvent } from '@/types/orchestrator'
+import type { AgentEvent, UsageUpdateEvent, ContextClearedEvent } from '@/types/orchestrator'
 import type { LogLine } from './useAgentStream'
 
 // ---------------------------------------------------------------------------
@@ -66,6 +66,10 @@ export interface UseAllAgentsStreamResult {
   /** Map of agentId → buffered log lines from the /stream endpoint */
   agentMessages: Map<string, LogLine[]>
   connectionState: ConnectionState
+  /** Map of agentId → latest usage snapshot from real-time events */
+  usageUpdates: Map<string, import('@/types/orchestrator').UsageUpdateEvent>
+  /** Map of agentId → latest context-cleared event */
+  contextClears: Map<string, import('@/types/orchestrator').ContextClearedEvent>
 }
 
 // ---------------------------------------------------------------------------
@@ -75,6 +79,8 @@ export interface UseAllAgentsStreamResult {
 export function useAllAgentsStream(): UseAllAgentsStreamResult {
   const [agentMessages, setAgentMessages] = useState<Map<string, LogLine[]>>(new Map())
   const [connectionState, setConnectionState] = useState<ConnectionState>('Disconnected')
+  const [usageUpdates, setUsageUpdates] = useState<Map<string, UsageUpdateEvent>>(new Map())
+  const [contextClears, setContextClears] = useState<Map<string, ContextClearedEvent>>(new Map())
 
   const managerRef = useRef<WebSocketManager | null>(null)
 
@@ -103,6 +109,26 @@ export function useAllAgentsStream(): UseAllAgentsStreamResult {
       if (parsed.type === 'agent:output') {
         setAgentMessages((prev) => addLine(prev, parsed.agentId, makeLine(parsed.line)))
       }
+
+      // Track latest usage update per agent
+      if (parsed.type === 'agent:usage_update') {
+        const evt = parsed as UsageUpdateEvent
+        setUsageUpdates((prev) => {
+          const next = new Map(prev)
+          next.set(evt.agentId, evt)
+          return next
+        })
+      }
+
+      // Track context cleared events per agent
+      if (parsed.type === 'agent:context_cleared') {
+        const evt = parsed as ContextClearedEvent
+        setContextClears((prev) => {
+          const next = new Map(prev)
+          next.set(evt.agentId, evt)
+          return next
+        })
+      }
     })
 
     manager.connect()
@@ -115,5 +141,5 @@ export function useAllAgentsStream(): UseAllAgentsStreamResult {
     }
   }, [])
 
-  return { agentMessages, connectionState }
+  return { agentMessages, connectionState, usageUpdates, contextClears }
 }

--- a/ui/src/hooks/useUsageMetrics.ts
+++ b/ui/src/hooks/useUsageMetrics.ts
@@ -8,11 +8,18 @@
  * - Aggregate totals: total cost, total tokens, cache hit ratio
  * - Auto-refresh on a configurable interval (same options as useMetrics)
  * - Pauses when the tab is hidden
+ * - Real-time updates from WebSocket events (debounced to avoid excessive re-renders)
  */
 
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { orchestratorClient } from '@/services/orchestrator'
-import type { Agent, AgentUsageStats } from '@/types/orchestrator'
+import { agentEventBus } from '@/services/eventBus'
+import type {
+  Agent,
+  AgentUsageStats,
+  UsageUpdateEvent,
+  ContextClearedEvent,
+} from '@/types/orchestrator'
 import type { RefreshInterval } from './useMetrics'
 
 // ---------------------------------------------------------------------------
@@ -66,11 +73,14 @@ const EMPTY_AGGREGATE: AggregateUsage = {
   cacheHitRatio: 0,
 }
 
+/** Debounce window for real-time event updates (ms) */
+const REALTIME_DEBOUNCE_MS = 2_000
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
-function computeAggregate(entries: AgentUsageEntry[]): AggregateUsage {
+export function computeAggregate(entries: AgentUsageEntry[]): AggregateUsage {
   let totalInputTokens = 0
   let totalOutputTokens = 0
   let totalCacheReadTokens = 0
@@ -104,6 +114,71 @@ function computeAggregate(entries: AgentUsageEntry[]): AggregateUsage {
   }
 }
 
+/**
+ * Apply a usage update event to an entries array, returning new entries + aggregate.
+ */
+function applyUsageEventToEntries(
+  entries: AgentUsageEntry[],
+  event: UsageUpdateEvent,
+): AgentUsageEntry[] {
+  return entries.map((entry) => {
+    if (entry.agentId !== event.agentId) return entry
+    const snapshot = event.usage
+    return {
+      ...entry,
+      stats: {
+        ...entry.stats,
+        cumulative: {
+          ...entry.stats.cumulative,
+          input_tokens: entry.stats.cumulative.input_tokens + snapshot.input_tokens,
+          output_tokens: entry.stats.cumulative.output_tokens + snapshot.output_tokens,
+          cache_read_input_tokens:
+            entry.stats.cumulative.cache_read_input_tokens + snapshot.cache_read_input_tokens,
+          cache_creation_input_tokens:
+            entry.stats.cumulative.cache_creation_input_tokens +
+            snapshot.cache_creation_input_tokens,
+          total_cost_usd: entry.stats.cumulative.total_cost_usd + snapshot.total_cost_usd,
+          num_turns: entry.stats.cumulative.num_turns + snapshot.num_turns,
+          duration_ms: entry.stats.cumulative.duration_ms + snapshot.duration_ms,
+          duration_api_ms: entry.stats.cumulative.duration_api_ms + snapshot.duration_api_ms,
+          result_count: entry.stats.cumulative.result_count + 1,
+        },
+      },
+    }
+  })
+}
+
+/**
+ * Apply a context cleared event: reset current session, bump session count.
+ */
+function applyContextClearToEntries(
+  entries: AgentUsageEntry[],
+  event: ContextClearedEvent,
+): AgentUsageEntry[] {
+  return entries.map((entry) => {
+    if (entry.agentId !== event.agentId) return entry
+    return {
+      ...entry,
+      stats: {
+        ...entry.stats,
+        current_session: {
+          input_tokens: 0,
+          output_tokens: 0,
+          cache_read_input_tokens: 0,
+          cache_creation_input_tokens: 0,
+          total_cost_usd: 0,
+          num_turns: 0,
+          duration_ms: 0,
+          duration_api_ms: 0,
+          result_count: 0,
+          started_at: event.timestamp,
+        },
+        session_count: entry.stats.session_count + 1,
+      },
+    }
+  })
+}
+
 // ---------------------------------------------------------------------------
 // Hook
 // ---------------------------------------------------------------------------
@@ -116,12 +191,29 @@ export function useUsageMetrics(refreshInterval: RefreshInterval = 30_000): UseU
 
   const timerRef = useRef<ReturnType<typeof setInterval> | null>(null)
   const mountedRef = useRef(true)
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  // Keep a mutable ref to entries so event handlers can read without stale closures
+  const entriesRef = useRef(entries)
+  entriesRef.current = entries
 
   useEffect(() => {
     mountedRef.current = true
     return () => {
       mountedRef.current = false
     }
+  }, [])
+
+  // Debounced commit: batches rapid event updates into a single state change
+  const scheduleCommit = useCallback((updatedEntries: AgentUsageEntry[]) => {
+    entriesRef.current = updatedEntries
+    if (debounceRef.current) clearTimeout(debounceRef.current)
+    debounceRef.current = setTimeout(() => {
+      if (!mountedRef.current) return
+      setEntries(entriesRef.current)
+      setAggregate(computeAggregate(entriesRef.current))
+      debounceRef.current = null
+    }, REALTIME_DEBOUNCE_MS)
   }, [])
 
   const fetchAll = useCallback(async () => {
@@ -149,6 +241,7 @@ export function useUsageMetrics(refreshInterval: RefreshInterval = 30_000): UseU
       }
 
       if (mountedRef.current) {
+        entriesRef.current = newEntries
         setEntries(newEntries)
         setAggregate(computeAggregate(newEntries))
         setError(undefined)
@@ -193,6 +286,36 @@ export function useUsageMetrics(refreshInterval: RefreshInterval = 30_000): UseU
       document.removeEventListener('visibilitychange', handleVisibility)
     }
   }, [refreshInterval, fetchAll])
+
+  // ---------------------------------------------------------------------------
+  // Real-time event bus subscriptions (debounced)
+  // ---------------------------------------------------------------------------
+
+  useEffect(() => {
+    const unsubUsage = agentEventBus.on<UsageUpdateEvent>(
+      'agent:usage_update',
+      (event) => {
+        if (!mountedRef.current) return
+        const updated = applyUsageEventToEntries(entriesRef.current, event)
+        scheduleCommit(updated)
+      },
+    )
+
+    const unsubCleared = agentEventBus.on<ContextClearedEvent>(
+      'agent:context_cleared',
+      (event) => {
+        if (!mountedRef.current) return
+        const updated = applyContextClearToEntries(entriesRef.current, event)
+        scheduleCommit(updated)
+      },
+    )
+
+    return () => {
+      unsubUsage()
+      unsubCleared()
+      if (debounceRef.current) clearTimeout(debounceRef.current)
+    }
+  }, [scheduleCommit])
 
   return {
     entries,

--- a/ui/src/test/hooks/useAgentUsage.test.ts
+++ b/ui/src/test/hooks/useAgentUsage.test.ts
@@ -1,0 +1,187 @@
+/**
+ * Tests for useAgentUsage hook — real-time event bus integration.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act, waitFor } from '@testing-library/react'
+import { useAgentUsage } from '@/hooks/useAgentUsage'
+import { agentEventBus } from '@/services/eventBus'
+import type { UsageUpdateEvent, ContextClearedEvent } from '@/types/orchestrator'
+
+// ---------------------------------------------------------------------------
+// Mock orchestratorClient
+// ---------------------------------------------------------------------------
+
+vi.mock('@/services/orchestrator', () => ({
+  orchestratorClient: {
+    getAgentUsage: vi.fn().mockResolvedValue({
+      agent_id: 'agent-1',
+      current_session: {
+        input_tokens: 100,
+        output_tokens: 50,
+        cache_read_input_tokens: 20,
+        cache_creation_input_tokens: 10,
+        total_cost_usd: 0.01,
+        num_turns: 2,
+        duration_ms: 1000,
+        duration_api_ms: 800,
+        result_count: 2,
+        started_at: '2024-01-01T00:00:00Z',
+      },
+      cumulative: {
+        input_tokens: 200,
+        output_tokens: 100,
+        cache_read_input_tokens: 40,
+        cache_creation_input_tokens: 20,
+        total_cost_usd: 0.02,
+        num_turns: 4,
+        duration_ms: 2000,
+        duration_api_ms: 1600,
+        result_count: 4,
+        started_at: '2024-01-01T00:00:00Z',
+      },
+      session_count: 1,
+    }),
+    clearContext: vi.fn().mockResolvedValue({
+      agent_id: 'agent-1',
+      new_session_number: 2,
+    }),
+  },
+}))
+
+beforeEach(() => {
+  vi.useFakeTimers()
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('useAgentUsage real-time events', () => {
+  it('loads initial usage data from API', async () => {
+    vi.useRealTimers()
+    const { result } = renderHook(() => useAgentUsage('agent-1', 0))
+
+    await waitFor(() => {
+      expect(result.current.usage).not.toBeNull()
+    })
+
+    expect(result.current.usage?.cumulative.input_tokens).toBe(200)
+    expect(result.current.loading).toBe(false)
+  })
+
+  it('optimistically updates usage on agent:usage_update event', async () => {
+    vi.useRealTimers()
+    const { result } = renderHook(() => useAgentUsage('agent-1', 0))
+
+    await waitFor(() => {
+      expect(result.current.usage).not.toBeNull()
+    })
+
+    const prevInput = result.current.usage!.cumulative.input_tokens
+
+    act(() => {
+      agentEventBus.emit<UsageUpdateEvent>({
+        type: 'agent:usage_update',
+        agentId: 'agent-1',
+        session_number: 1,
+        usage: {
+          input_tokens: 50,
+          output_tokens: 25,
+          cache_read_input_tokens: 10,
+          cache_creation_input_tokens: 5,
+          total_cost_usd: 0.005,
+          num_turns: 1,
+          duration_ms: 500,
+          duration_api_ms: 400,
+        },
+        timestamp: new Date().toISOString(),
+      })
+    })
+
+    expect(result.current.usage!.cumulative.input_tokens).toBe(prevInput + 50)
+    expect(result.current.usage!.cumulative.output_tokens).toBe(125)
+    expect(result.current.usage!.cumulative.result_count).toBe(5)
+  })
+
+  it('ignores usage_update events for other agents', async () => {
+    vi.useRealTimers()
+    const { result } = renderHook(() => useAgentUsage('agent-1', 0))
+
+    await waitFor(() => {
+      expect(result.current.usage).not.toBeNull()
+    })
+
+    const prevInput = result.current.usage!.cumulative.input_tokens
+
+    act(() => {
+      agentEventBus.emit<UsageUpdateEvent>({
+        type: 'agent:usage_update',
+        agentId: 'agent-OTHER',
+        session_number: 1,
+        usage: {
+          input_tokens: 999,
+          output_tokens: 0,
+          cache_read_input_tokens: 0,
+          cache_creation_input_tokens: 0,
+          total_cost_usd: 0,
+          num_turns: 1,
+          duration_ms: 0,
+          duration_api_ms: 0,
+        },
+        timestamp: new Date().toISOString(),
+      })
+    })
+
+    expect(result.current.usage!.cumulative.input_tokens).toBe(prevInput)
+  })
+
+  it('resets current session on context_cleared event', async () => {
+    vi.useRealTimers()
+    const { result } = renderHook(() => useAgentUsage('agent-1', 0))
+
+    await waitFor(() => {
+      expect(result.current.usage).not.toBeNull()
+    })
+
+    const prevSessionCount = result.current.usage!.session_count
+
+    act(() => {
+      agentEventBus.emit<ContextClearedEvent>({
+        type: 'agent:context_cleared',
+        agentId: 'agent-1',
+        new_session_number: 2,
+        timestamp: '2024-06-01T12:00:00Z',
+      })
+    })
+
+    expect(result.current.usage!.current_session?.input_tokens).toBe(0)
+    expect(result.current.usage!.current_session?.output_tokens).toBe(0)
+    expect(result.current.usage!.current_session?.started_at).toBe('2024-06-01T12:00:00Z')
+    expect(result.current.usage!.session_count).toBe(prevSessionCount + 1)
+    // Cumulative should be unchanged
+    expect(result.current.usage!.cumulative.input_tokens).toBe(200)
+  })
+
+  it('ignores context_cleared events for other agents', async () => {
+    vi.useRealTimers()
+    const { result } = renderHook(() => useAgentUsage('agent-1', 0))
+
+    await waitFor(() => {
+      expect(result.current.usage).not.toBeNull()
+    })
+
+    const prevSessionCount = result.current.usage!.session_count
+
+    act(() => {
+      agentEventBus.emit<ContextClearedEvent>({
+        type: 'agent:context_cleared',
+        agentId: 'agent-OTHER',
+        new_session_number: 5,
+        timestamp: new Date().toISOString(),
+      })
+    })
+
+    expect(result.current.usage!.session_count).toBe(prevSessionCount)
+  })
+})

--- a/ui/src/test/hooks/useAllAgentsStreamEvents.test.ts
+++ b/ui/src/test/hooks/useAllAgentsStreamEvents.test.ts
@@ -1,0 +1,181 @@
+/**
+ * Tests for useAllAgentsStream — usage_update and context_cleared event handling.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act, waitFor } from '@testing-library/react'
+import { useAllAgentsStream } from '@/hooks/useAllAgentsStream'
+import { MockWebSocket, installMockWebSocket } from '@/test/mocks/mockWebSocket'
+import { agentEventBus } from '@/services/eventBus'
+import type { UsageUpdateEvent, ContextClearedEvent } from '@/types/orchestrator'
+
+let lastWs: MockWebSocket | undefined
+let cleanup: () => void
+
+beforeEach(() => {
+  lastWs = undefined
+  cleanup = installMockWebSocket((ws) => {
+    lastWs = ws
+  })
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+  cleanup()
+})
+
+describe('useAllAgentsStream usage events', () => {
+  it('tracks usage_update events in usageUpdates map', async () => {
+    const { result } = renderHook(() => useAllAgentsStream())
+    await waitFor(() => expect(lastWs).toBeDefined())
+    await act(async () => {
+      lastWs!.simulateOpen()
+    })
+
+    await act(async () => {
+      lastWs!.simulateMessage(
+        JSON.stringify({
+          type: 'agent:usage_update',
+          agentId: 'agent-abc',
+          session_number: 1,
+          usage: {
+            input_tokens: 100,
+            output_tokens: 50,
+            cache_read_input_tokens: 10,
+            cache_creation_input_tokens: 5,
+            total_cost_usd: 0.01,
+            num_turns: 1,
+            duration_ms: 500,
+            duration_api_ms: 400,
+          },
+          timestamp: '2024-01-01T00:00:00Z',
+        }),
+      )
+    })
+
+    expect(result.current.usageUpdates.get('agent-abc')).toBeDefined()
+    expect(result.current.usageUpdates.get('agent-abc')!.usage.input_tokens).toBe(100)
+  })
+
+  it('tracks context_cleared events in contextClears map', async () => {
+    const { result } = renderHook(() => useAllAgentsStream())
+    await waitFor(() => expect(lastWs).toBeDefined())
+    await act(async () => {
+      lastWs!.simulateOpen()
+    })
+
+    await act(async () => {
+      lastWs!.simulateMessage(
+        JSON.stringify({
+          type: 'agent:context_cleared',
+          agentId: 'agent-xyz',
+          new_session_number: 3,
+          timestamp: '2024-01-01T12:00:00Z',
+        }),
+      )
+    })
+
+    expect(result.current.contextClears.get('agent-xyz')).toBeDefined()
+    expect(result.current.contextClears.get('agent-xyz')!.new_session_number).toBe(3)
+  })
+
+  it('emits usage_update events to the agentEventBus', async () => {
+    const received: UsageUpdateEvent[] = []
+    const unsub = agentEventBus.on<UsageUpdateEvent>('agent:usage_update', (event) => {
+      received.push(event)
+    })
+
+    renderHook(() => useAllAgentsStream())
+    await waitFor(() => expect(lastWs).toBeDefined())
+    await act(async () => {
+      lastWs!.simulateOpen()
+    })
+
+    await act(async () => {
+      lastWs!.simulateMessage(
+        JSON.stringify({
+          type: 'agent:usage_update',
+          agentId: 'agent-bus',
+          session_number: 1,
+          usage: {
+            input_tokens: 10,
+            output_tokens: 5,
+            cache_read_input_tokens: 0,
+            cache_creation_input_tokens: 0,
+            total_cost_usd: 0.001,
+            num_turns: 1,
+            duration_ms: 100,
+            duration_api_ms: 80,
+          },
+          timestamp: new Date().toISOString(),
+        }),
+      )
+    })
+
+    expect(received).toHaveLength(1)
+    expect(received[0].agentId).toBe('agent-bus')
+    unsub()
+  })
+
+  it('emits context_cleared events to the agentEventBus', async () => {
+    const received: ContextClearedEvent[] = []
+    const unsub = agentEventBus.on<ContextClearedEvent>('agent:context_cleared', (event) => {
+      received.push(event)
+    })
+
+    renderHook(() => useAllAgentsStream())
+    await waitFor(() => expect(lastWs).toBeDefined())
+    await act(async () => {
+      lastWs!.simulateOpen()
+    })
+
+    await act(async () => {
+      lastWs!.simulateMessage(
+        JSON.stringify({
+          type: 'agent:context_cleared',
+          agentId: 'agent-cleared',
+          new_session_number: 2,
+          timestamp: new Date().toISOString(),
+        }),
+      )
+    })
+
+    expect(received).toHaveLength(1)
+    expect(received[0].agentId).toBe('agent-cleared')
+    unsub()
+  })
+
+  it('replaces previous usage_update for same agent with latest', async () => {
+    const { result } = renderHook(() => useAllAgentsStream())
+    await waitFor(() => expect(lastWs).toBeDefined())
+    await act(async () => {
+      lastWs!.simulateOpen()
+    })
+
+    const makeUsageEvent = (tokens: number) =>
+      JSON.stringify({
+        type: 'agent:usage_update',
+        agentId: 'agent-same',
+        session_number: 1,
+        usage: {
+          input_tokens: tokens,
+          output_tokens: 0,
+          cache_read_input_tokens: 0,
+          cache_creation_input_tokens: 0,
+          total_cost_usd: 0,
+          num_turns: 1,
+          duration_ms: 0,
+          duration_api_ms: 0,
+        },
+        timestamp: new Date().toISOString(),
+      })
+
+    await act(async () => {
+      lastWs!.simulateMessage(makeUsageEvent(100))
+      lastWs!.simulateMessage(makeUsageEvent(200))
+    })
+
+    // Should have the latest value
+    expect(result.current.usageUpdates.get('agent-same')!.usage.input_tokens).toBe(200)
+  })
+})

--- a/ui/src/types/orchestrator.ts
+++ b/ui/src/types/orchestrator.ts
@@ -320,6 +320,16 @@ export interface UsageUpdateEvent {
   type: 'agent:usage_update'
   agentId: string
   usage: UsageSnapshot
+  session_number: number
+  timestamp: string
+}
+
+/** Agent context was cleared and a new session started */
+export interface ContextClearedEvent {
+  type: 'agent:context_cleared'
+  agentId: string
+  new_session_number: number
+  previous_session_usage?: SessionUsage
   timestamp: string
 }
 
@@ -332,6 +342,7 @@ export type AgentEvent =
   | WorkflowTaskDispatchedEvent
   | WorkflowTaskCompletedEvent
   | UsageUpdateEvent
+  | ContextClearedEvent
 
 // ---------------------------------------------------------------------------
 // Query params


### PR DESCRIPTION
## Summary

- Add **ContextClearedEvent** type and `session_number` field to **UsageUpdateEvent** in the `AgentEvent` union
- **useAgentStream**: parse incoming JSON events, emit to event bus, and invoke optional `onUsageUpdate`/`onContextCleared` callbacks
- **useAllAgentsStream**: track `usageUpdates` and `contextClears` maps per agent for global monitoring
- **useAgentUsage**: subscribe to `agentEventBus` for optimistic real-time updates — usage deltas applied immediately, context cleared resets current session
- **useUsageMetrics**: consume real-time events with a 2-second debounce window to avoid excessive chart re-renders

## Test plan

- [x] All 10 new tests pass (useAgentUsage real-time events + useAllAgentsStream usage events)
- [x] All 196 existing tests across 22 test files still pass
- [ ] Verify usage panel updates in real-time when an agent completes a turn
- [ ] Verify context cleared event resets the current session display
- [ ] Verify monitoring dashboard charts update with debounced batching

Closes #270

🤖 Generated with [Claude Code](https://claude.com/claude-code)