### PR TITLE
docs: add additional directories feature documentation

### DIFF
--- a/docs/public/additional-dirs.md
+++ b/docs/public/additional-dirs.md
@@ -1,0 +1,211 @@
+# Additional Directories
+
+By default, an agent can only read and write within its `working_dir`. The **additional directories** feature lets you grant an agent access to other paths on the filesystem. Each added path maps directly to Claude Code's `--add-dir` flag.
+
+Common use cases:
+
+- **Monorepo access** — agent works in one package but needs to read sibling packages
+- **Shared config or libraries** — company-wide configs, shared scripts, or tooling directories
+- **Reference repositories** — read a related repo without making it the working directory
+
+---
+
+## Configure via YAML template
+
+Add `additional_dirs` to an agent template under `.agentd/agents/`:
+
+```yaml
+name: my-agent
+working_dir: /path/to/project
+additional_dirs:
+  - ../shared-libraries      # relative: resolved relative to this YAML file
+  - /opt/company/configs     # absolute: used as-is
+  - ~/other-project          # tilde: expanded to the home directory
+```
+
+### Path resolution
+
+| Path type | Example | Resolved to |
+|-----------|---------|-------------|
+| Relative | `../shared-libs` | Joined with the YAML file's directory, then canonicalized |
+| Absolute | `/opt/configs` | Used as-is |
+| Tilde | `~/other-project` | Expanded to home directory |
+
+Relative paths are resolved at `agent apply` time, relative to the directory containing the YAML file — not relative to `working_dir` or `$PWD`.
+
+```yaml
+# .agentd/agents/worker.yml
+# File is at: /home/user/myproject/.agentd/agents/worker.yml
+# working_dir is: /home/user/myproject
+additional_dirs:
+  - ../../shared       # resolves to /home/user/shared
+  - /opt/tools         # used as /opt/tools
+```
+
+Apply the template:
+
+```bash
+agent apply .agentd/agents/worker.yml
+```
+
+---
+
+## Configure via CLI
+
+### At creation time
+
+Pass `--add-dir` one or more times when creating an agent:
+
+```bash
+agent orchestrator create-agent \
+  --name my-agent \
+  --add-dir /path/to/shared-libs \
+  --add-dir /opt/company/configs
+```
+
+### Add a directory to an existing agent
+
+```bash
+agent orchestrator add-dir <AGENT_ID> /path/to/dir
+```
+
+The directory must exist on the filesystem at the time of the call. The change is persisted immediately but **takes effect on the next agent restart**.
+
+**Example output:**
+
+```
+Agent ID: 550e8400-e29b-41d4-a716-446655440000
+Additional Dirs: /path/to/dir
+Note: restart the agent for directory changes to take effect.
+```
+
+### Remove a directory from an existing agent
+
+```bash
+agent orchestrator remove-dir <AGENT_ID> /path/to/dir
+```
+
+Removing a path that is not in the list is a no-op. The change **takes effect on the next agent restart**.
+
+---
+
+## Configure via API
+
+### Add a directory
+
+```
+POST /agents/{id}/dirs
+Content-Type: application/json
+```
+
+**Request body:**
+
+```json
+{ "path": "/path/to/dir" }
+```
+
+**Response:** `200 OK`
+
+```json
+{
+  "agent_id": "550e8400-e29b-41d4-a716-446655440000",
+  "additional_dirs": [
+    "/path/to/dir"
+  ],
+  "requires_restart": true
+}
+```
+
+**Errors:**
+- `404` — agent not found
+- `422` — path does not exist or is not a directory
+
+The operation is **idempotent** — adding a path that is already present is a no-op.
+
+**curl example:**
+
+```bash
+curl -X POST http://127.0.0.1:17006/agents/<ID>/dirs \
+  -H "Content-Type: application/json" \
+  -d '{"path": "/path/to/shared-libs"}'
+```
+
+---
+
+### Remove a directory
+
+```
+DELETE /agents/{id}/dirs
+Content-Type: application/json
+```
+
+**Request body:**
+
+```json
+{ "path": "/path/to/dir" }
+```
+
+**Response:** `200 OK`
+
+```json
+{
+  "agent_id": "550e8400-e29b-41d4-a716-446655440000",
+  "additional_dirs": [],
+  "requires_restart": true
+}
+```
+
+**Errors:**
+- `404` — agent not found
+
+The operation is **idempotent** — removing a path that is not in the list is a no-op.
+
+**curl example:**
+
+```bash
+curl -X DELETE http://127.0.0.1:17006/agents/<ID>/dirs \
+  -H "Content-Type: application/json" \
+  -d '{"path": "/path/to/shared-libs"}'
+```
+
+---
+
+## Restart behavior
+
+Directory changes are persisted to the database immediately but the running agent process is not affected until it is restarted. The API and CLI always set `"requires_restart": true` in the response as a reminder.
+
+To apply the change:
+
+```bash
+# Terminate the agent
+agent orchestrator delete-agent <AGENT_ID>
+
+# Re-create it (or use your YAML template)
+agent apply .agentd/agents/my-agent.yml
+```
+
+!!! tip "Workflow agents"
+    If the agent is managed by a workflow, the workflow will re-launch the agent automatically after it is terminated.
+
+---
+
+## Docker backend behavior
+
+For agents running in Docker containers, each path in `additional_dirs` is automatically bind-mounted into the container at the same absolute path. The mount is read-write, so the agent can read and write to those directories.
+
+```
+Host: /opt/company/configs  →  Container: /opt/company/configs  (bind-mount, rw)
+```
+
+Ensure the paths exist on the **host** before starting the agent; the orchestrator validates their existence at creation and add time.
+
+---
+
+## Security considerations
+
+!!! warning "Agents can read and write"
+    An agent has full read and write access to every directory in `additional_dirs`. Only add directories that the agent legitimately needs.
+
+- Validate that paths point to the intended directories — avoid accidentally adding sensitive parent directories (e.g., `/home/user` instead of `/home/user/project`).
+- For agents with broad filesystem access, consider pairing with a restrictive [tool policy](tool-policies.md) that limits which tools the agent can use.
+- In Docker environments the bind-mounts are read-write; there is no current support for read-only additional directories.

