### PR TITLE
feat(memory): implement LanceDB vector store backend

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -174,40 +174,19 @@ version = "53.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3a3ec4fe573f9d1f59d99c085197ef669b00b088ba1d7bb75224732d9357a74"
 dependencies = [
- "arrow-arith 53.4.1",
- "arrow-array 53.4.1",
- "arrow-buffer 53.4.1",
- "arrow-cast 53.4.1",
- "arrow-csv 53.4.1",
- "arrow-data 53.4.1",
- "arrow-ipc 53.4.1",
- "arrow-json 53.4.1",
- "arrow-ord 53.4.1",
- "arrow-row 53.4.1",
- "arrow-schema 53.4.1",
- "arrow-select 53.4.1",
- "arrow-string 53.4.1",
-]
-
-[[package]]
-name = "arrow"
-version = "54.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc208515aa0151028e464cc94a692156e945ce5126abd3537bb7fd6ba2143ed1"
-dependencies = [
- "arrow-arith 54.2.1",
- "arrow-array 54.2.1",
- "arrow-buffer 54.3.1",
- "arrow-cast 54.2.1",
- "arrow-csv 54.2.1",
- "arrow-data 54.3.1",
- "arrow-ipc 54.2.1",
- "arrow-json 54.2.1",
- "arrow-ord 54.2.1",
- "arrow-row 54.2.1",
- "arrow-schema 54.3.1",
- "arrow-select 54.2.1",
- "arrow-string 54.2.1",
+ "arrow-arith",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-csv",
+ "arrow-data",
+ "arrow-ipc",
+ "arrow-json",
+ "arrow-ord",
+ "arrow-row",
+ "arrow-schema",
+ "arrow-select",
+ "arrow-string",
 ]
 
 [[package]]
@@ -216,26 +195,12 @@ version = "53.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6dcf19f07792d8c7f91086c67b574a79301e367029b17fcf63fb854332246a10"
 dependencies = [
- "arrow-array 53.4.1",
- "arrow-buffer 53.4.1",
- "arrow-data 53.4.1",
- "arrow-schema 53.4.1",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
  "chrono",
  "half",
- "num",
-]
-
-[[package]]
-name = "arrow-arith"
-version = "54.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e07e726e2b3f7816a85c6a45b6ec118eeeabf0b2a8c208122ad949437181f49a"
-dependencies = [
- "arrow-array 54.2.1",
- "arrow-buffer 54.3.1",
- "arrow-data 54.3.1",
- "arrow-schema 54.3.1",
- "chrono",
  "num",
 ]
 
