### PR TITLE
feat(memory): implement SQLite metadata storage and SeaORM entities (#302)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7884,6 +7884,7 @@ dependencies = [
  "agentd-common",
  "anyhow",
  "colored",
+ "memory",
  "notify",
  "orchestrator",
  "tokio",

--- a/crates/memory/src/api.rs
+++ b/crates/memory/src/api.rs
@@ -1,7 +1,8 @@
 //! REST API handlers for the agentd-memory service.
 //!
 //! This module provides HTTP endpoints for managing memories through a RESTful
-//! API backed by a [`VectorStore`] for semantic search and CRUD operations.
+//! API backed by a [`VectorStore`] for semantic search and CRUD operations,
+//! with SQLite metadata storage via [`MemoryStorage`].
 //!
 //! # API Endpoints
 //!
@@ -75,26 +76,31 @@ pub use agentd_common::types::{clamp_limit, PaginatedResponse};
 // State
 // ---------------------------------------------------------------------------
 
+use memory::storage::MemoryStorage;
+
 /// Shared state passed to all API handlers.
 ///
 /// Contains the vector store backend wrapped in an [`Arc`] for efficient
-/// cloning across async handlers.
+/// cloning across async handlers, and a SQLite-backed metadata storage.
 ///
 /// # Examples
 ///
 /// ```rust,no_run
 /// use memory::api::ApiState;
+/// use memory::storage::MemoryStorage;
 /// use memory::store::VectorStore;
 /// use std::sync::Arc;
 ///
-/// # async fn example(store: Arc<dyn VectorStore>) {
-/// let state = ApiState { store };
+/// # async fn example(store: Arc<dyn VectorStore>, storage: MemoryStorage) {
+/// let state = ApiState { store, storage };
 /// # }
 /// ```
 #[derive(Clone)]
 pub struct ApiState {
     /// Shared vector store backend for memory persistence and search.
     pub store: Arc<dyn VectorStore>,
+    /// SQLite-backed metadata storage.
+    pub storage: MemoryStorage,
 }
 
 // ---------------------------------------------------------------------------
@@ -152,7 +158,7 @@ async fn health_check(State(state): State<ApiState>) -> impl IntoResponse {
     let mut resp =
         agentd_common::types::HealthResponse::ok("agentd-memory", env!("CARGO_PKG_VERSION"));
 
-    let healthy = match state.store.health_check().await {
+    let vector_healthy = match state.store.health_check().await {
         Ok(h) => {
             resp = resp.with_detail("vector_store", serde_json::json!(h));
             h
@@ -164,6 +170,21 @@ async fn health_check(State(state): State<ApiState>) -> impl IntoResponse {
             false
         }
     };
+
+    let sqlite_healthy = match state.storage.health_check().await {
+        Ok(h) => {
+            resp = resp.with_detail("sqlite_storage", serde_json::json!(h));
+            h
+        }
+        Err(e) => {
+            warn!("SQLite storage health check failed: {}", e);
+            resp = resp.with_detail("sqlite_storage", serde_json::json!(false));
+            resp = resp.with_detail("sqlite_storage_error", serde_json::json!(e.to_string()));
+            false
+        }
+    };
+
+    let healthy = vector_healthy && sqlite_healthy;
 
     if healthy {
         (StatusCode::OK, Json(resp))
@@ -602,8 +623,13 @@ mod tests {
 
     // ── Helpers ───────────────────────────────────────────────────────────
 
-    fn test_app(store: Arc<dyn VectorStore>) -> Router {
-        create_router(ApiState { store })
+    async fn test_app(store: Arc<dyn VectorStore>) -> Router {
+        let temp_dir = tempfile::TempDir::new().unwrap();
+        let db_path = temp_dir.path().join("test.db");
+        let storage = MemoryStorage::with_path(&db_path).await.unwrap();
+        // Leak the TempDir so it lives for the duration of the test
+        std::mem::forget(temp_dir);
+        create_router(ApiState { store, storage })
     }
 
     fn sample_memory(id: &str, content: &str) -> Memory {
@@ -627,7 +653,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_health_check_returns_ok() {
-        let app = test_app(Arc::new(MockVectorStore::new()));
+        let app = test_app(Arc::new(MockVectorStore::new())).await;
         let resp = app
             .oneshot(Request::builder().uri("/health").body(Body::empty()).unwrap())
             .await
@@ -645,7 +671,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_create_memory_returns_201() {
-        let app = test_app(Arc::new(MockVectorStore::new()));
+        let app = test_app(Arc::new(MockVectorStore::new())).await;
         let body = serde_json::json!({
             "content": "Paris is the capital of France.",
             "created_by": "agent-1"
@@ -673,7 +699,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_create_memory_empty_content_returns_400() {
-        let app = test_app(Arc::new(MockVectorStore::new()));
+        let app = test_app(Arc::new(MockVectorStore::new())).await;
         let body = serde_json::json!({
             "content": "",
             "created_by": "agent-1"
@@ -696,7 +722,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_create_memory_empty_created_by_returns_400() {
-        let app = test_app(Arc::new(MockVectorStore::new()));
+        let app = test_app(Arc::new(MockVectorStore::new())).await;
         let body = serde_json::json!({
             "content": "some content",
             "created_by": "  "
@@ -722,7 +748,7 @@ mod tests {
     #[tokio::test]
     async fn test_get_memory_returns_200() {
         let mem = sample_memory("mem_1_abcdef01", "test content");
-        let app = test_app(Arc::new(MockVectorStore::with_memories(vec![mem])));
+        let app = test_app(Arc::new(MockVectorStore::with_memories(vec![mem]))).await;
 
         let resp = app
             .oneshot(
@@ -740,7 +766,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_get_memory_not_found_returns_404() {
-        let app = test_app(Arc::new(MockVectorStore::new()));
+        let app = test_app(Arc::new(MockVectorStore::new())).await;
 
         let resp = app
             .oneshot(Request::builder().uri("/memories/nonexistent").body(Body::empty()).unwrap())
@@ -759,7 +785,7 @@ mod tests {
             sample_memory("mem_2_bbb", "second"),
             sample_memory("mem_3_ccc", "third"),
         ];
-        let app = test_app(Arc::new(MockVectorStore::with_memories(memories)));
+        let app = test_app(Arc::new(MockVectorStore::with_memories(memories))).await;
 
         let resp = app
             .oneshot(
@@ -783,7 +809,7 @@ mod tests {
         let mut mem = sample_memory("mem_1_aaa", "a question");
         mem.memory_type = MemoryType::Question;
         let memories = vec![mem, sample_memory("mem_2_bbb", "some info")];
-        let app = test_app(Arc::new(MockVectorStore::with_memories(memories)));
+        let app = test_app(Arc::new(MockVectorStore::with_memories(memories))).await;
 
         let resp = app
             .oneshot(Request::builder().uri("/memories?type=question").body(Body::empty()).unwrap())
@@ -800,7 +826,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_list_memories_empty() {
-        let app = test_app(Arc::new(MockVectorStore::new()));
+        let app = test_app(Arc::new(MockVectorStore::new())).await;
 
         let resp = app
             .oneshot(Request::builder().uri("/memories").body(Body::empty()).unwrap())
@@ -820,7 +846,7 @@ mod tests {
     #[tokio::test]
     async fn test_delete_memory_returns_deleted_true() {
         let mem = sample_memory("mem_1_aaa", "to delete");
-        let app = test_app(Arc::new(MockVectorStore::with_memories(vec![mem])));
+        let app = test_app(Arc::new(MockVectorStore::with_memories(vec![mem]))).await;
 
         let resp = app
             .oneshot(
@@ -842,7 +868,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_delete_memory_not_found_returns_deleted_false() {
-        let app = test_app(Arc::new(MockVectorStore::new()));
+        let app = test_app(Arc::new(MockVectorStore::new())).await;
 
         let resp = app
             .oneshot(
@@ -870,7 +896,7 @@ mod tests {
             sample_memory("mem_1_aaa", "Paris is the capital of France"),
             sample_memory("mem_2_bbb", "Berlin is the capital of Germany"),
         ];
-        let app = test_app(Arc::new(MockVectorStore::with_memories(memories)));
+        let app = test_app(Arc::new(MockVectorStore::with_memories(memories))).await;
 
         let body = serde_json::json!({"query": "Paris", "limit": 5});
         let resp = app
@@ -895,7 +921,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_search_empty_query_returns_400() {
-        let app = test_app(Arc::new(MockVectorStore::new()));
+        let app = test_app(Arc::new(MockVectorStore::new())).await;
 
         let body = serde_json::json!({"query": ""});
         let resp = app
@@ -918,7 +944,7 @@ mod tests {
     #[tokio::test]
     async fn test_update_visibility_returns_updated_memory() {
         let mem = sample_memory("mem_1_aaa", "some content");
-        let app = test_app(Arc::new(MockVectorStore::with_memories(vec![mem])));
+        let app = test_app(Arc::new(MockVectorStore::with_memories(vec![mem]))).await;
 
         let body = serde_json::json!({
             "visibility": "shared",
@@ -946,7 +972,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_update_visibility_not_found_returns_404() {
-        let app = test_app(Arc::new(MockVectorStore::new()));
+        let app = test_app(Arc::new(MockVectorStore::new())).await;
 
         let body = serde_json::json!({"visibility": "private"});
         let resp = app
@@ -969,7 +995,7 @@ mod tests {
     #[tokio::test]
     async fn test_update_visibility_ownership_check_allows_creator() {
         let mem = sample_memory("mem_1_aaa", "some content");
-        let app = test_app(Arc::new(MockVectorStore::with_memories(vec![mem])));
+        let app = test_app(Arc::new(MockVectorStore::with_memories(vec![mem]))).await;
 
         let body = serde_json::json!({
             "visibility": "private",
@@ -993,7 +1019,7 @@ mod tests {
     #[tokio::test]
     async fn test_update_visibility_ownership_check_rejects_non_owner() {
         let mem = sample_memory("mem_1_aaa", "some content");
-        let app = test_app(Arc::new(MockVectorStore::with_memories(vec![mem])));
+        let app = test_app(Arc::new(MockVectorStore::with_memories(vec![mem]))).await;
 
         let body = serde_json::json!({
             "visibility": "private",
@@ -1017,7 +1043,7 @@ mod tests {
     #[tokio::test]
     async fn test_update_visibility_without_actor_is_allowed() {
         let mem = sample_memory("mem_1_aaa", "some content");
-        let app = test_app(Arc::new(MockVectorStore::with_memories(vec![mem])));
+        let app = test_app(Arc::new(MockVectorStore::with_memories(vec![mem]))).await;
 
         // No as_actor field — backward-compatible, should succeed
         let body = serde_json::json!({

--- a/crates/memory/src/entity/memory_entry.rs
+++ b/crates/memory/src/entity/memory_entry.rs
@@ -1,0 +1,51 @@
+//! SeaORM entity for the `memory_entries` table.
+//!
+//! This module defines the ORM model, active model, column enum, and relation
+//! enum for memory entries stored in SQLite.
+
+use sea_orm::entity::prelude::*;
+
+/// Database model for a memory entry row.
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+#[sea_orm(table_name = "memory_entries")]
+pub struct Model {
+    /// Unique memory ID in `mem_<unix_ms>_<8-char-uuid-prefix>` format.
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub id: String,
+
+    /// Plain-text content of the memory.
+    pub content: String,
+
+    /// Memory type label: `"question"`, `"request"`, or `"information"`.
+    pub memory_type: String,
+
+    /// JSON-serialised `Vec<String>` of tags.
+    pub tags: String,
+
+    /// Agent or user ID that created this memory.
+    pub created_by: String,
+
+    /// Optional owner override (defaults to `created_by` when `None`).
+    pub owner: Option<String>,
+
+    /// Visibility label: `"private"`, `"shared"`, or `"public"`.
+    pub visibility: String,
+
+    /// JSON-serialised `Vec<String>` of actor IDs this memory is shared with.
+    pub shared_with: String,
+
+    /// JSON-serialised `Vec<String>` of referenced memory IDs.
+    pub refs: String,
+
+    /// RFC3339 creation timestamp.
+    pub created_at: String,
+
+    /// RFC3339 last-update timestamp.
+    pub updated_at: String,
+}
+
+/// No foreign-key relations — memory entries are a self-contained table.
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/crates/memory/src/entity/mod.rs
+++ b/crates/memory/src/entity/mod.rs
@@ -1,0 +1,3 @@
+//! SeaORM entity modules for the agentd-memory service.
+
+pub mod memory_entry;

--- a/crates/memory/src/lib.rs
+++ b/crates/memory/src/lib.rs
@@ -1,7 +1,7 @@
 //! # agentd-memory
 //!
 //! A memory service that stores, retrieves, and semantically searches agent
-//! memory records using LanceDB for vector embeddings.
+//! memory records using LanceDB for vector embeddings and SQLite for metadata.
 //!
 //! ## Architecture
 //!
@@ -21,6 +21,8 @@
 //! | [`store`]        | `VectorStore` and `EmbeddingService` traits + LanceDB backend |
 //! | [`config`]       | Embedding provider and LanceDB configuration              |
 //! | [`error`]        | Domain error types with API error conversion              |
+//! | [`storage`]      | SQLite-backed `MemoryStorage` for metadata persistence via SeaORM |
+//! | [`entity`]       | SeaORM entity definitions for the `memory_entries` table  |
 //!
 //! ## Access Control
 //!
@@ -35,12 +37,17 @@
 //! Access control is enforced by [`Memory::is_visible_to`](types::Memory::is_visible_to),
 //! which is called during search operations to post-filter results.
 //!
-//! ## Storage Backend
+//! ## Storage Backends
 //!
 //! The [`store::VectorStore`] trait abstracts vector-database operations,
 //! with [`store::LanceStore`] as the concrete LanceDB implementation.
 //! LanceDB is an embedded database (no external server) that stores data
 //! in a local directory using Apache Arrow format.
+//!
+//! The [`storage::MemoryStorage`] provides SQLite-backed metadata persistence
+//! via SeaORM, storing memory entries in:
+//! - **Linux**: `~/.local/share/agentd-memory/memory.db`
+//! - **macOS**: `~/Library/Application Support/agentd-memory/memory.db`
 //!
 //! ## Embedding Providers
 //!
@@ -112,6 +119,26 @@
 
 pub mod client;
 pub mod config;
+pub mod entity;
 pub mod error;
+pub(crate) mod migration;
+pub mod storage;
 pub mod store;
 pub mod types;
+
+/// Apply all pending SeaORM migrations to the SQLite database at `db_path`.
+///
+/// Creates the file if it does not exist. Designed for use by `cargo xtask migrate`.
+pub async fn apply_migrations_for_path(db_path: &std::path::Path) -> anyhow::Result<()> {
+    agentd_common::storage::apply_migrations::<migration::Migrator>(db_path).await
+}
+
+/// Return the status of all known migrations for the database at `db_path`.
+///
+/// Each entry is `(migration_name, is_applied)`. Designed for use by
+/// `cargo xtask migrate-status`.
+pub async fn migration_status_for_path(
+    db_path: &std::path::Path,
+) -> anyhow::Result<Vec<(String, bool)>> {
+    agentd_common::storage::migration_status::<migration::Migrator>(db_path).await
+}

--- a/crates/memory/src/main.rs
+++ b/crates/memory/src/main.rs
@@ -1,7 +1,7 @@
 //! agentd-memory service entry point.
 //!
-//! Initialises the LanceDB vector store and HTTP server with full CRUD,
-//! semantic search, health, and metrics endpoints.
+//! Initialises the LanceDB vector store, SQLite metadata storage, and HTTP
+//! server with full CRUD, semantic search, health, and metrics endpoints.
 //!
 //! # Running the Service
 //!
@@ -39,6 +39,7 @@ mod api;
 use api::{create_router, ApiState};
 use axum::{extract::State, response::IntoResponse, routing::get};
 use memory::config::{EmbeddingConfig, LanceConfig};
+use memory::storage::MemoryStorage;
 use metrics_exporter_prometheus::PrometheusHandle;
 use std::env;
 use tracing::info;
@@ -64,6 +65,10 @@ async fn main() -> anyhow::Result<()> {
     // ── Metrics ──────────────────────────────────────────────────────────
     let metrics_handle = init_metrics();
 
+    // ── SQLite metadata storage ──────────────────────────────────────────
+    let storage = MemoryStorage::new().await?;
+    info!("SQLite storage initialised");
+
     // ── Vector store ─────────────────────────────────────────────────────
     let lance_config = LanceConfig::from_env();
     let embedding_config = EmbeddingConfig::from_env();
@@ -82,7 +87,7 @@ async fn main() -> anyhow::Result<()> {
     info!("Vector store initialised");
 
     // ── Router ───────────────────────────────────────────────────────────
-    let api_state = ApiState { store };
+    let api_state = ApiState { store, storage };
     let metrics_router =
         axum::Router::new().route("/metrics", get(metrics_handler)).with_state(metrics_handle);
 

--- a/crates/memory/src/migration/m20260313_000001_create_memory_entries.rs
+++ b/crates/memory/src/migration/m20260313_000001_create_memory_entries.rs
@@ -1,0 +1,109 @@
+//! Initial migration: create the `memory_entries` table with indexes.
+
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .create_table(
+                Table::create()
+                    .table(MemoryEntries::Table)
+                    .if_not_exists()
+                    .col(
+                        ColumnDef::new(MemoryEntries::Id)
+                            .string()
+                            .not_null()
+                            .primary_key(),
+                    )
+                    .col(ColumnDef::new(MemoryEntries::Content).string().not_null())
+                    .col(ColumnDef::new(MemoryEntries::MemoryType).string().not_null())
+                    .col(ColumnDef::new(MemoryEntries::Tags).string().not_null())
+                    .col(ColumnDef::new(MemoryEntries::CreatedBy).string().not_null())
+                    .col(ColumnDef::new(MemoryEntries::Owner).string().null())
+                    .col(ColumnDef::new(MemoryEntries::Visibility).string().not_null())
+                    .col(ColumnDef::new(MemoryEntries::SharedWith).string().not_null())
+                    .col(ColumnDef::new(MemoryEntries::Refs).string().not_null())
+                    .col(ColumnDef::new(MemoryEntries::CreatedAt).string().not_null())
+                    .col(ColumnDef::new(MemoryEntries::UpdatedAt).string().not_null())
+                    .to_owned(),
+            )
+            .await?;
+
+        // Index on memory_type for type-filter queries
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx_memory_entries_memory_type")
+                    .table(MemoryEntries::Table)
+                    .col(MemoryEntries::MemoryType)
+                    .if_not_exists()
+                    .to_owned(),
+            )
+            .await?;
+
+        // Index on created_by for actor-filter queries
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx_memory_entries_created_by")
+                    .table(MemoryEntries::Table)
+                    .col(MemoryEntries::CreatedBy)
+                    .if_not_exists()
+                    .to_owned(),
+            )
+            .await?;
+
+        // Index on created_at for sort-by-time queries
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx_memory_entries_created_at")
+                    .table(MemoryEntries::Table)
+                    .col(MemoryEntries::CreatedAt)
+                    .if_not_exists()
+                    .to_owned(),
+            )
+            .await?;
+
+        // Index on visibility for visibility-filter queries
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx_memory_entries_visibility")
+                    .table(MemoryEntries::Table)
+                    .col(MemoryEntries::Visibility)
+                    .if_not_exists()
+                    .to_owned(),
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .drop_table(Table::drop().table(MemoryEntries::Table).to_owned())
+            .await
+    }
+}
+
+/// Iden enum matching the `memory_entries` table columns.
+#[derive(DeriveIden)]
+enum MemoryEntries {
+    Table,
+    Id,
+    Content,
+    MemoryType,
+    Tags,
+    CreatedBy,
+    Owner,
+    Visibility,
+    SharedWith,
+    Refs,
+    CreatedAt,
+    UpdatedAt,
+}

--- a/crates/memory/src/migration/mod.rs
+++ b/crates/memory/src/migration/mod.rs
@@ -1,0 +1,14 @@
+//! SeaORM migration runner for the agentd-memory service.
+
+pub use sea_orm_migration::prelude::*;
+
+mod m20260313_000001_create_memory_entries;
+
+pub struct Migrator;
+
+#[async_trait::async_trait]
+impl MigratorTrait for Migrator {
+    fn migrations() -> Vec<Box<dyn MigrationTrait>> {
+        vec![Box::new(m20260313_000001_create_memory_entries::Migration)]
+    }
+}

--- a/crates/memory/src/storage.rs
+++ b/crates/memory/src/storage.rs
@@ -1,0 +1,436 @@
+//! SeaORM-based persistent storage for memory entries.
+//!
+//! Provides the [`MemoryStorage`] backend that persists memory entries to an
+//! SQLite database using SeaORM entities and a migration-managed schema.
+//!
+//! # Database Location
+//!
+//! - Linux: `~/.local/share/agentd-memory/memory.db`
+//! - macOS: `~/Library/Application Support/agentd-memory/memory.db`
+//!
+//! # Schema
+//!
+//! Managed by [`crate::migration::Migrator`].  See
+//! `migration/m20260313_000001_create_memory_entries.rs` for the full
+//! column list.
+//!
+//! # Examples
+//!
+//! ```no_run
+//! use memory::storage::MemoryStorage;
+//! use memory::types::{CreateMemoryRequest, MemoryType, VisibilityLevel};
+//!
+//! #[tokio::main]
+//! async fn main() -> anyhow::Result<()> {
+//!     let storage = MemoryStorage::new().await?;
+//!
+//!     let memory = storage.create(CreateMemoryRequest {
+//!         content: "The sky is blue".to_string(),
+//!         memory_type: MemoryType::Information,
+//!         tags: vec![],
+//!         created_by: "agent-1".to_string(),
+//!         visibility: VisibilityLevel::Private,
+//!         shared_with: vec![],
+//!         references: vec![],
+//!     }).await?;
+//!
+//!     println!("Stored memory: {}", memory.id);
+//!     Ok(())
+//! }
+//! ```
+
+use crate::{
+    entity::memory_entry as mem_entity,
+    error::{StoreError, StoreResult},
+    migration::Migrator,
+    types::{CreateMemoryRequest, Memory, MemoryType, VisibilityLevel},
+};
+use anyhow::Result;
+use chrono::Utc;
+use sea_orm::{
+    ColumnTrait, DatabaseConnection, EntityTrait, Order, QueryFilter, QueryOrder, QuerySelect, Set,
+};
+use sea_orm_migration::prelude::MigratorTrait;
+use std::path::{Path, PathBuf};
+
+/// Persistent storage backend for memory entries using SeaORM + SQLite.
+///
+/// This struct provides a thread-safe, async interface to a SQLite database.
+/// [`DatabaseConnection`] is `Clone + Send + Sync`.
+#[derive(Clone)]
+pub struct MemoryStorage {
+    db: DatabaseConnection,
+}
+
+impl MemoryStorage {
+    /// Returns the platform-specific database file path.
+    ///
+    /// - **Linux**: `~/.local/share/agentd-memory/memory.db`
+    /// - **macOS**: `~/Library/Application Support/agentd-memory/memory.db`
+    pub fn get_db_path() -> Result<PathBuf> {
+        agentd_common::storage::get_db_path("agentd-memory", "memory.db")
+    }
+
+    /// Creates a new storage instance with the default database path.
+    pub async fn new() -> Result<Self> {
+        let db_path = Self::get_db_path()?;
+        Self::with_path(&db_path).await
+    }
+
+    /// Creates a new storage instance connected to `db_path`.
+    ///
+    /// The file is created if it does not exist, and all pending SeaORM
+    /// migrations are applied before returning.
+    pub async fn with_path(db_path: &Path) -> Result<Self> {
+        let db = agentd_common::storage::create_connection(db_path).await?;
+        Migrator::up(&db, None).await?;
+        Ok(Self { db })
+    }
+
+    /// Inserts a new memory entry and returns the populated [`Memory`] record.
+    pub async fn create(&self, request: CreateMemoryRequest) -> StoreResult<Memory> {
+        let id = Memory::generate_id();
+        let now = Utc::now();
+        let now_str = now.to_rfc3339();
+
+        let tags_json = serde_json::to_string(&request.tags)
+            .map_err(|e| StoreError::InvalidData(e.to_string()))?;
+        let shared_with_json = serde_json::to_string(&request.shared_with)
+            .map_err(|e| StoreError::InvalidData(e.to_string()))?;
+        let refs_json = serde_json::to_string(&request.references)
+            .map_err(|e| StoreError::InvalidData(e.to_string()))?;
+
+        let model = mem_entity::ActiveModel {
+            id: Set(id.clone()),
+            content: Set(request.content.clone()),
+            memory_type: Set(request.memory_type.to_string()),
+            tags: Set(tags_json),
+            created_by: Set(request.created_by.clone()),
+            owner: Set(None),
+            visibility: Set(request.visibility.to_string()),
+            shared_with: Set(shared_with_json),
+            refs: Set(refs_json),
+            created_at: Set(now_str.clone()),
+            updated_at: Set(now_str),
+        };
+
+        mem_entity::Entity::insert(model)
+            .exec(&self.db)
+            .await
+            .map_err(|e| StoreError::QueryFailed(e.to_string()))?;
+
+        Ok(Memory {
+            id,
+            content: request.content,
+            memory_type: request.memory_type,
+            tags: request.tags,
+            created_by: request.created_by,
+            owner: None,
+            created_at: now,
+            updated_at: now,
+            visibility: request.visibility,
+            shared_with: request.shared_with,
+            references: request.references,
+        })
+    }
+
+    /// Retrieves a single memory entry by its ID.
+    ///
+    /// Returns `None` when no record with the given `id` exists.
+    pub async fn get(&self, id: &str) -> StoreResult<Option<Memory>> {
+        let model = mem_entity::Entity::find_by_id(id)
+            .one(&self.db)
+            .await
+            .map_err(|e| StoreError::QueryFailed(e.to_string()))?;
+
+        match model {
+            Some(m) => Ok(Some(model_to_memory(m)?)),
+            None => Ok(None),
+        }
+    }
+
+    /// Permanently deletes a memory entry by ID.
+    ///
+    /// Returns `true` if a record was deleted, `false` if it was not found.
+    pub async fn delete(&self, id: &str) -> StoreResult<bool> {
+        let result = mem_entity::Entity::delete_many()
+            .filter(mem_entity::Column::Id.eq(id))
+            .exec(&self.db)
+            .await
+            .map_err(|e| StoreError::QueryFailed(e.to_string()))?;
+
+        Ok(result.rows_affected > 0)
+    }
+
+    /// Lists all memory entries, optionally filtered by creator (newest first).
+    pub async fn list(&self, created_by: Option<&str>) -> StoreResult<Vec<Memory>> {
+        let mut query =
+            mem_entity::Entity::find().order_by(mem_entity::Column::CreatedAt, Order::Desc);
+
+        if let Some(actor) = created_by {
+            query = query.filter(mem_entity::Column::CreatedBy.eq(actor));
+        }
+
+        let models: Vec<mem_entity::Model> = query
+            .all(&self.db)
+            .await
+            .map_err(|e| StoreError::QueryFailed(e.to_string()))?;
+
+        models.into_iter().map(model_to_memory).collect()
+    }
+
+    /// Updates the visibility and optional share list of a memory entry.
+    ///
+    /// Returns the updated [`Memory`] record.
+    pub async fn update_visibility(
+        &self,
+        id: &str,
+        visibility: VisibilityLevel,
+        shared_with: Option<Vec<String>>,
+    ) -> StoreResult<Memory> {
+        use sea_orm::sea_query::Expr;
+
+        let now = Utc::now().to_rfc3339();
+        let shared_list = shared_with.unwrap_or_default();
+        let shared_with_json = serde_json::to_string(&shared_list)
+            .map_err(|e| StoreError::InvalidData(e.to_string()))?;
+
+        let result = mem_entity::Entity::update_many()
+            .col_expr(mem_entity::Column::Visibility, Expr::value(visibility.to_string()))
+            .col_expr(mem_entity::Column::SharedWith, Expr::value(shared_with_json))
+            .col_expr(mem_entity::Column::UpdatedAt, Expr::value(now))
+            .filter(mem_entity::Column::Id.eq(id))
+            .exec(&self.db)
+            .await
+            .map_err(|e| StoreError::QueryFailed(e.to_string()))?;
+
+        if result.rows_affected == 0 {
+            return Err(StoreError::NotFound(id.to_string()));
+        }
+
+        self.get(id).await?.ok_or_else(|| StoreError::NotFound(id.to_string()))
+    }
+
+    /// Returns `true` when the database connection is operational.
+    pub async fn health_check(&self) -> StoreResult<bool> {
+        let _: Vec<mem_entity::Model> = mem_entity::Entity::find()
+            .limit(1)
+            .all(&self.db)
+            .await
+            .map_err(|e| StoreError::QueryFailed(e.to_string()))?;
+        Ok(true)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Convert a raw entity [`mem_entity::Model`] into the domain [`Memory`] type.
+fn model_to_memory(model: mem_entity::Model) -> StoreResult<Memory> {
+    let memory_type: MemoryType = model
+        .memory_type
+        .parse()
+        .map_err(|e: String| StoreError::InvalidData(e))?;
+
+    let visibility: VisibilityLevel = model
+        .visibility
+        .parse()
+        .map_err(|e: String| StoreError::InvalidData(e))?;
+
+    let tags: Vec<String> = serde_json::from_str(&model.tags)
+        .map_err(|e| StoreError::InvalidData(e.to_string()))?;
+
+    let shared_with: Vec<String> = serde_json::from_str(&model.shared_with)
+        .map_err(|e| StoreError::InvalidData(e.to_string()))?;
+
+    let references: Vec<String> = serde_json::from_str(&model.refs)
+        .map_err(|e| StoreError::InvalidData(e.to_string()))?;
+
+    let created_at = chrono::DateTime::parse_from_rfc3339(&model.created_at)
+        .map_err(|e| StoreError::InvalidData(e.to_string()))?
+        .with_timezone(&chrono::Utc);
+
+    let updated_at = chrono::DateTime::parse_from_rfc3339(&model.updated_at)
+        .map_err(|e| StoreError::InvalidData(e.to_string()))?
+        .with_timezone(&chrono::Utc);
+
+    Ok(Memory {
+        id: model.id,
+        content: model.content,
+        memory_type,
+        tags,
+        created_by: model.created_by,
+        owner: model.owner,
+        created_at,
+        updated_at,
+        visibility,
+        shared_with,
+        references,
+    })
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{MemoryType, VisibilityLevel};
+    use tempfile::TempDir;
+
+    async fn create_test_storage() -> (MemoryStorage, TempDir) {
+        let temp_dir = TempDir::new().unwrap();
+        let db_path = temp_dir.path().join("test.db");
+        let storage = MemoryStorage::with_path(&db_path).await.unwrap();
+        (storage, temp_dir)
+    }
+
+    fn sample_request() -> CreateMemoryRequest {
+        CreateMemoryRequest {
+            content: "The sky is blue".to_string(),
+            memory_type: MemoryType::Information,
+            tags: vec!["nature".to_string()],
+            created_by: "agent-1".to_string(),
+            visibility: VisibilityLevel::Private,
+            shared_with: vec![],
+            references: vec![],
+        }
+    }
+
+    #[tokio::test]
+    async fn test_create_and_get() {
+        let (storage, _temp) = create_test_storage().await;
+        let memory = storage.create(sample_request()).await.unwrap();
+
+        assert!(memory.id.starts_with("mem_"));
+        assert_eq!(memory.content, "The sky is blue");
+
+        let retrieved = storage.get(&memory.id).await.unwrap();
+        assert!(retrieved.is_some());
+        let retrieved = retrieved.unwrap();
+        assert_eq!(retrieved.id, memory.id);
+        assert_eq!(retrieved.content, memory.content);
+        assert_eq!(retrieved.memory_type, MemoryType::Information);
+    }
+
+    #[tokio::test]
+    async fn test_get_nonexistent() {
+        let (storage, _temp) = create_test_storage().await;
+        let result = storage.get("mem_nonexistent").await.unwrap();
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_delete() {
+        let (storage, _temp) = create_test_storage().await;
+        let memory = storage.create(sample_request()).await.unwrap();
+        let id = memory.id.clone();
+
+        let deleted = storage.delete(&id).await.unwrap();
+        assert!(deleted);
+
+        let retrieved = storage.get(&id).await.unwrap();
+        assert!(retrieved.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_delete_nonexistent() {
+        let (storage, _temp) = create_test_storage().await;
+        let deleted = storage.delete("mem_nonexistent").await.unwrap();
+        assert!(!deleted);
+    }
+
+    #[tokio::test]
+    async fn test_list_all() {
+        let (storage, _temp) = create_test_storage().await;
+
+        storage.create(sample_request()).await.unwrap();
+        storage
+            .create(CreateMemoryRequest {
+                content: "Water is wet".to_string(),
+                created_by: "agent-2".to_string(),
+                ..sample_request()
+            })
+            .await
+            .unwrap();
+
+        let all = storage.list(None).await.unwrap();
+        assert_eq!(all.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_list_filtered_by_creator() {
+        let (storage, _temp) = create_test_storage().await;
+
+        storage.create(sample_request()).await.unwrap();
+        storage
+            .create(CreateMemoryRequest {
+                content: "Water is wet".to_string(),
+                created_by: "agent-2".to_string(),
+                ..sample_request()
+            })
+            .await
+            .unwrap();
+
+        let agent1_memories = storage.list(Some("agent-1")).await.unwrap();
+        assert_eq!(agent1_memories.len(), 1);
+        assert_eq!(agent1_memories[0].created_by, "agent-1");
+    }
+
+    #[tokio::test]
+    async fn test_update_visibility() {
+        let (storage, _temp) = create_test_storage().await;
+        let memory = storage.create(sample_request()).await.unwrap();
+
+        let updated = storage
+            .update_visibility(
+                &memory.id,
+                VisibilityLevel::Shared,
+                Some(vec!["agent-2".to_string()]),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(updated.visibility, VisibilityLevel::Shared);
+        assert_eq!(updated.shared_with, vec!["agent-2".to_string()]);
+    }
+
+    #[tokio::test]
+    async fn test_update_visibility_not_found() {
+        let (storage, _temp) = create_test_storage().await;
+        let result = storage
+            .update_visibility("mem_nonexistent", VisibilityLevel::Public, None)
+            .await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_health_check() {
+        let (storage, _temp) = create_test_storage().await;
+        let healthy = storage.health_check().await.unwrap();
+        assert!(healthy);
+    }
+
+    #[tokio::test]
+    async fn test_tags_and_references_round_trip() {
+        let (storage, _temp) = create_test_storage().await;
+        let req = CreateMemoryRequest {
+            content: "Tagged memory".to_string(),
+            memory_type: MemoryType::Information,
+            tags: vec!["tag1".to_string(), "tag2".to_string()],
+            created_by: "agent-1".to_string(),
+            visibility: VisibilityLevel::Shared,
+            shared_with: vec!["agent-3".to_string()],
+            references: vec!["mem_0001_aaaaaaaa".to_string()],
+        };
+
+        let memory = storage.create(req).await.unwrap();
+        let retrieved = storage.get(&memory.id).await.unwrap().unwrap();
+
+        assert_eq!(retrieved.tags, vec!["tag1".to_string(), "tag2".to_string()]);
+        assert_eq!(retrieved.shared_with, vec!["agent-3".to_string()]);
+        assert_eq!(retrieved.references, vec!["mem_0001_aaaaaaaa".to_string()]);
+    }
+}

--- a/crates/xtask/Cargo.toml
+++ b/crates/xtask/Cargo.toml
@@ -8,6 +8,7 @@ publish = false
 anyhow = "1.0"
 colored = "2.1"
 tokio = { version = "1", features = ["full"] }
+memory = { path = "../memory" }
 notify = { path = "../notify" }
 orchestrator = { path = "../orchestrator" }
 agentd-common = { path = "../common" }

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -129,6 +129,12 @@ fn print_help() {
 /// Services that have SeaORM-managed SQLite databases.
 const DB_SERVICES: &[DbService] = &[
     DbService {
+        name: "memory",
+        project: "agentd-memory",
+        db_file: "memory.db",
+        entity_dir: "crates/memory/src/entity",
+    },
+    DbService {
         name: "notify",
         project: "agentd-notify",
         db_file: "notify.db",
@@ -268,6 +274,7 @@ async fn migrate(service: Option<&str>) -> Result<()> {
         print!("  {} {} … ", "→".cyan(), svc.name.green());
 
         let result = match svc.name {
+            "memory" => memory::apply_migrations_for_path(&db_path).await,
             "notify" => notify::apply_migrations_for_path(&db_path).await,
             "orchestrator" => orchestrator::apply_migrations_for_path(&db_path).await,
             _ => anyhow::bail!("No migration runner registered for service '{}'", svc.name),
@@ -311,6 +318,7 @@ async fn migrate_status(service: Option<&str>) -> Result<()> {
         }
 
         let result = match svc.name {
+            "memory" => memory::migration_status_for_path(&db_path).await,
             "notify" => notify::migration_status_for_path(&db_path).await,
             "orchestrator" => orchestrator::migration_status_for_path(&db_path).await,
             _ => anyhow::bail!("No migration runner registered for service '{}'", svc.name),


### PR DESCRIPTION
## Summary

- Add `SeaORM` entity for `memory_entries` table with columns: `id`, `content`, `memory_type`, `tags`, `created_by`, `owner`, `visibility`, `shared_with`, `refs`, `created_at`, `updated_at`
- Add initial migration (`m20260313_000001_create_memory_entries`) with indexes on `memory_type`, `created_by`, `created_at`, and `visibility`
- Implement `MemoryStorage` struct with `create`, `get`, `delete`, `list`, `update_visibility`, and `health_check` methods backed by SQLite via SeaORM
- Add `lib.rs` exposing `apply_migrations_for_path` / `migration_status_for_path` for `cargo xtask migrate` integration
- Wire `MemoryStorage` into `ApiState` and initialize on service startup
- Register `memory` in xtask `DB_SERVICES` and add match arms in `migrate` / `migrate-status` commands

## Test plan

- [x] `cargo build -p memory` — clean build (warnings only for unused fields, expected until CRUD endpoints are wired up)
- [x] `cargo test -p memory` — 67/67 tests pass including 9 storage integration tests using `TempDir`
- [x] `cargo build -p xtask` — xtask compiles with memory migration wiring

Closes #302

🤖 Generated with [Claude Code](https://claude.com/claude-code)