### PR TITLE
Add backend selection to AgentConfig and orchestrator startup

### DIFF
--- a/crates/cli/src/commands/apply.rs
+++ b/crates/cli/src/commands/apply.rs
@@ -544,6 +544,9 @@ async fn apply_agent(
         env: tmpl.env.clone(),
         auto_clear_threshold: tmpl.auto_clear_threshold,
         network_policy: parsed_network_policy,
+        docker_image: None,
+        extra_mounts: None,
+        resource_limits: None,
     };
 
     let agent = client.create_agent(&request).await?;

--- a/crates/cli/src/commands/orchestrator.rs
+++ b/crates/cli/src/commands/orchestrator.rs
@@ -851,6 +851,9 @@ async fn create_agent(
         env,
         auto_clear_threshold,
         network_policy: parsed_network_policy,
+        docker_image: None,
+        extra_mounts: None,
+        resource_limits: None,
     };
 
     let agent = client.create_agent(&request).await.context("Failed to create agent")?;
@@ -1961,6 +1964,9 @@ mod tests {
                 env: Default::default(),
                 auto_clear_threshold: None,
                 network_policy: None,
+                docker_image: None,
+                extra_mounts: None,
+                resource_limits: None,
             },
             session_id: Some("agentd-orch-abc123".to_string()),
             backend_type: Some("tmux".to_string()),

--- a/crates/orchestrator/src/api.rs
+++ b/crates/orchestrator/src/api.rs
@@ -113,6 +113,9 @@ async fn create_agent(
         env: req.env,
         auto_clear_threshold: req.auto_clear_threshold,
         network_policy: req.network_policy,
+        docker_image: req.docker_image,
+        extra_mounts: req.extra_mounts,
+        resource_limits: req.resource_limits,
     };
 
     let agent = state.manager.spawn_agent(req.name, config).await?;

