### PR TITLE
feat(ui): consolidate agent action buttons into a dropdown menu

### DIFF
--- a/ui/src/pages/agents/AgentDetail.tsx
+++ b/ui/src/pages/agents/AgentDetail.tsx
@@ -11,9 +11,20 @@
  * └───────────────────────────────────────────────────────────────────────┘
  */
 
-import { useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
-import { ArrowLeft, Copy, Eraser, Loader2, RefreshCw, Settings2, Trash2 } from 'lucide-react'
+import {
+  ArrowLeft,
+  ChevronDown,
+  Copy,
+  Eraser,
+  FolderPlus,
+  Loader2,
+  MoreHorizontal,
+  RefreshCw,
+  Settings2,
+  Trash2,
+} from 'lucide-react'
 import { AgentStatusBadge } from '@/components/agents/AgentStatusBadge'
 import { AgentConfigPanel } from '@/components/agents/AgentConfigPanel'
 import { AgentLogView } from '@/components/agents/AgentLogView'
@@ -257,6 +268,286 @@ function ClearContextDialog({ open, session, loading, onConfirm, onCancel }: Cle
 }
 
 // ---------------------------------------------------------------------------
+// Add Directory dialog
+// ---------------------------------------------------------------------------
+
+interface AddDirDialogProps {
+  open: boolean
+  onConfirm: (path: string) => Promise<void>
+  onClose: () => void
+}
+
+function AddDirDialog({ open, onConfirm, onClose }: AddDirDialogProps) {
+  const [path, setPath] = useState('')
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | undefined>()
+
+  if (!open) return null
+
+  async function handleSubmit() {
+    const trimmed = path.trim()
+    if (!trimmed) return
+    setSaving(true)
+    setError(undefined)
+    try {
+      await onConfirm(trimmed)
+      setPath('')
+      onClose()
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to add directory')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent) {
+    if (e.key === 'Enter') handleSubmit()
+    if (e.key === 'Escape') onClose()
+  }
+
+  const inputCls =
+    'block w-full rounded-md border border-gray-300 bg-white px-3 py-2 font-mono text-sm text-gray-900 focus:border-primary-500 focus:outline-none focus:ring-1 focus:ring-primary-500 dark:border-gray-600 dark:bg-gray-800 dark:text-white'
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+      <div className="absolute inset-0 bg-black/50" aria-hidden="true" onClick={onClose} />
+      <div
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby="add-dir-header-title"
+        className="relative w-full max-w-md rounded-lg bg-white p-6 shadow-xl dark:bg-gray-800"
+      >
+        <h2
+          id="add-dir-header-title"
+          className="mb-4 text-base font-semibold text-gray-900 dark:text-white"
+        >
+          Add Directory
+        </h2>
+
+        <p className="mb-3 text-sm text-gray-500 dark:text-gray-400">
+          Enter an absolute path to grant the agent access via{' '}
+          <code className="rounded bg-gray-100 px-1 py-0.5 font-mono text-xs dark:bg-gray-700">
+            --add-dir
+          </code>
+          .
+        </p>
+
+        {error && (
+          <p role="alert" className="mb-3 text-sm text-red-600 dark:text-red-400">
+            {error}
+          </p>
+        )}
+
+        <div className="flex flex-col gap-2">
+          <label
+            htmlFor="add-dir-header-path"
+            className="text-sm font-medium text-gray-700 dark:text-gray-300"
+          >
+            Directory path
+          </label>
+          <input
+            id="add-dir-header-path"
+            type="text"
+            value={path}
+            onChange={(e) => setPath(e.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder="/path/to/directory"
+            className={inputCls}
+            // eslint-disable-next-line jsx-a11y/no-autofocus
+            autoFocus
+            disabled={saving}
+          />
+        </div>
+
+        <p className="mt-3 text-xs text-amber-600 dark:text-amber-400">
+          Directory changes take effect on the next agent restart.
+        </p>
+
+        <div className="mt-5 flex justify-end gap-2">
+          <button
+            type="button"
+            onClick={onClose}
+            disabled={saving}
+            className="rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-300"
+          >
+            Cancel
+          </button>
+          <button
+            type="button"
+            onClick={handleSubmit}
+            disabled={saving || !path.trim()}
+            className="rounded-md bg-primary-600 px-4 py-2 text-sm font-medium text-white hover:bg-primary-700 disabled:opacity-50 transition-colors"
+          >
+            {saving ? 'Adding…' : 'Add Directory'}
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Actions dropdown menu
+// ---------------------------------------------------------------------------
+
+interface ActionsDropdownProps {
+  isRunning: boolean
+  clearing: boolean
+  onChangeModel: () => void
+  onAddDir: () => void
+  onClearContext: () => void
+  onTerminate: () => void
+}
+
+function ActionsDropdown({
+  isRunning,
+  clearing,
+  onChangeModel,
+  onAddDir,
+  onClearContext,
+  onTerminate,
+}: ActionsDropdownProps) {
+  const [open, setOpen] = useState(false)
+  const menuRef = useRef<HTMLDivElement>(null)
+  const buttonRef = useRef<HTMLButtonElement>(null)
+
+  // Close on outside click
+  useEffect(() => {
+    if (!open) return
+    function handlePointerDown(e: MouseEvent) {
+      if (menuRef.current && !menuRef.current.contains(e.target as Node)) {
+        setOpen(false)
+      }
+    }
+    document.addEventListener('mousedown', handlePointerDown)
+    return () => document.removeEventListener('mousedown', handlePointerDown)
+  }, [open])
+
+  // Escape to close, arrow keys to navigate
+  useEffect(() => {
+    if (!open) return
+    function handleKeyDown(e: KeyboardEvent) {
+      if (e.key === 'Escape') {
+        setOpen(false)
+        buttonRef.current?.focus()
+        return
+      }
+      if (e.key === 'ArrowDown' || e.key === 'ArrowUp') {
+        e.preventDefault()
+        const items = Array.from(
+          menuRef.current?.querySelectorAll<HTMLElement>('[role="menuitem"]:not([disabled])') ?? [],
+        )
+        if (items.length === 0) return
+        const idx = items.indexOf(document.activeElement as HTMLElement)
+        if (e.key === 'ArrowDown') {
+          items[(idx + 1) % items.length].focus()
+        } else {
+          items[(idx - 1 + items.length) % items.length].focus()
+        }
+      }
+    }
+    document.addEventListener('keydown', handleKeyDown)
+    return () => document.removeEventListener('keydown', handleKeyDown)
+  }, [open])
+
+  function pick(fn: () => void) {
+    setOpen(false)
+    fn()
+  }
+
+  const itemCls =
+    'flex w-full items-center gap-2.5 px-3 py-2 text-left text-sm focus:outline-none'
+  const normalItem = `${itemCls} text-gray-700 hover:bg-gray-50 focus:bg-gray-50 dark:text-gray-300 dark:hover:bg-gray-700/50 dark:focus:bg-gray-700/50`
+  const amberItem = `${itemCls} text-amber-700 hover:bg-amber-50 focus:bg-amber-50 dark:text-amber-400 dark:hover:bg-amber-900/20 dark:focus:bg-amber-900/20 disabled:opacity-50 disabled:cursor-not-allowed`
+  const redItem = `${itemCls} text-red-600 hover:bg-red-50 focus:bg-red-50 dark:text-red-400 dark:hover:bg-red-900/20 dark:focus:bg-red-900/20`
+
+  return (
+    <div ref={menuRef} className="relative">
+      <button
+        ref={buttonRef}
+        type="button"
+        aria-haspopup="menu"
+        aria-expanded={open}
+        onClick={() => setOpen((o) => !o)}
+        className="flex items-center gap-1.5 rounded-md border border-gray-300 bg-white px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-1 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700"
+      >
+        <MoreHorizontal size={14} aria-hidden="true" />
+        <span className="hidden sm:inline">Actions</span>
+        <ChevronDown
+          size={12}
+          aria-hidden="true"
+          className={`transition-transform ${open ? 'rotate-180' : ''}`}
+        />
+      </button>
+
+      {open && (
+        <div
+          role="menu"
+          aria-label="Agent actions"
+          className="absolute right-0 z-20 mt-1 w-52 rounded-md border border-gray-200 bg-white py-1 shadow-lg dark:border-gray-700 dark:bg-gray-800"
+        >
+          {/* Change Model */}
+          <button
+            role="menuitem"
+            type="button"
+            onClick={() => pick(onChangeModel)}
+            className={normalItem}
+          >
+            <Settings2 size={14} className="text-gray-400 dark:text-gray-500" aria-hidden="true" />
+            Change Model
+          </button>
+
+          {/* Add Directory */}
+          <button
+            role="menuitem"
+            type="button"
+            onClick={() => pick(onAddDir)}
+            className={normalItem}
+          >
+            <FolderPlus size={14} className="text-gray-400 dark:text-gray-500" aria-hidden="true" />
+            Add Directory
+          </button>
+
+          {/* Clear Context (amber / warning) */}
+          <button
+            role="menuitem"
+            type="button"
+            onClick={() => pick(onClearContext)}
+            disabled={!isRunning || clearing}
+            className={amberItem}
+          >
+            {clearing ? (
+              <Loader2
+                size={14}
+                className="animate-spin text-amber-500"
+                aria-hidden="true"
+              />
+            ) : (
+              <Eraser size={14} className="text-amber-500" aria-hidden="true" />
+            )}
+            Clear Context
+          </button>
+
+          {/* Divider */}
+          <div role="separator" className="my-1 border-t border-gray-100 dark:border-gray-700" />
+
+          {/* Terminate (red / danger) */}
+          <button
+            role="menuitem"
+            type="button"
+            onClick={() => pick(onTerminate)}
+            className={redItem}
+          >
+            <Trash2 size={14} className="text-red-500" aria-hidden="true" />
+            Terminate
+          </button>
+        </div>
+      )}
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
 // AgentDetail
 // ---------------------------------------------------------------------------
 
@@ -290,6 +581,7 @@ export function AgentDetail() {
   const [terminating, setTerminating] = useState(false)
   const [confirmClearContext, setConfirmClearContext] = useState(false)
   const [showModelDialog, setShowModelDialog] = useState(false)
+  const [showAddDirDialog, setShowAddDirDialog] = useState(false)
   const [policyEditing, setPolicyEditing] = useState(false)
   const [copied, setCopied] = useState(false)
 
@@ -443,53 +735,27 @@ export function AgentDetail() {
             </div>
           </div>
 
-          {/* Right: actions */}
+          {/* Right: actions — Refresh (standalone) + Actions dropdown */}
           <div className="flex flex-shrink-0 items-center gap-2">
-            {/* Refresh */}
+            {/* Refresh — kept standalone: frequent, low-risk, no confirmation */}
             <button
               type="button"
               aria-label="Refresh agent data"
               onClick={refetch}
-              className="rounded-md border border-gray-300 bg-white p-2 text-gray-500 hover:bg-gray-50 hover:text-gray-700 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-400 dark:hover:bg-gray-700"
+              className="rounded-md border border-gray-300 bg-white p-2 text-gray-500 hover:bg-gray-50 hover:text-gray-700 focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-1 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-400 dark:hover:bg-gray-700"
             >
               <RefreshCw size={14} aria-hidden="true" />
             </button>
 
-            {/* Change model */}
-            <button
-              type="button"
-              onClick={() => setShowModelDialog(true)}
-              className="flex items-center gap-1.5 rounded-md border border-gray-300 bg-white px-3 py-1.5 text-sm font-medium text-gray-700 hover:bg-gray-50 dark:border-gray-600 dark:bg-gray-800 dark:text-gray-300 dark:hover:bg-gray-700"
-            >
-              <Settings2 size={14} aria-hidden="true" />
-              Model
-            </button>
-
-            {/* Clear context */}
-            <button
-              type="button"
-              onClick={() => setConfirmClearContext(true)}
-              disabled={!isRunning || clearing}
-              title={!isRunning ? 'Agent must be running to clear context' : undefined}
-              className="flex items-center gap-1.5 rounded-md border border-amber-400 bg-amber-50 px-3 py-1.5 text-sm font-medium text-amber-700 hover:bg-amber-100 focus:outline-none focus:ring-2 focus:ring-amber-500 focus:ring-offset-1 disabled:opacity-50 disabled:cursor-not-allowed transition-colors dark:border-amber-600 dark:bg-amber-900/30 dark:text-amber-300 dark:hover:bg-amber-900/50"
-            >
-              {clearing ? (
-                <Loader2 size={14} className="animate-spin" aria-hidden="true" />
-              ) : (
-                <Eraser size={14} aria-hidden="true" />
-              )}
-              Clear Context
-            </button>
-
-            {/* Terminate */}
-            <button
-              type="button"
-              onClick={() => setConfirmTerminate(true)}
-              className="flex items-center gap-1.5 rounded-md bg-red-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-red-700 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-1 transition-colors"
-            >
-              <Trash2 size={14} aria-hidden="true" />
-              Terminate
-            </button>
+            {/* Actions dropdown */}
+            <ActionsDropdown
+              isRunning={isRunning}
+              clearing={clearing}
+              onChangeModel={() => setShowModelDialog(true)}
+              onAddDir={() => setShowAddDirDialog(true)}
+              onClearContext={() => setConfirmClearContext(true)}
+              onTerminate={() => setConfirmTerminate(true)}
+            />
           </div>
         </div>
       </div>
@@ -614,6 +880,12 @@ export function AgentDetail() {
         currentModel={agent.config.model}
         onSave={handleModelSave}
         onClose={() => setShowModelDialog(false)}
+      />
+
+      <AddDirDialog
+        open={showAddDirDialog}
+        onConfirm={handleAddDir}
+        onClose={() => setShowAddDirDialog(false)}
       />
     </div>
   )


### PR DESCRIPTION
## Summary

Replaces the four individual header action buttons (Change Model, Clear Context, Terminate, and the pending Add Directory from #359) with a single **Actions** dropdown, keeping **Refresh** as a standalone icon button.

## Changes

**New `ActionsDropdown` component** (inline in `AgentDetail.tsx`):
- Trigger: icon + hidden "Actions" label (visible on `sm+`) + rotating chevron
- `aria-haspopup="menu"`, `aria-expanded`, `role="menu"` / `role="menuitem"` for full screen-reader support
- Closes on outside click (mousedown on document) and Escape key (returns focus to trigger)
- Arrow-up / arrow-down keyboard navigation across enabled items

**Menu items:**
| Item | Icon | Style | Notes |
|---|---|---|---|
| Change Model | Settings2 | default | → `setShowModelDialog(true)` |
| Add Directory | FolderPlus | default | → `setShowAddDirDialog(true)` |
| Clear Context | Eraser | amber warning | disabled when not running or clearing |
| ─── | | separator | |
| Terminate | Trash2 | red danger | → `setConfirmTerminate(true)` |

**New `AddDirDialog`** component added to `AgentDetail.tsx` so the header dropdown can trigger directory addition independently of the per-entry add button inside `AgentConfigPanel`.

All existing dialog flows (ConfirmDialog, ClearContextDialog, ChangeModelDialog) are unchanged — only their triggers move into the dropdown.

## Test plan

- [x] `npx tsc --noEmit --skipLibCheck` — zero errors in production source
- [x] Refresh button remains standalone
- [x] Dropdown opens/closes on button click
- [x] Dropdown closes on outside click
- [x] Escape key closes dropdown and returns focus to trigger
- [x] Arrow keys navigate menu items (skipping disabled items)
- [x] Change Model → ChangeModelDialog opens
- [x] Add Directory → AddDirDialog opens, calls API, refetches
- [x] Clear Context → ClearContextDialog opens (disabled when agent not running)
- [x] Terminate → ConfirmDialog opens with danger styling
- [x] Mobile: icon-only trigger, no "Actions" text overflow
- [x] Dark mode: all menu item hover/focus states have dark: variants

Closes #360

🤖 Generated with [Claude Code](https://claude.com/claude-code)