### PR TITLE
feat: update CLI for Docker backend support

### DIFF
--- a/crates/cli/src/commands/apply.rs
+++ b/crates/cli/src/commands/apply.rs
@@ -52,6 +52,13 @@ pub struct AgentTemplate {
     pub auto_clear_threshold: Option<u64>,
     /// Network policy for Docker-backed agents (internet, isolated, host_network).
     pub network_policy: Option<String>,
+    /// Custom Docker image override for this agent.
+    pub docker_image: Option<String>,
+    /// Additional volume mounts for Docker containers.
+    #[serde(default)]
+    pub extra_mounts: Vec<orchestrator::types::VolumeMount>,
+    /// Resource limits for Docker containers.
+    pub resource_limits: Option<orchestrator::types::ResourceLimits>,
 }
 
 fn default_working_dir() -> String {
@@ -544,9 +551,9 @@ async fn apply_agent(
         env: tmpl.env.clone(),
         auto_clear_threshold: tmpl.auto_clear_threshold,
         network_policy: parsed_network_policy,
-        docker_image: None,
-        extra_mounts: None,
-        resource_limits: None,
+        docker_image: tmpl.docker_image.clone(),
+        extra_mounts: if tmpl.extra_mounts.is_empty() { None } else { Some(tmpl.extra_mounts.clone()) },
+        resource_limits: tmpl.resource_limits.clone(),
     };
 
     let agent = client.create_agent(&request).await?;

--- a/crates/cli/src/commands/orchestrator.rs
+++ b/crates/cli/src/commands/orchestrator.rs
@@ -193,6 +193,34 @@ pub enum OrchestratorCommand {
         /// Ignored for tmux-backed agents.
         #[arg(long)]
         network_policy: Option<String>,
+
+        /// Custom Docker image for the agent container.
+        ///
+        /// Overrides the default image set by AGENTD_DOCKER_IMAGE.
+        /// Ignored for tmux-backed agents.
+        #[arg(long)]
+        docker_image: Option<String>,
+
+        /// CPU limit for the Docker container (e.g., 2.0 means two full cores).
+        ///
+        /// Ignored for tmux-backed agents.
+        #[arg(long)]
+        cpu_limit: Option<f64>,
+
+        /// Memory limit in megabytes for the Docker container (e.g., 2048 for 2 GiB).
+        ///
+        /// Ignored for tmux-backed agents.
+        #[arg(long)]
+        memory_limit: Option<u64>,
+
+        /// Additional volume mount for the Docker container (host:container[:ro]).
+        ///
+        /// Can be specified multiple times for multiple mounts.
+        /// Format: /host/path:/container/path or /host/path:/container/path:ro
+        ///
+        /// Ignored for tmux-backed agents.
+        #[arg(long = "mount", value_name = "HOST:CONTAINER[:ro]")]
+        mounts: Vec<String>,
     },
 
     /// Get details of a specific agent.
@@ -229,6 +257,46 @@ pub enum OrchestratorCommand {
         /// Agent name (resolves to first matching running agent)
         #[arg(long, conflicts_with = "id")]
         name: Option<String>,
+    },
+
+    /// View logs from a Docker-backed agent's container.
+    ///
+    /// Fetches stdout/stderr from the agent's Docker container.
+    /// Only works for agents running on the Docker backend.
+    ///
+    /// # Examples
+    ///
+    /// View logs by agent ID:
+    ///
+    ///   agent orchestrator logs 550e8400-e29b-41d4-a716-446655440000
+    ///
+    /// View logs by agent name:
+    ///
+    ///   agent orchestrator logs --name my-agent
+    ///
+    /// Follow logs (tail -f style):
+    ///
+    ///   agent orchestrator logs --name my-agent --follow
+    ///
+    /// Show last 50 lines:
+    ///
+    ///   agent orchestrator logs --name my-agent --tail 50
+    Logs {
+        /// Agent ID (UUID)
+        #[arg(conflicts_with = "name")]
+        id: Option<String>,
+
+        /// Agent name (resolves to first matching agent)
+        #[arg(long, conflicts_with = "id")]
+        name: Option<String>,
+
+        /// Follow log output (stream new lines)
+        #[arg(long, short = 'f')]
+        follow: bool,
+
+        /// Number of lines to show from the end of the logs
+        #[arg(long, default_value = "100")]
+        tail: String,
     },
 
     /// Send a message/prompt to a running agent.
@@ -627,6 +695,10 @@ impl OrchestratorCommand {
                 env_vars,
                 auto_clear_threshold,
                 network_policy,
+                docker_image,
+                cpu_limit,
+                memory_limit,
+                mounts,
             } => {
                 create_agent(
                     client,
@@ -646,6 +718,10 @@ impl OrchestratorCommand {
                     env_vars,
                     *auto_clear_threshold,
                     network_policy.as_deref(),
+                    docker_image.as_deref(),
+                    *cpu_limit,
+                    *memory_limit,
+                    mounts,
                     json,
                 )
                 .await
@@ -654,6 +730,9 @@ impl OrchestratorCommand {
             OrchestratorCommand::DeleteAgent { id } => delete_agent(client, id, json).await,
             OrchestratorCommand::Attach { id, name } => {
                 attach_agent(client, id.as_deref(), name.as_deref()).await
+            }
+            OrchestratorCommand::Logs { id, name, follow, tail } => {
+                agent_logs(client, id.as_deref(), name.as_deref(), *follow, tail).await
             }
             OrchestratorCommand::SendMessage { id, message, msg_stdin } => {
                 send_message_cmd(client, id, message.as_deref(), *msg_stdin, json).await
@@ -793,6 +872,46 @@ fn parse_env_vars(raw: &[String]) -> Result<std::collections::HashMap<String, St
     Ok(map)
 }
 
+/// Parse `--mount` flag values into [`VolumeMount`] structs.
+///
+/// Expected format: `host_path:container_path` or `host_path:container_path:ro`
+fn parse_mount_flags(raw: &[String]) -> Result<Vec<orchestrator::types::VolumeMount>> {
+    let mut mounts = Vec::new();
+    for entry in raw {
+        let parts: Vec<&str> = entry.splitn(3, ':').collect();
+        match parts.len() {
+            2 => {
+                mounts.push(orchestrator::types::VolumeMount {
+                    host_path: parts[0].to_string(),
+                    container_path: parts[1].to_string(),
+                    read_only: false,
+                });
+            }
+            3 => {
+                let read_only = match parts[2] {
+                    "ro" => true,
+                    "rw" => false,
+                    other => bail!(
+                        "Invalid mount mode '{}' in '{}'. Expected 'ro' or 'rw'.",
+                        other,
+                        entry
+                    ),
+                };
+                mounts.push(orchestrator::types::VolumeMount {
+                    host_path: parts[0].to_string(),
+                    container_path: parts[1].to_string(),
+                    read_only,
+                });
+            }
+            _ => bail!(
+                "Invalid --mount value '{}': expected format host:container or host:container:ro",
+                entry
+            ),
+        }
+    }
+    Ok(mounts)
+}
+
 #[allow(clippy::too_many_arguments)]
 async fn create_agent(
     client: &OrchestratorClient,
@@ -812,6 +931,10 @@ async fn create_agent(
     env_vars: &[String],
     auto_clear_threshold: Option<u64>,
     network_policy: Option<&str>,
+    docker_image: Option<&str>,
+    cpu_limit: Option<f64>,
+    memory_limit: Option<u64>,
+    mounts: &[String],
     json: bool,
 ) -> Result<()> {
     // Resolve working directory: use provided value or default to $PWD
@@ -837,6 +960,19 @@ async fn create_agent(
             "Invalid --network-policy value. Valid options: internet, isolated, host_network",
         )?;
 
+    // Parse --mount flags into VolumeMount structs.
+    let extra_mounts = parse_mount_flags(mounts)?;
+
+    // Build resource limits from individual flags.
+    let resource_limits = if cpu_limit.is_some() || memory_limit.is_some() {
+        Some(orchestrator::types::ResourceLimits {
+            cpu_limit,
+            memory_limit_mb: memory_limit,
+        })
+    } else {
+        None
+    };
+
     let request = CreateAgentRequest {
         name: name.to_string(),
         working_dir: resolved_working_dir,
@@ -851,9 +987,9 @@ async fn create_agent(
         env,
         auto_clear_threshold,
         network_policy: parsed_network_policy,
-        docker_image: None,
-        extra_mounts: None,
-        resource_limits: None,
+        docker_image: docker_image.map(|s| s.to_string()),
+        extra_mounts: if extra_mounts.is_empty() { None } else { Some(extra_mounts) },
+        resource_limits,
     };
 
     let agent = client.create_agent(&request).await.context("Failed to create agent")?;
@@ -866,23 +1002,39 @@ async fn create_agent(
         display_agent(&agent);
     }
 
-    // If --attach was requested, exec into the tmux session
+    // If --attach was requested, exec into the session (tmux or docker)
     if attach {
         let session = agent
             .session_id
             .as_deref()
             .context("Agent response missing 'session_id' field — cannot attach")?;
 
-        println!();
-        println!("{}", format!("Attaching to tmux session: {session}").cyan());
+        let is_docker = agent.backend_type.as_deref() == Some("docker");
 
-        let status = std::process::Command::new("tmux")
-            .args(["attach-session", "-t", session])
-            .status()
-            .context("Failed to exec tmux attach-session")?;
+        if is_docker {
+            println!();
+            println!("{}", format!("Attaching to Docker container: {session}").cyan());
 
-        if !status.success() {
-            bail!("tmux attach-session exited with status: {status}");
+            let status = std::process::Command::new("docker")
+                .args(["exec", "-it", session, "bash"])
+                .status()
+                .context("Failed to exec docker exec")?;
+
+            if !status.success() {
+                bail!("docker exec exited with status: {status}");
+            }
+        } else {
+            println!();
+            println!("{}", format!("Attaching to tmux session: {session}").cyan());
+
+            let status = std::process::Command::new("tmux")
+                .args(["attach-session", "-t", session])
+                .status()
+                .context("Failed to exec tmux attach-session")?;
+
+            if !status.success() {
+                bail!("tmux attach-session exited with status: {status}");
+            }
         }
     }
 
@@ -946,41 +1098,154 @@ async fn attach_agent(
         .as_deref()
         .context(format!("Agent '{}' has no session. It may have crashed.", agent.name))?;
 
-    if std::process::Command::new("tmux")
-        .arg("-V")
+    let is_docker = agent.backend_type.as_deref() == Some("docker");
+
+    if is_docker {
+        // Docker backend: exec into the container
+        if std::process::Command::new("docker")
+            .arg("--version")
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+            .is_err()
+        {
+            bail!("docker is required but not found. Install Docker Desktop or Docker Engine.");
+        }
+
+        // Verify the container is running
+        let container_check = std::process::Command::new("docker")
+            .args(["inspect", "--format", "{{.State.Running}}", session])
+            .output();
+
+        match container_check {
+            Ok(output) if String::from_utf8_lossy(&output.stdout).trim() == "true" => {}
+            _ => bail!(
+                "Docker container '{}' is not running. Agent '{}' ({}) may have crashed.",
+                session,
+                agent.name,
+                agent.id
+            ),
+        }
+
+        println!(
+            "{}",
+            format!("Attaching to agent '{}' (container: {})...", agent.name, session).cyan()
+        );
+
+        let exit = std::process::Command::new("docker")
+            .args(["exec", "-it", session, "bash"])
+            .status()
+            .context("Failed to exec docker exec")?;
+
+        if !exit.success() {
+            bail!("docker exec exited with status: {}", exit);
+        }
+    } else {
+        // Tmux backend: attach to the tmux session
+        if std::process::Command::new("tmux")
+            .arg("-V")
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status()
+            .is_err()
+        {
+            bail!("tmux is required but not found. Install with: brew install tmux");
+        }
+
+        let session_check = std::process::Command::new("tmux")
+            .args(["has-session", "-t", session])
+            .stdout(std::process::Stdio::null())
+            .stderr(std::process::Stdio::null())
+            .status();
+
+        match session_check {
+            Ok(s) if s.success() => {}
+            _ => bail!(
+                "Tmux session '{}' no longer exists. Agent '{}' ({}) may have crashed.",
+                session,
+                agent.name,
+                agent.id
+            ),
+        }
+
+        println!(
+            "{}",
+            format!("Attaching to agent '{}' (session: {})...", agent.name, session).cyan()
+        );
+
+        let exit = std::process::Command::new("tmux")
+            .args(["attach-session", "-t", session])
+            .status()
+            .context("Failed to exec tmux attach-session")?;
+
+        if !exit.success() {
+            bail!("tmux attach-session exited with status: {}", exit);
+        }
+    }
+
+    Ok(())
+}
+
+// -- Logs --
+
+async fn agent_logs(
+    client: &OrchestratorClient,
+    id: Option<&str>,
+    name: Option<&str>,
+    follow: bool,
+    tail: &str,
+) -> Result<()> {
+    let agent = match (id, name) {
+        (Some(agent_id), _) => {
+            let uuid = parse_uuid(agent_id)?;
+            client.get_agent(&uuid).await.context(
+                "Agent not found. Use 'agent orchestrator list-agents' to see available agents.",
+            )?
+        }
+        (_, Some(agent_name)) => {
+            let resolved = resolve_agent_id(client, None, Some(agent_name)).await?;
+            client.get_agent(&resolved).await.context("Failed to get agent")?
+        }
+        (None, None) => bail!("Either an agent ID or --name must be provided."),
+    };
+
+    let is_docker = agent.backend_type.as_deref() == Some("docker");
+    if !is_docker {
+        bail!(
+            "Agent '{}' uses the {} backend. The 'logs' command is only available for Docker-backed agents.",
+            agent.name,
+            agent.backend_type.as_deref().unwrap_or("tmux")
+        );
+    }
+
+    let container = agent
+        .session_id
+        .as_deref()
+        .context(format!("Agent '{}' has no container ID. It may have crashed.", agent.name))?;
+
+    if std::process::Command::new("docker")
+        .arg("--version")
         .stdout(std::process::Stdio::null())
         .stderr(std::process::Stdio::null())
         .status()
         .is_err()
     {
-        bail!("tmux is required but not found. Install with: brew install tmux");
+        bail!("docker is required but not found. Install Docker Desktop or Docker Engine.");
     }
 
-    let session_check = std::process::Command::new("tmux")
-        .args(["has-session", "-t", session])
-        .stdout(std::process::Stdio::null())
-        .stderr(std::process::Stdio::null())
-        .status();
-
-    match session_check {
-        Ok(s) if s.success() => {}
-        _ => bail!(
-            "Tmux session '{}' no longer exists. Agent '{}' ({}) may have crashed.",
-            session,
-            agent.name,
-            agent.id
-        ),
+    let mut args = vec!["logs", "--tail", tail];
+    if follow {
+        args.push("-f");
     }
+    args.push(container);
 
-    println!("{}", format!("Attaching to agent '{}' (session: {})...", agent.name, session).cyan());
-
-    let exit = std::process::Command::new("tmux")
-        .args(["attach-session", "-t", session])
+    let status = std::process::Command::new("docker")
+        .args(&args)
         .status()
-        .context("Failed to exec tmux attach-session")?;
+        .context("Failed to exec docker logs")?;
 
-    if !exit.success() {
-        bail!("tmux attach-session exited with status: {}", exit);
+    if !status.success() {
+        bail!("docker logs exited with status: {}", status);
     }
 
     Ok(())
@@ -1870,6 +2135,13 @@ fn display_agent(agent: &AgentResponse) {
         AgentStatus::Failed => status_str.bright_red(),
     };
     println!("{}: {}", "Status".bold(), colored_status);
+    if let Some(ref backend) = agent.backend_type {
+        let backend_display = match backend.as_str() {
+            "docker" => backend.cyan(),
+            _ => backend.normal(),
+        };
+        println!("{}: {}", "Backend".bold(), backend_display);
+    }
     if let Some(session) = &agent.session_id {
         println!("{}: {}", "Session".bold(), session);
     }
@@ -1890,6 +2162,37 @@ fn display_agent(agent: &AgentResponse) {
         ToolPolicy::RequireApproval => "require_approval".bright_yellow().to_string(),
     };
     println!("{}: {}", "Tool Policy".bold(), policy_display);
+
+    // Docker-specific details
+    if agent.backend_type.as_deref() == Some("docker") {
+        if let Some(ref image) = agent.config.docker_image {
+            println!("{}: {}", "Docker Image".bold(), image.cyan());
+        }
+        if let Some(ref limits) = agent.config.resource_limits {
+            if let Some(cpu) = limits.cpu_limit {
+                println!("{}: {}", "CPU Limit".bold(), cpu);
+            }
+            if let Some(mem) = limits.memory_limit_mb {
+                println!("{}: {} MB", "Memory Limit".bold(), mem);
+            }
+        }
+        if let Some(ref mounts) = agent.config.extra_mounts {
+            for mount in mounts {
+                let ro = if mount.read_only { ":ro" } else { "" };
+                println!(
+                    "{}: {}:{}{}",
+                    "Mount".bold(),
+                    mount.host_path,
+                    mount.container_path,
+                    ro
+                );
+            }
+        }
+        if let Some(ref policy) = agent.config.network_policy {
+            println!("{}: {}", "Network Policy".bold(), policy);
+        }
+    }
+
     println!("{}: {}", "Created".bold(), agent.created_at);
 }
 
@@ -2728,5 +3031,108 @@ mod tests {
         ]);
 
         assert!(result.is_err(), "ID and --name should conflict");
+    }
+
+    #[test]
+    fn test_parse_mount_flags_basic() {
+        let mounts = vec!["/host/path:/container/path".to_string()];
+        let result = parse_mount_flags(&mounts).unwrap();
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].host_path, "/host/path");
+        assert_eq!(result[0].container_path, "/container/path");
+        assert!(!result[0].read_only);
+    }
+
+    #[test]
+    fn test_parse_mount_flags_read_only() {
+        let mounts = vec!["/host:/container:ro".to_string()];
+        let result = parse_mount_flags(&mounts).unwrap();
+        assert_eq!(result.len(), 1);
+        assert!(result[0].read_only);
+    }
+
+    #[test]
+    fn test_parse_mount_flags_read_write() {
+        let mounts = vec!["/host:/container:rw".to_string()];
+        let result = parse_mount_flags(&mounts).unwrap();
+        assert_eq!(result.len(), 1);
+        assert!(!result[0].read_only);
+    }
+
+    #[test]
+    fn test_parse_mount_flags_invalid_mode() {
+        let mounts = vec!["/host:/container:xyz".to_string()];
+        let result = parse_mount_flags(&mounts);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("Invalid mount mode"));
+    }
+
+    #[test]
+    fn test_parse_mount_flags_invalid_format() {
+        let mounts = vec!["no-colon".to_string()];
+        let result = parse_mount_flags(&mounts);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("Invalid --mount value"));
+    }
+
+    #[test]
+    fn test_parse_mount_flags_multiple() {
+        let mounts = vec![
+            "/a:/b".to_string(),
+            "/c:/d:ro".to_string(),
+            "/e:/f:rw".to_string(),
+        ];
+        let result = parse_mount_flags(&mounts).unwrap();
+        assert_eq!(result.len(), 3);
+        assert!(!result[0].read_only);
+        assert!(result[1].read_only);
+        assert!(!result[2].read_only);
+    }
+
+    #[test]
+    fn test_parse_mount_flags_empty() {
+        let mounts: Vec<String> = vec![];
+        let result = parse_mount_flags(&mounts).unwrap();
+        assert!(result.is_empty());
+    }
+
+    #[test]
+    fn test_display_agent_with_docker_backend() {
+        use chrono::Utc;
+        let agent = AgentResponse {
+            id: Uuid::new_v4(),
+            name: "docker-agent".to_string(),
+            status: AgentStatus::Running,
+            config: AgentConfig {
+                working_dir: "/workspace".to_string(),
+                user: None,
+                shell: "bash".to_string(),
+                interactive: false,
+                prompt: None,
+                worktree: false,
+                system_prompt: None,
+                tool_policy: Default::default(),
+                model: Some("opus".to_string()),
+                env: Default::default(),
+                auto_clear_threshold: None,
+                network_policy: Some(wrap::docker::NetworkPolicy::Internet),
+                docker_image: Some("custom:latest".to_string()),
+                extra_mounts: Some(vec![orchestrator::types::VolumeMount {
+                    host_path: "/host".to_string(),
+                    container_path: "/container".to_string(),
+                    read_only: true,
+                }]),
+                resource_limits: Some(orchestrator::types::ResourceLimits {
+                    cpu_limit: Some(2.0),
+                    memory_limit_mb: Some(4096),
+                }),
+            },
+            session_id: Some("abc123container".to_string()),
+            backend_type: Some("docker".to_string()),
+            created_at: Utc::now(),
+            updated_at: Utc::now(),
+        };
+        // Should not panic and should display Docker-specific details
+        display_agent(&agent);
     }
 }


### PR DESCRIPTION
## Summary

- Add Docker-specific flags to `create-agent` command: `--docker-image`, `--cpu-limit`, `--memory-limit`, `--mount host:container[:ro]`
- Make `attach` command backend-aware: auto-detects tmux vs Docker and uses `docker exec -it` for Docker-backed agents
- Add new `logs` command for viewing Docker container logs with `--follow` and `--tail` support
- Update `display_agent` to show backend type and Docker-specific details (image, CPU/memory limits, mounts, network policy)
- Update `apply.rs` templates to support `docker_image`, `extra_mounts`, and `resource_limits` fields
- Add 8 new tests for mount parsing and Docker display

Closes #288

## Test plan

- [x] All 50 orchestrator CLI tests pass (8 new)
- [x] All 102 orchestrator lib tests pass
- [x] `cargo build -p cli` succeeds
- [ ] Manual: `agent orchestrator create-agent --name test --docker-image custom:latest --cpu-limit 2.0 --memory-limit 4096 --mount /host:/container:ro`
- [ ] Manual: `agent orchestrator attach --name test` (Docker agent)
- [ ] Manual: `agent orchestrator logs --name test --follow`
- [ ] Manual: `agent orchestrator get-agent <id>` shows Docker details

🤖 Generated with [Claude Code](https://claude.com/claude-code)