### PR TITLE
feat(cli): add CLI commands and client for agentd-memory service

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1334,6 +1334,7 @@ dependencies = [
  "colored",
  "futures-util",
  "hook",
+ "memory",
  "mockito",
  "monitor",
  "notify",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -31,6 +31,7 @@ wrap = { path = "../wrap" }
 orchestrator = { path = "../orchestrator" }
 monitor = { path = "../monitor" }
 hook = { path = "../hook" }
+memory = { path = "../memory" }
 
 [dev-dependencies]
 mockito = "1.2"

--- a/crates/cli/src/commands/memory.rs
+++ b/crates/cli/src/commands/memory.rs
@@ -1,94 +1,751 @@
 //! Memory service command implementations.
 //!
-//! Provides CLI subcommands for interacting with the agentd-memory service.
-//! Additional subcommands (store, search, get, delete, visibility) will be
-//! added in subsequent issues once the storage layer is implemented.
+//! Provides CLI subcommands for interacting with the agentd-memory service,
+//! following berry-rs's CLI patterns (`remember`, `recall`, `search`, `forget`)
+//! adapted to agentd's conventions.
 //!
 //! # Available Commands
 //!
 //! - **health**: Check the health of the memory service
+//! - **remember**: Store a new memory record
+//! - **recall**: Retrieve a specific memory by ID
+//! - **search**: Semantic similarity search
+//! - **forget**: Delete a memory record
+//! - **list**: List memories with optional filters
+//! - **visibility**: Update visibility and share list
 //!
 //! # Examples
 //!
 //! ```bash
-//! agent memory health
+//! # Store a memory
+//! agent memory remember "Paris is the capital of France." \
+//!   --created-by agent-1 --type information --tags geography,europe
+//!
+//! # Semantic search
+//! agent memory search "capital of France" --limit 5
+//!
+//! # Recall a specific memory
+//! agent memory recall mem_1234567890_abcdef01
+//!
+//! # Delete a memory
+//! agent memory forget mem_1234567890_abcdef01
+//!
+//! # List with filters
+//! agent memory list --type question --visibility public --limit 20
+//!
+//! # Update visibility
+//! agent memory visibility mem_1234567890_abcdef01 shared --share-with agent-2,agent-3
 //! ```
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 use clap::Subcommand;
 use colored::*;
+use memory::client::MemoryClient;
+use memory::types::*;
+use prettytable::{format, Cell, Row, Table};
 
-/// Subcommands for the memory service.
+/// Subcommands for the agentd-memory service.
 ///
-/// Stub implementation — full CRUD and search commands will be added once
-/// the storage and embedding backends are wired up (see issue #302+).
+/// Manage agent memories: store, search, recall, and delete records with
+/// semantic search powered by LanceDB vector embeddings.
 #[derive(Debug, Subcommand)]
 pub enum MemoryCommand {
     /// Check the health of the memory service.
+    ///
+    /// # Examples
+    ///
+    /// ```bash
+    /// agent memory health
+    /// ```
     Health,
+
+    /// Store a new memory record.
+    ///
+    /// Creates a new memory with an embedding vector for semantic search.
+    /// Only `content` and `--created-by` are required; all other fields have
+    /// sensible defaults.
+    ///
+    /// # Examples
+    ///
+    /// ```bash
+    /// agent memory remember "Paris is the capital of France." --created-by agent-1
+    /// agent memory remember "How do I reset my password?" \
+    ///   --created-by user-42 --type question --tags auth,help \
+    ///   --visibility shared --share-with agent-support
+    /// ```
+    Remember {
+        /// The natural-language content to store.
+        content: String,
+
+        /// Identity of the actor creating this memory.
+        #[arg(long)]
+        created_by: String,
+
+        /// Memory type: information, question, or request.
+        #[arg(long, rename_all = "lower", default_value = "information")]
+        r#type: String,
+
+        /// Comma-separated tags for filtering.
+        #[arg(long)]
+        tags: Option<String>,
+
+        /// Visibility level: public, shared, or private.
+        #[arg(long, default_value = "public")]
+        visibility: String,
+
+        /// Comma-separated actor IDs to share with (used with --visibility shared).
+        #[arg(long)]
+        share_with: Option<String>,
+
+        /// Comma-separated reference IDs of related memories.
+        #[arg(long)]
+        references: Option<String>,
+    },
+
+    /// Retrieve a specific memory by ID.
+    ///
+    /// # Examples
+    ///
+    /// ```bash
+    /// agent memory recall mem_1234567890_abcdef01
+    /// agent memory recall mem_1234567890_abcdef01 --json
+    /// ```
+    Recall {
+        /// The memory ID to retrieve.
+        id: String,
+    },
+
+    /// Semantic similarity search over stored memories.
+    ///
+    /// Embeds the query text and finds the most similar memories using
+    /// vector similarity search.
+    ///
+    /// # Examples
+    ///
+    /// ```bash
+    /// agent memory search "capital of France"
+    /// agent memory search "password reset" --type question --limit 5
+    /// agent memory search "deployment steps" --as-actor agent-1 --tags devops
+    /// ```
+    Search {
+        /// Natural-language query for similarity search.
+        query: String,
+
+        /// Actor performing the search (controls visibility filtering).
+        #[arg(long)]
+        as_actor: Option<String>,
+
+        /// Filter by memory type.
+        #[arg(long, rename_all = "lower")]
+        r#type: Option<String>,
+
+        /// Comma-separated tags to filter by.
+        #[arg(long)]
+        tags: Option<String>,
+
+        /// Maximum number of results (default: 10).
+        #[arg(long, default_value = "10")]
+        limit: usize,
+
+        /// Only return memories created on or after this date (RFC3339).
+        #[arg(long)]
+        since: Option<String>,
+
+        /// Only return memories created on or before this date (RFC3339).
+        #[arg(long)]
+        until: Option<String>,
+    },
+
+    /// Delete a memory record.
+    ///
+    /// # Examples
+    ///
+    /// ```bash
+    /// agent memory forget mem_1234567890_abcdef01
+    /// ```
+    Forget {
+        /// The memory ID to delete.
+        id: String,
+    },
+
+    /// List memories with optional filters and pagination.
+    ///
+    /// # Examples
+    ///
+    /// ```bash
+    /// agent memory list
+    /// agent memory list --type question --limit 20
+    /// agent memory list --created-by agent-1 --visibility private
+    /// agent memory list --tag auth --limit 5 --offset 10
+    /// ```
+    List {
+        /// Filter by memory type.
+        #[arg(long, rename_all = "lower")]
+        r#type: Option<String>,
+
+        /// Filter by tag.
+        #[arg(long)]
+        tag: Option<String>,
+
+        /// Filter by creator identity.
+        #[arg(long)]
+        created_by: Option<String>,
+
+        /// Filter by visibility level.
+        #[arg(long)]
+        visibility: Option<String>,
+
+        /// Maximum number of items to return (default: 50).
+        #[arg(long, default_value = "50")]
+        limit: usize,
+
+        /// Number of items to skip for pagination.
+        #[arg(long, default_value = "0")]
+        offset: usize,
+    },
+
+    /// Update the visibility level and share list of a memory.
+    ///
+    /// # Examples
+    ///
+    /// ```bash
+    /// agent memory visibility mem_123_abc public
+    /// agent memory visibility mem_123_abc shared --share-with agent-2,agent-3
+    /// agent memory visibility mem_123_abc private
+    /// ```
+    Visibility {
+        /// The memory ID to update.
+        id: String,
+
+        /// New visibility level: public, shared, or private.
+        level: String,
+
+        /// Comma-separated actor IDs to share with (required for "shared" level).
+        #[arg(long)]
+        share_with: Option<String>,
+    },
 }
 
 impl MemoryCommand {
-    /// Execute the memory subcommand against the service at `base_url`.
-    pub async fn execute(&self, base_url: &str, json: bool) -> Result<()> {
+    /// Execute the memory subcommand using the provided client.
+    pub async fn execute(&self, client: &MemoryClient, json: bool) -> Result<()> {
         match self {
-            MemoryCommand::Health => {
-                let url = format!("{}/health", base_url);
-                let client = reqwest::Client::builder()
-                    .timeout(std::time::Duration::from_secs(5))
-                    .build()?;
+            MemoryCommand::Health => memory_health(client, json).await,
+            MemoryCommand::Remember {
+                content,
+                created_by,
+                r#type,
+                tags,
+                visibility,
+                share_with,
+                references,
+            } => {
+                remember(
+                    client,
+                    content,
+                    created_by,
+                    r#type,
+                    tags.as_deref(),
+                    visibility,
+                    share_with.as_deref(),
+                    references.as_deref(),
+                    json,
+                )
+                .await
+            }
+            MemoryCommand::Recall { id } => recall(client, id, json).await,
+            MemoryCommand::Search {
+                query,
+                as_actor,
+                r#type,
+                tags,
+                limit,
+                since,
+                until,
+            } => {
+                search(
+                    client,
+                    query,
+                    as_actor.as_deref(),
+                    r#type.as_deref(),
+                    tags.as_deref(),
+                    *limit,
+                    since.as_deref(),
+                    until.as_deref(),
+                    json,
+                )
+                .await
+            }
+            MemoryCommand::Forget { id } => forget(client, id, json).await,
+            MemoryCommand::List {
+                r#type,
+                tag,
+                created_by,
+                visibility,
+                limit,
+                offset,
+            } => {
+                list(
+                    client,
+                    r#type.as_deref(),
+                    tag.as_deref(),
+                    created_by.as_deref(),
+                    visibility.as_deref(),
+                    *limit,
+                    *offset,
+                    json,
+                )
+                .await
+            }
+            MemoryCommand::Visibility {
+                id,
+                level,
+                share_with,
+            } => update_visibility(client, id, level, share_with.as_deref(), json).await,
+        }
+    }
+}
 
-                match client.get(&url).send().await {
-                    Ok(resp) if resp.status().is_success() => {
-                        let body: serde_json::Value = resp.json().await?;
-                        if json {
-                            println!("{}", serde_json::to_string_pretty(&body)?);
-                        } else {
-                            let status = body["status"].as_str().unwrap_or("unknown");
-                            let version = body["version"].as_str().unwrap_or("unknown");
-                            println!(
-                                "{} agentd-memory {} (v{})",
-                                "✅".green(),
-                                status.green(),
-                                version
-                            );
-                        }
-                    }
-                    Ok(resp) => {
-                        let code = resp.status();
-                        if json {
-                            println!(
-                                "{}",
-                                serde_json::to_string_pretty(
-                                    &serde_json::json!({"error": format!("HTTP {}", code)})
-                                )?
-                            );
-                        } else {
-                            println!("{} HTTP {}", "❌".red(), code);
-                        }
-                    }
-                    Err(e) => {
-                        let msg = if e.is_connect() {
-                            "connection refused".to_string()
-                        } else if e.is_timeout() {
-                            "timeout".to_string()
-                        } else {
-                            e.to_string()
-                        };
-                        if json {
-                            println!(
-                                "{}",
-                                serde_json::to_string_pretty(
-                                    &serde_json::json!({"error": msg})
-                                )?
-                            );
-                        } else {
-                            println!("{} {}", "❌".red(), msg.red());
-                        }
-                    }
-                }
+// ---------------------------------------------------------------------------
+// Handlers
+// ---------------------------------------------------------------------------
+
+async fn memory_health(client: &MemoryClient, json: bool) -> Result<()> {
+    let body = client.health().await.context("Failed to reach memory service")?;
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&body)?);
+    } else {
+        let status = body["status"].as_str().unwrap_or("unknown");
+        let version = body["version"].as_str().unwrap_or("unknown");
+        let vector_ok = body["details"]["vector_store"]
+            .as_bool()
+            .unwrap_or(false);
+
+        println!(
+            "{} agentd-memory {} (v{})",
+            "✅".green(),
+            status.green(),
+            version
+        );
+        if vector_ok {
+            println!("   Vector store: {}", "healthy".green());
+        } else {
+            println!("   Vector store: {}", "unhealthy".red());
+        }
+    }
+    Ok(())
+}
+
+async fn remember(
+    client: &MemoryClient,
+    content: &str,
+    created_by: &str,
+    memory_type: &str,
+    tags: Option<&str>,
+    visibility: &str,
+    share_with: Option<&str>,
+    references: Option<&str>,
+    json: bool,
+) -> Result<()> {
+    let memory_type = memory_type
+        .parse::<MemoryType>()
+        .map_err(|e| anyhow::anyhow!("Invalid memory type: {e}"))?;
+    let visibility = visibility
+        .parse::<VisibilityLevel>()
+        .map_err(|e| anyhow::anyhow!("Invalid visibility level: {e}"))?;
+
+    let tags_vec: Vec<String> = tags
+        .map(|t| t.split(',').map(|s| s.trim().to_string()).filter(|s| !s.is_empty()).collect())
+        .unwrap_or_default();
+
+    let shared_vec: Vec<String> = share_with
+        .map(|s| s.split(',').map(|s| s.trim().to_string()).filter(|s| !s.is_empty()).collect())
+        .unwrap_or_default();
+
+    let refs_vec: Vec<String> = references
+        .map(|r| r.split(',').map(|s| s.trim().to_string()).filter(|s| !s.is_empty()).collect())
+        .unwrap_or_default();
+
+    let request = CreateMemoryRequest {
+        content: content.to_string(),
+        memory_type,
+        tags: tags_vec,
+        created_by: created_by.to_string(),
+        references: refs_vec,
+        visibility,
+        shared_with: shared_vec,
+    };
+
+    let memory = client
+        .create_memory(&request)
+        .await
+        .context("Failed to create memory")?;
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&memory)?);
+    } else {
+        println!("{}", "Memory created successfully!".green().bold());
+        display_memory(&memory);
+    }
+    Ok(())
+}
+
+async fn recall(client: &MemoryClient, id: &str, json: bool) -> Result<()> {
+    let memory = client
+        .get_memory(id)
+        .await
+        .context(format!("Failed to retrieve memory '{id}'"))?;
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&memory)?);
+    } else {
+        display_memory(&memory);
+    }
+    Ok(())
+}
+
+async fn search(
+    client: &MemoryClient,
+    query: &str,
+    as_actor: Option<&str>,
+    memory_type: Option<&str>,
+    tags: Option<&str>,
+    limit: usize,
+    since: Option<&str>,
+    until: Option<&str>,
+    json: bool,
+) -> Result<()> {
+    let memory_type = memory_type
+        .map(|t| {
+            t.parse::<MemoryType>()
+                .map_err(|e| anyhow::anyhow!("Invalid memory type: {e}"))
+        })
+        .transpose()?;
+
+    let tags_vec: Vec<String> = tags
+        .map(|t| t.split(',').map(|s| s.trim().to_string()).filter(|s| !s.is_empty()).collect())
+        .unwrap_or_default();
+
+    let from = since
+        .map(|s| {
+            chrono::DateTime::parse_from_rfc3339(s)
+                .map(|d| d.with_timezone(&chrono::Utc))
+                .map_err(|e| anyhow::anyhow!("Invalid --since date (expected RFC3339): {e}"))
+        })
+        .transpose()?;
+
+    let to = until
+        .map(|s| {
+            chrono::DateTime::parse_from_rfc3339(s)
+                .map(|d| d.with_timezone(&chrono::Utc))
+                .map_err(|e| anyhow::anyhow!("Invalid --until date (expected RFC3339): {e}"))
+        })
+        .transpose()?;
+
+    let request = SearchRequest {
+        query: query.to_string(),
+        as_actor: as_actor.map(String::from),
+        memory_type,
+        tags: tags_vec,
+        from,
+        to,
+        limit,
+    };
+
+    let response = client
+        .search_memories(&request)
+        .await
+        .context("Search failed")?;
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&response)?);
+    } else {
+        println!(
+            "Found {} result{}",
+            response.total.to_string().cyan(),
+            if response.total == 1 { "" } else { "s" }
+        );
+
+        if response.memories.is_empty() {
+            println!("{}", "No matching memories found.".yellow());
+        } else {
+            println!("{}", "═".repeat(80).cyan());
+            for memory in &response.memories {
+                display_memory_brief(memory);
+                println!("{}", "─".repeat(80).dimmed());
             }
         }
-        Ok(())
+    }
+    Ok(())
+}
+
+async fn forget(client: &MemoryClient, id: &str, json: bool) -> Result<()> {
+    let response = client
+        .delete_memory(id)
+        .await
+        .context(format!("Failed to delete memory '{id}'"))?;
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&response)?);
+    } else if response.deleted {
+        println!("{} Memory {} deleted", "✅".green(), id.cyan());
+    } else {
+        println!("{} Memory {} not found", "⚠️".yellow(), id.cyan());
+    }
+    Ok(())
+}
+
+async fn list(
+    client: &MemoryClient,
+    memory_type: Option<&str>,
+    tag: Option<&str>,
+    created_by: Option<&str>,
+    visibility: Option<&str>,
+    limit: usize,
+    offset: usize,
+    json: bool,
+) -> Result<()> {
+    // Validate filter values before sending
+    if let Some(t) = memory_type {
+        t.parse::<MemoryType>()
+            .map_err(|e| anyhow::anyhow!("Invalid memory type: {e}"))?;
+    }
+    if let Some(v) = visibility {
+        v.parse::<VisibilityLevel>()
+            .map_err(|e| anyhow::anyhow!("Invalid visibility level: {e}"))?;
+    }
+
+    let response = client
+        .list_memories(
+            memory_type,
+            tag,
+            created_by,
+            visibility,
+            Some(limit),
+            Some(offset),
+        )
+        .await
+        .context("Failed to list memories")?;
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&response)?);
+    } else {
+        println!(
+            "Showing {}/{} memories (offset {})",
+            response.items.len().to_string().cyan(),
+            response.total.to_string().cyan(),
+            offset
+        );
+
+        if response.items.is_empty() {
+            println!("{}", "No memories found.".yellow());
+        } else {
+            let mut table = Table::new();
+            table.set_format(*format::consts::FORMAT_BOX_CHARS);
+            table.set_titles(Row::new(vec![
+                Cell::new("ID").style_spec("Fb"),
+                Cell::new("Type").style_spec("Fb"),
+                Cell::new("Content").style_spec("Fb"),
+                Cell::new("Created By").style_spec("Fb"),
+                Cell::new("Visibility").style_spec("Fb"),
+                Cell::new("Tags").style_spec("Fb"),
+            ]));
+
+            for mem in &response.items {
+                let content_preview = if mem.content.len() > 50 {
+                    format!("{}…", &mem.content[..49])
+                } else {
+                    mem.content.clone()
+                };
+
+                table.add_row(Row::new(vec![
+                    Cell::new(&mem.id),
+                    Cell::new(&mem.memory_type.to_string()),
+                    Cell::new(&content_preview),
+                    Cell::new(&mem.created_by),
+                    Cell::new(&format_visibility(&mem.visibility)),
+                    Cell::new(&mem.tags.join(", ")),
+                ]));
+            }
+
+            table.printstd();
+        }
+    }
+    Ok(())
+}
+
+async fn update_visibility(
+    client: &MemoryClient,
+    id: &str,
+    level: &str,
+    share_with: Option<&str>,
+    json: bool,
+) -> Result<()> {
+    let visibility = level
+        .parse::<VisibilityLevel>()
+        .map_err(|e| anyhow::anyhow!("Invalid visibility level: {e}"))?;
+
+    let shared_vec: Option<Vec<String>> = share_with.map(|s| {
+        s.split(',')
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+            .collect()
+    });
+
+    let request = UpdateVisibilityRequest {
+        visibility,
+        shared_with: shared_vec,
+    };
+
+    let memory = client
+        .update_visibility(id, &request)
+        .await
+        .context(format!("Failed to update visibility for '{id}'"))?;
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&memory)?);
+    } else {
+        println!(
+            "{} Visibility updated for {}",
+            "✅".green(),
+            id.cyan()
+        );
+        display_memory(&memory);
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Display helpers
+// ---------------------------------------------------------------------------
+
+/// Display a full memory record with formatting.
+fn display_memory(memory: &Memory) {
+    println!("  {} {}", "ID:".bold(), memory.id.cyan());
+    println!("  {} {}", "Type:".bold(), memory.memory_type);
+    println!("  {} {}", "Content:".bold(), memory.content);
+    println!("  {} {}", "Created by:".bold(), memory.created_by);
+    println!(
+        "  {} {}",
+        "Created at:".bold(),
+        memory.created_at.format("%Y-%m-%d %H:%M:%S UTC")
+    );
+    println!(
+        "  {} {}",
+        "Visibility:".bold(),
+        format_visibility(&memory.visibility)
+    );
+    if !memory.shared_with.is_empty() {
+        println!(
+            "  {} {}",
+            "Shared with:".bold(),
+            memory.shared_with.join(", ")
+        );
+    }
+    if !memory.tags.is_empty() {
+        println!("  {} {}", "Tags:".bold(), memory.tags.join(", "));
+    }
+    if let Some(ref owner) = memory.owner {
+        println!("  {} {}", "Owner:".bold(), owner);
+    }
+    if !memory.references.is_empty() {
+        println!(
+            "  {} {}",
+            "References:".bold(),
+            memory.references.join(", ")
+        );
+    }
+}
+
+/// Display a brief one-line-ish memory summary for search results.
+fn display_memory_brief(memory: &Memory) {
+    println!("  {} {}", "ID:".bold(), memory.id.cyan());
+    println!(
+        "  {} [{}] {}",
+        "▸".dimmed(),
+        memory.memory_type.to_string().yellow(),
+        memory.content
+    );
+    if !memory.tags.is_empty() {
+        println!(
+            "  {} {}",
+            "Tags:".dimmed(),
+            memory.tags.join(", ").dimmed()
+        );
+    }
+}
+
+/// Format a visibility level with colour.
+fn format_visibility(level: &VisibilityLevel) -> String {
+    match level {
+        VisibilityLevel::Public => "public".green().to_string(),
+        VisibilityLevel::Shared => "shared".yellow().to_string(),
+        VisibilityLevel::Private => "private".red().to_string(),
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+
+    fn sample_memory() -> Memory {
+        let now = Utc::now();
+        Memory {
+            id: "mem_1_abcdef01".to_string(),
+            content: "Paris is the capital of France.".to_string(),
+            memory_type: MemoryType::Information,
+            tags: vec!["geography".to_string(), "europe".to_string()],
+            created_by: "agent-1".to_string(),
+            created_at: now,
+            updated_at: now,
+            owner: None,
+            visibility: VisibilityLevel::Public,
+            shared_with: vec![],
+            references: vec![],
+        }
+    }
+
+    #[test]
+    fn test_display_memory_does_not_panic() {
+        display_memory(&sample_memory());
+    }
+
+    #[test]
+    fn test_display_memory_brief_does_not_panic() {
+        display_memory_brief(&sample_memory());
+    }
+
+    #[test]
+    fn test_display_memory_with_all_fields() {
+        let mut mem = sample_memory();
+        mem.owner = Some("owner-1".to_string());
+        mem.shared_with = vec!["agent-2".to_string()];
+        mem.references = vec!["mem_0_ref1".to_string()];
+        mem.visibility = VisibilityLevel::Shared;
+        display_memory(&mem);
+    }
+
+    #[test]
+    fn test_format_visibility_public() {
+        let result = format_visibility(&VisibilityLevel::Public);
+        assert!(result.contains("public"));
+    }
+
+    #[test]
+    fn test_format_visibility_shared() {
+        let result = format_visibility(&VisibilityLevel::Shared);
+        assert!(result.contains("shared"));
+    }
+
+    #[test]
+    fn test_format_visibility_private() {
+        let result = format_visibility(&VisibilityLevel::Private);
+        assert!(result.contains("private"));
     }
 }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -81,6 +81,7 @@ use clap::{CommandFactory, Parser, Subcommand};
 use clap_complete::Shell;
 use colored::*;
 use commands::{AskCommand, MemoryCommand, NotifyCommand, OrchestratorCommand, WrapCommand};
+use memory::client::MemoryClient;
 use notify::client::NotifyClient;
 use orchestrator::client::OrchestratorClient;
 use std::env;
@@ -331,7 +332,8 @@ async fn main() -> Result<()> {
             // Use AGENTD_MEMORY_SERVICE_URL env var, default to production port
             let url = env::var("AGENTD_MEMORY_SERVICE_URL")
                 .unwrap_or_else(|_| "http://localhost:7008".to_string());
-            command.execute(&url, cli.json).await?;
+            let client = MemoryClient::new(url);
+            command.execute(&client, cli.json).await?;
         }
     }
 

--- a/crates/memory/Cargo.toml
+++ b/crates/memory/Cargo.toml
@@ -5,6 +5,10 @@ edition.workspace = true
 authors.workspace = true
 license.workspace = true
 
+[lib]
+name = "memory"
+path = "src/lib.rs"
+
 [[bin]]
 name = "agentd-memory"
 path = "src/main.rs"

--- a/crates/memory/src/api.rs
+++ b/crates/memory/src/api.rs
@@ -62,8 +62,8 @@ use serde::Deserialize;
 use std::sync::Arc;
 use tracing::{debug, info, warn};
 
-use crate::store::VectorStore;
-use crate::types::{
+use memory::store::VectorStore;
+use memory::types::{
     CreateMemoryRequest, DeleteResponse, Memory, MemoryType, SearchRequest, SearchResponse,
     UpdateVisibilityRequest, VisibilityLevel,
 };
@@ -516,8 +516,8 @@ async fn update_visibility(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::error::{StoreError, StoreResult};
-    use crate::types::CreateMemoryRequest;
+    use memory::error::{StoreError, StoreResult};
+    use memory::types::CreateMemoryRequest;
     use async_trait::async_trait;
     use axum::body::Body;
     use axum::http::{self, Request};

--- a/crates/memory/src/client.rs
+++ b/crates/memory/src/client.rs
@@ -1,0 +1,254 @@
+//! HTTP client for interacting with the agentd-memory service.
+//!
+//! Provides a strongly-typed client for making requests to the memory service
+//! REST API. Handles serialization, deserialization, and query parameter
+//! construction.
+//!
+//! # Examples
+//!
+//! ```no_run
+//! use memory::client::MemoryClient;
+//! use memory::types::*;
+//!
+//! # async fn example() -> anyhow::Result<()> {
+//! let client = MemoryClient::new("http://localhost:7008");
+//!
+//! // Create a memory
+//! let request = CreateMemoryRequest {
+//!     content: "Paris is the capital of France.".to_string(),
+//!     created_by: "agent-1".to_string(),
+//!     ..Default::default()
+//! };
+//! let memory = client.create_memory(&request).await?;
+//!
+//! // Semantic search
+//! let results = client.search_memories(&SearchRequest {
+//!     query: "capital of France".to_string(),
+//!     ..Default::default()
+//! }).await?;
+//! println!("Found {} results", results.total);
+//! # Ok(())
+//! # }
+//! ```
+
+use anyhow::{Context, Result};
+use serde::de::DeserializeOwned;
+use serde::Serialize;
+
+use crate::types::{
+    CreateMemoryRequest, DeleteResponse, Memory, SearchRequest, SearchResponse,
+    UpdateVisibilityRequest,
+};
+use agentd_common::types::PaginatedResponse;
+
+/// Client for the agentd-memory service REST API.
+///
+/// Provides strongly-typed methods for all memory operations including
+/// creating, listing, searching, and deleting memories.
+///
+/// # Examples
+///
+/// ```
+/// use memory::client::MemoryClient;
+///
+/// let client = MemoryClient::new("http://localhost:7008");
+/// ```
+#[derive(Clone)]
+pub struct MemoryClient {
+    client: reqwest::Client,
+    base_url: String,
+}
+
+impl MemoryClient {
+    /// Create a new memory service client.
+    ///
+    /// # Arguments
+    ///
+    /// * `base_url` - The base URL for the memory service (e.g., `"http://localhost:7008"`)
+    pub fn new(base_url: impl Into<String>) -> Self {
+        Self {
+            client: reqwest::Client::new(),
+            base_url: base_url.into(),
+        }
+    }
+
+    /// `POST /memories` — create a new memory record.
+    pub async fn create_memory(&self, request: &CreateMemoryRequest) -> Result<Memory> {
+        self.post("/memories", request).await
+    }
+
+    /// `GET /memories/:id` — retrieve a single memory by ID.
+    pub async fn get_memory(&self, id: &str) -> Result<Memory> {
+        self.get(&format!("/memories/{id}")).await
+    }
+
+    /// `GET /memories` — list memories with optional filters.
+    ///
+    /// # Arguments
+    ///
+    /// * `memory_type` — filter by type (`information`, `question`, `request`)
+    /// * `tag` — filter by tag (comma-separated for multiple)
+    /// * `created_by` — filter by creator identity
+    /// * `visibility` — filter by visibility level
+    /// * `limit` — max items per page
+    /// * `offset` — pagination offset
+    pub async fn list_memories(
+        &self,
+        memory_type: Option<&str>,
+        tag: Option<&str>,
+        created_by: Option<&str>,
+        visibility: Option<&str>,
+        limit: Option<usize>,
+        offset: Option<usize>,
+    ) -> Result<PaginatedResponse<Memory>> {
+        let mut params = Vec::new();
+        if let Some(t) = memory_type {
+            params.push(format!("type={t}"));
+        }
+        if let Some(t) = tag {
+            params.push(format!("tag={t}"));
+        }
+        if let Some(c) = created_by {
+            params.push(format!("created_by={c}"));
+        }
+        if let Some(v) = visibility {
+            params.push(format!("visibility={v}"));
+        }
+        if let Some(l) = limit {
+            params.push(format!("limit={l}"));
+        }
+        if let Some(o) = offset {
+            params.push(format!("offset={o}"));
+        }
+
+        let path = if params.is_empty() {
+            "/memories".to_string()
+        } else {
+            format!("/memories?{}", params.join("&"))
+        };
+
+        self.get(&path).await
+    }
+
+    /// `DELETE /memories/:id` — delete a memory.
+    pub async fn delete_memory(&self, id: &str) -> Result<DeleteResponse> {
+        self.delete_json(&format!("/memories/{id}")).await
+    }
+
+    /// `POST /memories/search` — semantic similarity search.
+    pub async fn search_memories(&self, request: &SearchRequest) -> Result<SearchResponse> {
+        self.post("/memories/search", request).await
+    }
+
+    /// `PUT /memories/:id/visibility` — update visibility and share list.
+    pub async fn update_visibility(
+        &self,
+        id: &str,
+        request: &UpdateVisibilityRequest,
+    ) -> Result<Memory> {
+        self.put(&format!("/memories/{id}/visibility"), request)
+            .await
+    }
+
+    /// `GET /health` — service health check.
+    pub async fn health(&self) -> Result<serde_json::Value> {
+        self.get("/health").await
+    }
+
+    // ── Internal helpers ──────────────────────────────────────────────────
+
+    async fn get<T: DeserializeOwned>(&self, path: &str) -> Result<T> {
+        let url = format!("{}{}", self.base_url, path);
+        let response =
+            self.client.get(&url).send().await.context(format!("Failed to GET {url}"))?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            anyhow::bail!("Request failed with status {status}: {body}");
+        }
+
+        response.json().await.context("Failed to parse response JSON")
+    }
+
+    async fn post<T: DeserializeOwned, B: Serialize>(&self, path: &str, body: &B) -> Result<T> {
+        let url = format!("{}{}", self.base_url, path);
+        let response = self
+            .client
+            .post(&url)
+            .json(body)
+            .send()
+            .await
+            .context(format!("Failed to POST {url}"))?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            anyhow::bail!("Request failed with status {status}: {body}");
+        }
+
+        response.json().await.context("Failed to parse response JSON")
+    }
+
+    async fn put<T: DeserializeOwned, B: Serialize>(&self, path: &str, body: &B) -> Result<T> {
+        let url = format!("{}{}", self.base_url, path);
+        let response = self
+            .client
+            .put(&url)
+            .json(body)
+            .send()
+            .await
+            .context(format!("Failed to PUT {url}"))?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            anyhow::bail!("Request failed with status {status}: {body}");
+        }
+
+        response.json().await.context("Failed to parse response JSON")
+    }
+
+    async fn delete_json<T: DeserializeOwned>(&self, path: &str) -> Result<T> {
+        let url = format!("{}{}", self.base_url, path);
+        let response =
+            self.client.delete(&url).send().await.context(format!("Failed to DELETE {url}"))?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            anyhow::bail!("Request failed with status {status}: {body}");
+        }
+
+        response.json().await.context("Failed to parse response JSON")
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_client_creation() {
+        let client = MemoryClient::new("http://localhost:7008");
+        assert_eq!(client.base_url, "http://localhost:7008");
+    }
+
+    #[test]
+    fn test_client_creation_with_string() {
+        let url = String::from("http://localhost:7008");
+        let client = MemoryClient::new(url);
+        assert_eq!(client.base_url, "http://localhost:7008");
+    }
+
+    #[test]
+    fn test_client_clone() {
+        let client1 = MemoryClient::new("http://localhost:7008");
+        let client2 = client1.clone();
+        assert_eq!(client1.base_url, client2.base_url);
+    }
+}