--- a/crates/orchestrator/src/entity/agent.rs
+++ b/crates/orchestrator/src/entity/agent.rs
@@ -38,6 +38,12 @@ pub struct Model {
     /// Optional network policy for Docker containers (e.g., "internet", "isolated", "host_network").
     /// Stored as nullable TEXT; maps to `Option<NetworkPolicy>` in the domain layer.
     pub network_policy: Option<String>,
+    /// Custom Docker image override for this agent. Nullable TEXT.
+    pub docker_image: Option<String>,
+    /// JSON-serialized `Vec<VolumeMount>` for additional Docker volume mounts.
+    pub extra_mounts: Option<String>,
+    /// JSON-serialized `ResourceLimits` (cpu_limit, memory_limit_mb).
+    pub resource_limits: Option<String>,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/crates/orchestrator/src/main.rs
+++ b/crates/orchestrator/src/main.rs
@@ -24,6 +24,7 @@ use tracing::{error, info};
 use uuid::Uuid;
 use websocket::ConnectionRegistry;
 use wrap::backend::{ExecutionBackend, TmuxBackend};
+use wrap::docker::DockerBackend;
 
 fn init_metrics() -> PrometheusHandle {
     let builder = metrics_exporter_prometheus::PrometheusBuilder::new();
@@ -48,15 +49,52 @@ async fn main() -> anyhow::Result<()> {
     info!("Agent storage initialized at: {:?}", AgentStorage::get_db_path()?);
     let storage = Arc::new(storage);
 
-    // Execution backend — defaults to tmux. Future: select based on config/env.
-    let backend: Arc<dyn ExecutionBackend> = Arc::new(TmuxBackend::new("agentd-orch"));
+    // Determine the port and WS base URL early — both the Docker backend
+    // and the AgentManager need it.
+    let port = env::var("PORT").unwrap_or_else(|_| "17006".to_string());
+    let port_num: u16 = port.parse().expect("PORT must be a valid u16");
+    let ws_base_url = format!("ws://127.0.0.1:{}", port);
+
+    // Execution backend — selected via AGENTD_BACKEND env var.
+    // Valid values: "tmux" (default), "docker".
+    let backend_mode = env::var("AGENTD_BACKEND").unwrap_or_else(|_| "tmux".to_string());
+    let backend: Arc<dyn ExecutionBackend> = match backend_mode.as_str() {
+        "tmux" => {
+            info!("Using tmux execution backend");
+            Arc::new(TmuxBackend::new("agentd-orch"))
+        }
+        "docker" => {
+            let image = env::var("AGENTD_DOCKER_IMAGE")
+                .unwrap_or_else(|_| wrap::docker::DEFAULT_IMAGE.to_string());
+            info!(image = %image, "Using Docker execution backend");
+
+            let docker_backend = DockerBackend::new("agentd-orch", &image)
+                .map_err(|e| anyhow::anyhow!("Failed to initialize Docker backend: {}", e))?
+                .with_orchestrator_port(port_num);
+
+            // Validate that the Docker daemon is reachable before proceeding.
+            // A simple `list_sessions` call exercises the Docker API.
+            docker_backend.list_sessions().await.map_err(|e| {
+                anyhow::anyhow!(
+                    "Docker daemon is unreachable (AGENTD_BACKEND=docker). \
+                     Ensure Docker is running and accessible: {}",
+                    e
+                )
+            })?;
+            info!("Docker daemon connectivity verified");
+
+            Arc::new(docker_backend)
+        }
+        other => {
+            anyhow::bail!(
+                "Unknown AGENTD_BACKEND value '{}'. Valid options: tmux, docker",
+                other
+            );
+        }
+    };
 
     // WebSocket connection registry.
     let registry = ConnectionRegistry::new();
-
-    // Determine the port and WS base URL.
-    let port = env::var("PORT").unwrap_or_else(|_| "17006".to_string());
-    let ws_base_url = format!("ws://127.0.0.1:{}", port);
 
     // Agent manager (Arc'd immediately so it can be shared with callbacks and API state).
     let manager =

--- a/crates/orchestrator/src/manager.rs
+++ b/crates/orchestrator/src/manager.rs
@@ -503,6 +503,9 @@ mod tests {
             env: HashMap::new(),
             auto_clear_threshold: None,
             network_policy: None,
+            docker_image: None,
+            extra_mounts: None,
+            resource_limits: None,
         }
     }
 

--- a/crates/orchestrator/src/migration/m20250312_000005_add_docker_config.rs
+++ b/crates/orchestrator/src/migration/m20250312_000005_add_docker_config.rs
@@ -1,0 +1,42 @@
+//! Migration: add Docker-specific config columns to the `agents` table.
+//!
+//! Adds three nullable columns for per-agent Docker settings:
+//! - `docker_image` (TEXT): custom image override
+//! - `extra_mounts` (TEXT): JSON-serialized `Vec<VolumeMount>`
+//! - `resource_limits` (TEXT): JSON-serialized `ResourceLimits`
+//!
+//! Existing rows get `NULL`, which the application layer interprets as
+//! "use the backend defaults".
+
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let db = manager.get_connection();
+
+        for stmt in [
+            "ALTER TABLE agents ADD COLUMN docker_image TEXT DEFAULT NULL",
+            "ALTER TABLE agents ADD COLUMN extra_mounts TEXT DEFAULT NULL",
+            "ALTER TABLE agents ADD COLUMN resource_limits TEXT DEFAULT NULL",
+        ] {
+            if let Err(e) = db.execute_unprepared(stmt).await {
+                // Idempotent: ignore if column already exists (e.g., re-run).
+                if !e.to_string().contains("duplicate column name") {
+                    return Err(e);
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn down(&self, _manager: &SchemaManager) -> Result<(), DbErr> {
+        // SQLite < 3.35.0 does not support DROP COLUMN, so we leave
+        // the columns in place on rollback for simplicity.
+        Ok(())
+    }
+}

--- a/crates/orchestrator/src/migration/mod.rs
+++ b/crates/orchestrator/src/migration/mod.rs
@@ -15,6 +15,7 @@ mod m20250305_000001_create_tables;
 mod m20250309_000002_add_usage_sessions;
 mod m20250310_000003_rename_tmux_session;
 mod m20250311_000004_add_network_policy;
+mod m20250312_000005_add_docker_config;
 
 /// The migration runner — applies all known migrations in order.
 pub struct Migrator;
@@ -27,6 +28,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20250309_000002_add_usage_sessions::Migration),
             Box::new(m20250310_000003_rename_tmux_session::Migration),
             Box::new(m20250311_000004_add_network_policy::Migration),
+            Box::new(m20250312_000005_add_docker_config::Migration),
         ]
     }
 }