@@ -246,27 +211,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7845c32b41f7053e37a075b3c2f29c6f5ea1b3ca6e5df7a2d325ee6e1b4a63cf"
 dependencies = [
  "ahash 0.8.12",
- "arrow-buffer 53.4.1",
- "arrow-data 53.4.1",
- "arrow-schema 53.4.1",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
  "chrono",
  "chrono-tz",
- "half",
- "hashbrown 0.15.5",
- "num",
-]
-
-[[package]]
-name = "arrow-array"
-version = "54.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2262eba4f16c78496adfd559a29fe4b24df6088efc9985a873d58e92be022d5"
-dependencies = [
- "ahash 0.8.12",
- "arrow-buffer 54.3.1",
- "arrow-data 54.3.1",
- "arrow-schema 54.3.1",
- "chrono",
  "half",
  "hashbrown 0.15.5",
  "num",
@@ -284,48 +233,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "arrow-buffer"
-version = "54.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "263f4801ff1839ef53ebd06f99a56cecd1dbaf314ec893d93168e2e860e0291c"
-dependencies = [
- "bytes",
- "half",
- "num",
-]
-
-[[package]]
 name = "arrow-cast"
 version = "53.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6365f8527d4f87b133eeb862f9b8093c009d41a210b8f101f91aa2392f61daac"
 dependencies = [
- "arrow-array 53.4.1",
- "arrow-buffer 53.4.1",
- "arrow-data 53.4.1",
- "arrow-schema 53.4.1",
- "arrow-select 53.4.1",
- "atoi",
- "base64",
- "chrono",
- "comfy-table",
- "half",
- "lexical-core",
- "num",
- "ryu",
-]
-
-[[package]]
-name = "arrow-cast"
-version = "54.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4103d88c5b441525ed4ac23153be7458494c2b0c9a11115848fdb9b81f6f886a"
-dependencies = [
- "arrow-array 54.2.1",
- "arrow-buffer 54.3.1",
- "arrow-data 54.3.1",
- "arrow-schema 54.3.1",
- "arrow-select 54.2.1",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
  "atoi",
  "base64",
  "chrono",
@@ -342,11 +259,11 @@ version = "53.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30dac4d23ac769300349197b845e0fd18c7f9f15d260d4659ae6b5a9ca06f586"
 dependencies = [
- "arrow-array 53.4.1",
- "arrow-buffer 53.4.1",
- "arrow-cast 53.4.1",
- "arrow-data 53.4.1",
- "arrow-schema 53.4.1",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-data",
+ "arrow-schema",
  "chrono",
  "csv",
  "csv-core",
@@ -356,41 +273,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "arrow-csv"
-version = "54.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d3cb0914486a3cae19a5cad2598e44e225d53157926d0ada03c20521191a65"
-dependencies = [
- "arrow-array 54.2.1",
- "arrow-cast 54.2.1",
- "arrow-schema 54.3.1",
- "chrono",
- "csv",
- "csv-core",
- "lazy_static",
- "regex",
-]
-
-[[package]]
 name = "arrow-data"
 version = "53.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd962fc3bf7f60705b25bcaa8eb3318b2545aa1d528656525ebdd6a17a6cd6fb"
 dependencies = [
- "arrow-buffer 53.4.1",
- "arrow-schema 53.4.1",
- "half",
- "num",
-]
-
-[[package]]
-name = "arrow-data"
-version = "54.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61cfdd7d99b4ff618f167e548b2411e5dd2c98c0ddebedd7df433d34c20a4429"
-dependencies = [
- "arrow-buffer 54.3.1",
- "arrow-schema 54.3.1",
+ "arrow-buffer",
+ "arrow-schema",
  "half",
  "num",
 ]
@@ -401,27 +290,14 @@ version = "53.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3527365b24372f9c948f16e53738eb098720eea2093ae73c7af04ac5e30a39b"
 dependencies = [
- "arrow-array 53.4.1",
- "arrow-buffer 53.4.1",
- "arrow-cast 53.4.1",
- "arrow-data 53.4.1",
- "arrow-schema 53.4.1",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-data",
+ "arrow-schema",
  "flatbuffers",
  "lz4_flex",
  "zstd",
-]
-
-[[package]]
-name = "arrow-ipc"
-version = "54.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddecdeab02491b1ce88885986e25002a3da34dd349f682c7cfe67bab7cc17b86"
-dependencies = [
- "arrow-array 54.2.1",
- "arrow-buffer 54.3.1",
- "arrow-data 54.3.1",
- "arrow-schema 54.3.1",
- "flatbuffers",
 ]
 
 [[package]]
@@ -430,31 +306,11 @@ version = "53.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acdec0024749fc0d95e025c0b0266d78613727b3b3a5d4cf8ea47eb6d38afdd1"
 dependencies = [
- "arrow-array 53.4.1",
- "arrow-buffer 53.4.1",
- "arrow-cast 53.4.1",
- "arrow-data 53.4.1",
- "arrow-schema 53.4.1",
- "chrono",
- "half",
- "indexmap 2.12.0",
- "lexical-core",
- "num",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "arrow-json"
-version = "54.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d03b9340013413eb84868682ace00a1098c81a5ebc96d279f7ebf9a4cac3c0fd"
-dependencies = [
- "arrow-array 54.2.1",
- "arrow-buffer 54.3.1",
- "arrow-cast 54.2.1",
- "arrow-data 54.3.1",
- "arrow-schema 54.3.1",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-data",
+ "arrow-schema",
  "chrono",
  "half",
  "indexmap 2.12.0",
@@ -470,26 +326,13 @@ version = "53.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "79af2db0e62a508d34ddf4f76bfd6109b6ecc845257c9cba6f939653668f89ac"
 dependencies = [
- "arrow-array 53.4.1",
- "arrow-buffer 53.4.1",
- "arrow-data 53.4.1",
- "arrow-schema 53.4.1",
- "arrow-select 53.4.1",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
  "half",
  "num",
-]
-
-[[package]]
-name = "arrow-ord"
-version = "54.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f841bfcc1997ef6ac48ee0305c4dfceb1f7c786fe31e67c1186edf775e1f1160"
-dependencies = [
- "arrow-array 54.2.1",
- "arrow-buffer 54.3.1",
- "arrow-data 54.3.1",
- "arrow-schema 54.3.1",
- "arrow-select 54.2.1",
 ]
 
 [[package]]
@@ -499,23 +342,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da30e9d10e9c52f09ea0cf15086d6d785c11ae8dcc3ea5f16d402221b6ac7735"
 dependencies = [
  "ahash 0.8.12",
- "arrow-array 53.4.1",
- "arrow-buffer 53.4.1",
- "arrow-data 53.4.1",
- "arrow-schema 53.4.1",
- "half",
-]
-
-[[package]]
-name = "arrow-row"
-version = "54.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1eeb55b0a0a83851aa01f2ca5ee5648f607e8506ba6802577afdda9d75cdedcd"
-dependencies = [
- "arrow-array 54.2.1",
- "arrow-buffer 54.3.1",
- "arrow-data 54.3.1",
- "arrow-schema 54.3.1",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
  "half",
 ]
 
@@ -529,36 +359,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "arrow-schema"
-version = "54.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39cfaf5e440be44db5413b75b72c2a87c1f8f0627117d110264048f2969b99e9"
-
-[[package]]
 name = "arrow-select"
 version = "53.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92fc337f01635218493c23da81a364daf38c694b05fc20569c3193c11c561984"
 dependencies = [
  "ahash 0.8.12",
- "arrow-array 53.4.1",
- "arrow-buffer 53.4.1",
- "arrow-data 53.4.1",
- "arrow-schema 53.4.1",
- "num",
-]
-
-[[package]]
-name = "arrow-select"
-version = "54.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e2932aece2d0c869dd2125feb9bd1709ef5c445daa3838ac4112dcfa0fda52c"
-dependencies = [
- "ahash 0.8.12",
- "arrow-array 54.2.1",
- "arrow-buffer 54.3.1",
- "arrow-data 54.3.1",
- "arrow-schema 54.3.1",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
  "num",
 ]
 
@@ -568,28 +378,11 @@ version = "53.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d596a9fc25dae556672d5069b090331aca8acb93cae426d8b7dcdf1c558fa0ce"
 dependencies = [
- "arrow-array 53.4.1",
- "arrow-buffer 53.4.1",
- "arrow-data 53.4.1",
- "arrow-schema 53.4.1",
- "arrow-select 53.4.1",
- "memchr",
- "num",
- "regex",
- "regex-syntax",
-]
-
-[[package]]
-name = "arrow-string"
-version = "54.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "912e38bd6a7a7714c1d9b61df80315685553b7455e8a6045c27531d8ecd5b458"
-dependencies = [
- "arrow-array 54.2.1",
- "arrow-buffer 54.3.1",
- "arrow-data 54.3.1",
- "arrow-schema 54.3.1",
- "arrow-select 54.2.1",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
  "memchr",
  "num",
  "regex",
@@ -1897,10 +1690,10 @@ version = "44.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "014fc8c384ecacedaabb3bc8359c2a6c6e9d8f7bea65be3434eccacfc37f52d9"
 dependencies = [
- "arrow 53.4.1",
- "arrow-array 53.4.1",
- "arrow-ipc 53.4.1",
- "arrow-schema 53.4.1",
+ "arrow",
+ "arrow-array",
+ "arrow-ipc",
+ "arrow-schema",
  "async-trait",
  "bytes",
  "chrono",
@@ -1942,7 +1735,7 @@ version = "44.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee60d33e210ef96070377ae667ece7caa0e959c8387496773d4a1a72f1a5012e"
 dependencies = [
- "arrow-schema 53.4.1",
+ "arrow-schema",
  "async-trait",
  "datafusion-common",
  "datafusion-execution",
@@ -1958,10 +1751,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b42b7d720fe21ed9cca2ebb635f3f13a12cfab786b41e0fba184fb2e620525b"
 dependencies = [
  "ahash 0.8.12",
- "arrow 53.4.1",
- "arrow-array 53.4.1",
- "arrow-buffer 53.4.1",
- "arrow-schema 53.4.1",
+ "arrow",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-schema",
  "half",
  "hashbrown 0.14.5",
  "indexmap 2.12.0",
@@ -1996,7 +1789,7 @@ version = "44.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e22cb02af47e756468b3cbfee7a83e3d4f2278d452deb4b033ba933c75169486"
 dependencies = [
- "arrow 53.4.1",
+ "arrow",
  "dashmap 6.1.0",
  "datafusion-common",
  "datafusion-expr",
@@ -2015,7 +1808,7 @@ version = "44.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62298eadb1d15b525df1315e61a71519ffc563d41d5c3b2a30fda2d70f77b93c"
 dependencies = [
- "arrow 53.4.1",
+ "arrow",
  "chrono",
  "datafusion-common",
  "datafusion-doc",
@@ -2035,7 +1828,7 @@ version = "44.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dda7f73c5fc349251cd3dcb05773c5bf55d2505a698ef9d38dfc712161ea2f55"
 dependencies = [
- "arrow 53.4.1",
+ "arrow",
  "datafusion-common",
  "itertools 0.13.0",
 ]
@@ -2046,8 +1839,8 @@ version = "44.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd197f3b2975424d3a4898ea46651be855a46721a56727515dbd5c9e2fb597da"
 dependencies = [
- "arrow 53.4.1",
- "arrow-buffer 53.4.1",
+ "arrow",
+ "arrow-buffer",
  "base64",
  "blake2",
  "blake3",
@@ -2077,8 +1870,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aabbe48fba18f9981b134124381bee9e46f93518b8ad2f9721ee296cef5affb9"
 dependencies = [
  "ahash 0.8.12",
- "arrow 53.4.1",
- "arrow-schema 53.4.1",
+ "arrow",
+ "arrow-schema",
  "datafusion-common",
  "datafusion-doc",
  "datafusion-execution",
@@ -2099,7 +1892,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7a3fefed9c8c11268d446d924baca8cabf52fe32f73fdaa20854bac6473590c"
 dependencies = [
  "ahash 0.8.12",
- "arrow 53.4.1",
+ "arrow",
  "datafusion-common",
  "datafusion-expr-common",
  "datafusion-physical-expr-common",
@@ -2111,11 +1904,11 @@ version = "44.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6360f27464fab857bec698af39b2ae331dc07c8bf008fb4de387a19cdc6815a5"
 dependencies = [
- "arrow 53.4.1",
- "arrow-array 53.4.1",
- "arrow-buffer 53.4.1",
- "arrow-ord 53.4.1",
- "arrow-schema 53.4.1",
+ "arrow",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-ord",
+ "arrow-schema",
  "datafusion-common",
  "datafusion-execution",
  "datafusion-expr",
@@ -2133,7 +1926,7 @@ version = "44.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5c35c070eb705c12795dab399c3809f4dfbc290678c624d3989490ca9b8449c1"
 dependencies = [
- "arrow 53.4.1",
+ "arrow",
  "async-trait",
  "datafusion-catalog",
  "datafusion-common",
@@ -2186,7 +1979,7 @@ version = "44.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53b520413906f755910422b016fb73884ae6e9e1b376de4f9584b6c0e031da75"
 dependencies = [
- "arrow 53.4.1",
+ "arrow",
  "chrono",
  "datafusion-common",
  "datafusion-expr",
@@ -2205,10 +1998,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "acd6ddc378f6ad19af95ccd6790dec8f8e1264bc4c70e99ddc1830c1a1c78ccd"
 dependencies = [
  "ahash 0.8.12",
- "arrow 53.4.1",
- "arrow-array 53.4.1",
- "arrow-buffer 53.4.1",
- "arrow-schema 53.4.1",
+ "arrow",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-schema",
  "datafusion-common",
  "datafusion-expr",
  "datafusion-expr-common",
@@ -2230,7 +2023,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06e6c05458eccd74b4c77ed6a1fe63d52434240711de7f6960034794dad1caf5"
 dependencies = [
  "ahash 0.8.12",
- "arrow 53.4.1",
+ "arrow",
  "datafusion-common",
  "datafusion-expr-common",
  "hashbrown 0.14.5",
@@ -2243,7 +2036,7 @@ version = "44.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9dc3a82190f49c37d377f31317e07ab5d7588b837adadba8ac367baad5dc2351"
 dependencies = [
- "arrow 53.4.1",
+ "arrow",
  "datafusion-common",
  "datafusion-execution",
  "datafusion-expr-common",
@@ -2260,11 +2053,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a6608bc9844b4ddb5ed4e687d173e6c88700b1d0482f43894617d18a1fe75da"
 dependencies = [
  "ahash 0.8.12",
- "arrow 53.4.1",
- "arrow-array 53.4.1",
- "arrow-buffer 53.4.1",
- "arrow-ord 53.4.1",
- "arrow-schema 53.4.1",
+ "arrow",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-ord",
+ "arrow-schema",
  "async-trait",
  "chrono",
  "datafusion-common",
@@ -2291,9 +2084,9 @@ version = "44.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a884061c79b33d0c8e84a6f4f4be8bdc12c0f53f5af28ddf5d6d95ac0b15fdc"
 dependencies = [
- "arrow 53.4.1",
- "arrow-array 53.4.1",
- "arrow-schema 53.4.1",
+ "arrow",
+ "arrow-array",
+ "arrow-schema",
  "bigdecimal",
  "datafusion-common",
  "datafusion-expr",
@@ -3539,14 +3332,14 @@ version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e62396c8c5922ba71f6b2678c0b01ce4c1227bd4c2cd512d05275e21b778956b"
 dependencies = [
- "arrow 53.4.1",
- "arrow-arith 53.4.1",
- "arrow-array 53.4.1",
- "arrow-buffer 53.4.1",
- "arrow-ord 53.4.1",
- "arrow-row 53.4.1",
- "arrow-schema 53.4.1",
- "arrow-select 53.4.1",
+ "arrow",
+ "arrow-arith",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-ord",
+ "arrow-row",
+ "arrow-schema",
+ "arrow-select",
  "async-recursion",
  "async-trait",
  "async_cell",
@@ -3600,12 +3393,12 @@ version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7eccef3c8d1c4d70687230abc461460fe421811c9f1de434b60794714ae76597"
 dependencies = [
- "arrow-array 53.4.1",
- "arrow-buffer 53.4.1",
- "arrow-cast 53.4.1",
- "arrow-data 53.4.1",
- "arrow-schema 53.4.1",
- "arrow-select 53.4.1",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
  "bytes",
  "getrandom 0.2.16",
  "half",
@@ -3619,9 +3412,9 @@ version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aff4d7fab171ddd57c4fc6b9e69620d628cef07b87b066bc4e795ec36fc02ac"
 dependencies = [
- "arrow-array 53.4.1",
- "arrow-buffer 53.4.1",
- "arrow-schema 53.4.1",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-schema",
  "async-trait",
  "byteorder",
  "bytes",
@@ -3657,12 +3450,12 @@ version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9216bd88f813516f89c5239f01be3206831d420619873717b9928221d621a1ca"
 dependencies = [
- "arrow 53.4.1",
- "arrow-array 53.4.1",
- "arrow-buffer 53.4.1",
- "arrow-ord 53.4.1",
- "arrow-schema 53.4.1",
- "arrow-select 53.4.1",
+ "arrow",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-ord",
+ "arrow-schema",
+ "arrow-select",
  "async-trait",
  "datafusion",
  "datafusion-common",
@@ -3685,14 +3478,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a34e8162a42357bd61ea2e12e7eff758bc29d2ff37e56e00db12bdd03f9b16b"
 dependencies = [
  "arrayref",
- "arrow 53.4.1",
- "arrow-arith 53.4.1",
- "arrow-array 53.4.1",
- "arrow-buffer 53.4.1",
- "arrow-cast 53.4.1",
- "arrow-data 53.4.1",
- "arrow-schema 53.4.1",
- "arrow-select 53.4.1",
+ "arrow",
+ "arrow-arith",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
  "bytemuck",
  "byteorder",
  "bytes",
@@ -3724,12 +3517,12 @@ version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d553e5f793b9d1a5fc3a70958c3c7b8587f2574261d3b8135c41d916fec77c0"
 dependencies = [
- "arrow-arith 53.4.1",
- "arrow-array 53.4.1",
- "arrow-buffer 53.4.1",
- "arrow-data 53.4.1",
- "arrow-schema 53.4.1",
- "arrow-select 53.4.1",
+ "arrow-arith",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
  "async-recursion",
  "async-trait",
  "byteorder",
@@ -3760,11 +3553,11 @@ version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4dfec270550c4518211843613944576d2ba837d98b4f6b4a9c8b3e06b5157cf9"
 dependencies = [
- "arrow 53.4.1",
- "arrow-array 53.4.1",
- "arrow-ord 53.4.1",
- "arrow-schema 53.4.1",
- "arrow-select 53.4.1",
+ "arrow",
+ "arrow-array",
+ "arrow-ord",
+ "arrow-schema",
+ "arrow-select",
  "async-recursion",
  "async-trait",
  "bitvec",
@@ -3814,14 +3607,14 @@ version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab51a9feb44f183a032385e2b32caf86104d5d43f368ae3a9dc530efb7a59003"
 dependencies = [
- "arrow 53.4.1",
- "arrow-arith 53.4.1",
- "arrow-array 53.4.1",
- "arrow-buffer 53.4.1",
- "arrow-cast 53.4.1",
- "arrow-data 53.4.1",
- "arrow-schema 53.4.1",
- "arrow-select 53.4.1",
+ "arrow",
+ "arrow-arith",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-cast",
+ "arrow-data",
+ "arrow-schema",
+ "arrow-select",
  "async-priority-channel",
  "async-recursion",
  "async-trait",
@@ -3854,9 +3647,9 @@ version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d3b4a0ce63444b6d52b9e586d45814f47642699f78f0a0221b8b839b1c25731"
 dependencies = [
- "arrow-array 53.4.1",
- "arrow-ord 53.4.1",
- "arrow-schema 53.4.1",
+ "arrow-array",
+ "arrow-ord",
+ "arrow-schema",
  "bitvec",
  "cc",
  "deepsize",
@@ -3879,11 +3672,11 @@ version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d717f3edae7c6b137906ddae46706dbc4ce7e102341967948abfbc81ffeb36ef"
 dependencies = [
- "arrow 53.4.1",
- "arrow-array 53.4.1",
- "arrow-buffer 53.4.1",
- "arrow-ipc 53.4.1",
- "arrow-schema 53.4.1",
+ "arrow",
+ "arrow-array",
+ "arrow-buffer",
+ "arrow-ipc",
+ "arrow-schema",
  "async-trait",
  "aws-credential-types",
  "aws-sdk-dynamodb",
@@ -3920,8 +3713,8 @@ version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ade9b394c80149cbba659455930e1c8ddc1cfd87eab864c07b773f2a246907a9"
 dependencies = [
- "arrow-array 53.4.1",
- "arrow-schema 53.4.1",
+ "arrow-array",
+ "arrow-schema",
  "lance-arrow",
  "num-traits",
  "rand 0.8.5",
@@ -3933,13 +3726,13 @@ version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2cd402d7e32b63681c60235ba68a124af5a6fd39c64eaf24284b9f2105b53f56"
 dependencies = [
- "arrow 53.4.1",
- "arrow-array 53.4.1",
- "arrow-cast 53.4.1",
- "arrow-data 53.4.1",
- "arrow-ipc 53.4.1",
- "arrow-ord 53.4.1",
- "arrow-schema 53.4.1",
+ "arrow",
+ "arrow-array",
+ "arrow-cast",
+ "arrow-data",
+ "arrow-ipc",
+ "arrow-ord",
+ "arrow-schema",
  "async-trait",
  "bytes",
  "chrono",
@@ -4207,13 +4000,13 @@ version = "0.2.0"
 dependencies = [
  "agentd-common",
  "anyhow",
- "arrow 54.2.1",
- "arrow-array 54.2.1",
- "arrow-schema 54.3.1",
+ "arrow-array",
+ "arrow-schema",
  "async-trait",
  "axum",
  "chrono",
  "directories",
+ "futures",
  "lancedb",
  "metrics",
  "metrics-exporter-prometheus",

--- a/crates/memory/Cargo.toml
+++ b/crates/memory/Cargo.toml
@@ -28,13 +28,17 @@ sea-orm-migration = { workspace = true }
 async-trait = "0.1"
 
 # Vector storage
+# arrow-array and arrow-schema must match the version used by lancedb 0.16 (53.x)
+# to avoid diamond-dependency type mismatches.
 lancedb = "0.16"
-arrow = { version = "54", features = ["prettyprint"] }
-arrow-array = "54"
-arrow-schema = "54"
+arrow-array = "53"
+arrow-schema = "53"
 
 # HTTP client for embedding API calls
 reqwest = { workspace = true, features = ["json"] }
+
+# Async stream utilities (TryStreamExt for LanceDB result streams)
+futures = "0.3"
 
 # Additional utilities
 uuid = { version = "1.11", features = ["v4", "serde"] }

--- a/crates/memory/src/config.rs
+++ b/crates/memory/src/config.rs
@@ -24,6 +24,7 @@
 
 use serde::{Deserialize, Serialize};
 use std::env;
+use std::path::PathBuf;
 
 /// Configuration for the embedding service.
 ///
@@ -101,6 +102,79 @@ impl EmbeddingConfig {
                 .unwrap_or_else(|_| "text-embedding-3-small".to_string()),
             api_key: env::var("AGENTD_MEMORY_EMBEDDING_API_KEY").ok(),
             base_url: env::var("AGENTD_MEMORY_EMBEDDING_ENDPOINT").ok(),
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// LanceDB configuration
+// ---------------------------------------------------------------------------
+
+/// Configuration for the LanceDB vector store backend.
+///
+/// # Environment Variables
+///
+/// | Variable                          | Default                              |
+/// |-----------------------------------|--------------------------------------|
+/// | `AGENTD_MEMORY_LANCE_PATH`        | XDG data dir / `agentd-memory/lancedb` |
+/// | `AGENTD_MEMORY_LANCE_TABLE`       | `"memories"`                         |
+///
+/// # Example
+///
+/// ```rust
+/// use memory::config::LanceConfig;
+///
+/// let config = LanceConfig::default();
+/// assert_eq!(config.table, "memories");
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(default)]
+pub struct LanceConfig {
+    /// Filesystem path to the LanceDB directory.
+    ///
+    /// LanceDB stores each table as a sub-directory here.
+    /// Defaults to the XDG-compliant data directory for `agentd-memory`.
+    pub path: String,
+
+    /// Table name for memory records.
+    pub table: String,
+}
+
+impl Default for LanceConfig {
+    fn default() -> Self {
+        let path = Self::default_path()
+            .to_string_lossy()
+            .to_string();
+        Self {
+            path,
+            table: "memories".to_string(),
+        }
+    }
+}
+
+impl LanceConfig {
+    /// Returns the platform-specific default LanceDB directory path.
+    ///
+    /// - **Linux**: `~/.local/share/agentd-memory/lancedb`
+    /// - **macOS**: `~/Library/Application Support/agentd-memory/lancedb`
+    pub fn default_path() -> PathBuf {
+        directories::ProjectDirs::from("", "", "agentd-memory")
+            .map(|dirs| dirs.data_dir().join("lancedb"))
+            .unwrap_or_else(|| PathBuf::from("lancedb"))
+    }
+
+    /// Load configuration from environment variables.
+    ///
+    /// | Variable                   | Default                         |
+    /// |----------------------------|---------------------------------|
+    /// | `AGENTD_MEMORY_LANCE_PATH` | XDG data dir / `lancedb`        |
+    /// | `AGENTD_MEMORY_LANCE_TABLE`| `"memories"`                    |
+    pub fn from_env() -> Self {
+        Self {
+            path: env::var("AGENTD_MEMORY_LANCE_PATH")
+                .unwrap_or_else(|_| Self::default_path().to_string_lossy().to_string()),
+            table: env::var("AGENTD_MEMORY_LANCE_TABLE")
+                .unwrap_or_else(|_| "memories".to_string()),
         }
     }
 }
@@ -195,5 +269,55 @@ mod tests {
         assert_eq!(cloned.model, config.model);
         assert_eq!(cloned.api_key, config.api_key);
         assert_eq!(cloned.base_url, config.base_url);
+    }
+
+    // ── LanceConfig ────────────────────────────────────────────────────────
+
+    #[test]
+    fn test_lance_default_table() {
+        let config = LanceConfig::default();
+        assert_eq!(config.table, "memories");
+    }
+
+    #[test]
+    fn test_lance_default_path_not_empty() {
+        let config = LanceConfig::default();
+        assert!(!config.path.is_empty());
+    }
+
+    #[test]
+    fn test_lance_default_path_contains_agentd_memory() {
+        let config = LanceConfig::default();
+        assert!(config.path.contains("agentd-memory") || config.path.contains("lancedb"));
+    }
+
+    #[test]
+    fn test_lance_from_env_defaults_when_vars_absent() {
+        let config = LanceConfig::from_env();
+        assert_eq!(config.table, "memories");
+        assert!(!config.path.is_empty());
+    }
+
+    #[test]
+    fn test_lance_serialization_roundtrip() {
+        let config = LanceConfig {
+            path: "/tmp/test-lance".to_string(),
+            table: "test_table".to_string(),
+        };
+        let json = serde_json::to_string(&config).unwrap();
+        let parsed: LanceConfig = serde_json::from_str(&json).unwrap();
+        assert_eq!(parsed.path, "/tmp/test-lance");
+        assert_eq!(parsed.table, "test_table");
+    }
+
+    #[test]
+    fn test_lance_clone() {
+        let config = LanceConfig {
+            path: "/tmp/lance".to_string(),
+            table: "memories".to_string(),
+        };
+        let cloned = config.clone();
+        assert_eq!(cloned.path, config.path);
+        assert_eq!(cloned.table, config.table);
     }
 }

--- a/crates/memory/src/store/lance.rs
+++ b/crates/memory/src/store/lance.rs
@@ -1,0 +1,700 @@
+//! LanceDB vector store implementation for agentd-memory.
+//!
+//! [`LanceStore`] implements the [`VectorStore`] trait using LanceDB — an
+//! embedded vector database that requires no external server.  Data lives in a
+//! local directory and is queried via Arrow-based record batches.
+//!
+//! # Data path
+//!
+//! The store opens (or creates) a LanceDB directory whose path comes from
+//! [`LanceConfig`].  The default resolves to the XDG-compliant data directory
+//! for `agentd-memory`:
+//!
+//! - **Linux**: `~/.local/share/agentd-memory/lancedb`
+//! - **macOS**: `~/Library/Application Support/agentd-memory/lancedb`
+//!
+//! # Schema
+//!
+//! Each row in the `memories` table represents one [`Memory`] record plus its
+//! embedding vector:
+//!
+//! | Column       | Arrow type                    | Notes                          |
+//! |--------------|-------------------------------|--------------------------------|
+//! | `id`         | `Utf8`                        | `mem_<ms>_<8hex>` format       |
+//! | `content`    | `LargeUtf8`                   | Natural-language content       |
+//! | `vector`     | `FixedSizeList<Float32, dim>` | Embedding vector               |
+//! | `memory_type`| `Utf8`                        | `"question"` / `"information"` |
+//! | `tags`       | `Utf8`                        | Comma-separated list           |
+//! | `created_by` | `Utf8`                        | Actor ID                       |
+//! | `created_at` | `Utf8`                        | RFC3339                        |
+//! | `updated_at` | `Utf8`                        | RFC3339                        |
+//! | `owner`      | `Utf8` (nullable)             | Optional owner override        |
+//! | `visibility` | `Utf8`                        | `"public"` / `"private"` / …   |
+//! | `shared_with`| `Utf8`                        | Comma-separated list           |
+//! | `refs`       | `Utf8`                        | Comma-separated reference IDs  |
+//!
+//! # Search strategy
+//!
+//! [`LanceStore::search`] embeds the query text, performs a vector similarity
+//! search with a `3×limit` over-fetch, and then post-filters results by
+//! visibility, tags, and date range before returning up to `limit` items.
+
+use std::sync::Arc;
+
+use arrow_array::{ArrayRef, RecordBatch, RecordBatchIterator, StringArray, types::Float32Type};
+use arrow_schema::{DataType, Field, Schema, SchemaRef};
+use async_trait::async_trait;
+use chrono::Utc;
+use futures::TryStreamExt;
+use lancedb::query::{ExecutableQuery, QueryBase};
+use tracing::{debug, info, warn};
+
+use crate::config::LanceConfig;
+use crate::error::{StoreError, StoreResult};
+use crate::store::{EmbeddingService, VectorStore};
+use crate::types::{CreateMemoryRequest, Memory, MemoryType, SearchRequest, VisibilityLevel};
+
+/// LanceDB vector store implementing [`VectorStore`].
+pub struct LanceStore {
+    db: lancedb::Connection,
+    table_name: String,
+    embedding_service: Arc<dyn EmbeddingService>,
+}
+
+impl LanceStore {
+    /// Open (or create) a LanceDB store at `config.path`.
+    ///
+    /// Only opens the connection; call [`VectorStore::initialize`] to ensure
+    /// the table exists before first use.
+    pub async fn new(
+        config: &LanceConfig,
+        embedding_service: Arc<dyn EmbeddingService>,
+    ) -> StoreResult<Self> {
+        let db = lancedb::connect(&config.path).execute().await.map_err(|e| {
+            StoreError::ConnectionFailed(format!("LanceDB connect failed: {}", e))
+        })?;
+
+        Ok(Self { db, table_name: config.table.clone(), embedding_service })
+    }
+
+    // ── Schema helpers ────────────────────────────────────────────────────
+
+    /// Build the Arrow schema for the memories table.
+    fn memory_schema(&self) -> SchemaRef {
+        let dim = self.embedding_service.dimension("") as i32;
+        Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Utf8, false),
+            Field::new("content", DataType::LargeUtf8, false),
+            Field::new(
+                "vector",
+                DataType::FixedSizeList(
+                    Arc::new(Field::new("item", DataType::Float32, true)),
+                    dim,
+                ),
+                true,
+            ),
+            Field::new("memory_type", DataType::Utf8, false),
+            Field::new("tags", DataType::Utf8, false),
+            Field::new("created_by", DataType::Utf8, false),
+            Field::new("created_at", DataType::Utf8, false),
+            Field::new("updated_at", DataType::Utf8, false),
+            Field::new("owner", DataType::Utf8, true),
+            Field::new("visibility", DataType::Utf8, false),
+            Field::new("shared_with", DataType::Utf8, false),
+            Field::new("refs", DataType::Utf8, false),
+        ]))
+    }
+
+    /// Convert a [`Memory`] and its embedding vector into an Arrow
+    /// [`RecordBatch`].
+    fn memory_to_batch(&self, memory: &Memory, embedding: Vec<f32>) -> StoreResult<RecordBatch> {
+        let schema = self.memory_schema();
+        let dim = self.embedding_service.dimension("") as i32;
+
+        let vector_array = arrow_array::FixedSizeListArray::from_iter_primitive::<Float32Type, _, _>(
+            vec![Some(embedding.into_iter().map(Some).collect::<Vec<_>>())],
+            dim,
+        );
+
+        let owner_array: ArrayRef = match &memory.owner {
+            Some(owner) => Arc::new(StringArray::from(vec![Some(owner.as_str())])),
+            None => Arc::new(StringArray::from(vec![None::<&str>])),
+        };
+
+        let memory_type_str = memory.memory_type.to_string();
+        let tags_str = memory.tags.join(",");
+        let created_at_str = memory.created_at.to_rfc3339();
+        let updated_at_str = memory.updated_at.to_rfc3339();
+        let visibility_str = memory.visibility.to_string();
+        let shared_with_str = memory.shared_with.join(",");
+        let refs_str = memory.references.join(",");
+
+        RecordBatch::try_new(
+            schema,
+            vec![
+                Arc::new(StringArray::from(vec![memory.id.as_str()])),
+                Arc::new(arrow_array::LargeStringArray::from(vec![memory.content.as_str()])),
+                Arc::new(vector_array),
+                Arc::new(StringArray::from(vec![memory_type_str.as_str()])),
+                Arc::new(StringArray::from(vec![tags_str.as_str()])),
+                Arc::new(StringArray::from(vec![memory.created_by.as_str()])),
+                Arc::new(StringArray::from(vec![created_at_str.as_str()])),
+                Arc::new(StringArray::from(vec![updated_at_str.as_str()])),
+                owner_array,
+                Arc::new(StringArray::from(vec![visibility_str.as_str()])),
+                Arc::new(StringArray::from(vec![shared_with_str.as_str()])),
+                Arc::new(StringArray::from(vec![refs_str.as_str()])),
+            ],
+        )
+        .map_err(|e| StoreError::InvalidData(format!("Failed to create RecordBatch: {}", e)))
+    }
+
+    // ── Row conversion ────────────────────────────────────────────────────
+
+    /// Convert a single row of a [`RecordBatch`] into a [`Memory`].
+    fn batch_row_to_memory(batch: &RecordBatch, row: usize) -> StoreResult<Memory> {
+        let get_str = |name: &str| -> StoreResult<String> {
+            if let Some(arr) = batch.column_by_name(name) {
+                if let Some(s) = arr.as_any().downcast_ref::<StringArray>() {
+                    return Ok(s.value(row).to_string());
+                }
+                if let Some(s) = arr.as_any().downcast_ref::<arrow_array::LargeStringArray>() {
+                    return Ok(s.value(row).to_string());
+                }
+            }
+            Err(StoreError::InvalidData(format!("Missing or unreadable field: {}", name)))
+        };
+
+        let get_str_opt = |name: &str| -> Option<String> {
+            if let Some(arr) = batch.column_by_name(name) {
+                if arr.is_null(row) {
+                    return None;
+                }
+                if let Some(s) = arr.as_any().downcast_ref::<StringArray>() {
+                    let val = s.value(row);
+                    if val.is_empty() {
+                        return None;
+                    }
+                    return Some(val.to_string());
+                }
+            }
+            None
+        };
+
+        let id = get_str("id")?;
+        let content = get_str("content")?;
+
+        let memory_type = get_str("memory_type")?
+            .parse::<MemoryType>()
+            .map_err(StoreError::InvalidData)?;
+
+        let tags: Vec<String> = get_str("tags")?
+            .split(',')
+            .filter(|s| !s.is_empty())
+            .map(String::from)
+            .collect();
+
+        let created_by = get_str("created_by")?;
+
+        let created_at = chrono::DateTime::parse_from_rfc3339(&get_str("created_at")?)
+            .map_err(|e| StoreError::InvalidData(e.to_string()))?
+            .with_timezone(&Utc);
+
+        let updated_at = chrono::DateTime::parse_from_rfc3339(&get_str("updated_at")?)
+            .map_err(|e| StoreError::InvalidData(e.to_string()))?
+            .with_timezone(&Utc);
+
+        let owner = get_str_opt("owner");
+
+        let visibility = get_str("visibility")?
+            .parse::<VisibilityLevel>()
+            .map_err(StoreError::InvalidData)?;
+
+        let shared_with: Vec<String> = get_str("shared_with")?
+            .split(',')
+            .filter(|s| !s.is_empty())
+            .map(String::from)
+            .collect();
+
+        // `refs` column may not exist in older tables — fall back to empty vec.
+        let references: Vec<String> = get_str("refs")
+            .unwrap_or_default()
+            .split(',')
+            .filter(|s| !s.is_empty())
+            .map(String::from)
+            .collect();
+
+        Ok(Memory {
+            id,
+            content,
+            memory_type,
+            tags,
+            created_by,
+            created_at,
+            updated_at,
+            owner,
+            visibility,
+            shared_with,
+            references,
+        })
+    }
+
+    /// Drain a LanceDB result stream into a `Vec<Memory>`.
+    ///
+    /// Rows that fail to parse are logged and skipped rather than aborting
+    /// the whole query.
+    async fn collect_memories(
+        &self,
+        stream: lancedb::arrow::SendableRecordBatchStream,
+    ) -> StoreResult<Vec<Memory>> {
+        let batches: Vec<RecordBatch> = stream.try_collect().await.map_err(|e| {
+            StoreError::QueryFailed(format!("Failed to collect LanceDB results: {}", e))
+        })?;
+
+        let mut memories = Vec::new();
+        for batch in &batches {
+            for row in 0..batch.num_rows() {
+                match Self::batch_row_to_memory(batch, row) {
+                    Ok(m) => memories.push(m),
+                    Err(e) => warn!("Skipping unparseable memory row: {}", e),
+                }
+            }
+        }
+        Ok(memories)
+    }
+
+    /// Open the memories table, returning an error if it does not exist.
+    async fn open_table(&self) -> StoreResult<lancedb::Table> {
+        self.db.open_table(&self.table_name).execute().await.map_err(|e| {
+            StoreError::InitializationFailed(format!(
+                "Failed to open LanceDB table '{}': {}",
+                self.table_name, e
+            ))
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// VectorStore implementation
+// ---------------------------------------------------------------------------
+
+#[async_trait]
+impl VectorStore for LanceStore {
+    /// Create the `memories` table with the Arrow schema derived from the
+    /// embedding dimension.  A no-op if the table already exists.
+    async fn initialize(&self) -> StoreResult<()> {
+        let tables = self.db.table_names().execute().await.map_err(|e| {
+            StoreError::InitializationFailed(format!("Failed to list LanceDB tables: {}", e))
+        })?;
+
+        if tables.contains(&self.table_name) {
+            debug!("LanceDB table '{}' already exists", self.table_name);
+            return Ok(());
+        }
+
+        let schema = self.memory_schema();
+        self.db
+            .create_empty_table(&self.table_name, schema)
+            .execute()
+            .await
+            .map_err(|e| {
+                StoreError::InitializationFailed(format!(
+                    "Failed to create LanceDB table '{}': {}",
+                    self.table_name, e
+                ))
+            })?;
+
+        info!("Created LanceDB table '{}'", self.table_name);
+        Ok(())
+    }
+
+    /// Generate an embedding for `request.content` and insert the record.
+    async fn create(&self, request: CreateMemoryRequest) -> StoreResult<Memory> {
+        let now = Utc::now();
+
+        let memory = Memory {
+            id: Memory::generate_id(),
+            content: request.content,
+            memory_type: request.memory_type,
+            tags: request.tags,
+            created_by: request.created_by,
+            created_at: now,
+            updated_at: now,
+            owner: None,
+            visibility: request.visibility,
+            shared_with: request.shared_with,
+            references: request.references,
+        };
+
+        // Embed the content
+        let embeddings =
+            self.embedding_service.embed(std::slice::from_ref(&memory.content)).await?;
+        let embedding = embeddings.into_iter().next().ok_or_else(|| {
+            StoreError::QueryFailed("Embedding service returned no vector".to_string())
+        })?;
+
+        let batch = self.memory_to_batch(&memory, embedding)?;
+        let schema = batch.schema();
+
+        let table = self.open_table().await?;
+        table
+            .add(RecordBatchIterator::new(vec![Ok(batch)], schema))
+            .execute()
+            .await
+            .map_err(|e| StoreError::QueryFailed(format!("Failed to insert memory: {}", e)))?;
+
+        Ok(memory)
+    }
+
+    /// Retrieve a single memory by exact ID match.
+    async fn get(&self, id: &str) -> StoreResult<Option<Memory>> {
+        let table = self.open_table().await?;
+
+        let stream = table
+            .query()
+            .only_if(format!("id = '{}'", id))
+            .execute()
+            .await
+            .map_err(|e| StoreError::QueryFailed(format!("LanceDB get query failed: {}", e)))?;
+
+        let mut memories = self.collect_memories(stream).await?;
+        Ok(memories.pop())
+    }
+
+    /// Delete a memory by ID.  Returns `false` when the ID was not found.
+    async fn delete(&self, id: &str) -> StoreResult<bool> {
+        if self.get(id).await?.is_none() {
+            return Ok(false);
+        }
+
+        let table = self.open_table().await?;
+        table
+            .delete(&format!("id = '{}'", id))
+            .await
+            .map_err(|e| StoreError::QueryFailed(format!("LanceDB delete failed: {}", e)))?;
+
+        Ok(true)
+    }
+
+    /// Semantic similarity search with post-filtering.
+    ///
+    /// Embeds `request.query`, fetches `3 × request.limit` nearest neighbours,
+    /// then post-filters by visibility, tags, and creation-date range before
+    /// returning up to `request.limit` results.
+    async fn search(&self, request: SearchRequest) -> StoreResult<Vec<Memory>> {
+        let table = self.open_table().await?;
+
+        // Embed the query
+        let embeddings =
+            self.embedding_service.embed(std::slice::from_ref(&request.query)).await?;
+        let query_vec = embeddings.into_iter().next().ok_or_else(|| {
+            StoreError::QueryFailed("Embedding service returned no vector for query".to_string())
+        })?;
+
+        // Vector search — over-fetch to allow for post-filtering
+        let overfetch = request.limit * 3;
+        let mut builder = table
+            .vector_search(query_vec)
+            .map_err(|e| StoreError::QueryFailed(format!("Vector search init failed: {}", e)))?
+            .limit(overfetch);
+
+        // Optional server-side type filter
+        if let Some(ref memory_type) = request.memory_type {
+            builder = builder.only_if(format!("memory_type = '{}'", memory_type));
+        }
+
+        let stream = builder
+            .execute()
+            .await
+            .map_err(|e| StoreError::QueryFailed(format!("Vector search failed: {}", e)))?;
+
+        let all = self.collect_memories(stream).await?;
+
+        // Post-filter: visibility, tags, date range
+        let filtered: Vec<Memory> = all
+            .into_iter()
+            .filter(|m| m.is_visible_to(request.as_actor.as_deref()))
+            .filter(|m| {
+                request.tags.is_empty() || request.tags.iter().any(|t| m.tags.contains(t))
+            })
+            .filter(|m| {
+                if let Some(ref from) = request.from {
+                    if m.created_at < *from {
+                        return false;
+                    }
+                }
+                if let Some(ref to) = request.to {
+                    if m.created_at > *to {
+                        return false;
+                    }
+                }
+                true
+            })
+            .take(request.limit)
+            .collect();
+
+        Ok(filtered)
+    }
+
+    /// Update the visibility tier and optional share list of a memory.
+    async fn update_visibility(
+        &self,
+        id: &str,
+        visibility: VisibilityLevel,
+        shared_with: Option<Vec<String>>,
+    ) -> StoreResult<Memory> {
+        let mut memory =
+            self.get(id).await?.ok_or_else(|| StoreError::NotFound(id.to_string()))?;
+
+        memory.visibility = visibility;
+        if let Some(shared) = shared_with {
+            memory.shared_with = shared;
+        }
+        memory.updated_at = Utc::now();
+
+        let table = self.open_table().await?;
+
+        // LanceDB update expressions must be SQL literals — strings need quotes.
+        table
+            .update()
+            .only_if(format!("id = '{}'", id))
+            .column("visibility", format!("'{}'", memory.visibility))
+            .column("shared_with", format!("'{}'", memory.shared_with.join(",")))
+            .column("updated_at", format!("'{}'", memory.updated_at.to_rfc3339()))
+            .execute()
+            .await
+            .map_err(|e| {
+                StoreError::QueryFailed(format!("Failed to update visibility: {}", e))
+            })?;
+
+        Ok(memory)
+    }
+
+    /// LanceDB is embedded — a successful connection implies a healthy store.
+    async fn health_check(&self) -> StoreResult<bool> {
+        Ok(true)
+    }
+
+    /// Return every memory in the table (used for migration / backup).
+    async fn list_all(&self) -> StoreResult<Vec<Memory>> {
+        let table = self.open_table().await?;
+
+        let stream = table
+            .query()
+            .execute()
+            .await
+            .map_err(|e| StoreError::QueryFailed(format!("list_all query failed: {}", e)))?;
+
+        let memories = self.collect_memories(stream).await?;
+        info!("list_all returned {} memories", memories.len());
+        Ok(memories)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::store::NoOpEmbedding;
+
+    /// Build the schema for a given dimension using the same logic as
+    /// [`LanceStore::memory_schema`] so we can verify field names and types
+    /// without standing up a real LanceDB instance.
+    fn make_schema(dim: i32) -> SchemaRef {
+        Arc::new(Schema::new(vec![
+            Field::new("id", DataType::Utf8, false),
+            Field::new("content", DataType::LargeUtf8, false),
+            Field::new(
+                "vector",
+                DataType::FixedSizeList(
+                    Arc::new(Field::new("item", DataType::Float32, true)),
+                    dim,
+                ),
+                true,
+            ),
+            Field::new("memory_type", DataType::Utf8, false),
+            Field::new("tags", DataType::Utf8, false),
+            Field::new("created_by", DataType::Utf8, false),
+            Field::new("created_at", DataType::Utf8, false),
+            Field::new("updated_at", DataType::Utf8, false),
+            Field::new("owner", DataType::Utf8, true),
+            Field::new("visibility", DataType::Utf8, false),
+            Field::new("shared_with", DataType::Utf8, false),
+            Field::new("refs", DataType::Utf8, false),
+        ]))
+    }
+
+    #[test]
+    fn test_schema_field_count() {
+        let schema = make_schema(1536);
+        assert_eq!(schema.fields().len(), 12);
+    }
+
+    #[test]
+    fn test_schema_field_names() {
+        let schema = make_schema(1536);
+        let names: Vec<&str> = schema.fields().iter().map(|f| f.name().as_str()).collect();
+        assert!(names.contains(&"id"));
+        assert!(names.contains(&"content"));
+        assert!(names.contains(&"vector"));
+        assert!(names.contains(&"memory_type"));
+        assert!(names.contains(&"tags"));
+        assert!(names.contains(&"created_by"));
+        assert!(names.contains(&"visibility"));
+        assert!(names.contains(&"shared_with"));
+        assert!(names.contains(&"refs"));
+        assert!(names.contains(&"owner"));
+    }
+
+    #[test]
+    fn test_schema_vector_is_fixed_size_list() {
+        let schema = make_schema(768);
+        let vector_field = schema.field_with_name("vector").unwrap();
+        match vector_field.data_type() {
+            DataType::FixedSizeList(_, dim) => assert_eq!(*dim, 768),
+            other => panic!("Expected FixedSizeList, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_schema_owner_is_nullable() {
+        let schema = make_schema(1536);
+        let owner_field = schema.field_with_name("owner").unwrap();
+        assert!(owner_field.is_nullable());
+    }
+
+    #[test]
+    fn test_schema_id_not_nullable() {
+        let schema = make_schema(1536);
+        let id_field = schema.field_with_name("id").unwrap();
+        assert!(!id_field.is_nullable());
+    }
+
+    #[test]
+    fn test_batch_row_to_memory_parses_correctly() {
+        use arrow_array::{LargeStringArray, StringArray};
+        use chrono::Utc;
+
+        let now = Utc::now();
+        let dim = 3i32;
+        let schema = make_schema(dim);
+
+        // Build a minimal record batch with one row
+        let id_arr = Arc::new(StringArray::from(vec!["mem_1_abcdef01"]));
+        let content_arr = Arc::new(LargeStringArray::from(vec!["Test content"]));
+        let vector_arr = Arc::new(
+            arrow_array::FixedSizeListArray::from_iter_primitive::<Float32Type, _, _>(
+                vec![Some(vec![Some(0.1), Some(0.2), Some(0.3)])],
+                dim,
+            ),
+        );
+        let memory_type_arr = Arc::new(StringArray::from(vec!["information"]));
+        let tags_arr = Arc::new(StringArray::from(vec!["tag1,tag2"]));
+        let created_by_arr = Arc::new(StringArray::from(vec!["agent-1"]));
+        let created_at_arr = Arc::new(StringArray::from(vec![now.to_rfc3339().as_str()]));
+        let updated_at_arr = Arc::new(StringArray::from(vec![now.to_rfc3339().as_str()]));
+        let owner_arr = Arc::new(StringArray::from(vec![None::<&str>]));
+        let visibility_arr = Arc::new(StringArray::from(vec!["public"]));
+        let shared_with_arr = Arc::new(StringArray::from(vec![""]));
+        let refs_arr = Arc::new(StringArray::from(vec![""]));
+
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![
+                id_arr,
+                content_arr,
+                vector_arr,
+                memory_type_arr,
+                tags_arr,
+                created_by_arr,
+                created_at_arr,
+                updated_at_arr,
+                owner_arr,
+                visibility_arr,
+                shared_with_arr,
+                refs_arr,
+            ],
+        )
+        .unwrap();
+
+        let memory = LanceStore::batch_row_to_memory(&batch, 0).unwrap();
+        assert_eq!(memory.id, "mem_1_abcdef01");
+        assert_eq!(memory.content, "Test content");
+        assert_eq!(memory.memory_type, MemoryType::Information);
+        assert_eq!(memory.tags, vec!["tag1".to_string(), "tag2".to_string()]);
+        assert_eq!(memory.created_by, "agent-1");
+        assert!(memory.owner.is_none());
+        assert_eq!(memory.visibility, VisibilityLevel::Public);
+        assert!(memory.shared_with.is_empty());
+        assert!(memory.references.is_empty());
+    }
+
+    #[test]
+    fn test_batch_row_to_memory_with_references() {
+        use arrow_array::{LargeStringArray, StringArray};
+        use chrono::Utc;
+
+        let now = Utc::now();
+        let dim = 3i32;
+        let schema = make_schema(dim);
+
+        let id_arr = Arc::new(StringArray::from(vec!["mem_2_11111111"]));
+        let content_arr = Arc::new(LargeStringArray::from(vec!["Ref content"]));
+        let vector_arr = Arc::new(
+            arrow_array::FixedSizeListArray::from_iter_primitive::<Float32Type, _, _>(
+                vec![Some(vec![Some(0.1), Some(0.2), Some(0.3)])],
+                dim,
+            ),
+        );
+        let memory_type_arr = Arc::new(StringArray::from(vec!["information"]));
+        let tags_arr = Arc::new(StringArray::from(vec![""]));
+        let created_by_arr = Arc::new(StringArray::from(vec!["agent-2"]));
+        let created_at_arr = Arc::new(StringArray::from(vec![now.to_rfc3339().as_str()]));
+        let updated_at_arr = Arc::new(StringArray::from(vec![now.to_rfc3339().as_str()]));
+        let owner_arr = Arc::new(StringArray::from(vec![Some("owner-1")]));
+        let visibility_arr = Arc::new(StringArray::from(vec!["shared"]));
+        let shared_with_arr = Arc::new(StringArray::from(vec!["agent-3,agent-4"]));
+        let refs_arr =
+            Arc::new(StringArray::from(vec!["mem_1_aaaaaaaa,mem_1_bbbbbbbb"]));
+
+        let batch = RecordBatch::try_new(
+            schema,
+            vec![
+                id_arr,
+                content_arr,
+                vector_arr,
+                memory_type_arr,
+                tags_arr,
+                created_by_arr,
+                created_at_arr,
+                updated_at_arr,
+                owner_arr,
+                visibility_arr,
+                shared_with_arr,
+                refs_arr,
+            ],
+        )
+        .unwrap();
+
+        let memory = LanceStore::batch_row_to_memory(&batch, 0).unwrap();
+        assert_eq!(memory.owner, Some("owner-1".to_string()));
+        assert_eq!(memory.visibility, VisibilityLevel::Shared);
+        assert_eq!(
+            memory.shared_with,
+            vec!["agent-3".to_string(), "agent-4".to_string()]
+        );
+        assert_eq!(
+            memory.references,
+            vec!["mem_1_aaaaaaaa".to_string(), "mem_1_bbbbbbbb".to_string()]
+        );
+    }
+
+    #[test]
+    fn test_noop_embedding_has_zero_dimension() {
+        let svc = Arc::new(NoOpEmbedding::new());
+        assert_eq!(svc.dimension(""), 0);
+    }
+}

--- a/crates/memory/src/store/lance_embedding.rs
+++ b/crates/memory/src/store/lance_embedding.rs
@@ -1,0 +1,153 @@
+//! Bridge between agentd-memory's [`EmbeddingService`] and LanceDB's
+//! [`EmbeddingFunction`] trait.
+//!
+//! LanceDB's embedding integration requires a synchronous trait while
+//! [`EmbeddingService`] is async.  [`AgentdEmbeddingBridge`] handles this by
+//! bridging to the current Tokio runtime via
+//! `tokio::runtime::Handle::current().block_on(...)`.
+
+use std::borrow::Cow;
+use std::sync::Arc;
+
+use arrow_array::types::Float32Type;
+use arrow_array::{Array, ArrayRef, FixedSizeListArray, StringArray};
+use arrow_schema::DataType;
+use lancedb::embeddings::EmbeddingFunction;
+
+use crate::store::EmbeddingService;
+
+/// Bridges agentd-memory's [`EmbeddingService`] to LanceDB's
+/// [`EmbeddingFunction`] trait.
+///
+/// LanceDB calls the embedding function synchronously; this bridge uses
+/// `tokio::runtime::Handle::current().block_on(...)` to run the async
+/// [`EmbeddingService::embed`] call on the current Tokio runtime.
+///
+/// # Panics
+///
+/// Panics if called outside a Tokio runtime context.
+pub struct AgentdEmbeddingBridge {
+    service: Arc<dyn EmbeddingService>,
+}
+
+impl AgentdEmbeddingBridge {
+    /// Create a new bridge wrapping `service`.
+    pub fn new(service: Arc<dyn EmbeddingService>) -> Self {
+        Self { service }
+    }
+}
+
+impl std::fmt::Debug for AgentdEmbeddingBridge {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AgentdEmbeddingBridge")
+            .field("dimension", &self.service.dimension(""))
+            .finish()
+    }
+}
+
+impl EmbeddingFunction for AgentdEmbeddingBridge {
+    fn name(&self) -> &str {
+        "agentd-embedding"
+    }
+
+    fn source_type(&self) -> lancedb::Result<Cow<'_, DataType>> {
+        Ok(Cow::Owned(DataType::Utf8))
+    }
+
+    fn dest_type(&self) -> lancedb::Result<Cow<'_, DataType>> {
+        let dim = self.service.dimension("") as i32;
+        Ok(Cow::Owned(DataType::FixedSizeList(
+            Arc::new(arrow_schema::Field::new("item", DataType::Float32, true)),
+            dim,
+        )))
+    }
+
+    fn compute_source_embeddings(&self, source: ArrayRef) -> lancedb::Result<ArrayRef> {
+        compute_embeddings(&self.service, source)
+    }
+
+    fn compute_query_embeddings(&self, input: ArrayRef) -> lancedb::Result<ArrayRef> {
+        compute_embeddings(&self.service, input)
+    }
+}
+
+/// Shared implementation: convert an Arrow `StringArray` into a
+/// `FixedSizeListArray` of embedding vectors by calling the service.
+fn compute_embeddings(
+    service: &Arc<dyn EmbeddingService>,
+    input: ArrayRef,
+) -> lancedb::Result<ArrayRef> {
+    let string_array = input
+        .as_any()
+        .downcast_ref::<StringArray>()
+        .ok_or_else(|| lancedb::Error::InvalidInput {
+            message: "Expected StringArray for embedding input".to_string(),
+        })?;
+
+    let texts: Vec<String> =
+        (0..string_array.len()).map(|i| string_array.value(i).to_string()).collect();
+
+    // Bridge async embed() to sync EmbeddingFunction via current Tokio handle.
+    let handle = tokio::runtime::Handle::current();
+    let svc = service.clone();
+    let embeddings =
+        handle.block_on(async move { svc.embed(&texts).await }).map_err(|e| {
+            lancedb::Error::Runtime { message: format!("Embedding failed: {}", e) }
+        })?;
+
+    let dim = service.dimension("") as i32;
+
+    let values: Vec<Option<Vec<Option<f32>>>> = embeddings
+        .into_iter()
+        .map(|emb| Some(emb.into_iter().map(Some).collect()))
+        .collect();
+
+    let array = FixedSizeListArray::from_iter_primitive::<Float32Type, _, _>(values, dim);
+    Ok(Arc::new(array) as ArrayRef)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::store::NoOpEmbedding;
+
+    #[test]
+    fn test_bridge_name() {
+        let svc = Arc::new(NoOpEmbedding::new());
+        let bridge = AgentdEmbeddingBridge::new(svc);
+        assert_eq!(bridge.name(), "agentd-embedding");
+    }
+
+    #[test]
+    fn test_bridge_source_type_is_utf8() {
+        let svc = Arc::new(NoOpEmbedding::new());
+        let bridge = AgentdEmbeddingBridge::new(svc);
+        assert_eq!(bridge.source_type().unwrap().as_ref(), &DataType::Utf8);
+    }
+
+    #[test]
+    fn test_bridge_debug_format() {
+        let svc = Arc::new(NoOpEmbedding::new());
+        let bridge = AgentdEmbeddingBridge::new(svc);
+        let debug = format!("{:?}", bridge);
+        assert!(debug.contains("AgentdEmbeddingBridge"));
+    }
+
+    #[test]
+    fn test_bridge_dest_type_noop_is_zero_dim() {
+        let svc = Arc::new(NoOpEmbedding::new());
+        let bridge = AgentdEmbeddingBridge::new(svc);
+        let dest = bridge.dest_type().unwrap();
+        match dest.as_ref() {
+            DataType::FixedSizeList(field, dim) => {
+                assert_eq!(*dim, 0);
+                assert_eq!(field.name(), "item");
+            }
+            other => panic!("Expected FixedSizeList, got {:?}", other),
+        }
+    }
+}

--- a/crates/memory/src/store/mod.rs
+++ b/crates/memory/src/store/mod.rs
@@ -1,12 +1,55 @@
 //! Storage abstractions for the agentd-memory service.
 //!
-//! This module exposes the [`VectorStore`] and [`EmbeddingService`] traits
-//! that decouple the service from concrete backend implementations, as well
-//! as the concrete embedding providers ([`OpenAIEmbedding`], [`NoOpEmbedding`])
-//! and the [`create_embedding_service`] factory.
+//! Exposes the [`VectorStore`] and [`EmbeddingService`] traits, the concrete
+//! embedding providers ([`OpenAIEmbedding`], [`NoOpEmbedding`]), the LanceDB
+//! backend ([`LanceStore`]), and the top-level [`create_store`] factory.
+//!
+//! # Factory usage
+//!
+//! ```rust,no_run
+//! use std::sync::Arc;
+//! use memory::config::{EmbeddingConfig, LanceConfig};
+//! use memory::store::create_store;
+//!
+//! # #[tokio::main]
+//! # async fn main() -> anyhow::Result<()> {
+//! let store = create_store(
+//!     &LanceConfig { path: "/tmp/test-lance".to_string(), table: "memories".to_string() },
+//!     &EmbeddingConfig::default(),
+//! ).await?;
+//! store.initialize().await?;
+//! # Ok(())
+//! # }
+//! ```
 
 mod traits;
 pub mod embedding;
+pub mod lance;
+pub(crate) mod lance_embedding;
 
 pub use embedding::{create_embedding_service, model_dimension, NoOpEmbedding, OpenAIEmbedding};
+pub use lance::LanceStore;
 pub use traits::{EmbeddingService, VectorStore};
+
+use std::sync::Arc;
+
+use crate::config::{EmbeddingConfig, LanceConfig};
+use crate::error::StoreResult;
+
+/// Build a [`LanceStore`] from `lance_config` and `embedding_config`.
+///
+/// Creates the embedding service, opens (or creates) the LanceDB directory,
+/// and returns an `Arc<dyn VectorStore>` ready for use.
+///
+/// Call [`VectorStore::initialize`] on the returned store before first use to
+/// ensure the table and indexes exist.
+pub async fn create_store(
+    lance_config: &LanceConfig,
+    embedding_config: &EmbeddingConfig,
+) -> StoreResult<Arc<dyn VectorStore>> {
+    let embedding_service: Arc<dyn EmbeddingService> =
+        Arc::from(create_embedding_service(embedding_config)?);
+
+    let store = LanceStore::new(lance_config, embedding_service).await?;
+    Ok(Arc::new(store))
+}


### PR DESCRIPTION
## Summary

- Implement `LanceStore` struct with full `VectorStore` trait implementation (initialize, create, get, delete, search, update_visibility, health_check, list_all)
- Add `AgentdEmbeddingBridge` to adapt async `EmbeddingService` to LanceDB's sync `EmbeddingFunction` trait via Tokio runtime handle
- Add `LanceConfig` with XDG-compliant data paths and env var support (`AGENTD_MEMORY_LANCE_PATH`, `AGENTD_MEMORY_LANCE_TABLE`)
- Add `create_store()` factory function for backend selection
- Arrow schema with 12 columns including embedding vectors as `FixedSizeList<Float32>`
- Semantic search with 3× over-fetch and post-filtering by visibility, tags, and date range

## Test plan

- [x] All 112 existing tests pass (including 17 new tests for lance + lance_embedding + config)
- [x] Schema tests verify field count, names, types, and nullability
- [x] `batch_row_to_memory` round-trip tests with full field coverage including references
- [x] Embedding bridge tests verify name, source/dest types, and debug format
- [x] LanceConfig tests verify defaults, env loading, serialization round-trip

Closes #303

🤖 Generated with [Claude Code](https://claude.com/claude-code)