--- a/crates/memory/src/lib.rs
+++ b/crates/memory/src/lib.rs
@@ -1,0 +1,39 @@
+//! # agentd-memory
+//!
+//! A memory service that stores, retrieves, and semantically searches agent
+//! memory records using LanceDB for vector embeddings.
+//!
+//! ## Architecture
+//!
+//! - **Types** ([`types`]): Core data structures (`Memory`, `MemoryType`, `VisibilityLevel`)
+//! - **HTTP Client** ([`client`]): Client for making requests to the memory service
+//! - **Storage** ([`store`]): Vector store traits and LanceDB backend
+//! - **Config** ([`config`]): Embedding and LanceDB configuration
+//! - **Errors** ([`error`]): Domain error types
+//!
+//! ## Client Example
+//!
+//! ```no_run
+//! use memory::client::MemoryClient;
+//! use memory::types::*;
+//!
+//! # async fn example() -> anyhow::Result<()> {
+//! let client = MemoryClient::new("http://localhost:7008");
+//!
+//! let request = CreateMemoryRequest {
+//!     content: "Paris is the capital of France.".to_string(),
+//!     created_by: "agent-1".to_string(),
+//!     ..Default::default()
+//! };
+//!
+//! let memory = client.create_memory(&request).await?;
+//! println!("Created: {}", memory.id);
+//! # Ok(())
+//! # }
+//! ```
+
+pub mod client;
+pub mod config;
+pub mod error;
+pub mod store;
+pub mod types;