--- a/crates/orchestrator/src/storage.rs
+++ b/crates/orchestrator/src/storage.rs
@@ -85,6 +85,13 @@ impl AgentStorage {
             updated_at: Set(agent.updated_at.to_rfc3339()),
             auto_clear_threshold: Set(agent.config.auto_clear_threshold.map(|v| v as i64)),
             network_policy: Set(agent.config.network_policy.as_ref().map(|p| p.to_string())),
+            docker_image: Set(agent.config.docker_image.clone()),
+            extra_mounts: Set(agent.config.extra_mounts.as_ref().map(|m| {
+                serde_json::to_string(m).unwrap_or_else(|_| "[]".to_string())
+            })),
+            resource_limits: Set(agent.config.resource_limits.as_ref().map(|r| {
+                serde_json::to_string(r).unwrap_or_else(|_| "{}".to_string())
+            })),
         };
 
         agent_entity::Entity::insert(model).exec(&self.db).await?;
@@ -120,6 +127,30 @@ impl AgentStorage {
             .col_expr(
                 agent_entity::Column::NetworkPolicy,
                 Expr::value(agent.config.network_policy.as_ref().map(|p| p.to_string())),
+            )
+            .col_expr(
+                agent_entity::Column::DockerImage,
+                Expr::value(agent.config.docker_image.clone()),
+            )
+            .col_expr(
+                agent_entity::Column::ExtraMounts,
+                Expr::value(
+                    agent
+                        .config
+                        .extra_mounts
+                        .as_ref()
+                        .map(|m| serde_json::to_string(m).unwrap_or_else(|_| "[]".to_string())),
+                ),
+            )
+            .col_expr(
+                agent_entity::Column::ResourceLimits,
+                Expr::value(
+                    agent
+                        .config
+                        .resource_limits
+                        .as_ref()
+                        .map(|r| serde_json::to_string(r).unwrap_or_else(|_| "{}".to_string())),
+                ),
             )
             .col_expr(agent_entity::Column::UpdatedAt, Expr::value(agent.updated_at.to_rfc3339()))
             .filter(agent_entity::Column::Id.eq(agent.id.to_string()))
@@ -478,6 +509,15 @@ fn model_to_agent(model: agent_entity::Model) -> Result<Agent> {
                 .map(|s| s.parse())
                 .transpose()
                 .unwrap_or(None),
+            docker_image: model.docker_image,
+            extra_mounts: model
+                .extra_mounts
+                .as_deref()
+                .and_then(|s| serde_json::from_str(s).ok()),
+            resource_limits: model
+                .resource_limits
+                .as_deref()
+                .and_then(|s| serde_json::from_str(s).ok()),
         },
         session_id: model.session_id,
         backend_type: model.backend_type,
@@ -542,6 +582,9 @@ mod tests {
                 env: HashMap::new(),
                 auto_clear_threshold: None,
                 network_policy: None,
+                docker_image: None,
+                extra_mounts: None,
+                resource_limits: None,
             },
         )
     }
