### PR TITLE
Add tests for usage tracking UI components and hooks

### DIFF
--- a/ui/src/test/components/agents/AgentUsagePanel.test.tsx
+++ b/ui/src/test/components/agents/AgentUsagePanel.test.tsx
@@ -1,0 +1,197 @@
+/**
+ * Tests for AgentUsagePanel component — rendering, formatting, cache efficiency,
+ * auto-clear threshold, and edge cases.
+ */
+
+import { describe, it, expect } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { AgentUsagePanel } from '@/components/agents/AgentUsagePanel'
+import { USAGE_STATS, USAGE_STATS_NO_SESSION, USAGE_STATS_ZERO } from '@/test/fixtures/usage'
+
+describe('AgentUsagePanel', () => {
+  // -------------------------------------------------------------------------
+  // Basic rendering
+  // -------------------------------------------------------------------------
+
+  it('renders the Usage heading', () => {
+    render(<AgentUsagePanel usage={USAGE_STATS} />)
+    expect(screen.getByText('Usage')).toBeInTheDocument()
+  })
+
+  it('displays session count badge', () => {
+    render(<AgentUsagePanel usage={USAGE_STATS} />)
+    expect(screen.getByText('Session 3')).toBeInTheDocument()
+  })
+
+  it('renders the section with correct aria-label', () => {
+    render(<AgentUsagePanel usage={USAGE_STATS} />)
+    expect(screen.getByLabelText('Agent usage statistics')).toBeInTheDocument()
+  })
+
+  // -------------------------------------------------------------------------
+  // Current session stats
+  // -------------------------------------------------------------------------
+
+  it('renders current session heading', () => {
+    render(<AgentUsagePanel usage={USAGE_STATS} />)
+    expect(screen.getByText('Current Session')).toBeInTheDocument()
+  })
+
+  it('displays current session stat cards with correct aria labels', () => {
+    render(<AgentUsagePanel usage={USAGE_STATS} />)
+    // Input tokens: 1500
+    expect(screen.getByLabelText(/Input tokens: 1,500/)).toBeInTheDocument()
+    // Output tokens: 800
+    expect(screen.getByLabelText(/Output tokens: 800/)).toBeInTheDocument()
+    // Cache read: 400
+    expect(screen.getByLabelText(/Cache read tokens: 400/)).toBeInTheDocument()
+    // Cache creation: 100
+    expect(screen.getByLabelText(/Cache creation tokens: 100/)).toBeInTheDocument()
+  })
+
+  it('displays cost formatted as currency', () => {
+    render(<AgentUsagePanel usage={USAGE_STATS} />)
+    // total_cost_usd = 0.025 → $0.0250
+    expect(screen.getByLabelText(/Total cost: \$0\.0250/)).toBeInTheDocument()
+  })
+
+  it('displays number of turns', () => {
+    render(<AgentUsagePanel usage={USAGE_STATS} />)
+    expect(screen.getByLabelText(/Number of turns: 5/)).toBeInTheDocument()
+  })
+
+  it('displays wall clock duration', () => {
+    render(<AgentUsagePanel usage={USAGE_STATS} />)
+    // duration_ms = 12000 → 12.0s
+    expect(screen.getByLabelText(/Wall clock duration: 12\.0s/)).toBeInTheDocument()
+  })
+
+  it('displays API duration', () => {
+    render(<AgentUsagePanel usage={USAGE_STATS} />)
+    // duration_api_ms = 8500 → 8.5s
+    expect(screen.getByLabelText(/API duration: 8\.5s/)).toBeInTheDocument()
+  })
+
+  it('displays result count', () => {
+    render(<AgentUsagePanel usage={USAGE_STATS} />)
+    expect(screen.getByText('5 result(s)')).toBeInTheDocument()
+  })
+
+  // -------------------------------------------------------------------------
+  // No active session
+  // -------------------------------------------------------------------------
+
+  it('shows "No active session" when current_session is missing', () => {
+    render(<AgentUsagePanel usage={USAGE_STATS_NO_SESSION} />)
+    expect(screen.getByText('No active session.')).toBeInTheDocument()
+  })
+
+  // -------------------------------------------------------------------------
+  // Cache efficiency
+  // -------------------------------------------------------------------------
+
+  it('renders cache efficiency progress bar', () => {
+    render(<AgentUsagePanel usage={USAGE_STATS} />)
+    const progressBars = screen.getAllByRole('progressbar')
+    // At least one for current session cache
+    expect(progressBars.length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('displays cache hit ratio label', () => {
+    render(<AgentUsagePanel usage={USAGE_STATS} />)
+    expect(screen.getByText('Cache Hit Ratio')).toBeInTheDocument()
+  })
+
+  it('shows correct cache efficiency label based on ratio', () => {
+    // Current session: cache_read=400, cache_creation=100, input=1500
+    // ratio = 400 / 2000 = 0.2 → "Low" (ratio <= 0.2)
+    render(<AgentUsagePanel usage={USAGE_STATS} />)
+    // Should show "Low" or "Moderate" based on the ratio boundary
+    const ratioText = screen.getAllByLabelText(/Cache hit ratio:/)[0]
+    expect(ratioText).toBeInTheDocument()
+  })
+
+  // -------------------------------------------------------------------------
+  // Cumulative stats (collapsible)
+  // -------------------------------------------------------------------------
+
+  it('renders cumulative toggle button collapsed by default', () => {
+    render(<AgentUsagePanel usage={USAGE_STATS} />)
+    const toggle = screen.getByRole('button', { name: /cumulative/i })
+    expect(toggle).toBeInTheDocument()
+    expect(toggle).toHaveAttribute('aria-expanded', 'false')
+  })
+
+  it('expands cumulative stats on click', () => {
+    render(<AgentUsagePanel usage={USAGE_STATS} />)
+    const toggle = screen.getByRole('button', { name: /cumulative/i })
+    fireEvent.click(toggle)
+    expect(toggle).toHaveAttribute('aria-expanded', 'true')
+
+    // Should show the cumulative body
+    expect(screen.getByLabelText('Cumulative statistics')).toBeInTheDocument()
+  })
+
+  it('shows session count in cumulative toggle label', () => {
+    render(<AgentUsagePanel usage={USAGE_STATS} />)
+    expect(screen.getByText(/Cumulative \(3 sessions\)/)).toBeInTheDocument()
+  })
+
+  it('shows singular session text for 1 session', () => {
+    const singleSessionUsage = { ...USAGE_STATS, session_count: 1 }
+    render(<AgentUsagePanel usage={singleSessionUsage} />)
+    expect(screen.getByText(/Cumulative \(1 session\)/)).toBeInTheDocument()
+  })
+
+  it('shows avg cost per session in expanded cumulative section', () => {
+    render(<AgentUsagePanel usage={USAGE_STATS} />)
+    const toggle = screen.getByRole('button', { name: /cumulative/i })
+    fireEvent.click(toggle)
+
+    // avg cost = 0.08 / 3 sessions ≈ $0.0267
+    expect(screen.getByText(/Avg cost \/ session/)).toBeInTheDocument()
+  })
+
+  // -------------------------------------------------------------------------
+  // Auto-clear threshold
+  // -------------------------------------------------------------------------
+
+  it('does not show auto-clear when threshold not provided', () => {
+    render(<AgentUsagePanel usage={USAGE_STATS} />)
+    expect(screen.queryByText('Auto-clear Threshold')).not.toBeInTheDocument()
+  })
+
+  it('shows auto-clear threshold progress when configured', () => {
+    render(<AgentUsagePanel usage={USAGE_STATS} autoClearThreshold={0.10} />)
+    expect(screen.getByText('Auto-clear Threshold')).toBeInTheDocument()
+    expect(screen.getByLabelText(/Auto-clear threshold progress/)).toBeInTheDocument()
+  })
+
+  it('shows warning when approaching threshold', () => {
+    // Current session cost = 0.025, threshold = 0.03 → progress = 83% > 80%
+    render(<AgentUsagePanel usage={USAGE_STATS} autoClearThreshold={0.03} />)
+    expect(screen.getByText('Approaching auto-clear threshold')).toBeInTheDocument()
+  })
+
+  it('does not show warning when far from threshold', () => {
+    // Current session cost = 0.025, threshold = 1.00 → progress = 2.5%
+    render(<AgentUsagePanel usage={USAGE_STATS} autoClearThreshold={1.0} />)
+    expect(screen.queryByText('Approaching auto-clear threshold')).not.toBeInTheDocument()
+  })
+
+  it('does not show auto-clear when no active session', () => {
+    render(<AgentUsagePanel usage={USAGE_STATS_NO_SESSION} autoClearThreshold={0.10} />)
+    expect(screen.queryByText('Auto-clear Threshold')).not.toBeInTheDocument()
+  })
+
+  // -------------------------------------------------------------------------
+  // Zero usage
+  // -------------------------------------------------------------------------
+
+  it('handles zero usage gracefully', () => {
+    render(<AgentUsagePanel usage={USAGE_STATS_ZERO} />)
+    expect(screen.getByText('Current Session')).toBeInTheDocument()
+    // Should render without errors
+    expect(screen.getByLabelText('Agent usage statistics')).toBeInTheDocument()
+  })
+})

--- a/ui/src/test/fixtures/usage.ts
+++ b/ui/src/test/fixtures/usage.ts
@@ -1,0 +1,229 @@
+/**
+ * Shared test fixtures for usage tracking data.
+ *
+ * Usage:
+ *   import { USAGE_STATS, SESSION_USAGE, USAGE_SNAPSHOT } from '@/test/fixtures/usage'
+ */
+
+import type {
+  AgentUsageStats,
+  SessionUsage,
+  UsageSnapshot,
+  ClearContextResponse,
+} from '@/types/orchestrator'
+import type { AgentUsageEntry, AggregateUsage } from '@/hooks/useUsageMetrics'
+
+// ---------------------------------------------------------------------------
+// SessionUsage fixtures
+// ---------------------------------------------------------------------------
+
+export const SESSION_USAGE: SessionUsage = {
+  input_tokens: 1500,
+  output_tokens: 800,
+  cache_read_input_tokens: 400,
+  cache_creation_input_tokens: 100,
+  total_cost_usd: 0.025,
+  num_turns: 5,
+  duration_ms: 12_000,
+  duration_api_ms: 8_500,
+  result_count: 5,
+  started_at: '2024-06-15T10:00:00Z',
+}
+
+export const EMPTY_SESSION: SessionUsage = {
+  input_tokens: 0,
+  output_tokens: 0,
+  cache_read_input_tokens: 0,
+  cache_creation_input_tokens: 0,
+  total_cost_usd: 0,
+  num_turns: 0,
+  duration_ms: 0,
+  duration_api_ms: 0,
+  result_count: 0,
+  started_at: '2024-06-15T12:00:00Z',
+}
+
+// ---------------------------------------------------------------------------
+// AgentUsageStats fixtures
+// ---------------------------------------------------------------------------
+
+export const USAGE_STATS: AgentUsageStats = {
+  agent_id: 'agent-usage-1',
+  current_session: { ...SESSION_USAGE },
+  cumulative: {
+    input_tokens: 5000,
+    output_tokens: 2500,
+    cache_read_input_tokens: 1200,
+    cache_creation_input_tokens: 300,
+    total_cost_usd: 0.08,
+    num_turns: 15,
+    duration_ms: 45_000,
+    duration_api_ms: 32_000,
+    result_count: 15,
+    started_at: '2024-06-10T08:00:00Z',
+  },
+  session_count: 3,
+}
+
+export const USAGE_STATS_NO_SESSION: AgentUsageStats = {
+  agent_id: 'agent-usage-2',
+  cumulative: {
+    input_tokens: 2000,
+    output_tokens: 1000,
+    cache_read_input_tokens: 500,
+    cache_creation_input_tokens: 100,
+    total_cost_usd: 0.03,
+    num_turns: 8,
+    duration_ms: 20_000,
+    duration_api_ms: 15_000,
+    result_count: 8,
+    started_at: '2024-06-12T09:00:00Z',
+  },
+  session_count: 2,
+}
+
+export const USAGE_STATS_ZERO: AgentUsageStats = {
+  agent_id: 'agent-usage-zero',
+  current_session: { ...EMPTY_SESSION },
+  cumulative: {
+    input_tokens: 0,
+    output_tokens: 0,
+    cache_read_input_tokens: 0,
+    cache_creation_input_tokens: 0,
+    total_cost_usd: 0,
+    num_turns: 0,
+    duration_ms: 0,
+    duration_api_ms: 0,
+    result_count: 0,
+    started_at: '2024-06-15T12:00:00Z',
+  },
+  session_count: 0,
+}
+
+// ---------------------------------------------------------------------------
+// UsageSnapshot fixture (single-turn delta)
+// ---------------------------------------------------------------------------
+
+export const USAGE_SNAPSHOT: UsageSnapshot = {
+  input_tokens: 100,
+  output_tokens: 50,
+  cache_read_input_tokens: 20,
+  cache_creation_input_tokens: 10,
+  total_cost_usd: 0.005,
+  num_turns: 1,
+  duration_ms: 3000,
+  duration_api_ms: 2200,
+}
+
+// ---------------------------------------------------------------------------
+// ClearContextResponse fixture
+// ---------------------------------------------------------------------------
+
+export const CLEAR_CONTEXT_RESPONSE: ClearContextResponse = {
+  agent_id: 'agent-usage-1',
+  new_session_number: 4,
+  session_usage: { ...SESSION_USAGE },
+}
+
+// ---------------------------------------------------------------------------
+// AgentUsageEntry fixtures (for useUsageMetrics)
+// ---------------------------------------------------------------------------
+
+export const USAGE_ENTRY_ALPHA: AgentUsageEntry = {
+  agentId: 'agent-alpha',
+  name: 'Agent Alpha',
+  stats: {
+    agent_id: 'agent-alpha',
+    current_session: {
+      input_tokens: 500,
+      output_tokens: 250,
+      cache_read_input_tokens: 100,
+      cache_creation_input_tokens: 30,
+      total_cost_usd: 0.01,
+      num_turns: 3,
+      duration_ms: 6000,
+      duration_api_ms: 4000,
+      result_count: 3,
+      started_at: '2024-06-15T10:00:00Z',
+    },
+    cumulative: {
+      input_tokens: 2000,
+      output_tokens: 1000,
+      cache_read_input_tokens: 600,
+      cache_creation_input_tokens: 100,
+      total_cost_usd: 0.04,
+      num_turns: 10,
+      duration_ms: 25000,
+      duration_api_ms: 18000,
+      result_count: 10,
+      started_at: '2024-06-10T08:00:00Z',
+    },
+    session_count: 2,
+  },
+}
+
+export const USAGE_ENTRY_BETA: AgentUsageEntry = {
+  agentId: 'agent-beta',
+  name: 'Agent Beta',
+  stats: {
+    agent_id: 'agent-beta',
+    current_session: {
+      input_tokens: 300,
+      output_tokens: 150,
+      cache_read_input_tokens: 50,
+      cache_creation_input_tokens: 20,
+      total_cost_usd: 0.005,
+      num_turns: 2,
+      duration_ms: 4000,
+      duration_api_ms: 3000,
+      result_count: 2,
+      started_at: '2024-06-15T11:00:00Z',
+    },
+    cumulative: {
+      input_tokens: 1000,
+      output_tokens: 500,
+      cache_read_input_tokens: 200,
+      cache_creation_input_tokens: 50,
+      total_cost_usd: 0.02,
+      num_turns: 5,
+      duration_ms: 12000,
+      duration_api_ms: 9000,
+      result_count: 5,
+      started_at: '2024-06-11T09:00:00Z',
+    },
+    session_count: 1,
+  },
+}
+
+// ---------------------------------------------------------------------------
+// AggregateUsage fixture
+// ---------------------------------------------------------------------------
+
+export const AGGREGATE_USAGE: AggregateUsage = {
+  totalInputTokens: 3000,
+  totalOutputTokens: 1500,
+  totalCacheReadTokens: 800,
+  totalCacheCreationTokens: 150,
+  totalCostUsd: 0.06,
+  totalTokens: 5450,
+  // cacheHitRatio = 800 / (800 + 150 + 3000) = 800 / 3950 ≈ 0.2025
+  cacheHitRatio: 800 / (800 + 150 + 3000),
+}
+
+// ---------------------------------------------------------------------------
+// Factory helpers
+// ---------------------------------------------------------------------------
+
+export function makeSessionUsage(overrides?: Partial<SessionUsage>): SessionUsage {
+  return { ...SESSION_USAGE, ...overrides }
+}
+
+export function makeUsageStats(overrides?: Partial<AgentUsageStats>): AgentUsageStats {
+  return { ...USAGE_STATS, ...overrides }
+}
+
+export function makeUsageEntry(
+  overrides?: Partial<AgentUsageEntry>,
+): AgentUsageEntry {
+  return { ...USAGE_ENTRY_ALPHA, ...overrides }
+}

--- a/ui/src/test/hooks/useAgentUsageExtended.test.ts
+++ b/ui/src/test/hooks/useAgentUsageExtended.test.ts
@@ -1,0 +1,199 @@
+/**
+ * Extended tests for useAgentUsage hook — auto-refresh, clearContext action,
+ * error handling, and cleanup.
+ *
+ * Complements the existing useAgentUsage.test.ts which covers real-time events.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, act, waitFor } from '@testing-library/react'
+import { useAgentUsage } from '@/hooks/useAgentUsage'
+import { USAGE_STATS } from '@/test/fixtures/usage'
+
+// ---------------------------------------------------------------------------
+// Mock orchestratorClient
+// ---------------------------------------------------------------------------
+
+const mockGetAgentUsage = vi.fn()
+const mockClearContext = vi.fn()
+
+vi.mock('@/services/orchestrator', () => ({
+  orchestratorClient: {
+    getAgentUsage: (...args: unknown[]) => mockGetAgentUsage(...args),
+    clearContext: (...args: unknown[]) => mockClearContext(...args),
+  },
+}))
+
+beforeEach(() => {
+  mockGetAgentUsage.mockReset().mockResolvedValue({ ...USAGE_STATS })
+  mockClearContext.mockReset().mockResolvedValue({
+    agent_id: 'agent-1',
+    new_session_number: 4,
+  })
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+describe('useAgentUsage extended', () => {
+  it('fetches usage on mount and sets loading states', async () => {
+    const { result } = renderHook(() => useAgentUsage('agent-1', 0))
+
+    // Initially loading
+    expect(result.current.loading).toBe(true)
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false)
+    })
+
+    expect(result.current.usage).not.toBeNull()
+    expect(result.current.usage?.agent_id).toBe('agent-usage-1')
+    expect(result.current.error).toBeNull()
+    expect(mockGetAgentUsage).toHaveBeenCalledWith('agent-1')
+  })
+
+  it('handles API errors gracefully', async () => {
+    mockGetAgentUsage.mockRejectedValue(new Error('Network timeout'))
+
+    const { result } = renderHook(() => useAgentUsage('agent-err', 0))
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false)
+    })
+
+    expect(result.current.usage).toBeNull()
+    expect(result.current.error).toBe('Network timeout')
+  })
+
+  it('auto-refreshes on configured interval', async () => {
+    vi.useFakeTimers()
+
+    renderHook(() => useAgentUsage('agent-1', 5000))
+
+    // Initial fetch
+    await vi.advanceTimersByTimeAsync(0)
+    expect(mockGetAgentUsage).toHaveBeenCalledTimes(1)
+
+    // Advance to first refresh
+    await vi.advanceTimersByTimeAsync(5000)
+    expect(mockGetAgentUsage).toHaveBeenCalledTimes(2)
+
+    // Advance to second refresh
+    await vi.advanceTimersByTimeAsync(5000)
+    expect(mockGetAgentUsage).toHaveBeenCalledTimes(3)
+  })
+
+  it('does not auto-refresh when interval is 0', async () => {
+    vi.useFakeTimers()
+
+    renderHook(() => useAgentUsage('agent-1', 0))
+
+    await vi.advanceTimersByTimeAsync(0)
+    expect(mockGetAgentUsage).toHaveBeenCalledTimes(1)
+
+    await vi.advanceTimersByTimeAsync(30000)
+    // Should still be 1 — no auto-refresh
+    expect(mockGetAgentUsage).toHaveBeenCalledTimes(1)
+  })
+
+  it('clearContext calls API and refreshes usage data', async () => {
+    const { result } = renderHook(() => useAgentUsage('agent-1', 0))
+
+    await waitFor(() => {
+      expect(result.current.usage).not.toBeNull()
+    })
+
+    expect(result.current.clearing).toBe(false)
+
+    await act(async () => {
+      const response = await result.current.clearContext()
+      expect(response.new_session_number).toBe(4)
+    })
+
+    expect(mockClearContext).toHaveBeenCalledWith('agent-1')
+    // clearContext triggers a refresh, so getAgentUsage called again
+    expect(mockGetAgentUsage).toHaveBeenCalledTimes(2)
+  })
+
+  it('clearing state toggles during clearContext', async () => {
+    // Make clearContext slow
+    mockClearContext.mockImplementation(
+      () => new Promise((resolve) => setTimeout(() => resolve({ agent_id: 'agent-1', new_session_number: 4 }), 100)),
+    )
+
+    const { result } = renderHook(() => useAgentUsage('agent-1', 0))
+
+    await waitFor(() => {
+      expect(result.current.usage).not.toBeNull()
+    })
+
+    // Start clearing (don't await yet)
+    let clearPromise: Promise<unknown>
+    act(() => {
+      clearPromise = result.current.clearContext()
+    })
+
+    // Should be clearing
+    expect(result.current.clearing).toBe(true)
+
+    await act(async () => {
+      await clearPromise!
+    })
+
+    expect(result.current.clearing).toBe(false)
+  })
+
+  it('cleans up interval on unmount', async () => {
+    vi.useFakeTimers()
+
+    const { unmount } = renderHook(() => useAgentUsage('agent-1', 5000))
+
+    await vi.advanceTimersByTimeAsync(0)
+    expect(mockGetAgentUsage).toHaveBeenCalledTimes(1)
+
+    unmount()
+
+    // Advance past when the next refresh would fire
+    await vi.advanceTimersByTimeAsync(10000)
+    // Should still only be 1 call — interval was cleaned up
+    expect(mockGetAgentUsage).toHaveBeenCalledTimes(1)
+  })
+
+  it('refresh method triggers a manual fetch', async () => {
+    const { result } = renderHook(() => useAgentUsage('agent-1', 0))
+
+    await waitFor(() => {
+      expect(result.current.usage).not.toBeNull()
+    })
+
+    expect(mockGetAgentUsage).toHaveBeenCalledTimes(1)
+
+    act(() => {
+      result.current.refresh()
+    })
+
+    await waitFor(() => {
+      expect(mockGetAgentUsage).toHaveBeenCalledTimes(2)
+    })
+  })
+
+  it('re-fetches when agentId changes', async () => {
+    const { result, rerender } = renderHook(
+      ({ id }: { id: string }) => useAgentUsage(id, 0),
+      { initialProps: { id: 'agent-1' } },
+    )
+
+    await waitFor(() => {
+      expect(result.current.usage).not.toBeNull()
+    })
+
+    expect(mockGetAgentUsage).toHaveBeenCalledWith('agent-1')
+
+    rerender({ id: 'agent-2' })
+
+    await waitFor(() => {
+      expect(mockGetAgentUsage).toHaveBeenCalledWith('agent-2')
+    })
+  })
+})

--- a/ui/src/test/hooks/useUsageMetrics.test.ts
+++ b/ui/src/test/hooks/useUsageMetrics.test.ts
@@ -1,0 +1,177 @@
+/**
+ * Tests for useUsageMetrics hook — aggregation, cache ratio, partial failures,
+ * auto-refresh, and computeAggregate helper.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { renderHook, waitFor } from '@testing-library/react'
+import { computeAggregate } from '@/hooks/useUsageMetrics'
+import { USAGE_ENTRY_ALPHA, USAGE_ENTRY_BETA } from '@/test/fixtures/usage'
+import type { AgentUsageEntry } from '@/hooks/useUsageMetrics'
+
+// ---------------------------------------------------------------------------
+// Mock orchestratorClient
+// ---------------------------------------------------------------------------
+
+const mockListAgents = vi.fn()
+const mockGetAgentUsage = vi.fn()
+
+vi.mock('@/services/orchestrator', () => ({
+  orchestratorClient: {
+    listAgents: (...args: unknown[]) => mockListAgents(...args),
+    getAgentUsage: (...args: unknown[]) => mockGetAgentUsage(...args),
+  },
+}))
+
+// Mock eventBus to avoid side-effects
+vi.mock('@/services/eventBus', () => ({
+  agentEventBus: {
+    on: () => () => {},
+    emit: () => {},
+  },
+}))
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  mockListAgents.mockReset()
+  mockGetAgentUsage.mockReset()
+})
+
+afterEach(() => {
+  vi.useRealTimers()
+})
+
+// ---------------------------------------------------------------------------
+// computeAggregate (pure function) tests
+// ---------------------------------------------------------------------------
+
+describe('computeAggregate', () => {
+  it('returns zeros for empty entries', () => {
+    const result = computeAggregate([])
+    expect(result.totalInputTokens).toBe(0)
+    expect(result.totalOutputTokens).toBe(0)
+    expect(result.totalCostUsd).toBe(0)
+    expect(result.totalTokens).toBe(0)
+    expect(result.cacheHitRatio).toBe(0)
+  })
+
+  it('aggregates tokens across multiple entries', () => {
+    const entries: AgentUsageEntry[] = [USAGE_ENTRY_ALPHA, USAGE_ENTRY_BETA]
+    const result = computeAggregate(entries)
+
+    // Alpha: input=2000, output=1000, cacheRead=600, cacheCreation=100
+    // Beta:  input=1000, output=500,  cacheRead=200, cacheCreation=50
+    expect(result.totalInputTokens).toBe(3000)
+    expect(result.totalOutputTokens).toBe(1500)
+    expect(result.totalCacheReadTokens).toBe(800)
+    expect(result.totalCacheCreationTokens).toBe(150)
+  })
+
+  it('sums cost across entries', () => {
+    const entries: AgentUsageEntry[] = [USAGE_ENTRY_ALPHA, USAGE_ENTRY_BETA]
+    const result = computeAggregate(entries)
+
+    // Alpha: 0.04, Beta: 0.02
+    expect(result.totalCostUsd).toBeCloseTo(0.06, 6)
+  })
+
+  it('computes correct cache hit ratio', () => {
+    const entries: AgentUsageEntry[] = [USAGE_ENTRY_ALPHA, USAGE_ENTRY_BETA]
+    const result = computeAggregate(entries)
+
+    // cacheRead=800, cacheCreation=150, input=3000
+    // ratio = 800 / (800 + 150 + 3000) = 800 / 3950
+    expect(result.cacheHitRatio).toBeCloseTo(800 / 3950, 4)
+  })
+
+  it('computes totalTokens as sum of all token types', () => {
+    const entries: AgentUsageEntry[] = [USAGE_ENTRY_ALPHA]
+    const result = computeAggregate(entries)
+
+    // input=2000, output=1000, cacheRead=600, cacheCreation=100
+    expect(result.totalTokens).toBe(2000 + 1000 + 600 + 100)
+  })
+
+  it('handles single entry', () => {
+    const result = computeAggregate([USAGE_ENTRY_ALPHA])
+    expect(result.totalInputTokens).toBe(2000)
+    expect(result.totalCostUsd).toBe(0.04)
+  })
+})
+
+// ---------------------------------------------------------------------------
+// useUsageMetrics hook tests
+// ---------------------------------------------------------------------------
+
+describe('useUsageMetrics hook', () => {
+  it('fetches data on mount and populates entries', async () => {
+    vi.useRealTimers()
+
+    mockListAgents.mockResolvedValue({
+      items: [
+        { id: 'a1', name: 'Agent One', status: 'Running' },
+        { id: 'a2', name: 'Agent Two', status: 'Running' },
+      ],
+      total: 2,
+    })
+    mockGetAgentUsage
+      .mockResolvedValueOnce(USAGE_ENTRY_ALPHA.stats)
+      .mockResolvedValueOnce(USAGE_ENTRY_BETA.stats)
+
+    // Import dynamically to allow mock setup
+    const { useUsageMetrics } = await import('@/hooks/useUsageMetrics')
+    const { result } = renderHook(() => useUsageMetrics(10_000))
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false)
+    })
+
+    expect(result.current.entries).toHaveLength(2)
+    expect(result.current.entries[0].agentId).toBe('a1')
+    expect(result.current.entries[1].agentId).toBe('a2')
+    expect(result.current.aggregate.totalInputTokens).toBeGreaterThan(0)
+  })
+
+  it('handles partial failures gracefully', async () => {
+    vi.useRealTimers()
+
+    mockListAgents.mockResolvedValue({
+      items: [
+        { id: 'a1', name: 'Agent One', status: 'Running' },
+        { id: 'a2', name: 'Agent Fail', status: 'Running' },
+      ],
+      total: 2,
+    })
+    mockGetAgentUsage
+      .mockResolvedValueOnce(USAGE_ENTRY_ALPHA.stats)
+      .mockRejectedValueOnce(new Error('Network error'))
+
+    const { useUsageMetrics } = await import('@/hooks/useUsageMetrics')
+    const { result } = renderHook(() => useUsageMetrics(10_000))
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false)
+    })
+
+    // Only the successful agent should appear
+    expect(result.current.entries).toHaveLength(1)
+    expect(result.current.entries[0].agentId).toBe('a1')
+    expect(result.current.error).toBeUndefined()
+  })
+
+  it('sets error when listAgents fails', async () => {
+    vi.useRealTimers()
+
+    mockListAgents.mockRejectedValue(new Error('Server down'))
+
+    const { useUsageMetrics } = await import('@/hooks/useUsageMetrics')
+    const { result } = renderHook(() => useUsageMetrics(10_000))
+
+    await waitFor(() => {
+      expect(result.current.loading).toBe(false)
+    })
+
+    expect(result.current.error).toBe('Server down')
+    expect(result.current.entries).toHaveLength(0)
+  })
+})

--- a/ui/src/test/mocks/handlers/orchestrator.ts
+++ b/ui/src/test/mocks/handlers/orchestrator.ts
@@ -89,6 +89,29 @@ export const orchestratorHandlers = [
   ),
 
   // -------------------------------------------------------------------------
+  // Agent context management
+  // -------------------------------------------------------------------------
+
+  http.post(`${BASE}/agents/:id/clear-context`, ({ params }) =>
+    HttpResponse.json({
+      agent_id: String(params.id),
+      new_session_number: 2,
+      session_usage: {
+        input_tokens: 100,
+        output_tokens: 50,
+        cache_read_input_tokens: 20,
+        cache_creation_input_tokens: 10,
+        total_cost_usd: 0.01,
+        num_turns: 2,
+        duration_ms: 1000,
+        duration_api_ms: 800,
+        result_count: 2,
+        started_at: '2024-01-01T00:00:00Z',
+      },
+    }),
+  ),
+
+  // -------------------------------------------------------------------------
   // Agent actions
   // -------------------------------------------------------------------------
 

--- a/ui/src/test/services/orchestrator-usage.test.ts
+++ b/ui/src/test/services/orchestrator-usage.test.ts
@@ -1,0 +1,190 @@
+/**
+ * Tests for OrchestratorClient usage and context management endpoints.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { OrchestratorClient } from '@/services/orchestrator'
+import { ApiError } from '@/types/common'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeJsonResponse(status: number, body: unknown) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: new Headers({ 'content-type': 'application/json' }),
+  })
+}
+
+function mockFetch(status: number, body: unknown) {
+  vi.stubGlobal('fetch', vi.fn().mockResolvedValue(makeJsonResponse(status, body)))
+}
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const usageResponse = {
+  agent_id: 'agent-uuid-1',
+  current_session: {
+    input_tokens: 500,
+    output_tokens: 250,
+    cache_read_input_tokens: 100,
+    cache_creation_input_tokens: 50,
+    total_cost_usd: 0.015,
+    num_turns: 3,
+    duration_ms: 8000,
+    duration_api_ms: 5500,
+    result_count: 3,
+    started_at: '2024-06-15T10:00:00Z',
+  },
+  cumulative: {
+    input_tokens: 2000,
+    output_tokens: 1000,
+    cache_read_input_tokens: 500,
+    cache_creation_input_tokens: 200,
+    total_cost_usd: 0.06,
+    num_turns: 12,
+    duration_ms: 35000,
+    duration_api_ms: 25000,
+    result_count: 12,
+    started_at: '2024-06-10T08:00:00Z',
+  },
+  session_count: 3,
+}
+
+const clearContextResponse = {
+  agent_id: 'agent-uuid-1',
+  new_session_number: 4,
+  session_usage: usageResponse.current_session,
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('OrchestratorClient usage endpoints', () => {
+  let client: OrchestratorClient
+
+  beforeEach(() => {
+    client = new OrchestratorClient({
+      baseUrl: 'http://localhost:17006',
+      maxRetries: 1,
+    })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  // -------------------------------------------------------------------------
+  // getAgentUsage
+  // -------------------------------------------------------------------------
+
+  describe('getAgentUsage', () => {
+    it('calls GET /agents/:id/usage and returns deserialized response', async () => {
+      mockFetch(200, usageResponse)
+      const result = await client.getAgentUsage('agent-uuid-1')
+
+      expect(result.agent_id).toBe('agent-uuid-1')
+      expect(result.current_session?.input_tokens).toBe(500)
+      expect(result.cumulative.total_cost_usd).toBe(0.06)
+      expect(result.session_count).toBe(3)
+
+      const calledUrl = vi.mocked(fetch).mock.calls[0][0] as string
+      expect(calledUrl).toContain('/agents/agent-uuid-1/usage')
+    })
+
+    it('uses GET method', async () => {
+      mockFetch(200, usageResponse)
+      await client.getAgentUsage('agent-uuid-1')
+
+      const callInit = vi.mocked(fetch).mock.calls[0][1] as RequestInit
+      expect(callInit.method).toBe('GET')
+    })
+
+    it('throws ApiError on 404', async () => {
+      mockFetch(404, { error: 'Agent not found' })
+      await expect(client.getAgentUsage('missing')).rejects.toMatchObject({
+        status: 404,
+        message: 'Agent not found',
+      })
+    })
+
+    it('throws ApiError on 500', async () => {
+      mockFetch(500, { error: 'Internal server error' })
+      await expect(client.getAgentUsage('agent-uuid-1')).rejects.toMatchObject({
+        status: 500,
+        message: 'Internal server error',
+      })
+    })
+
+    it('thrown error is an ApiError instance', async () => {
+      mockFetch(500, { error: 'fail' })
+      let caught: unknown = null
+      try {
+        await client.getAgentUsage('agent-uuid-1')
+      } catch (e) {
+        caught = e
+      }
+      expect(caught).toBeInstanceOf(ApiError)
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // clearContext
+  // -------------------------------------------------------------------------
+
+  describe('clearContext', () => {
+    it('calls POST /agents/:id/clear-context and returns response', async () => {
+      mockFetch(200, clearContextResponse)
+      const result = await client.clearContext('agent-uuid-1')
+
+      expect(result.agent_id).toBe('agent-uuid-1')
+      expect(result.new_session_number).toBe(4)
+
+      const calledUrl = vi.mocked(fetch).mock.calls[0][0] as string
+      expect(calledUrl).toContain('/agents/agent-uuid-1/clear-context')
+    })
+
+    it('uses POST method', async () => {
+      mockFetch(200, clearContextResponse)
+      await client.clearContext('agent-uuid-1')
+
+      const callInit = vi.mocked(fetch).mock.calls[0][1] as RequestInit
+      expect(callInit.method).toBe('POST')
+    })
+
+    it('sends empty JSON body', async () => {
+      mockFetch(200, clearContextResponse)
+      await client.clearContext('agent-uuid-1')
+
+      const callInit = vi.mocked(fetch).mock.calls[0][1] as RequestInit
+      const body = JSON.parse(callInit.body as string)
+      expect(body).toEqual({})
+    })
+
+    it('throws ApiError on 404', async () => {
+      mockFetch(404, { error: 'Agent not found' })
+      await expect(client.clearContext('missing')).rejects.toMatchObject({
+        status: 404,
+        message: 'Agent not found',
+      })
+    })
+
+    it('throws ApiError on 500', async () => {
+      mockFetch(500, { error: 'Internal server error' })
+      await expect(client.clearContext('agent-uuid-1')).rejects.toMatchObject({
+        status: 500,
+        message: 'Internal server error',
+      })
+    })
+
+    it('returns session_usage when provided', async () => {
+      mockFetch(200, clearContextResponse)
+      const result = await client.clearContext('agent-uuid-1')
+      expect(result.session_usage?.input_tokens).toBe(500)
+    })
+  })
+})


### PR DESCRIPTION
## Summary
- Add shared test fixtures (`test/fixtures/usage.ts`) with factory helpers for `SessionUsage`, `AgentUsageStats`, `UsageSnapshot`, `ClearContextResponse`, and `AgentUsageEntry`
- Add `useUsageMetrics` hook tests: `computeAggregate` pure function (6 tests), data fetching with partial failures and error propagation (3 tests)
- Add extended `useAgentUsage` hook tests: auto-refresh intervals, `clearContext` action with clearing state, cleanup on unmount, manual refresh, agentId re-fetch (9 tests)
- Add `AgentUsagePanel` component tests: stat card rendering, number formatting, cache efficiency bar, cumulative collapse toggle, auto-clear threshold progress/warning, edge cases (25 tests)
- Add `OrchestratorClient` usage endpoint tests: `getAgentUsage` and `clearContext` with correct HTTP methods, deserialization, 404/500 error handling (11 tests)
- Add MSW handler for `POST /agents/:id/clear-context` endpoint

## Test plan
- [x] All 54 new tests pass
- [x] All 100 existing related tests still pass (hooks, components, services, integration)
- [x] No pre-existing test regressions

Closes #272

🤖 Generated with [Claude Code](https://claude.com/claude-code)