### PR TITLE
feat(ui): add useMemories and useMemorySearch hooks

### DIFF
--- a/ui/src/hooks/index.ts
+++ b/ui/src/hooks/index.ts
@@ -60,3 +60,15 @@ export type {
   AggregateUsage,
   UseUsageMetricsResult,
 } from './useUsageMetrics'
+
+export { useMemories, parseMemorySearchParams, buildMemorySearchParams } from './useMemories'
+export type {
+  MemorySortField,
+  MemorySortDir,
+  MemoryFilters,
+  UseMemoriesOptions,
+  UseMemoriesResult,
+} from './useMemories'
+
+export { useMemorySearch } from './useMemorySearch'
+export type { UseMemorySearchResult } from './useMemorySearch'

--- a/ui/src/hooks/useMemories.ts
+++ b/ui/src/hooks/useMemories.ts
@@ -1,0 +1,312 @@
+/**
+ * useMemories — hook for memory list management.
+ *
+ * Provides:
+ * - Paginated memory list with filtering (type, tag, visibility, created_by)
+ * - CRUD actions: create, delete, updateVisibility
+ * - Auto-refresh every 30 seconds (configurable)
+ * - URL search params sync for bookmarkable filter/pagination state
+ * - Error handling with mapApiError and toast notifications
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { memoryClient } from '@/services/memory'
+import { useToast, mapApiError } from '@/hooks/useToast'
+import type {
+  CreateMemoryRequest,
+  Memory,
+  MemoryListParams,
+  MemoryType,
+  UpdateVisibilityRequest,
+  VisibilityLevel,
+} from '@/types/memory'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type MemorySortField = 'created_at' | 'updated_at' | 'type'
+export type MemorySortDir = 'asc' | 'desc'
+
+export interface MemoryFilters {
+  /** Filter by memory type. */
+  type?: MemoryType
+  /** Filter by tag. */
+  tag?: string
+  /** Filter by creator identity. */
+  created_by?: string
+  /** Filter by visibility level. */
+  visibility?: VisibilityLevel
+}
+
+export interface UseMemoriesOptions {
+  /** Filters to apply on the server side. */
+  filters?: MemoryFilters
+  /** Client-side content search string. */
+  search?: string
+  /** Page number (1-based). */
+  page?: number
+  /** Items per page. */
+  pageSize?: number
+  /** Sort column. */
+  sortBy?: MemorySortField
+  /** Sort direction. */
+  sortDir?: MemorySortDir
+  /** Pause auto-refresh (e.g. when a dialog is open). */
+  paused?: boolean
+  /** Override auto-refresh interval (ms); default 30 000. */
+  refreshInterval?: number
+}
+
+export interface UseMemoriesResult {
+  /** Memories on the current page (after filter + sort). */
+  memories: Memory[]
+  /** Total matching memories (before pagination). */
+  total: number
+  /** All memories returned by the API (before client-side filtering). */
+  allMemories: Memory[]
+  loading: boolean
+  /** True while a background refresh is running (initial load uses `loading`). */
+  refreshing: boolean
+  error?: string
+  /** Trigger a manual refresh. */
+  refetch: () => void
+  /** Create a new memory; returns the created Memory. */
+  createMemory: (request: CreateMemoryRequest) => Promise<Memory>
+  /** Delete a memory by id. */
+  deleteMemory: (id: string) => Promise<void>
+  /** Update visibility and share list for a memory. */
+  updateVisibility: (id: string, request: UpdateVisibilityRequest) => Promise<Memory>
+}
+
+// ---------------------------------------------------------------------------
+// Sorting helpers
+// ---------------------------------------------------------------------------
+
+function compareMemories(
+  a: Memory,
+  b: Memory,
+  field: MemorySortField,
+  dir: MemorySortDir,
+): number {
+  let result = 0
+  if (field === 'created_at') {
+    result = new Date(a.created_at).getTime() - new Date(b.created_at).getTime()
+  } else if (field === 'updated_at') {
+    result = new Date(a.updated_at).getTime() - new Date(b.updated_at).getTime()
+  } else if (field === 'type') {
+    result = a.type.localeCompare(b.type)
+  }
+  return dir === 'asc' ? result : -result
+}
+
+// ---------------------------------------------------------------------------
+// URL search params helpers
+// ---------------------------------------------------------------------------
+
+/** Read memory filter/pagination state from URL search params. */
+export function parseMemorySearchParams(params: URLSearchParams): {
+  filters: MemoryFilters
+  page: number
+  pageSize: number
+  search: string
+  sortBy: MemorySortField
+  sortDir: MemorySortDir
+} {
+  return {
+    filters: {
+      type: (params.get('type') as MemoryType) || undefined,
+      tag: params.get('tag') || undefined,
+      created_by: params.get('created_by') || undefined,
+      visibility: (params.get('visibility') as VisibilityLevel) || undefined,
+    },
+    page: Number(params.get('page')) || 1,
+    pageSize: Number(params.get('pageSize')) || DEFAULT_PAGE_SIZE,
+    search: params.get('search') || '',
+    sortBy: (params.get('sortBy') as MemorySortField) || 'created_at',
+    sortDir: (params.get('sortDir') as MemorySortDir) || 'desc',
+  }
+}
+
+/** Write memory filter/pagination state to URL search params. */
+export function buildMemorySearchParams(options: {
+  filters?: MemoryFilters
+  page?: number
+  pageSize?: number
+  search?: string
+  sortBy?: MemorySortField
+  sortDir?: MemorySortDir
+}): URLSearchParams {
+  const params = new URLSearchParams()
+  if (options.filters?.type) params.set('type', options.filters.type)
+  if (options.filters?.tag) params.set('tag', options.filters.tag)
+  if (options.filters?.created_by) params.set('created_by', options.filters.created_by)
+  if (options.filters?.visibility) params.set('visibility', options.filters.visibility)
+  if (options.page && options.page > 1) params.set('page', String(options.page))
+  if (options.pageSize && options.pageSize !== DEFAULT_PAGE_SIZE)
+    params.set('pageSize', String(options.pageSize))
+  if (options.search) params.set('search', options.search)
+  if (options.sortBy && options.sortBy !== 'created_at') params.set('sortBy', options.sortBy)
+  if (options.sortDir && options.sortDir !== 'desc') params.set('sortDir', options.sortDir)
+  return params
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const DEFAULT_PAGE_SIZE = 50
+const DEFAULT_REFRESH_INTERVAL = 30_000
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+export function useMemories({
+  filters = {},
+  search = '',
+  page = 1,
+  pageSize = DEFAULT_PAGE_SIZE,
+  sortBy = 'created_at',
+  sortDir = 'desc',
+  paused = false,
+  refreshInterval = DEFAULT_REFRESH_INTERVAL,
+}: UseMemoriesOptions = {}): UseMemoriesResult {
+  const [allMemories, setAllMemories] = useState<Memory[]>([])
+  const [loading, setLoading] = useState(true)
+  const [refreshing, setRefreshing] = useState(false)
+  const [error, setError] = useState<string | undefined>()
+  const toast = useToast()
+
+  const timerRef = useRef<ReturnType<typeof setInterval> | null>(null)
+
+  // -------------------------------------------------------------------------
+  // Fetch
+  // -------------------------------------------------------------------------
+
+  const fetchMemories = useCallback(
+    async (isBackground = false) => {
+      if (isBackground) {
+        setRefreshing(true)
+      } else {
+        setLoading(true)
+        setError(undefined)
+      }
+
+      try {
+        const params: MemoryListParams = {
+          limit: 200,
+          ...(filters.type ? { type: filters.type } : {}),
+          ...(filters.tag ? { tag: filters.tag } : {}),
+          ...(filters.created_by ? { created_by: filters.created_by } : {}),
+          ...(filters.visibility ? { visibility: filters.visibility } : {}),
+        }
+        const result = await memoryClient.listMemories(params)
+        setAllMemories(result.items)
+        setError(undefined)
+      } catch (err) {
+        const msg = mapApiError(err)
+        setError(msg)
+      } finally {
+        setLoading(false)
+        setRefreshing(false)
+      }
+    },
+    [filters.type, filters.tag, filters.created_by, filters.visibility],
+  )
+
+  // -------------------------------------------------------------------------
+  // Initial fetch + auto-refresh
+  // -------------------------------------------------------------------------
+
+  useEffect(() => {
+    fetchMemories(false)
+  }, [fetchMemories])
+
+  useEffect(() => {
+    if (paused) {
+      if (timerRef.current) clearInterval(timerRef.current)
+      return
+    }
+    timerRef.current = setInterval(() => fetchMemories(true), refreshInterval)
+    return () => {
+      if (timerRef.current) clearInterval(timerRef.current)
+    }
+  }, [paused, refreshInterval, fetchMemories])
+
+  // -------------------------------------------------------------------------
+  // Client-side filter, sort, paginate
+  // -------------------------------------------------------------------------
+
+  const filtered = allMemories.filter((m) => {
+    if (search) {
+      return m.content.toLowerCase().includes(search.toLowerCase())
+    }
+    return true
+  })
+
+  const sorted = [...filtered].sort((a, b) => compareMemories(a, b, sortBy, sortDir))
+  const total = sorted.length
+  const start = (page - 1) * pageSize
+  const memories = sorted.slice(start, start + pageSize)
+
+  // -------------------------------------------------------------------------
+  // Actions
+  // -------------------------------------------------------------------------
+
+  const refetch = useCallback(() => fetchMemories(false), [fetchMemories])
+
+  const createMemory = useCallback(
+    async (request: CreateMemoryRequest): Promise<Memory> => {
+      try {
+        const created = await memoryClient.createMemory(request)
+        await fetchMemories(true)
+        return created
+      } catch (err) {
+        toast.apiError(err, 'Failed to create memory')
+        throw err
+      }
+    },
+    [fetchMemories, toast],
+  )
+
+  const deleteMemory = useCallback(
+    async (id: string): Promise<void> => {
+      try {
+        await memoryClient.deleteMemory(id)
+        setAllMemories((prev) => prev.filter((m) => m.id !== id))
+      } catch (err) {
+        toast.apiError(err, 'Failed to delete memory')
+        throw err
+      }
+    },
+    [toast],
+  )
+
+  const updateVisibility = useCallback(
+    async (id: string, request: UpdateVisibilityRequest): Promise<Memory> => {
+      try {
+        const updated = await memoryClient.updateVisibility(id, request)
+        setAllMemories((prev) => prev.map((m) => (m.id === id ? updated : m)))
+        return updated
+      } catch (err) {
+        toast.apiError(err, 'Failed to update visibility')
+        throw err
+      }
+    },
+    [toast],
+  )
+
+  return {
+    memories,
+    total,
+    allMemories,
+    loading,
+    refreshing,
+    error,
+    refetch,
+    createMemory,
+    deleteMemory,
+    updateVisibility,
+  }
+}

--- a/ui/src/hooks/useMemorySearch.ts
+++ b/ui/src/hooks/useMemorySearch.ts
@@ -1,0 +1,79 @@
+/**
+ * useMemorySearch — hook for semantic memory search.
+ *
+ * Provides:
+ * - Execute semantic similarity search against the memory service
+ * - Clear results to reset the search state
+ * - Loading and error state management
+ * - Error handling with mapApiError and toast notifications
+ */
+
+import { useCallback, useState } from 'react'
+import { memoryClient } from '@/services/memory'
+import { useToast, mapApiError } from '@/hooks/useToast'
+import type { Memory, SearchRequest } from '@/types/memory'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface UseMemorySearchResult {
+  /** Matching memory records, ordered by similarity score. */
+  results: Memory[]
+  /** Total number of matches from the last search. */
+  total: number
+  /** True while a search request is in flight. */
+  searching: boolean
+  /** Error message from the last search, if any. */
+  error?: string
+  /** Execute a semantic similarity search. */
+  search: (request: SearchRequest) => Promise<void>
+  /** Clear results and reset to the initial state. */
+  clear: () => void
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+export function useMemorySearch(): UseMemorySearchResult {
+  const [results, setResults] = useState<Memory[]>([])
+  const [total, setTotal] = useState(0)
+  const [searching, setSearching] = useState(false)
+  const [error, setError] = useState<string | undefined>()
+  const toast = useToast()
+
+  const search = useCallback(
+    async (request: SearchRequest): Promise<void> => {
+      setSearching(true)
+      setError(undefined)
+      try {
+        const response = await memoryClient.searchMemories(request)
+        setResults(response.memories)
+        setTotal(response.total)
+      } catch (err) {
+        const msg = mapApiError(err)
+        setError(msg)
+        toast.apiError(err, 'Memory search failed')
+      } finally {
+        setSearching(false)
+      }
+    },
+    [toast],
+  )
+
+  const clear = useCallback(() => {
+    setResults([])
+    setTotal(0)
+    setError(undefined)
+  }, [])
+
+  return {
+    results,
+    total,
+    searching,
+    error,
+    search,
+    clear,
+  }
+}

--- a/ui/src/test/hooks/useMemories.test.ts
+++ b/ui/src/test/hooks/useMemories.test.ts
@@ -1,0 +1,251 @@
+/**
+ * Tests for useMemories hook.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor, act } from '@testing-library/react'
+import { useMemories } from '@/hooks/useMemories'
+import { memoryClient } from '@/services/memory'
+import type { Memory } from '@/types/memory'
+
+// ---------------------------------------------------------------------------
+// Mock useToast
+// ---------------------------------------------------------------------------
+
+const mockApiError = vi.fn().mockReturnValue('toast-id')
+vi.mock('@/hooks/useToast', () => ({
+  useToast: () => ({
+    success: vi.fn(),
+    error: vi.fn(),
+    warning: vi.fn(),
+    info: vi.fn(),
+    dismiss: vi.fn(),
+    clear: vi.fn(),
+    apiError: mockApiError,
+  }),
+  mapApiError: (err: unknown) =>
+    err instanceof Error ? err.message : String(err),
+}))
+
+// ---------------------------------------------------------------------------
+// Test fixtures
+// ---------------------------------------------------------------------------
+
+function makeMemory(overrides: Partial<Memory> = {}): Memory {
+  return {
+    id: 'mem_1234567890_abcdef12',
+    content: 'Test memory content',
+    type: 'information',
+    tags: ['test'],
+    created_by: 'agent-1',
+    owner: undefined,
+    created_at: '2024-01-15T10:00:00Z',
+    updated_at: '2024-01-15T10:00:00Z',
+    visibility: 'public',
+    shared_with: [],
+    references: [],
+    ...overrides,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// useMemories
+// ---------------------------------------------------------------------------
+
+describe('useMemories', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    mockApiError.mockClear()
+  })
+
+  it('fetches and returns memories', async () => {
+    const mem = makeMemory()
+    vi.spyOn(memoryClient, 'listMemories').mockResolvedValue({
+      items: [mem],
+      total: 1,
+      limit: 200,
+      offset: 0,
+    })
+
+    const { result } = renderHook(() => useMemories())
+    await waitFor(() => expect(result.current.loading).toBe(false))
+
+    expect(result.current.memories).toHaveLength(1)
+    expect(result.current.memories[0].content).toBe('Test memory content')
+    expect(result.current.total).toBe(1)
+  })
+
+  it('sets error on fetch failure', async () => {
+    vi.spyOn(memoryClient, 'listMemories').mockRejectedValue(
+      new Error('Service unavailable'),
+    )
+
+    const { result } = renderHook(() => useMemories())
+    await waitFor(() => expect(result.current.loading).toBe(false))
+
+    expect(result.current.error).toBe('Service unavailable')
+    expect(result.current.memories).toHaveLength(0)
+  })
+
+  it('filters by client-side content search', async () => {
+    const m1 = makeMemory({ id: 'm1', content: 'Deploy the API' })
+    const m2 = makeMemory({ id: 'm2', content: 'Fix the bug' })
+    vi.spyOn(memoryClient, 'listMemories').mockResolvedValue({
+      items: [m1, m2],
+      total: 2,
+      limit: 200,
+      offset: 0,
+    })
+
+    const { result } = renderHook(() => useMemories({ search: 'deploy' }))
+    await waitFor(() => expect(result.current.loading).toBe(false))
+
+    expect(result.current.memories).toHaveLength(1)
+    expect(result.current.memories[0].content).toBe('Deploy the API')
+  })
+
+  it('passes server-side filters to listMemories', async () => {
+    const spy = vi.spyOn(memoryClient, 'listMemories').mockResolvedValue({
+      items: [],
+      total: 0,
+      limit: 200,
+      offset: 0,
+    })
+
+    const { result } = renderHook(() =>
+      useMemories({
+        filters: { type: 'question', visibility: 'private' },
+      }),
+    )
+    await waitFor(() => expect(result.current.loading).toBe(false))
+
+    expect(spy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        type: 'question',
+        visibility: 'private',
+        limit: 200,
+      }),
+    )
+  })
+
+  it('sorts by created_at descending by default', async () => {
+    const m1 = makeMemory({ id: 'm1', created_at: '2024-01-10T00:00:00Z' })
+    const m2 = makeMemory({ id: 'm2', created_at: '2024-01-20T00:00:00Z' })
+    vi.spyOn(memoryClient, 'listMemories').mockResolvedValue({
+      items: [m1, m2],
+      total: 2,
+      limit: 200,
+      offset: 0,
+    })
+
+    const { result } = renderHook(() => useMemories())
+    await waitFor(() => expect(result.current.loading).toBe(false))
+
+    expect(result.current.memories[0].id).toBe('m2')
+    expect(result.current.memories[1].id).toBe('m1')
+  })
+
+  it('paginates results', async () => {
+    const items = Array.from({ length: 5 }, (_, i) =>
+      makeMemory({ id: `m${i}`, created_at: `2024-01-0${i + 1}T00:00:00Z` }),
+    )
+    vi.spyOn(memoryClient, 'listMemories').mockResolvedValue({
+      items,
+      total: 5,
+      limit: 200,
+      offset: 0,
+    })
+
+    const { result } = renderHook(() => useMemories({ page: 2, pageSize: 2 }))
+    await waitFor(() => expect(result.current.loading).toBe(false))
+
+    // Sorted desc: m4, m3, m2, m1, m0 → page 2 (size 2) = m2, m1
+    expect(result.current.memories).toHaveLength(2)
+    expect(result.current.total).toBe(5)
+  })
+
+  it('createMemory calls client and refreshes', async () => {
+    const existing = makeMemory()
+    vi.spyOn(memoryClient, 'listMemories').mockResolvedValue({
+      items: [existing],
+      total: 1,
+      limit: 200,
+      offset: 0,
+    })
+    const created = makeMemory({ id: 'new-mem', content: 'New memory' })
+    vi.spyOn(memoryClient, 'createMemory').mockResolvedValue(created)
+
+    const { result } = renderHook(() => useMemories())
+    await waitFor(() => expect(result.current.loading).toBe(false))
+
+    const returned = await act(() =>
+      result.current.createMemory({ content: 'New memory', created_by: 'user-1' }),
+    )
+    expect(returned.id).toBe('new-mem')
+  })
+
+  it('deleteMemory removes memory from state', async () => {
+    const mem = makeMemory()
+    vi.spyOn(memoryClient, 'listMemories').mockResolvedValue({
+      items: [mem],
+      total: 1,
+      limit: 200,
+      offset: 0,
+    })
+    vi.spyOn(memoryClient, 'deleteMemory').mockResolvedValue({ deleted: true })
+
+    const { result } = renderHook(() => useMemories())
+    await waitFor(() => expect(result.current.loading).toBe(false))
+    expect(result.current.memories).toHaveLength(1)
+
+    await act(() => result.current.deleteMemory(mem.id))
+    await waitFor(() => expect(result.current.memories).toHaveLength(0))
+  })
+
+  it('updateVisibility updates memory in state', async () => {
+    const mem = makeMemory({ visibility: 'public' })
+    vi.spyOn(memoryClient, 'listMemories').mockResolvedValue({
+      items: [mem],
+      total: 1,
+      limit: 200,
+      offset: 0,
+    })
+    const updated = { ...mem, visibility: 'private' as const }
+    vi.spyOn(memoryClient, 'updateVisibility').mockResolvedValue(updated)
+
+    const { result } = renderHook(() => useMemories())
+    await waitFor(() => expect(result.current.loading).toBe(false))
+
+    await act(() =>
+      result.current.updateVisibility(mem.id, { visibility: 'private' }),
+    )
+    await waitFor(() =>
+      expect(result.current.memories[0].visibility).toBe('private'),
+    )
+  })
+
+  it('shows toast on createMemory failure', async () => {
+    vi.spyOn(memoryClient, 'listMemories').mockResolvedValue({
+      items: [],
+      total: 0,
+      limit: 200,
+      offset: 0,
+    })
+    vi.spyOn(memoryClient, 'createMemory').mockRejectedValue(
+      new Error('Bad request'),
+    )
+
+    const { result } = renderHook(() => useMemories())
+    await waitFor(() => expect(result.current.loading).toBe(false))
+
+    await expect(
+      act(() =>
+        result.current.createMemory({ content: 'test', created_by: 'user-1' }),
+      ),
+    ).rejects.toThrow('Bad request')
+    expect(mockApiError).toHaveBeenCalledWith(
+      expect.any(Error),
+      'Failed to create memory',
+    )
+  })
+})

--- a/ui/src/test/hooks/useMemorySearch.test.ts
+++ b/ui/src/test/hooks/useMemorySearch.test.ts
@@ -1,0 +1,169 @@
+/**
+ * Tests for useMemorySearch hook.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { renderHook, waitFor, act } from '@testing-library/react'
+import { useMemorySearch } from '@/hooks/useMemorySearch'
+import { memoryClient } from '@/services/memory'
+import type { Memory } from '@/types/memory'
+
+// ---------------------------------------------------------------------------
+// Mock useToast
+// ---------------------------------------------------------------------------
+
+const mockApiError = vi.fn().mockReturnValue('toast-id')
+vi.mock('@/hooks/useToast', () => ({
+  useToast: () => ({
+    success: vi.fn(),
+    error: vi.fn(),
+    warning: vi.fn(),
+    info: vi.fn(),
+    dismiss: vi.fn(),
+    clear: vi.fn(),
+    apiError: mockApiError,
+  }),
+  mapApiError: (err: unknown) =>
+    err instanceof Error ? err.message : String(err),
+}))
+
+// ---------------------------------------------------------------------------
+// Test fixtures
+// ---------------------------------------------------------------------------
+
+function makeMemory(overrides: Partial<Memory> = {}): Memory {
+  return {
+    id: 'mem_1234567890_abcdef12',
+    content: 'Test memory content',
+    type: 'information',
+    tags: ['test'],
+    created_by: 'agent-1',
+    owner: undefined,
+    created_at: '2024-01-15T10:00:00Z',
+    updated_at: '2024-01-15T10:00:00Z',
+    visibility: 'public',
+    shared_with: [],
+    references: [],
+    ...overrides,
+  }
+}
+
+// ---------------------------------------------------------------------------
+// useMemorySearch
+// ---------------------------------------------------------------------------
+
+describe('useMemorySearch', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    mockApiError.mockClear()
+  })
+
+  it('starts with empty results', () => {
+    const { result } = renderHook(() => useMemorySearch())
+
+    expect(result.current.results).toHaveLength(0)
+    expect(result.current.total).toBe(0)
+    expect(result.current.searching).toBe(false)
+    expect(result.current.error).toBeUndefined()
+  })
+
+  it('executes search and returns results', async () => {
+    const mem = makeMemory({ content: 'Deployment procedure' })
+    vi.spyOn(memoryClient, 'searchMemories').mockResolvedValue({
+      memories: [mem],
+      total: 1,
+    })
+
+    const { result } = renderHook(() => useMemorySearch())
+
+    await act(() => result.current.search({ query: 'deployment' }))
+
+    await waitFor(() => expect(result.current.searching).toBe(false))
+    expect(result.current.results).toHaveLength(1)
+    expect(result.current.results[0].content).toBe('Deployment procedure')
+    expect(result.current.total).toBe(1)
+  })
+
+  it('passes all search parameters to the client', async () => {
+    const spy = vi.spyOn(memoryClient, 'searchMemories').mockResolvedValue({
+      memories: [],
+      total: 0,
+    })
+
+    const { result } = renderHook(() => useMemorySearch())
+
+    await act(() =>
+      result.current.search({
+        query: 'test',
+        as_actor: 'user-1',
+        type: 'question',
+        tags: ['important'],
+        limit: 5,
+      }),
+    )
+
+    expect(spy).toHaveBeenCalledWith({
+      query: 'test',
+      as_actor: 'user-1',
+      type: 'question',
+      tags: ['important'],
+      limit: 5,
+    })
+  })
+
+  it('sets error on search failure', async () => {
+    vi.spyOn(memoryClient, 'searchMemories').mockRejectedValue(
+      new Error('Vector search unavailable'),
+    )
+
+    const { result } = renderHook(() => useMemorySearch())
+
+    await act(() => result.current.search({ query: 'test' }))
+
+    await waitFor(() => expect(result.current.searching).toBe(false))
+    expect(result.current.error).toBe('Vector search unavailable')
+    expect(result.current.results).toHaveLength(0)
+    expect(mockApiError).toHaveBeenCalledWith(
+      expect.any(Error),
+      'Memory search failed',
+    )
+  })
+
+  it('clears results and error', async () => {
+    const mem = makeMemory()
+    vi.spyOn(memoryClient, 'searchMemories').mockResolvedValue({
+      memories: [mem],
+      total: 1,
+    })
+
+    const { result } = renderHook(() => useMemorySearch())
+
+    // Search first
+    await act(() => result.current.search({ query: 'test' }))
+    await waitFor(() => expect(result.current.results).toHaveLength(1))
+
+    // Then clear
+    act(() => result.current.clear())
+
+    expect(result.current.results).toHaveLength(0)
+    expect(result.current.total).toBe(0)
+    expect(result.current.error).toBeUndefined()
+  })
+
+  it('clears previous error on new search', async () => {
+    vi.spyOn(memoryClient, 'searchMemories')
+      .mockRejectedValueOnce(new Error('First failure'))
+      .mockResolvedValueOnce({ memories: [], total: 0 })
+
+    const { result } = renderHook(() => useMemorySearch())
+
+    // First search fails
+    await act(() => result.current.search({ query: 'bad' }))
+    await waitFor(() => expect(result.current.error).toBe('First failure'))
+
+    // Second search succeeds — error should be cleared
+    await act(() => result.current.search({ query: 'good' }))
+    await waitFor(() => expect(result.current.searching).toBe(false))
+    expect(result.current.error).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## Summary

- Adds `useMemories` hook with paginated listing, server-side filters (type, tag, visibility, created_by), client-side content search, column sorting, auto-refresh (30s), and CRUD actions (create, delete, updateVisibility) with toast error handling
- Adds `useMemorySearch` hook for semantic similarity search with loading/error state and clear/reset
- Adds URL search params helpers (`parseMemorySearchParams`, `buildMemorySearchParams`) for bookmarkable filter/pagination state
- Exports all new hooks and types from the hooks barrel file

## Test plan

- [x] 16 unit tests pass (10 for useMemories, 6 for useMemorySearch)
- [x] TypeScript type check passes clean (`tsc --noEmit`)
- [x] ESLint passes clean on new files
- [ ] Manual: verify hooks work with live memory service when UI pages are built

Closes #379

🤖 Generated with [Claude Code](https://claude.com/claude-code)