@@ -890,5 +933,80 @@ mod tests {
         assert!(stats.current_session.is_none());
         assert_eq!(stats.cumulative.input_tokens, 0);
         assert_eq!(stats.cumulative.result_count, 0);
+    }
+
+    // -----------------------------------------------------------------------
+    // Docker config persistence tests
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_add_with_docker_config() {
+        use crate::types::{ResourceLimits, VolumeMount};
+
+        let (storage, _tmp) = create_test_storage().await;
+        let mut agent = test_agent("docker-agent");
+        agent.config.docker_image = Some("custom:v2".to_string());
+        agent.config.extra_mounts = Some(vec![VolumeMount {
+            host_path: "/data/models".to_string(),
+            container_path: "/models".to_string(),
+            read_only: true,
+        }]);
+        agent.config.resource_limits =
+            Some(ResourceLimits { cpu_limit: Some(4.0), memory_limit_mb: Some(8192) });
+
+        storage.add(&agent).await.unwrap();
+        let retrieved = storage.get(&agent.id).await.unwrap().unwrap();
+
+        assert_eq!(retrieved.config.docker_image, Some("custom:v2".to_string()));
+        let mounts = retrieved.config.extra_mounts.unwrap();
+        assert_eq!(mounts.len(), 1);
+        assert_eq!(mounts[0].host_path, "/data/models");
+        assert!(mounts[0].read_only);
+        let limits = retrieved.config.resource_limits.unwrap();
+        assert_eq!(limits.cpu_limit, Some(4.0));
+        assert_eq!(limits.memory_limit_mb, Some(8192));
+    }
+
+    #[tokio::test]
+    async fn test_docker_config_defaults_to_none() {
+        let (storage, _tmp) = create_test_storage().await;
+        let agent = test_agent("no-docker-agent");
+
+        storage.add(&agent).await.unwrap();
+        let retrieved = storage.get(&agent.id).await.unwrap().unwrap();
+
+        assert_eq!(retrieved.config.docker_image, None);
+        assert_eq!(retrieved.config.extra_mounts, None);
+        assert_eq!(retrieved.config.resource_limits, None);
+    }
+
+    #[tokio::test]
+    async fn test_update_persists_docker_config() {
+        use crate::types::ResourceLimits;
+
+        let (storage, _tmp) = create_test_storage().await;
+        let mut agent = test_agent("docker-update-agent");
+        storage.add(&agent).await.unwrap();
+
+        // Set docker fields and update.
+        agent.config.docker_image = Some("new-image:latest".to_string());
+        agent.config.resource_limits =
+            Some(ResourceLimits { cpu_limit: Some(2.0), memory_limit_mb: None });
+        agent.updated_at = chrono::Utc::now();
+        storage.update(&agent).await.unwrap();
+
+        let retrieved = storage.get(&agent.id).await.unwrap().unwrap();
+        assert_eq!(retrieved.config.docker_image, Some("new-image:latest".to_string()));
+        assert_eq!(retrieved.config.resource_limits.as_ref().unwrap().cpu_limit, Some(2.0));
+
+        // Clear docker fields and update.
+        agent.config.docker_image = None;
+        agent.config.resource_limits = None;
+        agent.updated_at = chrono::Utc::now();
+        storage.update(&agent).await.unwrap();
+
+        let retrieved = storage.get(&agent.id).await.unwrap().unwrap();
+        assert_eq!(retrieved.config.docker_image, None);
+        assert_eq!(retrieved.config.resource_limits, None);
     }
 }

--- a/crates/orchestrator/src/types.rs
+++ b/crates/orchestrator/src/types.rs
@@ -3,6 +3,35 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use uuid::Uuid;
 
+/// A volume mount specification for Docker-backed agents.
+///
+/// Maps a host directory into the container at a specified path,
+/// optionally as read-only. These are ignored for tmux backends.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct VolumeMount {
+    /// Path on the host machine.
+    pub host_path: String,
+    /// Mount point inside the container.
+    pub container_path: String,
+    /// If true, mount as read-only. Defaults to `false`.
+    #[serde(default)]
+    pub read_only: bool,
+}
+
+/// Resource limits for Docker-backed agent containers.
+///
+/// These are translated to Docker's `NanoCpus` and `Memory` host-config
+/// fields. Ignored for tmux backends.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct ResourceLimits {
+    /// Number of CPUs (e.g., `2.0` means two full cores).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cpu_limit: Option<f64>,
+    /// Memory cap in megabytes (e.g., `2048` for 2 GiB).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub memory_limit_mb: Option<u64>,
+}
+
 /// Status of an agent managed by the orchestrator.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -137,6 +166,24 @@ pub struct AgentConfig {
     /// Defaults to `Internet` (bridge network with outbound access).
     #[serde(skip_serializing_if = "Option::is_none")]
     pub network_policy: Option<wrap::docker::NetworkPolicy>,
