### PR TITLE
feat(ui): add memory create dialog and semantic search panel

### DIFF
--- a/ui/src/components/memories/CreateMemoryDialog.tsx
+++ b/ui/src/components/memories/CreateMemoryDialog.tsx
@@ -1,0 +1,343 @@
+/**
+ * CreateMemoryDialog — modal form for creating a new memory record.
+ *
+ * Fields:
+ * - Content (required) — multiline textarea
+ * - Memory type — dropdown (Information, Question, Request)
+ * - Tags — comma-separated input
+ * - Visibility — dropdown (Public, Shared, Private)
+ * - Shared with — text input (only shown when visibility is "Shared")
+ * - Created by — text input (required)
+ *
+ * Follows the WorkflowForm dialog pattern with:
+ * - Focus trap and ESC to close
+ * - Client-side validation
+ * - Success/error toast notifications
+ */
+
+import { useEffect, useRef, useState } from 'react'
+import { X } from 'lucide-react'
+import { FocusTrap } from '@/components/common/FocusTrap'
+import { useToast } from '@/hooks/useToast'
+import type { CreateMemoryRequest, MemoryType, VisibilityLevel } from '@/types/memory'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface CreateMemoryDialogProps {
+  open: boolean
+  onSave: (request: CreateMemoryRequest) => Promise<unknown>
+  onClose: () => void
+}
+
+interface FormErrors {
+  content?: string
+  created_by?: string
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const TYPE_OPTIONS: Array<{ value: MemoryType; label: string }> = [
+  { value: 'information', label: 'Information' },
+  { value: 'question', label: 'Question' },
+  { value: 'request', label: 'Request' },
+]
+
+const VISIBILITY_OPTIONS: Array<{ value: VisibilityLevel; label: string }> = [
+  { value: 'public', label: 'Public' },
+  { value: 'shared', label: 'Shared' },
+  { value: 'private', label: 'Private' },
+]
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function CreateMemoryDialog({ open, onSave, onClose }: CreateMemoryDialogProps) {
+  const contentRef = useRef<HTMLTextAreaElement>(null)
+  const toast = useToast()
+
+  // Form state
+  const [content, setContent] = useState('')
+  const [memoryType, setMemoryType] = useState<MemoryType>('information')
+  const [tagsRaw, setTagsRaw] = useState('')
+  const [visibility, setVisibility] = useState<VisibilityLevel>('public')
+  const [sharedWithRaw, setSharedWithRaw] = useState('')
+  const [createdBy, setCreatedBy] = useState('')
+  const [errors, setErrors] = useState<FormErrors>({})
+  const [saving, setSaving] = useState(false)
+  const [saveError, setSaveError] = useState<string | undefined>()
+
+  // Reset form when dialog opens/closes
+  useEffect(() => {
+    if (!open) return
+    setContent('')
+    setMemoryType('information')
+    setTagsRaw('')
+    setVisibility('public')
+    setSharedWithRaw('')
+    setCreatedBy('')
+    setErrors({})
+    setSaveError(undefined)
+    setSaving(false)
+    // Focus the textarea after render
+    setTimeout(() => contentRef.current?.focus(), 50)
+  }, [open])
+
+  if (!open) return null
+
+  // Validation
+  function validate(): FormErrors {
+    const e: FormErrors = {}
+    if (!content.trim()) e.content = 'Content is required'
+    if (!createdBy.trim()) e.created_by = 'Created by is required'
+    return e
+  }
+
+  // Submit
+  async function handleSave() {
+    const e = validate()
+    if (Object.keys(e).length > 0) {
+      setErrors(e)
+      return
+    }
+
+    setSaving(true)
+    setSaveError(undefined)
+    try {
+      const tags = tagsRaw
+        .split(',')
+        .map((t) => t.trim())
+        .filter(Boolean)
+
+      const sharedWith = visibility === 'shared'
+        ? sharedWithRaw
+            .split(',')
+            .map((s) => s.trim())
+            .filter(Boolean)
+        : undefined
+
+      const request: CreateMemoryRequest = {
+        content: content.trim(),
+        created_by: createdBy.trim(),
+        type: memoryType,
+        tags: tags.length > 0 ? tags : undefined,
+        visibility,
+        shared_with: sharedWith,
+      }
+
+      await onSave(request)
+      toast.success('Memory created')
+      onClose()
+    } catch (err) {
+      setSaveError(err instanceof Error ? err.message : 'Failed to create memory')
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+      {/* Backdrop */}
+      <div
+        className="absolute inset-0 bg-black/50"
+        onClick={onClose}
+        aria-hidden="true"
+      />
+
+      {/* Focus-trapped dialog panel */}
+      <FocusTrap active onEscape={onClose}>
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="create-memory-title"
+          className="relative z-10 w-full max-w-lg max-h-[90vh] overflow-y-auto rounded-xl bg-white dark:bg-gray-900 shadow-xl"
+        >
+          {/* Header */}
+          <div className="sticky top-0 z-10 flex items-center justify-between border-b border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 px-6 py-4">
+            <h2 id="create-memory-title" className="text-lg font-semibold text-gray-900 dark:text-white">
+              Create Memory
+            </h2>
+            <button
+              type="button"
+              onClick={onClose}
+              className="rounded p-1 text-gray-400 hover:text-gray-700 dark:hover:text-gray-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary-500"
+              aria-label="Close dialog"
+            >
+              <X size={18} />
+            </button>
+          </div>
+
+          {/* Body */}
+          <div className="px-6 py-5 space-y-4">
+            {saveError && (
+              <p className="rounded-md bg-red-50 dark:bg-red-900/20 px-3 py-2 text-sm text-red-700 dark:text-red-400">
+                {saveError}
+              </p>
+            )}
+
+            {/* Content */}
+            <div>
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                Content <span className="text-red-500">*</span>
+              </label>
+              <textarea
+                ref={contentRef}
+                value={content}
+                onChange={(e) => setContent(e.target.value)}
+                placeholder="Enter the memory content…"
+                rows={4}
+                className={fieldClass(errors.content)}
+              />
+              {errors.content && <p className="mt-1 text-xs text-red-500">{errors.content}</p>}
+            </div>
+
+            {/* Created by */}
+            <div>
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                Created by <span className="text-red-500">*</span>
+              </label>
+              <input
+                type="text"
+                value={createdBy}
+                onChange={(e) => setCreatedBy(e.target.value)}
+                placeholder="e.g. agent-1 or user@example.com"
+                className={fieldClass(errors.created_by)}
+              />
+              {errors.created_by && <p className="mt-1 text-xs text-red-500">{errors.created_by}</p>}
+            </div>
+
+            {/* Type + Visibility row */}
+            <div className="grid grid-cols-2 gap-3">
+              <div>
+                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                  Type
+                </label>
+                <select
+                  value={memoryType}
+                  onChange={(e) => setMemoryType(e.target.value as MemoryType)}
+                  className={fieldClass()}
+                >
+                  {TYPE_OPTIONS.map((opt) => (
+                    <option key={opt.value} value={opt.value}>
+                      {opt.label}
+                    </option>
+                  ))}
+                </select>
+              </div>
+
+              <div>
+                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                  Visibility
+                </label>
+                <select
+                  value={visibility}
+                  onChange={(e) => setVisibility(e.target.value as VisibilityLevel)}
+                  className={fieldClass()}
+                >
+                  {VISIBILITY_OPTIONS.map((opt) => (
+                    <option key={opt.value} value={opt.value}>
+                      {opt.label}
+                    </option>
+                  ))}
+                </select>
+              </div>
+            </div>
+
+            {/* Shared with (conditional) */}
+            {visibility === 'shared' && (
+              <div>
+                <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                  Shared with <span className="text-gray-400">(comma-separated)</span>
+                </label>
+                <input
+                  type="text"
+                  value={sharedWithRaw}
+                  onChange={(e) => setSharedWithRaw(e.target.value)}
+                  placeholder="e.g. agent-2, user@example.com"
+                  className={fieldClass()}
+                />
+              </div>
+            )}
+
+            {/* Tags */}
+            <div>
+              <label className="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1">
+                Tags <span className="text-gray-400">(comma-separated)</span>
+              </label>
+              <input
+                type="text"
+                value={tagsRaw}
+                onChange={(e) => setTagsRaw(e.target.value)}
+                placeholder="e.g. deployment, api, critical"
+                className={fieldClass()}
+              />
+              {/* Tag preview chips */}
+              {tagsRaw.trim() && (
+                <div className="mt-2 flex flex-wrap gap-1.5">
+                  {tagsRaw
+                    .split(',')
+                    .map((t) => t.trim())
+                    .filter(Boolean)
+                    .map((tag, i) => (
+                      <span
+                        key={`${tag}-${i}`}
+                        className="rounded-full bg-gray-200 dark:bg-gray-700 px-2 py-0.5 text-[11px] font-medium text-gray-700 dark:text-gray-300"
+                      >
+                        {tag}
+                      </span>
+                    ))}
+                </div>
+              )}
+            </div>
+          </div>
+
+          {/* Footer */}
+          <div className="sticky bottom-0 flex items-center justify-end gap-3 border-t border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 px-6 py-4">
+            <button
+              type="button"
+              onClick={onClose}
+              disabled={saving}
+              className="rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 hover:bg-gray-50 dark:hover:bg-gray-700 transition-colors disabled:opacity-50"
+            >
+              Cancel
+            </button>
+            <button
+              type="button"
+              onClick={handleSave}
+              disabled={saving}
+              className="rounded-md bg-primary-600 px-4 py-2 text-sm font-medium text-white hover:bg-primary-700 transition-colors disabled:opacity-50"
+            >
+              {saving ? 'Creating…' : 'Create memory'}
+            </button>
+          </div>
+        </div>
+      </FocusTrap>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Style helpers
+// ---------------------------------------------------------------------------
+
+function fieldClass(error?: string, extra = ''): string {
+  return [
+    'w-full rounded-md border px-3 py-2 text-sm',
+    'bg-white dark:bg-gray-900',
+    'text-gray-900 dark:text-white',
+    'focus:outline-none focus:ring-2 focus:ring-primary-500',
+    'disabled:cursor-not-allowed disabled:opacity-50',
+    error
+      ? 'border-red-400 dark:border-red-500'
+      : 'border-gray-300 dark:border-gray-600',
+    extra,
+  ]
+    .filter(Boolean)
+    .join(' ')
+}
+
+export default CreateMemoryDialog

--- a/ui/src/components/memories/MemorySearch.tsx
+++ b/ui/src/components/memories/MemorySearch.tsx
@@ -1,0 +1,295 @@
+/**
+ * MemorySearch — semantic similarity search panel for memories.
+ *
+ * Features:
+ * - Search input with submit button (Enter key or click)
+ * - Expandable advanced filters (type, tag, date range, limit)
+ * - Results displayed as MemoryCard components
+ * - Loading spinner during search
+ * - Empty state when no results found
+ * - Clear/reset button to return to default list view
+ */
+
+import { useState } from 'react'
+import { ChevronDown, ChevronRight, Loader2, Search, X } from 'lucide-react'
+import { useMemorySearch } from '@/hooks/useMemorySearch'
+import { MemoryCard } from '@/components/memories/MemoryCard'
+import type { Memory, MemoryType, SearchRequest } from '@/types/memory'
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface MemorySearchProps {
+  /** Called when the user wants to switch back to list view. */
+  onSwitchToList: () => void
+  /** Called when user clicks edit visibility on a search result. */
+  onEditVisibility: (memory: Memory) => void
+  /** Called when user clicks delete on a search result. */
+  onDelete: (id: string) => void
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const TYPE_OPTIONS: Array<{ value: MemoryType | ''; label: string }> = [
+  { value: '', label: 'Any type' },
+  { value: 'information', label: 'Information' },
+  { value: 'question', label: 'Question' },
+  { value: 'request', label: 'Request' },
+]
+
+const LIMIT_OPTIONS = [5, 10, 20, 50]
+
+const selectClass =
+  'rounded-md border border-gray-600 bg-gray-800 px-3 py-1.5 text-sm text-gray-300 focus:outline-none focus:ring-2 focus:ring-primary-500'
+
+const inputClass =
+  'rounded-md border border-gray-600 bg-gray-800 px-3 py-1.5 text-sm text-gray-300 placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-primary-500'
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function MemorySearch({
+  onSwitchToList,
+  onEditVisibility,
+  onDelete,
+}: MemorySearchProps) {
+  const { results, total, searching, error, search, clear } = useMemorySearch()
+
+  // Search form state
+  const [query, setQuery] = useState('')
+  const [showAdvanced, setShowAdvanced] = useState(false)
+  const [filterType, setFilterType] = useState<MemoryType | ''>('')
+  const [filterTag, setFilterTag] = useState('')
+  const [filterFrom, setFilterFrom] = useState('')
+  const [filterTo, setFilterTo] = useState('')
+  const [limit, setLimit] = useState(10)
+  const [hasSearched, setHasSearched] = useState(false)
+
+  const handleSearch = () => {
+    if (!query.trim()) return
+    const request: SearchRequest = {
+      query: query.trim(),
+      limit,
+      ...(filterType ? { type: filterType } : {}),
+      ...(filterTag ? { tags: filterTag.split(',').map((t) => t.trim()).filter(Boolean) } : {}),
+      ...(filterFrom ? { from: filterFrom } : {}),
+      ...(filterTo ? { to: filterTo } : {}),
+    }
+    search(request)
+    setHasSearched(true)
+  }
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter') handleSearch()
+  }
+
+  const handleClear = () => {
+    setQuery('')
+    setFilterType('')
+    setFilterTag('')
+    setFilterFrom('')
+    setFilterTo('')
+    setLimit(10)
+    setHasSearched(false)
+    clear()
+  }
+
+  const handleBackToList = () => {
+    handleClear()
+    onSwitchToList()
+  }
+
+  return (
+    <div>
+      {/* Search input row */}
+      <div className="flex items-center gap-2 mb-3">
+        <div className="relative flex-1">
+          <Search size={16} className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400" aria-hidden="true" />
+          <input
+            type="text"
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder="Semantic search across memories…"
+            aria-label="Semantic search query"
+            className="w-full rounded-md border border-gray-600 bg-gray-800 pl-9 pr-3 py-2 text-sm text-gray-300 placeholder-gray-500 focus:outline-none focus:ring-2 focus:ring-primary-500"
+          />
+        </div>
+
+        <button
+          type="button"
+          onClick={handleSearch}
+          disabled={!query.trim() || searching}
+          className="rounded-md bg-primary-600 px-4 py-2 text-sm font-medium text-white hover:bg-primary-500 disabled:opacity-50 transition-colors"
+        >
+          {searching ? (
+            <Loader2 size={16} className="animate-spin" />
+          ) : (
+            'Search'
+          )}
+        </button>
+
+        {hasSearched && (
+          <button
+            type="button"
+            onClick={handleClear}
+            aria-label="Clear search"
+            className="rounded-md p-2 text-gray-400 hover:bg-gray-700 hover:text-white transition-colors"
+          >
+            <X size={16} />
+          </button>
+        )}
+      </div>
+
+      {/* Advanced filters toggle */}
+      <button
+        type="button"
+        onClick={() => setShowAdvanced((v) => !v)}
+        aria-expanded={showAdvanced}
+        className="mb-3 flex items-center gap-1 text-xs text-gray-400 hover:text-gray-300"
+      >
+        {showAdvanced ? (
+          <ChevronDown size={12} aria-hidden="true" />
+        ) : (
+          <ChevronRight size={12} aria-hidden="true" />
+        )}
+        Advanced filters
+      </button>
+
+      {/* Advanced filters panel */}
+      {showAdvanced && (
+        <div className="mb-4 flex flex-wrap items-center gap-2 rounded-lg border border-gray-700 bg-gray-800/50 p-3">
+          {/* Type filter */}
+          <select
+            aria-label="Filter by type"
+            value={filterType}
+            onChange={(e) => setFilterType(e.target.value as MemoryType | '')}
+            className={selectClass}
+          >
+            {TYPE_OPTIONS.map((opt) => (
+              <option key={opt.value} value={opt.value}>
+                {opt.label}
+              </option>
+            ))}
+          </select>
+
+          {/* Tag filter */}
+          <input
+            type="text"
+            aria-label="Filter by tags"
+            placeholder="Tags…"
+            value={filterTag}
+            onChange={(e) => setFilterTag(e.target.value)}
+            className={[inputClass, 'w-28'].join(' ')}
+          />
+
+          {/* From date */}
+          <input
+            type="date"
+            aria-label="From date"
+            value={filterFrom}
+            onChange={(e) => setFilterFrom(e.target.value)}
+            className={[inputClass, 'w-36'].join(' ')}
+          />
+
+          {/* To date */}
+          <input
+            type="date"
+            aria-label="To date"
+            value={filterTo}
+            onChange={(e) => setFilterTo(e.target.value)}
+            className={[inputClass, 'w-36'].join(' ')}
+          />
+
+          {/* Limit */}
+          <select
+            aria-label="Result limit"
+            value={limit}
+            onChange={(e) => setLimit(Number(e.target.value))}
+            className={selectClass}
+          >
+            {LIMIT_OPTIONS.map((n) => (
+              <option key={n} value={n}>
+                Max {n}
+              </option>
+            ))}
+          </select>
+        </div>
+      )}
+
+      {/* Back to list link */}
+      <div className="mb-4">
+        <button
+          type="button"
+          onClick={handleBackToList}
+          className="text-xs text-primary-400 hover:text-primary-300 transition-colors"
+        >
+          ← Back to memory list
+        </button>
+      </div>
+
+      {/* Search loading */}
+      {searching && (
+        <div className="flex items-center justify-center gap-2 py-12 text-sm text-gray-400">
+          <Loader2 size={16} className="animate-spin" />
+          Searching memories…
+        </div>
+      )}
+
+      {/* Search error */}
+      {!searching && error && (
+        <div className="rounded-lg border border-red-800 bg-red-900/20 px-4 py-3 text-sm text-red-400">
+          {error}
+        </div>
+      )}
+
+      {/* No results */}
+      {!searching && !error && hasSearched && results.length === 0 && (
+        <div className="py-12 text-center">
+          <Search size={32} className="mx-auto mb-3 text-gray-600" aria-hidden="true" />
+          <p className="text-gray-400">No matching memories found</p>
+          <p className="mt-1 text-xs text-gray-600">
+            Try a different query or adjust the advanced filters.
+          </p>
+        </div>
+      )}
+
+      {/* Search results */}
+      {!searching && results.length > 0 && (
+        <>
+          <div className="mb-3 text-xs text-gray-500">
+            {total} result{total !== 1 ? 's' : ''} for &ldquo;{query}&rdquo;
+          </div>
+          <ul className="space-y-3" aria-label="Search results">
+            {results.map((m) => (
+              <li key={m.id}>
+                <MemoryCard
+                  memory={m}
+                  onEditVisibility={onEditVisibility}
+                  onDelete={onDelete}
+                />
+              </li>
+            ))}
+          </ul>
+        </>
+      )}
+
+      {/* Initial state (before any search) */}
+      {!searching && !error && !hasSearched && (
+        <div className="py-12 text-center">
+          <Search size={32} className="mx-auto mb-3 text-gray-600" aria-hidden="true" />
+          <p className="text-gray-400">Enter a query to search memories</p>
+          <p className="mt-1 text-xs text-gray-600">
+            Uses semantic similarity to find the most relevant memories.
+          </p>
+        </div>
+      )}
+    </div>
+  )
+}
+
+export default MemorySearch

--- a/ui/src/pages/memories/MemoryList.tsx
+++ b/ui/src/pages/memories/MemoryList.tsx
@@ -2,17 +2,19 @@
  * MemoryList — full memory management page.
  *
  * Features:
+ * - Tab toggle between Browse (list) and Semantic Search modes
  * - Filter by type, visibility, creator, tag, and content search
  * - Sort by created_at, updated_at, type
  * - Paginated list of memory cards
- * - Create, delete, and edit visibility actions
+ * - Create memory dialog
+ * - Delete confirmation dialog
  * - URL query param sync for filters/sort/pagination
  * - Loading skeleton, error state, and empty state
  */
 
 import { useEffect, useState } from 'react'
 import { useSearchParams } from 'react-router-dom'
-import { Brain, Plus, RefreshCw } from 'lucide-react'
+import { Brain, List, Plus, RefreshCw, Search } from 'lucide-react'
 import {
   useMemories,
   type MemoryFilters as MemoryFiltersType,
@@ -21,10 +23,18 @@ import {
 } from '@/hooks/useMemories'
 import { MemoryCard } from '@/components/memories/MemoryCard'
 import { MemoryFilters } from '@/components/memories/MemoryFilters'
+import { MemorySearch } from '@/components/memories/MemorySearch'
+import { CreateMemoryDialog } from '@/components/memories/CreateMemoryDialog'
 import { Pagination } from '@/components/common/Pagination'
 import { ConfirmDialog } from '@/components/common/ConfirmDialog'
 import { CardSkeleton } from '@/components/common/LoadingSkeleton'
 import type { Memory } from '@/types/memory'
+
+// ---------------------------------------------------------------------------
+// View mode
+// ---------------------------------------------------------------------------
+
+type ViewMode = 'list' | 'search'
 
 // ---------------------------------------------------------------------------
 // URL sync helpers
@@ -49,6 +59,11 @@ function sortDirFromParam(p: string | null): MemorySortDir {
   return 'desc'
 }
 
+function viewModeFromParam(p: string | null): ViewMode {
+  if (p === 'search') return 'search'
+  return 'list'
+}
+
 // ---------------------------------------------------------------------------
 // Constants
 // ---------------------------------------------------------------------------
@@ -61,6 +76,11 @@ const DEFAULT_PAGE_SIZE = 20
 
 export function MemoryList() {
   const [searchParams, setSearchParams] = useSearchParams()
+
+  // View mode
+  const [viewMode, setViewModeState] = useState<ViewMode>(() =>
+    viewModeFromParam(searchParams.get('view')),
+  )
 
   // State initialised from URL params
   const [filters, setFiltersState] = useState<MemoryFiltersType>(() =>
@@ -78,6 +98,7 @@ export function MemoryList() {
   // Sync state → URL
   useEffect(() => {
     const params: Record<string, string> = {}
+    if (viewMode !== 'list') params['view'] = viewMode
     if (filters.type) params['type'] = filters.type
     if (filters.visibility) params['visibility'] = filters.visibility
     if (filters.created_by) params['created_by'] = filters.created_by
@@ -87,7 +108,7 @@ export function MemoryList() {
     if (sortDir !== 'desc') params['sortDir'] = sortDir
     if (page > 1) params['page'] = String(page)
     setSearchParams(params, { replace: true })
-  }, [filters, search, sortBy, sortDir, page, setSearchParams])
+  }, [viewMode, filters, search, sortBy, sortDir, page, setSearchParams])
 
   // Reset page to 1 when filters change
   const setFilters = (f: MemoryFiltersType) => {
@@ -101,6 +122,10 @@ export function MemoryList() {
   const setSort = (field: MemorySortField, dir: MemorySortDir) => {
     setSortByState(field)
     setSortDirState(dir)
+    setPageState(1)
+  }
+  const setViewMode = (mode: ViewMode) => {
+    setViewModeState(mode)
     setPageState(1)
   }
 
@@ -122,9 +147,14 @@ export function MemoryList() {
     pageSize: DEFAULT_PAGE_SIZE,
     sortBy,
     sortDir,
+    // Pause auto-refresh when in search view (search has its own fetch)
+    paused: viewMode === 'search',
   })
 
   const totalPages = Math.ceil(total / DEFAULT_PAGE_SIZE)
+
+  // Create dialog state
+  const [showCreateDialog, setShowCreateDialog] = useState(false)
 
   // Delete confirmation state
   const [deleteTarget, setDeleteTarget] = useState<string | null>(null)
@@ -143,20 +173,7 @@ export function MemoryList() {
 
   // Edit visibility — placeholder for future dialog
   const handleEditVisibility = (_memory: Memory) => {
-    // TODO: Open visibility edit dialog (issue #381+)
-    // For now this is a no-op; the button is wired up for future use
-  }
-
-  // Quick create — placeholder for future dialog
-  const handleCreate = async () => {
-    // TODO: Open create memory dialog (issue #381+)
-    // Demo: create a sample memory to verify the flow works
-    await createMemory({
-      content: 'New memory created from the UI',
-      created_by: 'ui-user',
-      type: 'information',
-      tags: ['ui'],
-    })
+    // TODO: Open visibility edit dialog (future issue)
   }
 
   return (
@@ -164,131 +181,192 @@ export function MemoryList() {
       {/* Page header */}
       <div className="mb-6 flex flex-wrap items-center gap-3">
         <h1 className="text-xl font-semibold text-gray-900 dark:text-white">Memories</h1>
-        <span className="rounded-full bg-gray-700 px-2.5 py-0.5 text-xs font-medium text-gray-300">
-          {total}
-        </span>
+        {viewMode === 'list' && (
+          <span className="rounded-full bg-gray-700 px-2.5 py-0.5 text-xs font-medium text-gray-300">
+            {total}
+          </span>
+        )}
         <div className="flex-1" />
+
+        {/* View mode toggle */}
+        <div className="flex rounded-md border border-gray-600" role="group" aria-label="View mode">
+          <button
+            type="button"
+            onClick={() => setViewMode('list')}
+            aria-pressed={viewMode === 'list'}
+            className={[
+              'flex items-center gap-1.5 rounded-l-md px-3 py-1.5 text-xs font-medium transition-colors',
+              viewMode === 'list'
+                ? 'bg-primary-600 text-white'
+                : 'bg-gray-800 text-gray-400 hover:text-white',
+            ].join(' ')}
+          >
+            <List size={14} aria-hidden="true" />
+            Browse
+          </button>
+          <button
+            type="button"
+            onClick={() => setViewMode('search')}
+            aria-pressed={viewMode === 'search'}
+            className={[
+              'flex items-center gap-1.5 rounded-r-md px-3 py-1.5 text-xs font-medium transition-colors',
+              viewMode === 'search'
+                ? 'bg-primary-600 text-white'
+                : 'bg-gray-800 text-gray-400 hover:text-white',
+            ].join(' ')}
+          >
+            <Search size={14} aria-hidden="true" />
+            Search
+          </button>
+        </div>
 
         {/* Create button */}
         <button
           type="button"
-          onClick={handleCreate}
+          onClick={() => setShowCreateDialog(true)}
           className="flex items-center gap-1.5 rounded-md bg-primary-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-primary-500 transition-colors"
         >
           <Plus size={14} aria-hidden="true" />
           New Memory
         </button>
 
-        {/* Refresh */}
-        <button
-          type="button"
-          onClick={refetch}
-          aria-label="Refresh memories"
-          className={[
-            'rounded-md p-2 text-gray-400 hover:bg-gray-700 hover:text-white transition-colors',
-            refreshing ? 'animate-spin' : '',
-          ].join(' ')}
-        >
-          <RefreshCw size={16} />
-        </button>
-      </div>
-
-      {/* Filters row */}
-      <div className="mb-4">
-        <MemoryFilters
-          filters={filters}
-          sortBy={sortBy}
-          sortDir={sortDir}
-          search={search}
-          onFiltersChange={setFilters}
-          onSortChange={setSort}
-          onSearchChange={setSearch}
-        />
-      </div>
-
-      {/* Count summary */}
-      {!loading && !error && memories.length > 0 && (
-        <div className="mb-4 flex items-center rounded-lg border border-gray-700 bg-gray-800 px-4 py-2">
-          <span className="text-xs text-gray-500">
-            {total} memor{total !== 1 ? 'ies' : 'y'}
-            {search && ` matching "${search}"`}
-          </span>
-        </div>
-      )}
-
-      {/* Loading state */}
-      {loading && (
-        <div className="space-y-3">
-          {Array.from({ length: 3 }).map((_, i) => (
-            <CardSkeleton key={i} />
-          ))}
-        </div>
-      )}
-
-      {/* Error state */}
-      {!loading && error && (
-        <div className="rounded-lg border border-red-800 bg-red-900/20 px-4 py-3 text-sm text-red-400">
-          <p>{error}</p>
+        {/* Refresh (list mode only) */}
+        {viewMode === 'list' && (
           <button
             type="button"
             onClick={refetch}
-            className="mt-2 rounded-md px-3 py-1 text-xs font-medium bg-red-900/40 text-red-300 hover:bg-red-900/60 transition-colors"
+            aria-label="Refresh memories"
+            className={[
+              'rounded-md p-2 text-gray-400 hover:bg-gray-700 hover:text-white transition-colors',
+              refreshing ? 'animate-spin' : '',
+            ].join(' ')}
           >
-            Retry
+            <RefreshCw size={16} />
           </button>
-        </div>
+        )}
+      </div>
+
+      {/* ============================================================ */}
+      {/* Search mode                                                  */}
+      {/* ============================================================ */}
+      {viewMode === 'search' && (
+        <MemorySearch
+          onSwitchToList={() => setViewMode('list')}
+          onEditVisibility={handleEditVisibility}
+          onDelete={setDeleteTarget}
+        />
       )}
 
-      {/* Empty state */}
-      {!loading && !error && memories.length === 0 && (
-        <div className="py-16 text-center">
-          <Brain size={40} className="mx-auto mb-3 text-gray-600" aria-hidden="true" />
-          <p className="text-gray-400">No memories found</p>
-          <p className="mt-1 text-xs text-gray-600">
-            {search || filters.type || filters.visibility || filters.tag || filters.created_by
-              ? 'Try adjusting your filters or search query.'
-              : 'Get started by creating your first memory.'}
-          </p>
-          {!search && !filters.type && !filters.visibility && (
-            <button
-              type="button"
-              onClick={handleCreate}
-              className="mt-4 inline-flex items-center gap-1.5 rounded-md bg-primary-600 px-4 py-2 text-sm font-medium text-white hover:bg-primary-500 transition-colors"
-            >
-              <Plus size={14} aria-hidden="true" />
-              Create Memory
-            </button>
+      {/* ============================================================ */}
+      {/* List mode                                                    */}
+      {/* ============================================================ */}
+      {viewMode === 'list' && (
+        <>
+          {/* Filters row */}
+          <div className="mb-4">
+            <MemoryFilters
+              filters={filters}
+              sortBy={sortBy}
+              sortDir={sortDir}
+              search={search}
+              onFiltersChange={setFilters}
+              onSortChange={setSort}
+              onSearchChange={setSearch}
+            />
+          </div>
+
+          {/* Count summary */}
+          {!loading && !error && memories.length > 0 && (
+            <div className="mb-4 flex items-center rounded-lg border border-gray-700 bg-gray-800 px-4 py-2">
+              <span className="text-xs text-gray-500">
+                {total} memor{total !== 1 ? 'ies' : 'y'}
+                {search && ` matching "${search}"`}
+              </span>
+            </div>
           )}
-        </div>
-      )}
 
-      {/* Memory list */}
-      {!loading && memories.length > 0 && (
-        <ul className="space-y-3" aria-label="Memories">
-          {memories.map((m) => (
-            <li key={m.id}>
-              <MemoryCard
-                memory={m}
-                onEditVisibility={handleEditVisibility}
-                onDelete={setDeleteTarget}
+          {/* Loading state */}
+          {loading && (
+            <div className="space-y-3">
+              {Array.from({ length: 3 }).map((_, i) => (
+                <CardSkeleton key={i} />
+              ))}
+            </div>
+          )}
+
+          {/* Error state */}
+          {!loading && error && (
+            <div className="rounded-lg border border-red-800 bg-red-900/20 px-4 py-3 text-sm text-red-400">
+              <p>{error}</p>
+              <button
+                type="button"
+                onClick={refetch}
+                className="mt-2 rounded-md px-3 py-1 text-xs font-medium bg-red-900/40 text-red-300 hover:bg-red-900/60 transition-colors"
+              >
+                Retry
+              </button>
+            </div>
+          )}
+
+          {/* Empty state */}
+          {!loading && !error && memories.length === 0 && (
+            <div className="py-16 text-center">
+              <Brain size={40} className="mx-auto mb-3 text-gray-600" aria-hidden="true" />
+              <p className="text-gray-400">No memories found</p>
+              <p className="mt-1 text-xs text-gray-600">
+                {search || filters.type || filters.visibility || filters.tag || filters.created_by
+                  ? 'Try adjusting your filters or search query.'
+                  : 'Get started by creating your first memory.'}
+              </p>
+              {!search && !filters.type && !filters.visibility && (
+                <button
+                  type="button"
+                  onClick={() => setShowCreateDialog(true)}
+                  className="mt-4 inline-flex items-center gap-1.5 rounded-md bg-primary-600 px-4 py-2 text-sm font-medium text-white hover:bg-primary-500 transition-colors"
+                >
+                  <Plus size={14} aria-hidden="true" />
+                  Create Memory
+                </button>
+              )}
+            </div>
+          )}
+
+          {/* Memory list */}
+          {!loading && memories.length > 0 && (
+            <ul className="space-y-3" aria-label="Memories">
+              {memories.map((m) => (
+                <li key={m.id}>
+                  <MemoryCard
+                    memory={m}
+                    onEditVisibility={handleEditVisibility}
+                    onDelete={setDeleteTarget}
+                  />
+                </li>
+              ))}
+            </ul>
+          )}
+
+          {/* Pagination */}
+          {!loading && totalPages > 1 && (
+            <div className="mt-6">
+              <Pagination
+                page={page}
+                totalPages={totalPages}
+                totalItems={total}
+                pageSize={DEFAULT_PAGE_SIZE}
+                onPageChange={setPageState}
               />
-            </li>
-          ))}
-        </ul>
+            </div>
+          )}
+        </>
       )}
 
-      {/* Pagination */}
-      {!loading && totalPages > 1 && (
-        <div className="mt-6">
-          <Pagination
-            page={page}
-            totalPages={totalPages}
-            totalItems={total}
-            pageSize={DEFAULT_PAGE_SIZE}
-            onPageChange={setPageState}
-          />
-        </div>
-      )}
+      {/* Create memory dialog */}
+      <CreateMemoryDialog
+        open={showCreateDialog}
+        onSave={createMemory}
+        onClose={() => setShowCreateDialog(false)}
+      />
 
       {/* Delete confirmation dialog */}
       <ConfirmDialog

--- a/ui/src/test/components/memories/CreateMemoryDialog.test.tsx
+++ b/ui/src/test/components/memories/CreateMemoryDialog.test.tsx
@@ -1,0 +1,164 @@
+/**
+ * Tests for CreateMemoryDialog component.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { CreateMemoryDialog } from '@/components/memories/CreateMemoryDialog'
+
+// Mock useToast
+const mockSuccess = vi.fn()
+vi.mock('@/hooks/useToast', () => ({
+  useToast: () => ({
+    success: mockSuccess,
+    error: vi.fn(),
+    warning: vi.fn(),
+    info: vi.fn(),
+    dismiss: vi.fn(),
+    clear: vi.fn(),
+    apiError: vi.fn(),
+  }),
+  mapApiError: (err: unknown) =>
+    err instanceof Error ? err.message : String(err),
+}))
+
+// Mock useFocusTrap (just render children)
+vi.mock('@/hooks/useFocusTrap', () => ({
+  useFocusTrap: () => ({ current: null }),
+}))
+
+describe('CreateMemoryDialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('does not render when closed', () => {
+    render(
+      <CreateMemoryDialog open={false} onSave={vi.fn()} onClose={vi.fn()} />,
+    )
+    expect(screen.queryByText('Create Memory')).toBeNull()
+  })
+
+  it('renders form fields when open', () => {
+    render(
+      <CreateMemoryDialog open={true} onSave={vi.fn()} onClose={vi.fn()} />,
+    )
+    expect(screen.getByText('Create Memory')).toBeTruthy()
+    expect(screen.getByPlaceholderText('Enter the memory content…')).toBeTruthy()
+    expect(screen.getByPlaceholderText(/agent-1 or user/)).toBeTruthy()
+    expect(screen.getByPlaceholderText(/deployment, api/)).toBeTruthy()
+    expect(screen.getByText('Create memory')).toBeTruthy()
+    expect(screen.getByText('Cancel')).toBeTruthy()
+  })
+
+  it('shows validation errors when submitting empty form', async () => {
+    render(
+      <CreateMemoryDialog open={true} onSave={vi.fn()} onClose={vi.fn()} />,
+    )
+    fireEvent.click(screen.getByText('Create memory'))
+    expect(screen.getByText('Content is required')).toBeTruthy()
+    expect(screen.getByText('Created by is required')).toBeTruthy()
+  })
+
+  it('calls onSave with form data on valid submit', async () => {
+    const onSave = vi.fn().mockResolvedValue({})
+    const onClose = vi.fn()
+    render(
+      <CreateMemoryDialog open={true} onSave={onSave} onClose={onClose} />,
+    )
+
+    fireEvent.change(screen.getByPlaceholderText('Enter the memory content…'), {
+      target: { value: 'Test memory content' },
+    })
+    fireEvent.change(screen.getByPlaceholderText(/agent-1 or user/), {
+      target: { value: 'test-user' },
+    })
+    fireEvent.change(screen.getByPlaceholderText(/deployment, api/), {
+      target: { value: 'tag1, tag2' },
+    })
+
+    fireEvent.click(screen.getByText('Create memory'))
+
+    await waitFor(() => {
+      expect(onSave).toHaveBeenCalledWith(
+        expect.objectContaining({
+          content: 'Test memory content',
+          created_by: 'test-user',
+          type: 'information',
+          tags: ['tag1', 'tag2'],
+          visibility: 'public',
+        }),
+      )
+    })
+
+    await waitFor(() => {
+      expect(mockSuccess).toHaveBeenCalledWith('Memory created')
+      expect(onClose).toHaveBeenCalled()
+    })
+  })
+
+  it('shows shared_with field when visibility is shared', () => {
+    render(
+      <CreateMemoryDialog open={true} onSave={vi.fn()} onClose={vi.fn()} />,
+    )
+    // Initially no shared_with field
+    expect(screen.queryByPlaceholderText(/agent-2, user/)).toBeNull()
+
+    // Change visibility to shared
+    const visibilitySelect = screen.getAllByRole('combobox').find(
+      (el) => (el as HTMLSelectElement).value === 'public',
+    )
+    fireEvent.change(visibilitySelect!, { target: { value: 'shared' } })
+
+    // Now shared_with field should appear
+    expect(screen.getByPlaceholderText(/agent-2, user/)).toBeTruthy()
+  })
+
+  it('shows tag preview chips', () => {
+    render(
+      <CreateMemoryDialog open={true} onSave={vi.fn()} onClose={vi.fn()} />,
+    )
+    fireEvent.change(screen.getByPlaceholderText(/deployment, api/), {
+      target: { value: 'alpha, beta' },
+    })
+    expect(screen.getByText('alpha')).toBeTruthy()
+    expect(screen.getByText('beta')).toBeTruthy()
+  })
+
+  it('shows save error message on failure', async () => {
+    const onSave = vi.fn().mockRejectedValue(new Error('Server error'))
+    render(
+      <CreateMemoryDialog open={true} onSave={onSave} onClose={vi.fn()} />,
+    )
+
+    fireEvent.change(screen.getByPlaceholderText('Enter the memory content…'), {
+      target: { value: 'Content' },
+    })
+    fireEvent.change(screen.getByPlaceholderText(/agent-1 or user/), {
+      target: { value: 'user' },
+    })
+    fireEvent.click(screen.getByText('Create memory'))
+
+    await waitFor(() => {
+      expect(screen.getByText('Server error')).toBeTruthy()
+    })
+  })
+
+  it('calls onClose when Cancel is clicked', () => {
+    const onClose = vi.fn()
+    render(
+      <CreateMemoryDialog open={true} onSave={vi.fn()} onClose={onClose} />,
+    )
+    fireEvent.click(screen.getByText('Cancel'))
+    expect(onClose).toHaveBeenCalled()
+  })
+
+  it('calls onClose when close button is clicked', () => {
+    const onClose = vi.fn()
+    render(
+      <CreateMemoryDialog open={true} onSave={vi.fn()} onClose={onClose} />,
+    )
+    fireEvent.click(screen.getByLabelText('Close dialog'))
+    expect(onClose).toHaveBeenCalled()
+  })
+})

--- a/ui/src/test/components/memories/MemorySearch.test.tsx
+++ b/ui/src/test/components/memories/MemorySearch.test.tsx
@@ -1,0 +1,190 @@
+/**
+ * Tests for MemorySearch component.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { MemorySearch } from '@/components/memories/MemorySearch'
+import { memoryClient } from '@/services/memory'
+import type { Memory } from '@/types/memory'
+
+// Mock useToast
+vi.mock('@/hooks/useToast', () => ({
+  useToast: () => ({
+    success: vi.fn(),
+    error: vi.fn(),
+    warning: vi.fn(),
+    info: vi.fn(),
+    dismiss: vi.fn(),
+    clear: vi.fn(),
+    apiError: vi.fn(),
+  }),
+  mapApiError: (err: unknown) =>
+    err instanceof Error ? err.message : String(err),
+}))
+
+function makeMemory(overrides: Partial<Memory> = {}): Memory {
+  return {
+    id: 'mem_123',
+    content: 'Search result memory',
+    type: 'information',
+    tags: ['test'],
+    created_by: 'agent-1',
+    owner: undefined,
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+    visibility: 'public',
+    shared_with: [],
+    references: [],
+    ...overrides,
+  }
+}
+
+describe('MemorySearch', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  const defaultProps = {
+    onSwitchToList: vi.fn(),
+    onEditVisibility: vi.fn(),
+    onDelete: vi.fn(),
+  }
+
+  it('renders search input and initial state', () => {
+    render(<MemorySearch {...defaultProps} />)
+    expect(screen.getByLabelText('Semantic search query')).toBeTruthy()
+    expect(screen.getByText('Search')).toBeTruthy()
+    expect(screen.getByText('Enter a query to search memories')).toBeTruthy()
+  })
+
+  it('disables search button when query is empty', () => {
+    render(<MemorySearch {...defaultProps} />)
+    const button = screen.getByText('Search')
+    expect((button as HTMLButtonElement).disabled).toBe(true)
+  })
+
+  it('executes search on button click', async () => {
+    const mem = makeMemory({ content: 'Deployment procedure' })
+    vi.spyOn(memoryClient, 'searchMemories').mockResolvedValue({
+      memories: [mem],
+      total: 1,
+    })
+
+    render(<MemorySearch {...defaultProps} />)
+
+    fireEvent.change(screen.getByLabelText('Semantic search query'), {
+      target: { value: 'deployment' },
+    })
+    fireEvent.click(screen.getByText('Search'))
+
+    await waitFor(() => {
+      expect(screen.getByText('Deployment procedure')).toBeTruthy()
+    })
+    expect(screen.getByText(/1 result/)).toBeTruthy()
+  })
+
+  it('executes search on Enter key', async () => {
+    vi.spyOn(memoryClient, 'searchMemories').mockResolvedValue({
+      memories: [],
+      total: 0,
+    })
+
+    render(<MemorySearch {...defaultProps} />)
+
+    const input = screen.getByLabelText('Semantic search query')
+    fireEvent.change(input, { target: { value: 'test query' } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+
+    await waitFor(() => {
+      expect(memoryClient.searchMemories).toHaveBeenCalledWith(
+        expect.objectContaining({ query: 'test query' }),
+      )
+    })
+  })
+
+  it('shows no results message', async () => {
+    vi.spyOn(memoryClient, 'searchMemories').mockResolvedValue({
+      memories: [],
+      total: 0,
+    })
+
+    render(<MemorySearch {...defaultProps} />)
+
+    fireEvent.change(screen.getByLabelText('Semantic search query'), {
+      target: { value: 'nonexistent' },
+    })
+    fireEvent.click(screen.getByText('Search'))
+
+    await waitFor(() => {
+      expect(screen.getByText('No matching memories found')).toBeTruthy()
+    })
+  })
+
+  it('shows error on search failure', async () => {
+    vi.spyOn(memoryClient, 'searchMemories').mockRejectedValue(
+      new Error('Search unavailable'),
+    )
+
+    render(<MemorySearch {...defaultProps} />)
+
+    fireEvent.change(screen.getByLabelText('Semantic search query'), {
+      target: { value: 'test' },
+    })
+    fireEvent.click(screen.getByText('Search'))
+
+    await waitFor(() => {
+      expect(screen.getByText('Search unavailable')).toBeTruthy()
+    })
+  })
+
+  it('toggles advanced filters', () => {
+    render(<MemorySearch {...defaultProps} />)
+
+    expect(screen.queryByLabelText('Filter by type')).toBeNull()
+
+    fireEvent.click(screen.getByText('Advanced filters'))
+
+    expect(screen.getByLabelText('Filter by type')).toBeTruthy()
+    expect(screen.getByLabelText('Filter by tags')).toBeTruthy()
+    expect(screen.getByLabelText('From date')).toBeTruthy()
+    expect(screen.getByLabelText('To date')).toBeTruthy()
+    expect(screen.getByLabelText('Result limit')).toBeTruthy()
+  })
+
+  it('calls onSwitchToList when back link is clicked', () => {
+    const onSwitchToList = vi.fn()
+    render(<MemorySearch {...defaultProps} onSwitchToList={onSwitchToList} />)
+
+    fireEvent.click(screen.getByText(/Back to memory list/))
+    expect(onSwitchToList).toHaveBeenCalled()
+  })
+
+  it('clears results when clear button is clicked', async () => {
+    const mem = makeMemory()
+    vi.spyOn(memoryClient, 'searchMemories').mockResolvedValue({
+      memories: [mem],
+      total: 1,
+    })
+
+    render(<MemorySearch {...defaultProps} />)
+
+    // Search first
+    fireEvent.change(screen.getByLabelText('Semantic search query'), {
+      target: { value: 'test' },
+    })
+    fireEvent.click(screen.getByText('Search'))
+
+    await waitFor(() => {
+      expect(screen.getByText('Search result memory')).toBeTruthy()
+    })
+
+    // Clear
+    fireEvent.click(screen.getByLabelText('Clear search'))
+
+    await waitFor(() => {
+      expect(screen.queryByText('Search result memory')).toBeNull()
+      expect(screen.getByText('Enter a query to search memories')).toBeTruthy()
+    })
+  })
+})


### PR DESCRIPTION
## Summary

- Adds `CreateMemoryDialog.tsx` modal form with content textarea, created_by, type dropdown, visibility dropdown (with conditional shared_with field), tags input with live chip preview, client-side validation, FocusTrap for accessibility, ESC to close, and success/error toasts
- Adds `MemorySearch.tsx` semantic search panel with query input (Enter key or button click), expandable advanced filters (type, tag, date range, result limit), results displayed as MemoryCard components, loading spinner, error state, empty state, and clear/reset
- Updates `MemoryList.tsx` with Browse/Search view mode toggle (URL-synced via `?view=search`), replaces placeholder create handler with proper dialog, wires search panel to delete/visibility actions

## Test plan

- [x] 18 new unit tests pass (9 CreateMemoryDialog, 9 MemorySearch)
- [x] All 44 memory-related tests pass (existing + new)
- [x] TypeScript type check passes clean (`tsc --noEmit`)
- [x] ESLint passes clean on all new and modified files
- [ ] Manual: verify create dialog opens, validates, and submits
- [ ] Manual: verify semantic search returns results from live memory service
- [ ] Manual: verify view toggle persists in URL params

Closes #381

🤖 Generated with [Claude Code](https://claude.com/claude-code)