--- a/docs/public/services/orchestrator.md
+++ b/docs/public/services/orchestrator.md
@@ -130,6 +130,7 @@ Content-Type: application/json
 | `tool_policy` | object | no | `{"mode":"allow_all"}` | Tool use restrictions (see [Tool Policy](#tool-policy)) |
 | `model` | string | no | | Model to use — accepts aliases (`sonnet`, `opus`, `haiku`) or full names (`claude-sonnet-4-6`). Maps to the `--model` flag. |
 | `env` | object | no | `{}` | Environment variables set when launching the agent. Commonly used for `ANTHROPIC_API_KEY`, `ANTHROPIC_BASE_URL`. Values are write-only — the API returns `"***"` in responses. |
+| `additional_dirs` | array | no | `[]` | Extra directories the agent can read and write, in addition to `working_dir`. Each entry maps to a `--add-dir` flag. See [Additional Directories](../additional-dirs.md). |
 | `auto_clear_threshold` | integer | no | | Automatically clear context when cumulative input tokens for the session exceeds this value. |
 | `network_policy` | string | no | | Network policy for Docker-backed agents (`internet`, `isolated`, `host`). Ignored for tmux backends. |
 
@@ -255,6 +256,85 @@ Content-Type: application/json
 
 !!! tip "Auto-clear threshold"
     Set `auto_clear_threshold` when creating an agent to automatically clear context when input tokens exceed the threshold, without manual intervention.
+
+---
+
+### Manage Additional Directories
+
+Add or remove filesystem directories the agent can access. Each directory maps to Claude Code's `--add-dir` flag. Changes are persisted immediately but **take effect on the next agent restart**.
+
+See [Additional Directories](../additional-dirs.md) for full details including YAML template configuration and Docker behavior.
+
+#### Add a directory
+
+```
+POST /agents/{id}/dirs
+Content-Type: application/json
+```
+
+**Request body:**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `path` | string | yes | Absolute path to the directory. Must exist and be a directory at call time. |
+
+**Response:** `200 OK`
+
+```json
+{
+  "agent_id": "550e8400-e29b-41d4-a716-446655440000",
+  "additional_dirs": ["/path/to/shared-libs"],
+  "requires_restart": true
+}
+```
+
+**Errors:**
+- `404` — agent not found
+- `422` — path does not exist or is not a directory
+
+Adding a path that is already present is a no-op (idempotent).
+
+**Example:**
+```bash
+curl -X POST http://127.0.0.1:17006/agents/<ID>/dirs \
+  -H "Content-Type: application/json" \
+  -d '{"path": "/path/to/shared-libs"}'
+```
+
+#### Remove a directory
+
+```
+DELETE /agents/{id}/dirs
+Content-Type: application/json
+```
+
+**Request body:**
+
+| Field | Type | Required | Description |
+|-------|------|----------|-------------|
+| `path` | string | yes | Path to remove. |
+
+**Response:** `200 OK`
+
+```json
+{
+  "agent_id": "550e8400-e29b-41d4-a716-446655440000",
+  "additional_dirs": [],
+  "requires_restart": true
+}
+```
+
+**Errors:**
+- `404` — agent not found
+
+Removing a path that is not in the list is a no-op (idempotent).
+
+**Example:**
+```bash
+curl -X DELETE http://127.0.0.1:17006/agents/<ID>/dirs \
+  -H "Content-Type: application/json" \
+  -d '{"path": "/path/to/shared-libs"}'
+```
 
 ---
 
@@ -675,6 +755,22 @@ agent orchestrator health
 agent orchestrator health --json
 ```
 
+### Manage Additional Directories
+
+Add or remove directories from an agent's accessible paths:
+
+```bash
+# Add a directory (must exist; takes effect on next restart)
+agent orchestrator add-dir <AGENT_ID> /path/to/dir
+
+# Remove a directory (takes effect on next restart)
+agent orchestrator remove-dir <AGENT_ID> /path/to/dir
+```
+
+Both commands print the updated directory list and a restart reminder. See [Additional Directories](../additional-dirs.md) for full details.
+
+---
+
 ### Validate Template
 
 Check a workflow prompt template for errors:
@@ -782,7 +878,9 @@ agent teardown .agentd/
 # Create an agent using the CLI
 agent orchestrator create-agent \
   --name planner \
-  --prompt "Analyze the codebase and propose improvements"
+  --prompt "Analyze the codebase and propose improvements" \
+  --add-dir /path/to/shared-libs \
+  --add-dir /opt/configs
 
 # Monitor the output in real-time
 agent orchestrator stream --all

--- a/docs/public/templates.md
+++ b/docs/public/templates.md
@@ -72,6 +72,12 @@ shell: zsh                      # Shell to use (default: zsh)
 interactive: false              # Interactive mode (default: false)
 worktree: false                 # Use git worktree (default: false)
 
+# Optional — grant access to directories outside working_dir
+additional_dirs:
+  - ../shared-libraries         # relative: resolved relative to this YAML file
+  - /opt/company/configs        # absolute: used as-is
+  - ~/other-project             # tilde: expanded to home directory
+
 # Optional — no default
 prompt: "Analyze the codebase"  # Initial prompt sent after agent connects
 system_prompt: |                # System prompt for the agent session
@@ -93,6 +99,7 @@ tool_policy:
 |-------|------|---------|-------------|
 | `name` | string | **required** | Unique agent name |
 | `working_dir` | string | `"."` | Working directory. `"."` resolves to `$PWD` |
+| `additional_dirs` | list | `[]` | Extra directories the agent can access (see [Additional Directories](additional-dirs.md)) |
 | `shell` | string | `"zsh"` | Shell for the tmux session |
 | `interactive` | bool | `false` | Run in interactive mode (no WebSocket) |
 | `worktree` | bool | `false` | Start with `--worktree` for isolated git worktree |
@@ -105,6 +112,8 @@ tool_policy:
 - `"."` → resolves to the current working directory (`$PWD`) at apply time
 - Relative paths → resolved relative to the YAML file's directory
 - Absolute paths → used as-is
+
+The same resolution rules apply to each entry in `additional_dirs`. See [Additional Directories](additional-dirs.md) for full details.
 
 ---
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -87,6 +87,7 @@ nav:
   - Installation: public/install.md
   - Tool Policies: public/tool-policies.md
   - Templates: public/templates.md
+  - Additional Directories: public/additional-dirs.md
   - Services:
       - Orchestrator: public/services/orchestrator.md
       - Notify: public/services/notify.md


### PR DESCRIPTION
## Summary

- New page `docs/public/additional-dirs.md` covering all methods for configuring additional directories on agents
- Updated `docs/public/templates.md` — added `additional_dirs` to the agent schema table and example YAML
- Updated `docs/public/services/orchestrator.md` — added `additional_dirs` to Create Agent request body, documented `POST /agents/{id}/dirs` and `DELETE /agents/{id}/dirs` endpoints, and added `add-dir`/`remove-dir` CLI commands
- Updated `mkdocs.yml` nav to include the new page

## What's covered

- [x] YAML template example with `additional_dirs` and path resolution rules
- [x] CLI command reference for `add-dir` / `remove-dir` and `--add-dir` at creation
- [x] API endpoint documentation with curl examples
- [x] Restart-required behavior documented
- [x] Docker backend bind-mount behavior documented
- [x] Security considerations

## Test plan

- [ ] `mkdocs serve` renders the new page without errors
- [ ] Links from `templates.md` and `orchestrator.md` to `additional-dirs.md` resolve correctly
- [ ] Nav entry appears in the sidebar

Closes #361

🤖 Generated with [Claude Code](https://claude.com/claude-code)