### PR TITLE
feat(ui): add usage cost indicators to agent list and dashboard summary

### DIFF
--- a/ui/src/components/agents/AgentTable.tsx
+++ b/ui/src/components/agents/AgentTable.tsx
@@ -15,7 +15,7 @@ import { ArrowUpDown, ChevronDown, ChevronUp, Eye, Trash2 } from 'lucide-react'
 import { AgentStatusBadge } from './AgentStatusBadge'
 import { ConfirmDialog } from '@/components/common/ConfirmDialog'
 import { ListItemSkeleton } from '@/components/common/LoadingSkeleton'
-import type { Agent } from '@/types/orchestrator'
+import type { Agent, AgentUsageStats } from '@/types/orchestrator'
 import type { SortDir, SortField } from '@/hooks/useAgents'
 
 // ---------------------------------------------------------------------------
@@ -32,6 +32,8 @@ export interface AgentTableProps {
   onBulkDelete: (ids: string[]) => Promise<void>
   selectedIds: string[]
   onSelectChange: (ids: string[]) => void
+  /** Per-agent usage stats keyed by agent ID */
+  usageMap?: Map<string, AgentUsageStats>
 }
 
 // ---------------------------------------------------------------------------
@@ -76,7 +78,7 @@ function SortHeader({ field, label, currentSort, currentDir, onSort }: SortHeade
 function EmptyState() {
   return (
     <tr>
-      <td colSpan={7} className="py-12 text-center">
+      <td colSpan={10} className="py-12 text-center">
         <p className="text-sm text-gray-500 dark:text-gray-400">No agents found.</p>
         <p className="mt-1 text-xs text-gray-400 dark:text-gray-500">
           Create your first agent using the button above.
@@ -90,14 +92,45 @@ function EmptyState() {
 // Row
 // ---------------------------------------------------------------------------
 
+// ---------------------------------------------------------------------------
+// Formatting helpers
+// ---------------------------------------------------------------------------
+
+/** Format a USD cost value for display */
+function formatCost(usd: number): string {
+  if (usd < 0.01) return '<$0.01'
+  return `$${usd.toFixed(2)}`
+}
+
+/** Format a token count compactly (e.g. 1.2k, 3.4M) */
+function formatTokens(count: number): string {
+  if (count >= 1_000_000) return `${(count / 1_000_000).toFixed(1)}M`
+  if (count >= 1_000) return `${(count / 1_000).toFixed(1)}k`
+  return String(count)
+}
+
+/** Compute cache hit ratio as a percentage string */
+function formatCacheHit(stats: AgentUsageStats): string {
+  const c = stats.cumulative
+  const total = c.cache_read_input_tokens + c.cache_creation_input_tokens + c.input_tokens
+  if (total === 0) return '—'
+  const ratio = c.cache_read_input_tokens / total
+  return `${(ratio * 100).toFixed(0)}%`
+}
+
+// ---------------------------------------------------------------------------
+// Row
+// ---------------------------------------------------------------------------
+
 interface AgentRowProps {
   agent: Agent
   selected: boolean
   onSelect: (id: string, checked: boolean) => void
   onDelete: (id: string) => void
+  usage?: AgentUsageStats
 }
 
-function AgentRow({ agent, selected, onSelect, onDelete }: AgentRowProps) {
+function AgentRow({ agent, selected, onSelect, onDelete, usage }: AgentRowProps) {
   const navigate = useNavigate()
 
   const formattedDate = new Date(agent.created_at).toLocaleDateString(undefined, {
@@ -108,6 +141,8 @@ function AgentRow({ agent, selected, onSelect, onDelete }: AgentRowProps) {
 
   const workingDir = agent.config.working_dir
   const displayDir = workingDir.length > 30 ? `…${workingDir.slice(-29)}` : workingDir
+
+  const dash = <span className="text-gray-300 dark:text-gray-600">—</span>
 
   return (
     <tr
@@ -143,6 +178,21 @@ function AgentRow({ agent, selected, onSelect, onDelete }: AgentRowProps) {
       {/* Model */}
       <td className="px-4 py-3 text-sm text-gray-500 dark:text-gray-400">
         {agent.config.model ?? <span className="italic opacity-50">default</span>}
+      </td>
+
+      {/* Cost */}
+      <td className="hidden px-4 py-3 text-sm text-gray-500 dark:text-gray-400 whitespace-nowrap lg:table-cell">
+        {usage ? formatCost(usage.cumulative.total_cost_usd) : dash}
+      </td>
+
+      {/* Tokens */}
+      <td className="hidden px-4 py-3 text-sm text-gray-500 dark:text-gray-400 whitespace-nowrap lg:table-cell">
+        {usage ? formatTokens(usage.cumulative.input_tokens + usage.cumulative.output_tokens) : dash}
+      </td>
+
+      {/* Cache Hit */}
+      <td className="hidden px-4 py-3 text-sm text-gray-500 dark:text-gray-400 whitespace-nowrap xl:table-cell">
+        {usage ? formatCacheHit(usage) : dash}
       </td>
 
       {/* Working Directory */}
@@ -194,6 +244,7 @@ export function AgentTable({
   onBulkDelete,
   selectedIds,
   onSelectChange,
+  usageMap,
 }: AgentTableProps) {
   const [deleteTarget, setDeleteTarget] = useState<string | null>(null)
   const [bulkDeletePending, setBulkDeletePending] = useState(false)
@@ -303,6 +354,33 @@ export function AgentTable({
               <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400">
                 Model
               </th>
+              <th className="hidden px-4 py-3 text-left text-xs text-gray-500 dark:text-gray-400 lg:table-cell">
+                <SortHeader
+                  field="cost"
+                  label="Cost"
+                  currentSort={sortBy}
+                  currentDir={sortDir}
+                  onSort={onSort}
+                />
+              </th>
+              <th className="hidden px-4 py-3 text-left text-xs text-gray-500 dark:text-gray-400 lg:table-cell">
+                <SortHeader
+                  field="tokens"
+                  label="Tokens"
+                  currentSort={sortBy}
+                  currentDir={sortDir}
+                  onSort={onSort}
+                />
+              </th>
+              <th className="hidden px-4 py-3 text-left text-xs text-gray-500 dark:text-gray-400 xl:table-cell">
+                <SortHeader
+                  field="cache"
+                  label="Cache Hit"
+                  currentSort={sortBy}
+                  currentDir={sortDir}
+                  onSort={onSort}
+                />
+              </th>
               <th className="px-4 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-400">
                 Working Directory
               </th>
@@ -324,7 +402,7 @@ export function AgentTable({
           <tbody className="divide-y divide-gray-100 bg-white dark:divide-gray-700 dark:bg-gray-900">
             {loading ? (
               <tr>
-                <td colSpan={7} className="p-4">
+                <td colSpan={10} className="p-4">
                   <ListItemSkeleton rows={5} />
                 </td>
               </tr>
@@ -338,6 +416,7 @@ export function AgentTable({
                   selected={selectedIds.includes(agent.id)}
                   onSelect={toggleOne}
                   onDelete={(id) => setDeleteTarget(id)}
+                  usage={usageMap?.get(agent.id)}
                 />
               ))
             )}

--- a/ui/src/components/dashboard/AgentSummary.tsx
+++ b/ui/src/components/dashboard/AgentSummary.tsx
@@ -5,7 +5,7 @@
 
 import { useNavigate } from 'react-router-dom'
 import { ResponsivePie } from '@nivo/pie'
-import { Plus, RefreshCw } from 'lucide-react'
+import { DollarSign, Hash, Layers, Plus, RefreshCw } from 'lucide-react'
 import { StatusBadge } from '@/components/common/StatusBadge'
 import { ChartSkeleton, ListItemSkeleton } from '@/components/common/LoadingSkeleton'
 import type { UseAgentSummaryResult } from '@/hooks/useAgentSummary'
@@ -60,6 +60,7 @@ export function AgentSummary({
   counts,
   recentAgents,
   total,
+  aggregateUsage,
   loading,
   error,
   onCreateAgent,
@@ -176,6 +177,45 @@ export function AgentSummary({
                   </span>
                 ) : null,
               )}
+            </div>
+          )}
+
+          {/* Aggregate usage stats */}
+          {aggregateUsage && (
+            <div className="mt-3 grid grid-cols-3 gap-2" data-testid="aggregate-usage">
+              <div className="rounded-md bg-gray-50 px-3 py-2 dark:bg-gray-700/50">
+                <div className="flex items-center gap-1 text-xs text-gray-400 dark:text-gray-500">
+                  <DollarSign size={12} />
+                  Total Cost
+                </div>
+                <p className="mt-0.5 text-sm font-semibold text-gray-900 dark:text-white">
+                  ${aggregateUsage.totalCostUsd < 0.01 && aggregateUsage.totalCostUsd > 0
+                    ? '<0.01'
+                    : aggregateUsage.totalCostUsd.toFixed(2)}
+                </p>
+              </div>
+              <div className="rounded-md bg-gray-50 px-3 py-2 dark:bg-gray-700/50">
+                <div className="flex items-center gap-1 text-xs text-gray-400 dark:text-gray-500">
+                  <Hash size={12} />
+                  Tokens
+                </div>
+                <p className="mt-0.5 text-sm font-semibold text-gray-900 dark:text-white">
+                  {aggregateUsage.totalTokens >= 1_000_000
+                    ? `${(aggregateUsage.totalTokens / 1_000_000).toFixed(1)}M`
+                    : aggregateUsage.totalTokens >= 1_000
+                      ? `${(aggregateUsage.totalTokens / 1_000).toFixed(1)}k`
+                      : aggregateUsage.totalTokens}
+                </p>
+              </div>
+              <div className="rounded-md bg-gray-50 px-3 py-2 dark:bg-gray-700/50">
+                <div className="flex items-center gap-1 text-xs text-gray-400 dark:text-gray-500">
+                  <Layers size={12} />
+                  Cache Hit
+                </div>
+                <p className="mt-0.5 text-sm font-semibold text-gray-900 dark:text-white">
+                  {aggregateUsage.cacheHitPercent.toFixed(0)}%
+                </p>
+              </div>
             </div>
           )}
 

--- a/ui/src/hooks/index.ts
+++ b/ui/src/hooks/index.ts
@@ -2,7 +2,7 @@ export { useServiceHealth } from './useServiceHealth'
 export type { ServiceHealth, UseServiceHealthResult } from './useServiceHealth'
 
 export { useAgentSummary } from './useAgentSummary'
-export type { AgentStatusCounts, UseAgentSummaryResult } from './useAgentSummary'
+export type { AgentStatusCounts, AggregateUsageSummary, UseAgentSummaryResult } from './useAgentSummary'
 
 export { useNotificationSummary } from './useNotificationSummary'
 export type {

--- a/ui/src/hooks/useAgentSummary.ts
+++ b/ui/src/hooks/useAgentSummary.ts
@@ -5,7 +5,7 @@
 
 import { useCallback, useEffect, useState } from 'react'
 import { orchestratorClient } from '@/services/orchestrator'
-import type { Agent, AgentStatus } from '@/types/orchestrator'
+import type { Agent, AgentStatus, AgentUsageStats } from '@/types/orchestrator'
 
 export interface AgentStatusCounts {
   Running: number
@@ -14,20 +14,52 @@ export interface AgentStatusCounts {
   Failed: number
 }
 
+/** Aggregate usage stats across all agents */
+export interface AggregateUsageSummary {
+  totalCostUsd: number
+  totalTokens: number
+  cacheHitPercent: number
+}
+
 export interface UseAgentSummaryResult {
   counts: AgentStatusCounts
   recentAgents: Agent[]
   total: number
+  /** Aggregate usage stats (null while loading or on error) */
+  aggregateUsage: AggregateUsageSummary | null
   loading: boolean
   error?: string
 }
 
 const EMPTY_COUNTS: AgentStatusCounts = { Running: 0, Pending: 0, Stopped: 0, Failed: 0 }
 
+function computeAggregateUsage(usageList: AgentUsageStats[]): AggregateUsageSummary {
+  let totalCostUsd = 0
+  let totalTokens = 0
+  let totalCacheRead = 0
+  let totalCacheCreation = 0
+  let totalInput = 0
+
+  for (const stats of usageList) {
+    const c = stats.cumulative
+    totalCostUsd += c.total_cost_usd
+    totalTokens += c.input_tokens + c.output_tokens
+    totalCacheRead += c.cache_read_input_tokens
+    totalCacheCreation += c.cache_creation_input_tokens
+    totalInput += c.input_tokens
+  }
+
+  const cacheTotal = totalCacheRead + totalCacheCreation + totalInput
+  const cacheHitPercent = cacheTotal > 0 ? (totalCacheRead / cacheTotal) * 100 : 0
+
+  return { totalCostUsd, totalTokens, cacheHitPercent }
+}
+
 export function useAgentSummary(): UseAgentSummaryResult {
   const [counts, setCounts] = useState<AgentStatusCounts>(EMPTY_COUNTS)
   const [recentAgents, setRecentAgents] = useState<Agent[]>([])
   const [total, setTotal] = useState(0)
+  const [aggregateUsage, setAggregateUsage] = useState<AggregateUsageSummary | null>(null)
   const [loading, setLoading] = useState(true)
   const [error, setError] = useState<string | undefined>()
 
@@ -50,9 +82,19 @@ export function useAgentSummary(): UseAgentSummaryResult {
         (a, b) => new Date(b.updated_at).getTime() - new Date(a.updated_at).getTime(),
       )
 
+      // Fetch usage for each agent in parallel (best-effort)
+      const usageResults = await Promise.allSettled(
+        agents.map((agent) => orchestratorClient.getAgentUsage(agent.id)),
+      )
+      const usageList: AgentUsageStats[] = []
+      for (const r of usageResults) {
+        if (r.status === 'fulfilled') usageList.push(r.value)
+      }
+
       setCounts(newCounts)
       setRecentAgents(sorted.slice(0, 5))
       setTotal(result.total)
+      setAggregateUsage(usageList.length > 0 ? computeAggregateUsage(usageList) : null)
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Failed to load agents')
     } finally {
@@ -64,5 +106,5 @@ export function useAgentSummary(): UseAgentSummaryResult {
     void fetch()
   }, [fetch])
 
-  return { counts, recentAgents, total, loading, error }
+  return { counts, recentAgents, total, aggregateUsage, loading, error }
 }

--- a/ui/src/hooks/useAgents.ts
+++ b/ui/src/hooks/useAgents.ts
@@ -11,13 +11,13 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { orchestratorClient } from '@/services/orchestrator'
-import type { Agent, AgentStatus, CreateAgentRequest } from '@/types/orchestrator'
+import type { Agent, AgentStatus, AgentUsageStats, CreateAgentRequest } from '@/types/orchestrator'
 
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
 
-export type SortField = 'name' | 'status' | 'created_at'
+export type SortField = 'name' | 'status' | 'created_at' | 'cost' | 'tokens' | 'cache'
 export type SortDir = 'asc' | 'desc'
 
 export interface UseAgentsOptions {
@@ -46,6 +46,8 @@ export interface UseAgentsResult {
   total: number
   /** All agents returned by the API (before client-side filtering) */
   allAgents: Agent[]
+  /** Per-agent usage stats keyed by agent ID */
+  usageMap: Map<string, AgentUsageStats>
   loading: boolean
   /** True while a background refresh is running (initial load uses loading) */
   refreshing: boolean
@@ -64,7 +66,13 @@ export interface UseAgentsResult {
 // Sorting helpers
 // ---------------------------------------------------------------------------
 
-function compareAgents(a: Agent, b: Agent, field: SortField, dir: SortDir): number {
+function compareAgents(
+  a: Agent,
+  b: Agent,
+  field: SortField,
+  dir: SortDir,
+  usageMap?: Map<string, AgentUsageStats>,
+): number {
   let result = 0
   if (field === 'name') {
     result = a.name.localeCompare(b.name)
@@ -72,6 +80,26 @@ function compareAgents(a: Agent, b: Agent, field: SortField, dir: SortDir): numb
     result = a.status.localeCompare(b.status)
   } else if (field === 'created_at') {
     result = new Date(a.created_at).getTime() - new Date(b.created_at).getTime()
+  } else if (field === 'cost' && usageMap) {
+    const aCost = usageMap.get(a.id)?.cumulative.total_cost_usd ?? 0
+    const bCost = usageMap.get(b.id)?.cumulative.total_cost_usd ?? 0
+    result = aCost - bCost
+  } else if (field === 'tokens' && usageMap) {
+    const aTokens = usageMap.get(a.id)?.cumulative.input_tokens ?? 0
+    const bTokens = usageMap.get(b.id)?.cumulative.input_tokens ?? 0
+    result = aTokens - bTokens
+  } else if (field === 'cache' && usageMap) {
+    const aStats = usageMap.get(a.id)?.cumulative
+    const bStats = usageMap.get(b.id)?.cumulative
+    const aRatio = aStats
+      ? aStats.cache_read_input_tokens /
+        (aStats.cache_read_input_tokens + aStats.cache_creation_input_tokens + aStats.input_tokens || 1)
+      : 0
+    const bRatio = bStats
+      ? bStats.cache_read_input_tokens /
+        (bStats.cache_read_input_tokens + bStats.cache_creation_input_tokens + bStats.input_tokens || 1)
+      : 0
+    result = aRatio - bRatio
   }
   return dir === 'asc' ? result : -result
 }
@@ -94,6 +122,7 @@ export function useAgents({
   refreshInterval = DEFAULT_REFRESH_INTERVAL,
 }: UseAgentsOptions = {}): UseAgentsResult {
   const [allAgents, setAllAgents] = useState<Agent[]>([])
+  const [usageMap, setUsageMap] = useState<Map<string, AgentUsageStats>>(new Map())
   const [loading, setLoading] = useState(true)
   const [refreshing, setRefreshing] = useState(false)
   const [error, setError] = useState<string | undefined>()
@@ -121,6 +150,20 @@ export function useAgents({
         }
         const result = await orchestratorClient.listAgents(params)
         setAllAgents(result.items)
+
+        // Fetch usage for each agent in parallel (best-effort)
+        const usageResults = await Promise.allSettled(
+          result.items.map((agent) => orchestratorClient.getAgentUsage(agent.id)),
+        )
+        const newUsageMap = new Map<string, AgentUsageStats>()
+        for (let i = 0; i < result.items.length; i++) {
+          const r = usageResults[i]
+          if (r.status === 'fulfilled') {
+            newUsageMap.set(result.items[i].id, r.value)
+          }
+        }
+        setUsageMap(newUsageMap)
+
         setError(undefined)
       } catch (err) {
         const msg = err instanceof Error ? err.message : 'Failed to load agents'
@@ -169,7 +212,7 @@ export function useAgents({
     return true
   })
 
-  const sorted = [...filtered].sort((a, b) => compareAgents(a, b, sortBy, sortDir))
+  const sorted = [...filtered].sort((a, b) => compareAgents(a, b, sortBy, sortDir, usageMap))
 
   const total = sorted.length
   const start = (page - 1) * pageSize
@@ -204,6 +247,7 @@ export function useAgents({
     agents,
     total,
     allAgents,
+    usageMap,
     loading,
     refreshing,
     error,

--- a/ui/src/test/components/agents/AgentTableUsage.test.tsx
+++ b/ui/src/test/components/agents/AgentTableUsage.test.tsx
@@ -1,0 +1,141 @@
+/**
+ * Tests for AgentTable usage columns (Cost, Tokens, Cache Hit).
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import type { ReactNode } from 'react'
+import { AgentTable } from '@/components/agents/AgentTable'
+import { makeAgentList, resetAgentSeq } from '@/test/mocks/factories'
+import type { SortField, SortDir } from '@/hooks/useAgents'
+import type { AgentUsageStats } from '@/types/orchestrator'
+
+function wrapper({ children }: { children: ReactNode }) {
+  return <MemoryRouter>{children}</MemoryRouter>
+}
+
+function makeUsageStats(overrides?: Partial<AgentUsageStats['cumulative']>): AgentUsageStats {
+  return {
+    agent_id: '',
+    cumulative: {
+      input_tokens: 1000,
+      output_tokens: 500,
+      cache_read_input_tokens: 200,
+      cache_creation_input_tokens: 50,
+      total_cost_usd: 0.15,
+      num_turns: 5,
+      duration_ms: 3000,
+      duration_api_ms: 2500,
+      result_count: 5,
+      started_at: '2024-01-01T00:00:00Z',
+      ...overrides,
+    },
+    session_count: 1,
+  }
+}
+
+const defaultProps = {
+  agents: [],
+  loading: false,
+  sortBy: 'created_at' as SortField,
+  sortDir: 'desc' as SortDir,
+  onSort: vi.fn(),
+  onDelete: vi.fn(),
+  onBulkDelete: vi.fn(),
+  selectedIds: [],
+  onSelectChange: vi.fn(),
+}
+
+describe('AgentTable usage columns', () => {
+  beforeEach(() => {
+    resetAgentSeq()
+  })
+
+  it('renders Cost column header with sort button', () => {
+    const agents = makeAgentList(1)
+    render(<AgentTable {...defaultProps} agents={agents} />, { wrapper })
+    expect(screen.getByRole('button', { name: /cost/i })).toBeInTheDocument()
+  })
+
+  it('renders Tokens column header with sort button', () => {
+    const agents = makeAgentList(1)
+    render(<AgentTable {...defaultProps} agents={agents} />, { wrapper })
+    expect(screen.getByRole('button', { name: /tokens/i })).toBeInTheDocument()
+  })
+
+  it('renders Cache Hit column header with sort button', () => {
+    const agents = makeAgentList(1)
+    render(<AgentTable {...defaultProps} agents={agents} />, { wrapper })
+    expect(screen.getByRole('button', { name: /cache hit/i })).toBeInTheDocument()
+  })
+
+  it('calls onSort with "cost" when Cost header is clicked', () => {
+    const onSort = vi.fn()
+    const agents = makeAgentList(1)
+    render(<AgentTable {...defaultProps} agents={agents} onSort={onSort} />, { wrapper })
+    fireEvent.click(screen.getByRole('button', { name: /cost/i }))
+    expect(onSort).toHaveBeenCalledWith('cost')
+  })
+
+  it('calls onSort with "tokens" when Tokens header is clicked', () => {
+    const onSort = vi.fn()
+    const agents = makeAgentList(1)
+    render(<AgentTable {...defaultProps} agents={agents} onSort={onSort} />, { wrapper })
+    fireEvent.click(screen.getByRole('button', { name: /tokens/i }))
+    expect(onSort).toHaveBeenCalledWith('tokens')
+  })
+
+  it('calls onSort with "cache" when Cache Hit header is clicked', () => {
+    const onSort = vi.fn()
+    const agents = makeAgentList(1)
+    render(<AgentTable {...defaultProps} agents={agents} onSort={onSort} />, { wrapper })
+    fireEvent.click(screen.getByRole('button', { name: /cache hit/i }))
+    expect(onSort).toHaveBeenCalledWith('cache')
+  })
+
+  it('displays formatted cost when usageMap is provided', () => {
+    const agents = makeAgentList(1)
+    const usageMap = new Map<string, AgentUsageStats>()
+    usageMap.set(agents[0].id, makeUsageStats({ total_cost_usd: 1.23 }))
+    render(<AgentTable {...defaultProps} agents={agents} usageMap={usageMap} />, { wrapper })
+    expect(screen.getByText('$1.23')).toBeInTheDocument()
+  })
+
+  it('displays formatted tokens when usageMap is provided', () => {
+    const agents = makeAgentList(1)
+    const usageMap = new Map<string, AgentUsageStats>()
+    usageMap.set(agents[0].id, makeUsageStats({ input_tokens: 15000, output_tokens: 5000 }))
+    render(<AgentTable {...defaultProps} agents={agents} usageMap={usageMap} />, { wrapper })
+    expect(screen.getByText('20.0k')).toBeInTheDocument()
+  })
+
+  it('displays cache hit percentage when usageMap is provided', () => {
+    const agents = makeAgentList(1)
+    const usageMap = new Map<string, AgentUsageStats>()
+    // cache_read=200, cache_creation=50, input=1000 → 200/1250 = 16%
+    usageMap.set(agents[0].id, makeUsageStats())
+    render(<AgentTable {...defaultProps} agents={agents} usageMap={usageMap} />, { wrapper })
+    expect(screen.getByText('16%')).toBeInTheDocument()
+  })
+
+  it('shows dash when usageMap is not provided', () => {
+    const agents = makeAgentList(1)
+    render(<AgentTable {...defaultProps} agents={agents} />, { wrapper })
+    // Without usageMap, the cost/tokens/cache cells should show dashes
+    const dashes = screen.getAllByText('—')
+    expect(dashes.length).toBeGreaterThanOrEqual(3)
+  })
+
+  it('shows dash for agents not in usageMap', () => {
+    const agents = makeAgentList(2)
+    const usageMap = new Map<string, AgentUsageStats>()
+    // Only provide usage for first agent
+    usageMap.set(agents[0].id, makeUsageStats({ total_cost_usd: 5.0 }))
+    render(<AgentTable {...defaultProps} agents={agents} usageMap={usageMap} />, { wrapper })
+    expect(screen.getByText('$5.00')).toBeInTheDocument()
+    // Second agent should have dashes
+    const dashes = screen.getAllByText('—')
+    expect(dashes.length).toBeGreaterThanOrEqual(3)
+  })
+})

--- a/ui/src/test/components/dashboard/AgentSummaryUsage.test.tsx
+++ b/ui/src/test/components/dashboard/AgentSummaryUsage.test.tsx
@@ -1,0 +1,103 @@
+/**
+ * Tests for AgentSummary aggregate usage stats display.
+ */
+
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import type { ReactNode } from 'react'
+import { AgentSummary } from '@/components/dashboard/AgentSummary'
+import type { UseAgentSummaryResult } from '@/hooks/useAgentSummary'
+
+// Mock @nivo/pie to avoid rendering actual SVGs in tests
+vi.mock('@nivo/pie', () => ({
+  ResponsivePie: () => <div data-testid="mock-pie" />,
+}))
+
+function wrapper({ children }: { children: ReactNode }) {
+  return <MemoryRouter>{children}</MemoryRouter>
+}
+
+const baseProps: UseAgentSummaryResult = {
+  counts: { Running: 2, Pending: 0, Stopped: 1, Failed: 0 },
+  recentAgents: [],
+  total: 3,
+  aggregateUsage: null,
+  loading: false,
+  error: undefined,
+}
+
+describe('AgentSummary aggregate usage', () => {
+  it('does not render aggregate usage when aggregateUsage is null', () => {
+    render(<AgentSummary {...baseProps} />, { wrapper })
+    expect(screen.queryByTestId('aggregate-usage')).not.toBeInTheDocument()
+  })
+
+  it('renders total cost', () => {
+    const props = {
+      ...baseProps,
+      aggregateUsage: { totalCostUsd: 12.34, totalTokens: 50000, cacheHitPercent: 45 },
+    }
+    render(<AgentSummary {...props} />, { wrapper })
+    expect(screen.getByTestId('aggregate-usage')).toBeInTheDocument()
+    expect(screen.getByText('$12.34')).toBeInTheDocument()
+  })
+
+  it('renders total tokens formatted as k', () => {
+    const props = {
+      ...baseProps,
+      aggregateUsage: { totalCostUsd: 0.5, totalTokens: 150000, cacheHitPercent: 30 },
+    }
+    render(<AgentSummary {...props} />, { wrapper })
+    expect(screen.getByText('150.0k')).toBeInTheDocument()
+  })
+
+  it('renders total tokens formatted as M', () => {
+    const props = {
+      ...baseProps,
+      aggregateUsage: { totalCostUsd: 5.0, totalTokens: 2500000, cacheHitPercent: 60 },
+    }
+    render(<AgentSummary {...props} />, { wrapper })
+    expect(screen.getByText('2.5M')).toBeInTheDocument()
+  })
+
+  it('renders cache hit percentage', () => {
+    const props = {
+      ...baseProps,
+      aggregateUsage: { totalCostUsd: 1.0, totalTokens: 10000, cacheHitPercent: 72 },
+    }
+    render(<AgentSummary {...props} />, { wrapper })
+    expect(screen.getByText('72%')).toBeInTheDocument()
+  })
+
+  it('renders small cost as <0.01', () => {
+    const props = {
+      ...baseProps,
+      aggregateUsage: { totalCostUsd: 0.005, totalTokens: 100, cacheHitPercent: 0 },
+    }
+    render(<AgentSummary {...props} />, { wrapper })
+    expect(screen.getByText('$<0.01')).toBeInTheDocument()
+  })
+
+  it('renders labels for all three stats', () => {
+    const props = {
+      ...baseProps,
+      aggregateUsage: { totalCostUsd: 1.0, totalTokens: 1000, cacheHitPercent: 50 },
+    }
+    render(<AgentSummary {...props} />, { wrapper })
+    expect(screen.getByText('Total Cost')).toBeInTheDocument()
+    expect(screen.getByText('Tokens')).toBeInTheDocument()
+    expect(screen.getByText('Cache Hit')).toBeInTheDocument()
+  })
+
+  it('does not render aggregate usage when loading', () => {
+    const props = {
+      ...baseProps,
+      loading: true,
+      aggregateUsage: { totalCostUsd: 1.0, totalTokens: 1000, cacheHitPercent: 50 },
+    }
+    render(<AgentSummary {...props} />, { wrapper })
+    // Loading state shows skeletons, not the content
+    expect(screen.queryByTestId('aggregate-usage')).not.toBeInTheDocument()
+  })
+})

--- a/ui/src/test/mocks/handlers/orchestrator.ts
+++ b/ui/src/test/mocks/handlers/orchestrator.ts
@@ -54,6 +54,41 @@ export const orchestratorHandlers = [
   }),
 
   // -------------------------------------------------------------------------
+  // Agent usage
+  // -------------------------------------------------------------------------
+
+  http.get(`${BASE}/agents/:id/usage`, ({ params }) =>
+    HttpResponse.json({
+      agent_id: String(params.id),
+      current_session: {
+        input_tokens: 100,
+        output_tokens: 50,
+        cache_read_input_tokens: 20,
+        cache_creation_input_tokens: 10,
+        total_cost_usd: 0.01,
+        num_turns: 2,
+        duration_ms: 1000,
+        duration_api_ms: 800,
+        result_count: 2,
+        started_at: '2024-01-01T00:00:00Z',
+      },
+      cumulative: {
+        input_tokens: 200,
+        output_tokens: 100,
+        cache_read_input_tokens: 40,
+        cache_creation_input_tokens: 20,
+        total_cost_usd: 0.02,
+        num_turns: 4,
+        duration_ms: 2000,
+        duration_api_ms: 1600,
+        result_count: 4,
+        started_at: '2024-01-01T00:00:00Z',
+      },
+      session_count: 1,
+    }),
+  ),
+
+  // -------------------------------------------------------------------------
   // Agent actions
   // -------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary
- Add **Cost**, **Tokens**, and **Cache Hit** columns to the agent table with sortable headers, responsively hidden on smaller screens (`lg:table-cell` / `xl:table-cell`)
- Extend `useAgents` hook to fetch per-agent usage data in parallel via `getAgentUsage`, returning a `usageMap` for the table
- Add aggregate usage stats row (total cost, total tokens, cache hit %) to the dashboard `AgentSummary` card via `useAgentSummary`
- Add MSW handler for `/agents/:id/usage` endpoint to support existing integration tests
- 19 new tests across `AgentTableUsage.test.tsx` (11) and `AgentSummaryUsage.test.tsx` (8)

## Test plan
- [x] All new tests pass (19/19)
- [x] Existing AgentTable tests pass (10/10)
- [x] Existing useAgents hook tests pass (11/11)
- [x] Existing agentSummary integration tests pass (4/4)
- [ ] Manual verification: confirm columns show formatted values with usage data
- [ ] Manual verification: confirm columns show "—" when usage is unavailable
- [ ] Manual verification: confirm responsive hiding on smaller viewports

Closes #271

🤖 Generated with [Claude Code](https://claude.com/claude-code)