--- a/crates/memory/src/main.rs
+++ b/crates/memory/src/main.rs
@@ -35,14 +35,10 @@
 //! - `POST /memories/search`         — semantic similarity search
 
 mod api;
-pub mod config;
-pub mod error;
-pub mod store;
-pub mod types;
 
 use api::{create_router, ApiState};
 use axum::{extract::State, response::IntoResponse, routing::get};
-use config::{EmbeddingConfig, LanceConfig};
+use memory::config::{EmbeddingConfig, LanceConfig};
 use metrics_exporter_prometheus::PrometheusHandle;
 use std::env;
 use tracing::info;
@@ -80,7 +76,7 @@ async fn main() -> anyhow::Result<()> {
         "Initialising vector store"
     );
 
-    let store = store::create_store(&lance_config, &embedding_config).await?;
+    let store = memory::store::create_store(&lance_config, &embedding_config).await?;
     store.initialize().await?;
 
     info!("Vector store initialised");

--- a/crates/memory/src/types/requests.rs
+++ b/crates/memory/src/types/requests.rs
@@ -26,7 +26,7 @@ use super::{Memory, MemoryType, VisibilityLevel};
 ///   "shared_with": ["agent-support"]
 /// }
 /// ```
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct CreateMemoryRequest {
     /// The natural-language content to store.
     pub content: String,


### PR DESCRIPTION
## Summary

- Add `MemoryClient` in `crates/memory/src/client.rs` following the `NotifyClient` pattern with strongly-typed methods for all memory API endpoints
- Add `lib.rs` to the memory crate so it can be imported as a library by the CLI
- Implement full CLI subcommands using berry-rs naming conventions:
  - `agent memory remember <content>` — store a new memory (with `--type`, `--tags`, `--visibility`, `--share-with`, `--references` flags)
  - `agent memory recall <id>` — retrieve a specific memory
  - `agent memory search <query>` — semantic similarity search (with `--type`, `--tags`, `--limit`, `--since`, `--until`, `--as-actor` flags)
  - `agent memory forget <id>` — delete a memory
  - `agent memory list` — list with type/tag/creator/visibility filters + pagination
  - `agent memory visibility <id> <level>` — update visibility & share list
  - `agent memory health` — service health check with vector store status
- All commands support `--json` flag for machine-readable output
- Human-readable output uses colored tables (prettytable) and formatted detail views
- Input validation for memory type, visibility level, and RFC3339 date parsing
- Uses `AGENTD_MEMORY_SERVICE_URL` env var (default `http://localhost:7008`)

## Test plan

- [x] All 227 tests pass across memory (130) and CLI (97) crates
- [x] Memory client tests: creation, clone, string conversion
- [x] CLI memory command tests: display helpers, format_visibility for all levels
- [x] All existing tests continue to pass (no regressions)
- [x] Doc-tests pass for both crates

Closes #306

🤖 Generated with [Claude Code](https://claude.com/claude-code)