### PR TITLE
feat(memory): implement embedding service with OpenAI-compatible provider support (#304)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4217,6 +4217,7 @@ dependencies = [
  "lancedb",
  "metrics",
  "metrics-exporter-prometheus",
+ "reqwest",
  "sea-orm",
  "sea-orm-migration",
  "serde",

--- a/crates/memory/Cargo.toml
+++ b/crates/memory/Cargo.toml
@@ -33,6 +33,9 @@ arrow = { version = "54", features = ["prettyprint"] }
 arrow-array = "54"
 arrow-schema = "54"
 
+# HTTP client for embedding API calls
+reqwest = { workspace = true, features = ["json"] }
+
 # Additional utilities
 uuid = { version = "1.11", features = ["v4", "serde"] }
 chrono = { version = "0.4", features = ["serde"] }

--- a/crates/memory/src/config.rs
+++ b/crates/memory/src/config.rs
@@ -1,0 +1,199 @@
+//! Configuration types for the agentd-memory service.
+//!
+//! Provides [`EmbeddingConfig`] which describes the embedding provider and
+//! can be loaded from environment variables.
+//!
+//! # Environment Variables
+//!
+//! | Variable                             | Default                        | Description                                 |
+//! |--------------------------------------|--------------------------------|---------------------------------------------|
+//! | `AGENTD_MEMORY_EMBEDDING_PROVIDER`   | `"none"`                       | Provider: `"openai"` or `"none"`            |
+//! | `AGENTD_MEMORY_EMBEDDING_MODEL`      | `"text-embedding-3-small"`     | Model name                                  |
+//! | `AGENTD_MEMORY_EMBEDDING_API_KEY`    | —                              | API key (required for remote OpenAI calls)  |
+//! | `AGENTD_MEMORY_EMBEDDING_ENDPOINT`   | `"https://api.openai.com/v1"`  | Base URL; use Ollama's URL for local runs   |
+//!
+//! # Example
+//!
+//! ```rust
+//! use memory::config::EmbeddingConfig;
+//!
+//! // Load from environment
+//! let config = EmbeddingConfig::from_env();
+//! assert!(!config.provider.is_empty() || config.provider == "none");
+//! ```
+
+use serde::{Deserialize, Serialize};
+use std::env;
+
+/// Configuration for the embedding service.
+///
+/// Controls which provider and model are used to convert text into embedding
+/// vectors for semantic search.
+///
+/// # Example
+///
+/// ```rust
+/// use memory::config::EmbeddingConfig;
+///
+/// let config = EmbeddingConfig {
+///     provider: "openai".to_string(),
+///     model: "text-embedding-3-small".to_string(),
+///     api_key: Some("sk-...".to_string()),
+///     base_url: None,
+/// };
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct EmbeddingConfig {
+    /// Embedding provider: `"openai"` (also works with Ollama) or `"none"`.
+    ///
+    /// `"none"` disables embeddings; any call to [`embed`] will return an
+    /// error explaining that the service is not configured.
+    pub provider: String,
+
+    /// Model name understood by the provider.
+    ///
+    /// Well-known models with pre-configured dimensions:
+    /// - OpenAI: `text-embedding-3-small` (1536), `text-embedding-3-large` (3072), `text-embedding-ada-002` (1536)
+    /// - Ollama: `nomic-embed-text` (768), `mxbai-embed-large` (1024), `all-minilm` (384), `snowflake-arctic-embed` (1024)
+    pub model: String,
+
+    /// API key sent as a `Bearer` token.
+    ///
+    /// Required for remote OpenAI calls; omit for Ollama or other localhost
+    /// providers.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub api_key: Option<String>,
+
+    /// Override the default API base URL.
+    ///
+    /// Defaults to `"https://api.openai.com/v1"` when `None`.
+    /// Set to `"http://localhost:11434/v1"` for Ollama.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub base_url: Option<String>,
+}
+
+impl Default for EmbeddingConfig {
+    fn default() -> Self {
+        Self {
+            provider: "none".to_string(),
+            model: "text-embedding-3-small".to_string(),
+            api_key: None,
+            base_url: None,
+        }
+    }
+}
+
+impl EmbeddingConfig {
+    /// Load configuration from environment variables.
+    ///
+    /// | Variable                             | Default                       |
+    /// |--------------------------------------|-------------------------------|
+    /// | `AGENTD_MEMORY_EMBEDDING_PROVIDER`   | `"none"`                      |
+    /// | `AGENTD_MEMORY_EMBEDDING_MODEL`      | `"text-embedding-3-small"`    |
+    /// | `AGENTD_MEMORY_EMBEDDING_API_KEY`    | `None`                        |
+    /// | `AGENTD_MEMORY_EMBEDDING_ENDPOINT`   | `None` (uses provider default)|
+    pub fn from_env() -> Self {
+        Self {
+            provider: env::var("AGENTD_MEMORY_EMBEDDING_PROVIDER")
+                .unwrap_or_else(|_| "none".to_string()),
+            model: env::var("AGENTD_MEMORY_EMBEDDING_MODEL")
+                .unwrap_or_else(|_| "text-embedding-3-small".to_string()),
+            api_key: env::var("AGENTD_MEMORY_EMBEDDING_API_KEY").ok(),
+            base_url: env::var("AGENTD_MEMORY_EMBEDDING_ENDPOINT").ok(),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_default_provider_is_none() {
+        let config = EmbeddingConfig::default();
+        assert_eq!(config.provider, "none");
+    }
+
+    #[test]
+    fn test_default_model() {
+        let config = EmbeddingConfig::default();
+        assert_eq!(config.model, "text-embedding-3-small");
+    }
+
+    #[test]
+    fn test_default_api_key_is_none() {
+        let config = EmbeddingConfig::default();
+        assert!(config.api_key.is_none());
+    }
+
+    #[test]
+    fn test_default_base_url_is_none() {
+        let config = EmbeddingConfig::default();
+        assert!(config.base_url.is_none());
+    }
+
+    #[test]
+    fn test_from_env_defaults_when_vars_absent() {
+        // Ensure vars are not set in this process
+        let config = EmbeddingConfig::from_env();
+        // Provider defaults to "none" when unset
+        // (we can't unset the vars set by other tests, so just check type)
+        assert!(!config.model.is_empty());
+    }
+
+    #[test]
+    fn test_serialization_omits_none_fields() {
+        let config = EmbeddingConfig {
+            provider: "none".to_string(),
+            model: "text-embedding-3-small".to_string(),
+            api_key: None,
+            base_url: None,
+        };
+        let json = serde_json::to_string(&config).unwrap();
+        assert!(!json.contains("api_key"));
+        assert!(!json.contains("base_url"));
+    }
+
+    #[test]
+    fn test_serialization_includes_present_fields() {
+        let config = EmbeddingConfig {
+            provider: "openai".to_string(),
+            model: "text-embedding-3-small".to_string(),
+            api_key: Some("sk-test".to_string()),
+            base_url: Some("https://api.openai.com/v1".to_string()),
+        };
+        let json = serde_json::to_string(&config).unwrap();
+        assert!(json.contains("sk-test"));
+        assert!(json.contains("api.openai.com"));
+    }
+
+    #[test]
+    fn test_deserialization_with_defaults() {
+        let json = r#"{"provider":"openai","model":"text-embedding-3-large"}"#;
+        let config: EmbeddingConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(config.provider, "openai");
+        assert_eq!(config.model, "text-embedding-3-large");
+        assert!(config.api_key.is_none());
+        assert!(config.base_url.is_none());
+    }
+
+    #[test]
+    fn test_clone() {
+        let config = EmbeddingConfig {
+            provider: "openai".to_string(),
+            model: "nomic-embed-text".to_string(),
+            api_key: Some("key".to_string()),
+            base_url: Some("http://localhost:11434/v1".to_string()),
+        };
+        let cloned = config.clone();
+        assert_eq!(cloned.provider, config.provider);
+        assert_eq!(cloned.model, config.model);
+        assert_eq!(cloned.api_key, config.api_key);
+        assert_eq!(cloned.base_url, config.base_url);
+    }
+}

--- a/crates/memory/src/main.rs
+++ b/crates/memory/src/main.rs
@@ -22,6 +22,7 @@
 //! - `GET /metrics` — Prometheus metrics
 
 mod api;
+pub mod config;
 pub mod error;
 pub mod store;
 pub mod types;

--- a/crates/memory/src/store/embedding.rs
+++ b/crates/memory/src/store/embedding.rs
@@ -1,0 +1,535 @@
+//! Embedding service implementations for the agentd-memory service.
+//!
+//! Provides text-to-vector conversion via an OpenAI-compatible HTTP API
+//! ([`OpenAIEmbedding`]) and a no-op fallback ([`NoOpEmbedding`]) used when
+//! embeddings are not configured.
+//!
+//! Use [`create_embedding_service`] as the primary entry point — it reads an
+//! [`EmbeddingConfig`] and returns the appropriate boxed [`EmbeddingService`].
+//!
+//! # Provider selection
+//!
+//! | `config.provider` | Result                              |
+//! |-------------------|-------------------------------------|
+//! | `"openai"`        | [`OpenAIEmbedding`] (also Ollama)   |
+//! | `"none"` / `""`   | [`NoOpEmbedding`] (always errors)   |
+//! | anything else     | [`StoreError::InitializationFailed`]|
+//!
+//! # Ollama (local) usage
+//!
+//! Point `config.base_url` at `http://localhost:11434/v1` and leave
+//! `config.api_key` as `None` — no auth header will be sent.
+//!
+//! # Example
+//!
+//! ```rust,no_run
+//! use memory::config::EmbeddingConfig;
+//! use memory::store::create_embedding_service;
+//!
+//! # #[tokio::main]
+//! # async fn main() -> anyhow::Result<()> {
+//! let config = EmbeddingConfig {
+//!     provider: "openai".to_string(),
+//!     model: "text-embedding-3-small".to_string(),
+//!     api_key: Some("sk-...".to_string()),
+//!     base_url: None,
+//! };
+//! let svc = create_embedding_service(&config)?;
+//! println!("Dimension: {}", svc.dimension("text-embedding-3-small"));
+//! # Ok(())
+//! # }
+//! ```
+
+use async_trait::async_trait;
+use reqwest::Client;
+use serde::{Deserialize, Serialize};
+use tracing::debug;
+
+use crate::config::EmbeddingConfig;
+use crate::error::{StoreError, StoreResult};
+use crate::store::EmbeddingService;
+
+// ---------------------------------------------------------------------------
+// Dimension lookup
+// ---------------------------------------------------------------------------
+
+/// Return the known vector dimension for `model`, or 1536 as a safe default.
+///
+/// Covers the most common OpenAI and Ollama models. Unknown models fall back
+/// to 1536 (the OpenAI default), which is compatible with most downstream
+/// tooling.
+pub fn model_dimension(model: &str) -> usize {
+    match model {
+        // OpenAI
+        "text-embedding-3-small" => 1536,
+        "text-embedding-3-large" => 3072,
+        "text-embedding-ada-002" => 1536,
+        // Ollama / open-source
+        "nomic-embed-text" => 768,
+        "mxbai-embed-large" => 1024,
+        "all-minilm" => 384,
+        "snowflake-arctic-embed" => 1024,
+        _ => 1536, // OpenAI-compatible default
+    }
+}
+
+// ---------------------------------------------------------------------------
+// OpenAI-compatible embedding provider
+// ---------------------------------------------------------------------------
+
+/// Embedding provider that calls any OpenAI-compatible `/embeddings` endpoint.
+///
+/// Works with:
+/// - **OpenAI** — pass an API key; default base URL is used.
+/// - **Ollama** — point `base_url` at `http://localhost:11434/v1`; no API key needed.
+/// - **Other compatible APIs** — set `base_url` to your endpoint.
+///
+/// # Authentication
+///
+/// An `Authorization: Bearer <key>` header is sent only when `api_key` is
+/// non-empty. For `localhost` / `127.0.0.1` URLs the key can be omitted.
+pub struct OpenAIEmbedding {
+    client: Client,
+    api_key: String,
+    model: String,
+    base_url: String,
+}
+
+impl OpenAIEmbedding {
+    /// Construct a new provider from `config`.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`StoreError::InitializationFailed`] when the API key is absent
+    /// and the base URL is not a localhost address.
+    pub fn new(config: &EmbeddingConfig) -> StoreResult<Self> {
+        let base_url = config
+            .base_url
+            .clone()
+            .unwrap_or_else(|| "https://api.openai.com/v1".to_string());
+
+        let is_local =
+            base_url.contains("localhost") || base_url.contains("127.0.0.1");
+
+        let api_key = match config.api_key.clone() {
+            Some(key) => key,
+            None if is_local => String::new(),
+            None => {
+                return Err(StoreError::InitializationFailed(
+                    "OpenAI API key required for embeddings. \
+                     Set AGENTD_MEMORY_EMBEDDING_API_KEY or use a localhost endpoint."
+                        .to_string(),
+                ))
+            }
+        };
+
+        Ok(Self {
+            client: Client::new(),
+            api_key,
+            model: config.model.clone(),
+            base_url,
+        })
+    }
+}
+
+// Internal request / response shapes for the OpenAI embeddings endpoint.
+#[derive(Debug, Serialize)]
+struct EmbeddingRequest {
+    model: String,
+    input: Vec<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct EmbeddingResponse {
+    data: Vec<EmbeddingData>,
+}
+
+#[derive(Debug, Deserialize)]
+struct EmbeddingData {
+    embedding: Vec<f32>,
+}
+
+#[async_trait]
+impl EmbeddingService for OpenAIEmbedding {
+    /// Call the `/embeddings` endpoint and return one vector per input text.
+    ///
+    /// Returns an empty `Vec` when `texts` is empty without making an HTTP
+    /// request.
+    async fn embed(&self, texts: &[String]) -> StoreResult<Vec<Vec<f32>>> {
+        if texts.is_empty() {
+            return Ok(vec![]);
+        }
+
+        let url = format!("{}/embeddings", self.base_url);
+
+        debug!(
+            "Generating embeddings for {} texts using model {} at {}",
+            texts.len(),
+            self.model,
+            self.base_url
+        );
+
+        let body = EmbeddingRequest {
+            model: self.model.clone(),
+            input: texts.to_vec(),
+        };
+
+        let mut req = self.client.post(&url).header("Content-Type", "application/json");
+
+        if !self.api_key.is_empty() {
+            req = req.header("Authorization", format!("Bearer {}", self.api_key));
+        }
+
+        let resp = req.json(&body).send().await.map_err(|e| {
+            StoreError::QueryFailed(format!("Embedding request failed: {}", e))
+        })?;
+
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let body = resp.text().await.unwrap_or_default();
+            return Err(StoreError::QueryFailed(format!(
+                "Embedding API error (HTTP {}): {}",
+                status, body
+            )));
+        }
+
+        let parsed: EmbeddingResponse = resp.json().await.map_err(|e| {
+            StoreError::InvalidData(format!("Failed to parse embedding response: {}", e))
+        })?;
+
+        let embeddings: Vec<Vec<f32>> =
+            parsed.data.into_iter().map(|d| d.embedding).collect();
+
+        debug!(
+            "Generated {} embeddings with dimension {}",
+            embeddings.len(),
+            embeddings.first().map(|e| e.len()).unwrap_or(0)
+        );
+
+        Ok(embeddings)
+    }
+
+    /// Return the vector dimension for `model`.
+    ///
+    /// When `model` is empty the instance's configured model is used.
+    fn dimension(&self, model: &str) -> usize {
+        let m = if model.is_empty() { self.model.as_str() } else { model };
+        model_dimension(m)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// No-op fallback
+// ---------------------------------------------------------------------------
+
+/// Embedding service that always returns an error.
+///
+/// Used when no provider is configured (`provider = "none"`). All calls to
+/// [`embed`] fail with [`StoreError::InitializationFailed`], clearly
+/// indicating that the service needs to be configured.
+pub struct NoOpEmbedding;
+
+impl NoOpEmbedding {
+    /// Create a new `NoOpEmbedding`.
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for NoOpEmbedding {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl EmbeddingService for NoOpEmbedding {
+    async fn embed(&self, _texts: &[String]) -> StoreResult<Vec<Vec<f32>>> {
+        Err(StoreError::InitializationFailed(
+            "Embedding service not configured. \
+             Set AGENTD_MEMORY_EMBEDDING_PROVIDER and related environment variables."
+                .to_string(),
+        ))
+    }
+
+    /// Always returns `0` — no embeddings are produced by this provider.
+    fn dimension(&self, _model: &str) -> usize {
+        0
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+/// Build an [`EmbeddingService`] from `config`.
+///
+/// # Errors
+///
+/// - [`StoreError::InitializationFailed`] if `config.provider` is `"openai"`
+///   but no API key is provided for a remote endpoint.
+/// - [`StoreError::InitializationFailed`] for unknown provider names.
+pub fn create_embedding_service(
+    config: &EmbeddingConfig,
+) -> StoreResult<Box<dyn EmbeddingService>> {
+    match config.provider.to_lowercase().as_str() {
+        "openai" => {
+            let svc = OpenAIEmbedding::new(config)?;
+            Ok(Box::new(svc))
+        }
+        "none" | "" => {
+            tracing::warn!(
+                "No embedding provider configured — semantic search will not work. \
+                 Set AGENTD_MEMORY_EMBEDDING_PROVIDER=openai to enable."
+            );
+            Ok(Box::new(NoOpEmbedding::new()))
+        }
+        other => Err(StoreError::InitializationFailed(format!(
+            "Unknown embedding provider: '{}'. Supported providers: openai, none",
+            other
+        ))),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn openai_config(model: &str) -> EmbeddingConfig {
+        EmbeddingConfig {
+            provider: "openai".to_string(),
+            model: model.to_string(),
+            api_key: Some("test-key".to_string()),
+            base_url: None,
+        }
+    }
+
+    fn local_config(model: &str) -> EmbeddingConfig {
+        EmbeddingConfig {
+            provider: "openai".to_string(),
+            model: model.to_string(),
+            api_key: None,
+            base_url: Some("http://localhost:11434/v1".to_string()),
+        }
+    }
+
+    // ── model_dimension lookup ─────────────────────────────────────────────
+
+    #[test]
+    fn test_model_dimension_text_embedding_3_small() {
+        assert_eq!(model_dimension("text-embedding-3-small"), 1536);
+    }
+
+    #[test]
+    fn test_model_dimension_text_embedding_3_large() {
+        assert_eq!(model_dimension("text-embedding-3-large"), 3072);
+    }
+
+    #[test]
+    fn test_model_dimension_ada_002() {
+        assert_eq!(model_dimension("text-embedding-ada-002"), 1536);
+    }
+
+    #[test]
+    fn test_model_dimension_nomic_embed_text() {
+        assert_eq!(model_dimension("nomic-embed-text"), 768);
+    }
+
+    #[test]
+    fn test_model_dimension_mxbai_embed_large() {
+        assert_eq!(model_dimension("mxbai-embed-large"), 1024);
+    }
+
+    #[test]
+    fn test_model_dimension_all_minilm() {
+        assert_eq!(model_dimension("all-minilm"), 384);
+    }
+
+    #[test]
+    fn test_model_dimension_snowflake_arctic_embed() {
+        assert_eq!(model_dimension("snowflake-arctic-embed"), 1024);
+    }
+
+    #[test]
+    fn test_model_dimension_unknown_defaults_to_1536() {
+        assert_eq!(model_dimension("some-unknown-model"), 1536);
+    }
+
+    // ── OpenAIEmbedding construction ───────────────────────────────────────
+
+    #[test]
+    fn test_openai_construction_with_api_key() {
+        let config = openai_config("text-embedding-3-small");
+        assert!(OpenAIEmbedding::new(&config).is_ok());
+    }
+
+    #[test]
+    fn test_openai_requires_api_key_for_remote() {
+        let config = EmbeddingConfig {
+            provider: "openai".to_string(),
+            model: "text-embedding-3-small".to_string(),
+            api_key: None,
+            base_url: None,
+        };
+        match OpenAIEmbedding::new(&config) {
+            Err(e) => assert!(e.to_string().contains("API key required")),
+            Ok(_) => panic!("Expected error when API key missing for remote service"),
+        }
+    }
+
+    #[test]
+    fn test_openai_no_key_required_for_localhost() {
+        let config = local_config("nomic-embed-text");
+        assert!(OpenAIEmbedding::new(&config).is_ok());
+    }
+
+    #[test]
+    fn test_openai_no_key_required_for_127_0_0_1() {
+        let config = EmbeddingConfig {
+            provider: "openai".to_string(),
+            model: "nomic-embed-text".to_string(),
+            api_key: None,
+            base_url: Some("http://127.0.0.1:11434/v1".to_string()),
+        };
+        assert!(OpenAIEmbedding::new(&config).is_ok());
+    }
+
+    // ── OpenAIEmbedding::dimension ─────────────────────────────────────────
+
+    #[test]
+    fn test_dimension_configured_model_when_arg_empty() {
+        let svc = OpenAIEmbedding::new(&openai_config("text-embedding-3-large")).unwrap();
+        assert_eq!(svc.dimension(""), 3072);
+    }
+
+    #[test]
+    fn test_dimension_uses_arg_model_when_provided() {
+        let svc = OpenAIEmbedding::new(&openai_config("text-embedding-3-small")).unwrap();
+        assert_eq!(svc.dimension("text-embedding-3-large"), 3072);
+    }
+
+    #[test]
+    fn test_dimension_small_via_trait() {
+        let svc = OpenAIEmbedding::new(&openai_config("text-embedding-3-small")).unwrap();
+        assert_eq!(svc.dimension("text-embedding-3-small"), 1536);
+    }
+
+    #[test]
+    fn test_dimension_ollama_nomic() {
+        let svc = OpenAIEmbedding::new(&local_config("nomic-embed-text")).unwrap();
+        assert_eq!(svc.dimension("nomic-embed-text"), 768);
+    }
+
+    #[test]
+    fn test_dimension_ollama_mxbai() {
+        let svc = OpenAIEmbedding::new(&local_config("mxbai-embed-large")).unwrap();
+        assert_eq!(svc.dimension("mxbai-embed-large"), 1024);
+    }
+
+    #[test]
+    fn test_dimension_all_minilm() {
+        let svc = OpenAIEmbedding::new(&local_config("all-minilm")).unwrap();
+        assert_eq!(svc.dimension("all-minilm"), 384);
+    }
+
+    // ── NoOpEmbedding ──────────────────────────────────────────────────────
+
+    #[test]
+    fn test_noop_dimension_is_zero() {
+        let svc = NoOpEmbedding::new();
+        assert_eq!(svc.dimension("text-embedding-3-small"), 0);
+    }
+
+    #[test]
+    fn test_noop_default_dimension_is_zero() {
+        let svc = NoOpEmbedding::default();
+        assert_eq!(svc.dimension(""), 0);
+    }
+
+    #[tokio::test]
+    async fn test_noop_embed_returns_error() {
+        let svc = NoOpEmbedding::new();
+        let result = svc.embed(&["hello".to_string()]).await;
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("not configured"));
+    }
+
+    // ── create_embedding_service factory ──────────────────────────────────
+
+    #[test]
+    fn test_factory_openai_provider() {
+        let config = openai_config("text-embedding-3-small");
+        let result = create_embedding_service(&config);
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().dimension("text-embedding-3-small"), 1536);
+    }
+
+    #[test]
+    fn test_factory_none_provider() {
+        let config = EmbeddingConfig {
+            provider: "none".to_string(),
+            model: String::new(),
+            api_key: None,
+            base_url: None,
+        };
+        let result = create_embedding_service(&config);
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().dimension(""), 0);
+    }
+
+    #[test]
+    fn test_factory_empty_provider_treated_as_none() {
+        let config = EmbeddingConfig {
+            provider: String::new(),
+            model: String::new(),
+            api_key: None,
+            base_url: None,
+        };
+        let result = create_embedding_service(&config);
+        assert!(result.is_ok());
+        assert_eq!(result.unwrap().dimension(""), 0);
+    }
+
+    #[test]
+    fn test_factory_unknown_provider_errors() {
+        let config = EmbeddingConfig {
+            provider: "unknown_provider".to_string(),
+            model: String::new(),
+            api_key: None,
+            base_url: None,
+        };
+        match create_embedding_service(&config) {
+            Err(e) => assert!(e.to_string().contains("Unknown embedding provider")),
+            Ok(_) => panic!("Expected error for unknown provider"),
+        }
+    }
+
+    #[test]
+    fn test_factory_provider_case_insensitive() {
+        let config = EmbeddingConfig {
+            provider: "OpenAI".to_string(),
+            model: "text-embedding-3-small".to_string(),
+            api_key: Some("key".to_string()),
+            base_url: None,
+        };
+        assert!(create_embedding_service(&config).is_ok());
+    }
+
+    #[test]
+    fn test_factory_openai_dimension_large() {
+        let config = openai_config("text-embedding-3-large");
+        let svc = create_embedding_service(&config).unwrap();
+        assert_eq!(svc.dimension("text-embedding-3-large"), 3072);
+    }
+
+    #[tokio::test]
+    async fn test_openai_embed_empty_slice_returns_empty() {
+        let svc = OpenAIEmbedding::new(&openai_config("text-embedding-3-small")).unwrap();
+        let result = svc.embed(&[]).await.unwrap();
+        assert!(result.is_empty());
+    }
+}

--- a/crates/memory/src/store/mod.rs
+++ b/crates/memory/src/store/mod.rs
@@ -1,9 +1,12 @@
 //! Storage abstractions for the agentd-memory service.
 //!
 //! This module exposes the [`VectorStore`] and [`EmbeddingService`] traits
-//! that decouple the service from concrete backend implementations.
-//! LanceDB-backed implementations will be added in a subsequent issue.
+//! that decouple the service from concrete backend implementations, as well
+//! as the concrete embedding providers ([`OpenAIEmbedding`], [`NoOpEmbedding`])
+//! and the [`create_embedding_service`] factory.
 
 mod traits;
+pub mod embedding;
 
+pub use embedding::{create_embedding_service, model_dimension, NoOpEmbedding, OpenAIEmbedding};
 pub use traits::{EmbeddingService, VectorStore};


### PR DESCRIPTION
## Summary

- Add `EmbeddingConfig` struct (`provider`, `model`, `api_key`, `base_url`) with `from_env()` loader reading `AGENTD_MEMORY_EMBEDDING_PROVIDER`, `AGENTD_MEMORY_EMBEDDING_MODEL`, `AGENTD_MEMORY_EMBEDDING_API_KEY`, `AGENTD_MEMORY_EMBEDDING_ENDPOINT`
- Implement `OpenAIEmbedding` provider that calls any OpenAI-compatible `/embeddings` endpoint; works with OpenAI (requires API key) and Ollama (localhost — no key needed, auth header skipped)
- Implement `NoOpEmbedding` fallback that returns `StoreError::InitializationFailed` on any `embed()` call — used when provider is `"none"` or unset
- Add `model_dimension(model: &str)` free function covering OpenAI (`text-embedding-3-small` → 1536, `text-embedding-3-large` → 3072, `text-embedding-ada-002` → 1536) and Ollama (`nomic-embed-text` → 768, `mxbai-embed-large` → 1024, `all-minilm` → 384, `snowflake-arctic-embed` → 1024); unknown models default to 1536
- Add `create_embedding_service(config)` factory: `"openai"` → `OpenAIEmbedding`, `"none"`/`""` → `NoOpEmbedding`, unknown → error
- Expose `pub mod config` from crate root and `pub mod embedding` from `store/`
- Add `reqwest` workspace dependency to memory crate for HTTP calls

## Test plan

- [x] `cargo build -p memory` — clean build
- [x] `cargo test -p memory` — 94/94 tests pass, including:
  - Model dimension lookups for all known OpenAI and Ollama models
  - `OpenAIEmbedding` construction (API key required for remote, optional for localhost)
  - `NoOpEmbedding` always errors on embed, dimension always 0
  - Factory provider selection and case-insensitivity
  - Empty slice returns empty vec without HTTP call
  - `EmbeddingConfig` serialization, deserialization, and `from_env()` defaults

Closes #304

🤖 Generated with [Claude Code](https://claude.com/claude-code)