+    /// Custom Docker image override for this agent.
+    ///
+    /// When set, the Docker backend uses this image instead of its default.
+    /// Ignored for tmux backends.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub docker_image: Option<String>,
+    /// Additional volume mounts for Docker-backed agents.
+    ///
+    /// These are appended to the default `/workspace` bind mount.
+    /// Ignored for tmux backends.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub extra_mounts: Option<Vec<VolumeMount>>,
+    /// Resource limits (CPU, memory) for Docker-backed agents.
+    ///
+    /// Overrides the backend's default limits when set. Ignored for
+    /// tmux backends.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub resource_limits: Option<ResourceLimits>,
 }
 
 fn default_shell() -> String {
@@ -222,6 +269,15 @@ pub struct CreateAgentRequest {
     /// Network policy for Docker-backed agents.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub network_policy: Option<wrap::docker::NetworkPolicy>,
+    /// Custom Docker image override for this agent.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub docker_image: Option<String>,
+    /// Additional volume mounts for Docker-backed agents.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub extra_mounts: Option<Vec<VolumeMount>>,
+    /// Resource limits (CPU, memory) for Docker-backed agents.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub resource_limits: Option<ResourceLimits>,
 }
 
 /// Response body for agent endpoints.
@@ -573,6 +629,9 @@ mod tests {
             env: HashMap::new(),
             auto_clear_threshold: None,
             network_policy: None,
+            docker_image: None,
+            extra_mounts: None,
+            resource_limits: None,
         };
         let json = serde_json::to_string(&config).unwrap();
         assert!(json.contains("\"model\":\"opus\""));
@@ -596,6 +655,9 @@ mod tests {
             env: HashMap::new(),
             auto_clear_threshold: None,
             network_policy: None,
+            docker_image: None,
+            extra_mounts: None,
+            resource_limits: None,
         };
         let json = serde_json::to_string(&config).unwrap();
         assert!(!json.contains("model"));
@@ -617,6 +679,9 @@ mod tests {
             env: HashMap::new(),
             auto_clear_threshold: None,
             network_policy: None,
+            docker_image: None,
+            extra_mounts: None,
+            resource_limits: None,
         };
         let json = serde_json::to_string(&request).unwrap();
         assert!(json.contains("\"model\":\"sonnet\""));
@@ -644,6 +709,9 @@ mod tests {
             env: env.clone(),
             auto_clear_threshold: None,
             network_policy: None,
+            docker_image: None,
+            extra_mounts: None,
+            resource_limits: None,
         };
 
         let json = serde_json::to_string(&config).unwrap();
@@ -669,6 +737,9 @@ mod tests {
             env: HashMap::new(),
             auto_clear_threshold: None,
             network_policy: None,
+            docker_image: None,
+            extra_mounts: None,
+            resource_limits: None,
         };
 
         let json = serde_json::to_string(&config).unwrap();
@@ -706,6 +777,9 @@ mod tests {
             env: env.clone(),
             auto_clear_threshold: None,
             network_policy: None,
+            docker_image: None,
+            extra_mounts: None,
+            resource_limits: None,
         };
 
         let json = serde_json::to_string(&request).unwrap();
@@ -734,6 +808,9 @@ mod tests {
             env,
             auto_clear_threshold: None,
             network_policy: None,
+            docker_image: None,
+            extra_mounts: None,
+            resource_limits: None,
         };
         let agent = Agent::new("test".to_string(), config);
         let response = AgentResponse::from(agent);
@@ -781,5 +858,122 @@ mod tests {
         assert_eq!(ToolPolicy::AllowAll.mode_str(), "allow_all");
         assert_eq!(ToolPolicy::DenyAll.mode_str(), "deny_all");
         assert_eq!(ToolPolicy::RequireApproval.mode_str(), "require_approval");
+    }
+
+    // -- Docker config types --
+
+    #[test]
+    fn test_volume_mount_serialization() {
+        let mount = VolumeMount {
+            host_path: "/data/models".to_string(),
+            container_path: "/models".to_string(),
+            read_only: true,
+        };
+        let json = serde_json::to_string(&mount).unwrap();
+        assert!(json.contains("\"read_only\":true"));
+
+        let deserialized: VolumeMount = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized, mount);
+    }
+
+    #[test]
+    fn test_volume_mount_read_only_defaults_false() {
+        let json = r#"{"host_path":"/data","container_path":"/mnt"}"#;
+        let mount: VolumeMount = serde_json::from_str(json).unwrap();
+        assert!(!mount.read_only);
+    }
+
+    #[test]
+    fn test_resource_limits_serialization() {
+        let limits = ResourceLimits { cpu_limit: Some(2.0), memory_limit_mb: Some(4096) };
+        let json = serde_json::to_string(&limits).unwrap();
+        assert!(json.contains("\"cpu_limit\":2.0"));
+        assert!(json.contains("\"memory_limit_mb\":4096"));
+
+        let deserialized: ResourceLimits = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized, limits);
+    }
+
+    #[test]
+    fn test_resource_limits_partial() {
+        let limits = ResourceLimits { cpu_limit: Some(1.5), memory_limit_mb: None };
+        let json = serde_json::to_string(&limits).unwrap();
+        assert!(json.contains("\"cpu_limit\":1.5"));
+        assert!(!json.contains("memory_limit_mb"));
+
+        let deserialized: ResourceLimits = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized, limits);
+    }
+
+    #[test]
+    fn test_agent_config_docker_fields_omitted_when_none() {
+        let config = AgentConfig {
+            working_dir: "/tmp".to_string(),
+            user: None,
+            shell: "zsh".to_string(),
+            interactive: false,
+            prompt: None,
+            worktree: false,
+            system_prompt: None,
+            tool_policy: ToolPolicy::default(),
+            model: None,
+            env: HashMap::new(),
+            auto_clear_threshold: None,
+            network_policy: None,
+            docker_image: None,
+            extra_mounts: None,
+            resource_limits: None,
+        };
+        let json = serde_json::to_string(&config).unwrap();
+        assert!(!json.contains("docker_image"));
+        assert!(!json.contains("extra_mounts"));
+        assert!(!json.contains("resource_limits"));
+    }
+
+    #[test]
+    fn test_agent_config_with_docker_fields() {
+        let config = AgentConfig {
+            working_dir: "/tmp".to_string(),
+            user: None,
+            shell: "zsh".to_string(),
+            interactive: false,
+            prompt: None,
+            worktree: false,
+            system_prompt: None,
+            tool_policy: ToolPolicy::default(),
+            model: None,
+            env: HashMap::new(),
+            auto_clear_threshold: None,
+            network_policy: None,
+            docker_image: Some("custom-image:v1".to_string()),
+            extra_mounts: Some(vec![VolumeMount {
+                host_path: "/data".to_string(),
+                container_path: "/mnt/data".to_string(),
+                read_only: true,
+            }]),
+            resource_limits: Some(ResourceLimits {
+                cpu_limit: Some(4.0),
+                memory_limit_mb: Some(8192),
+            }),
+        };
+        let json = serde_json::to_string(&config).unwrap();
+        assert!(json.contains("custom-image:v1"));
+        assert!(json.contains("/data"));
+        assert!(json.contains("8192"));
+
+        let deserialized: AgentConfig = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized.docker_image, Some("custom-image:v1".to_string()));
+        assert_eq!(deserialized.extra_mounts.as_ref().unwrap().len(), 1);
+        assert_eq!(deserialized.resource_limits.as_ref().unwrap().cpu_limit, Some(4.0));
+    }
+
+    #[test]
+    fn test_agent_config_backward_compat_missing_docker_fields() {
+        // Old JSON without docker fields should deserialize successfully
+        let json = r#"{"working_dir":"/tmp","shell":"zsh","tool_policy":{"mode":"allow_all"}}"#;
+        let config: AgentConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(config.docker_image, None);
+        assert_eq!(config.extra_mounts, None);
+        assert_eq!(config.resource_limits, None);
     }
 }


