### PR TITLE
Scaffold agentd-memory crate with workspace integration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "crates/cli",
     "crates/common",
     "crates/hook",
+    "crates/memory",
     "crates/monitor",
     "crates/notify",
     "crates/orchestrator",

--- a/crates/cli/src/commands/memory.rs
+++ b/crates/cli/src/commands/memory.rs
@@ -1,0 +1,53 @@
+//! Memory service command implementations.
+//!
+//! This module provides CLI subcommands for interacting with the agentd-memory
+//! service. Commands for storing, retrieving, and searching memory records via
+//! semantic search will be added in subsequent issues.
+//!
+//! # Available Commands
+//!
+//! - **health**: Check the health of the memory service
+//!
+//! # Examples
+//!
+//! ## Check memory service health
+//!
+//! ```bash
+//! agent memory health
+//! ```
+
+use anyhow::Result;
+use clap::Subcommand;
+use colored::*;
+
+/// Subcommands for the memory service.
+#[derive(Debug, Subcommand)]
+pub enum MemoryCommand {
+    /// Check the health of the memory service
+    Health,
+}
+
+impl MemoryCommand {
+    /// Execute the memory subcommand.
+    pub async fn execute(&self, base_url: &str, _json: bool) -> Result<()> {
+        match self {
+            MemoryCommand::Health => {
+                let url = format!("{}/health", base_url);
+                let client = reqwest::Client::new();
+                match client.get(&url).send().await {
+                    Ok(resp) if resp.status().is_success() => {
+                        let body: serde_json::Value = resp.json().await?;
+                        println!("{}", serde_json::to_string_pretty(&body)?);
+                    }
+                    Ok(resp) => {
+                        println!("{} HTTP {}", "error:".red().bold(), resp.status());
+                    }
+                    Err(e) => {
+                        println!("{} {}", "error:".red().bold(), e);
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+}

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -30,11 +30,13 @@
 
 pub mod apply;
 pub mod ask;
+pub mod memory;
 pub mod notify;
 pub mod orchestrator;
 pub mod wrap;
 
 pub use ask::AskCommand;
+pub use memory::MemoryCommand;
 pub use notify::NotifyCommand;
 pub use orchestrator::OrchestratorCommand;
 pub use wrap::WrapCommand;

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -80,7 +80,7 @@ use ask::client::AskClient;
 use clap::{CommandFactory, Parser, Subcommand};
 use clap_complete::Shell;
 use colored::*;
-use commands::{AskCommand, NotifyCommand, OrchestratorCommand, WrapCommand};
+use commands::{AskCommand, MemoryCommand, NotifyCommand, OrchestratorCommand, WrapCommand};
 use notify::client::NotifyClient;
 use orchestrator::client::OrchestratorClient;
 use std::env;
@@ -228,6 +228,15 @@ enum Commands {
     /// The monitor daemon watches system metrics and creates notifications for
     /// alerts and anomalies.
     Monitor,
+    /// Interact with the memory service
+    ///
+    /// Store, retrieve, and semantically search agent memory records. The memory
+    /// service runs on port 7008 by default and uses LanceDB for vector storage
+    /// and SQLite for metadata.
+    Memory {
+        #[command(subcommand)]
+        command: MemoryCommand,
+    },
 }
 
 /// Main entry point for the agent CLI.
@@ -318,6 +327,12 @@ async fn main() -> Result<()> {
         Commands::Monitor => {
             monitor::run(monitor::config::MonitorConfig::from_env()).await?;
         }
+        Commands::Memory { command } => {
+            // Use AGENTD_MEMORY_SERVICE_URL env var, default to production port
+            let url = env::var("AGENTD_MEMORY_SERVICE_URL")
+                .unwrap_or_else(|_| "http://localhost:7008".to_string());
+            command.execute(&url, cli.json).await?;
+        }
     }
 
     Ok(())
@@ -359,6 +374,11 @@ const SERVICES: &[ServiceDef] = &[
         name: "monitor",
         env_var: "AGENTD_MONITOR_SERVICE_URL",
         default_url: "http://localhost:7003",
+    },
+    ServiceDef {
+        name: "memory",
+        env_var: "AGENTD_MEMORY_SERVICE_URL",
+        default_url: "http://localhost:7008",
     },
 ];
 

--- a/crates/memory/Cargo.toml
+++ b/crates/memory/Cargo.toml
@@ -1,0 +1,45 @@
+[package]
+name = "memory"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+
+[[bin]]
+name = "agentd-memory"
+path = "src/main.rs"
+
+[dependencies]
+tokio = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+anyhow = { workspace = true }
+thiserror = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+
+# HTTP API server
+axum = { workspace = true }
+tower-http = { workspace = true, features = ["cors"] }
+
+# Database
+sea-orm = { workspace = true }
+sea-orm-migration = { workspace = true }
+async-trait = "0.1"
+
+# Vector storage
+lancedb = "0.16"
+arrow = { version = "54", features = ["prettyprint"] }
+arrow-array = "54"
+arrow-schema = "54"
+
+# Additional utilities
+uuid = { version = "1.11", features = ["v4", "serde"] }
+chrono = { version = "0.4", features = ["serde"] }
+directories = "6.0.0"
+agentd-common = { path = "../common" }
+metrics = { workspace = true }
+metrics-exporter-prometheus = { workspace = true }
+
+[dev-dependencies]
+tempfile = "3.14"

--- a/crates/memory/src/api.rs
+++ b/crates/memory/src/api.rs
@@ -1,0 +1,79 @@
+//! REST API handlers for the memory service.
+//!
+//! This module provides HTTP endpoints for the agentd-memory service. Currently
+//! only the `/health` endpoint is implemented as part of the initial scaffold.
+//! Storage, semantic search, and full CRUD endpoints will be added in subsequent
+//! issues.
+//!
+//! # API Endpoints
+//!
+//! - `GET /health` - Health check endpoint
+//!
+//! # Examples
+//!
+//! ## Creating a Router
+//!
+//! ```no_run
+//! use memory::api::{create_router, ApiState};
+//!
+//! #[tokio::main]
+//! async fn main() -> anyhow::Result<()> {
+//!     let state = ApiState {};
+//!     let router = create_router(state);
+//!
+//!     // Bind and serve
+//!     let listener = tokio::net::TcpListener::bind("127.0.0.1:17008").await?;
+//!     axum::serve(listener, router).await?;
+//!     Ok(())
+//! }
+//! ```
+
+use axum::{response::IntoResponse, Json, Router};
+
+/// Shared state passed to all API handlers.
+///
+/// Will be extended with storage backends (SQLite via SeaORM for metadata,
+/// LanceDB for vector embeddings) in subsequent issues.
+#[derive(Clone)]
+pub struct ApiState {}
+
+/// Creates and configures the Axum router with all API endpoints.
+///
+/// # Arguments
+///
+/// * `state` - The API state (currently empty; will hold storage in future issues)
+///
+/// # Returns
+///
+/// Returns a configured [`Router`] ready to serve HTTP requests.
+pub fn create_router(state: ApiState) -> Router {
+    Router::new().route("/health", axum::routing::get(health_check)).with_state(state)
+}
+
+/// Health check endpoint handler.
+///
+/// Returns basic service information including status and version.
+///
+/// # Endpoint
+///
+/// `GET /health`
+///
+/// # Response
+///
+/// Returns HTTP 200 with JSON body:
+/// ```json
+/// {
+///   "status": "ok",
+///   "service": "agentd-memory",
+///   "version": "0.2.0"
+/// }
+/// ```
+///
+/// # Examples
+///
+/// ```bash
+/// curl http://localhost:17008/health
+/// ```
+async fn health_check() -> impl IntoResponse {
+    Json(agentd_common::types::HealthResponse::ok("agentd-memory", env!("CARGO_PKG_VERSION")))
+}

--- a/crates/memory/src/main.rs
+++ b/crates/memory/src/main.rs
@@ -1,0 +1,112 @@
+//! agentd-memory service entry point.
+//!
+//! This is the main executable for the memory service. It initializes the
+//! HTTP server with health and metrics endpoints. Storage backends (SQLite
+//! via SeaORM for metadata and LanceDB for vector embeddings) will be
+//! initialized in subsequent issues.
+//!
+//! # Features
+//!
+//! - REST API on `http://127.0.0.1:17008` (dev default)
+//! - Structured logging with tracing
+//! - Prometheus metrics endpoint
+//!
+//! # Running the Service
+//!
+//! ```bash
+//! # Run with default INFO logging
+//! cargo run -p memory
+//!
+//! # Run with DEBUG logging
+//! RUST_LOG=debug cargo run -p memory
+//!
+//! # Run the release build
+//! cargo run -p memory --release
+//! ```
+//!
+//! # Environment Variables
+//!
+//! - `RUST_LOG` - Controls logging level (e.g., `debug`, `info`, `warn`, `error`)
+//!   Defaults to `info` if not set.
+//! - `AGENTD_PORT` - Override the listen port (default `17008` dev / `7008` prod)
+//!
+//! # API Endpoints
+//!
+//! Once running, the service exposes the following endpoints:
+//!
+//! - `GET /health` - Health check
+//! - `GET /metrics` - Prometheus metrics
+
+mod api;
+mod types;
+
+use api::{create_router, ApiState};
+use axum::{extract::State, response::IntoResponse, routing::get};
+use metrics_exporter_prometheus::PrometheusHandle;
+use std::env;
+use tracing::info;
+
+fn init_metrics() -> PrometheusHandle {
+    let builder = metrics_exporter_prometheus::PrometheusBuilder::new();
+    let handle = builder.install_recorder().expect("failed to install metrics recorder");
+    metrics::gauge!("service_info", "version" => env!("CARGO_PKG_VERSION"), "service" => "memory")
+        .set(1.0);
+    handle
+}
+
+async fn metrics_handler(State(handle): State<PrometheusHandle>) -> impl IntoResponse {
+    handle.render()
+}
+
+/// Main entry point for the agentd-memory service.
+///
+/// This function performs the following initialization steps:
+/// 1. Sets up structured logging with tracing
+/// 2. Initializes Prometheus metrics
+/// 3. Creates and configures the Axum HTTP router
+/// 4. Starts the HTTP server on `127.0.0.1:17008` (dev default)
+///
+/// # Returns
+///
+/// Returns `Ok(())` on successful shutdown, or an error if initialization
+/// or server startup fails.
+///
+/// # Errors
+///
+/// Returns an error if:
+/// - Unable to bind to the network address
+/// - The HTTP server encounters a fatal error
+///
+/// # Panics
+///
+/// Does not panic under normal operation.
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    agentd_common::server::init_tracing();
+
+    info!("Starting agentd-memory service...");
+
+    // Initialize Prometheus metrics
+    let metrics_handle = init_metrics();
+
+    // Create API state and router with metrics endpoint and tracing middleware
+    let api_state = ApiState {};
+    let metrics_router =
+        axum::Router::new().route("/metrics", get(metrics_handler)).with_state(metrics_handle);
+
+    let app = create_router(api_state)
+        .merge(metrics_router)
+        .layer(agentd_common::server::trace_layer())
+        .layer(agentd_common::server::cors_layer());
+
+    // Bind to address (use AGENTD_PORT env var, default 17008 for dev, 7008 for production)
+    let port = env::var("AGENTD_PORT").unwrap_or_else(|_| "17008".to_string());
+    let addr = format!("127.0.0.1:{port}");
+    let listener = tokio::net::TcpListener::bind(&addr).await?;
+    info!("Memory API server listening on http://{}", addr);
+
+    // Start the HTTP server
+    axum::serve(listener, app).await?;
+
+    Ok(())
+}

--- a/crates/memory/src/types.rs
+++ b/crates/memory/src/types.rs
@@ -1,0 +1,23 @@
+//! Shared types for the agentd-memory service.
+//!
+//! This module defines the core data types used throughout the memory service,
+//! including memory records, visibility controls, and API request/response types.
+//! Full type definitions for memory entries, embeddings, and semantic search will
+//! be added in subsequent issues.
+
+use serde::{Deserialize, Serialize};
+
+/// Placeholder type representing a memory record.
+///
+/// Full fields (content, embedding, visibility, tags, source, etc.) will be
+/// defined when the types issue is addressed.
+#[allow(dead_code)]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MemoryRecord {
+    /// Unique identifier for this memory record.
+    pub id: uuid::Uuid,
+    /// Human-readable content of the memory.
+    pub content: String,
+    /// When this record was created.
+    pub created_at: chrono::DateTime<chrono::Utc>,
+}

--- a/crates/xtask/src/platform/mod.rs
+++ b/crates/xtask/src/platform/mod.rs
@@ -36,10 +36,12 @@ pub const SERVICES: &[ServiceInfo] = &[
     ServiceInfo { name: "notify", binary: "agentd-notify", port: 7004, extra_env: &[] },
     ServiceInfo { name: "wrap", binary: "agentd-wrap", port: 7005, extra_env: &[] },
     ServiceInfo { name: "orchestrator", binary: "agentd-orchestrator", port: 7006, extra_env: &[] },
+    ServiceInfo { name: "memory", binary: "agentd-memory", port: 7008, extra_env: &[] },
 ];
 
 /// All valid service names.
-pub const SERVICE_NAMES: &[&str] = &["ask", "hook", "monitor", "notify", "wrap", "orchestrator"];
+pub const SERVICE_NAMES: &[&str] =
+    &["ask", "hook", "monitor", "notify", "wrap", "orchestrator", "memory"];
 
 /// Look up a service by short name.
 #[cfg(test)]
@@ -92,8 +94,8 @@ mod tests {
 
     #[test]
     fn test_service_info_completeness() {
-        assert_eq!(SERVICES.len(), 6);
-        assert_eq!(SERVICE_NAMES.len(), 6);
+        assert_eq!(SERVICES.len(), 7);
+        assert_eq!(SERVICE_NAMES.len(), 7);
 
         // Every service name should have a corresponding ServiceInfo
         for name in SERVICE_NAMES {


### PR DESCRIPTION
## Summary

- Create `crates/memory/` with `Cargo.toml`, `src/main.rs`, `src/api.rs`, and `src/types.rs` following the established service pattern (Axum + SeaORM + metrics)
- Add `lancedb = "0.16"` and `arrow = "54"` as dependencies for future vector storage
- Register `crates/memory` in the workspace `Cargo.toml` members list
- Implement `/health` and `/metrics` endpoints; service listens on port 17008 (dev) / 7008 (prod)
- Register `memory` service in `crates/xtask/src/platform/mod.rs` (`SERVICES` + `SERVICE_NAMES`)
- Add `Memory` subcommand stub to the CLI (`crates/cli/src/main.rs` + `commands/memory.rs`)

## Test plan

- [x] `cargo check -p memory` — compiles cleanly
- [x] `cargo check -p cli` — compiles cleanly with new Memory subcommand
- [x] `cargo test -p xtask` — all 12 platform tests pass, including service completeness/uniqueness checks
- [x] `cargo test -p memory` — scaffold only, passes with 0 failures

Closes #300

🤖 Generated with [Claude Code](https://claude.com/claude-code)