### PR DESCRIPTION
## Summary

- Add `VolumeMount` and `ResourceLimits` types for Docker-specific per-agent configuration
- Extend `AgentConfig` and `CreateAgentRequest` with `docker_image`, `extra_mounts`, and `resource_limits` fields (all optional, ignored by tmux backend)
- Implement `AGENTD_BACKEND` env var (`tmux` | `docker`, default `tmux`) to select execution backend at orchestrator startup
- Add `AGENTD_DOCKER_IMAGE` env var for overriding the default container image
- Validate Docker daemon reachability early when `docker` backend is selected
- Add database migration for the three new nullable columns (`docker_image`, `extra_mounts`, `resource_limits`)
- Full backward compatibility — existing JSON and DB records deserialize without error

## Test plan

- [x] All 102 orchestrator tests pass (10 new tests for types, serialization, storage persistence, and backward compat)
- [x] Clippy clean with `-D warnings` across orchestrator, wrap, and cli
- [x] Full workspace build succeeds
- [ ] Manual: start with `AGENTD_BACKEND=tmux` (default) — behaves as before
- [ ] Manual: start with `AGENTD_BACKEND=docker` without Docker running — should fail with clear error
- [ ] Manual: start with `AGENTD_BACKEND=docker` with Docker running — should log connectivity verified
- [ ] Manual: create agent with `docker_image`, `extra_mounts`, `resource_limits` via API — fields persist and round-trip

Closes #287

🤖 Generated with [Claude Code](https://claude.com/claude-code)