### PR TITLE
feat(ui): add memory route to sidebar navigation and App router

### DIFF
--- a/ui/src/components/search/SearchPalette.tsx
+++ b/ui/src/components/search/SearchPalette.tsx
@@ -24,7 +24,7 @@ import type { SearchResult } from '@/hooks/useSearch'
 
 /** Flatten all result groups into an ordered list for keyboard navigation */
 function flattenResults(results: ReturnType<typeof useSearch>['results']): SearchResult[] {
-  return [...results.actions, ...results.agents, ...results.notifications]
+  return [...results.actions, ...results.agents, ...results.notifications, ...results.memories]
 }
 
 // ---------------------------------------------------------------------------

--- a/ui/src/components/search/SearchResults.tsx
+++ b/ui/src/components/search/SearchResults.tsx
@@ -158,7 +158,7 @@ export function SearchResults({ query, results, loading, activeId, onSelect }: S
   }
 
   const hasResults =
-    results.actions.length > 0 || results.agents.length > 0 || results.notifications.length > 0
+    results.actions.length > 0 || results.agents.length > 0 || results.notifications.length > 0 || results.memories.length > 0
 
   if (!hasResults) {
     return <NoResults query={query} />
@@ -197,6 +197,18 @@ export function SearchResults({ query, results, loading, activeId, onSelect }: S
             : undefined
         }
         viewAllLabel={`View all notification results for "${query}" →`}
+      />
+      <ResultSection
+        heading={`Memories${results.memories.length === 5 ? ' (showing top 5)' : ''}`}
+        items={results.memories}
+        activeId={activeId}
+        onSelect={onSelect}
+        viewAllHref={
+          results.memories.length === 5
+            ? `/memories?search=${encodeURIComponent(query)}`
+            : undefined
+        }
+        viewAllLabel={`View all memory results for "${query}" →`}
       />
     </div>
   )

--- a/ui/src/hooks/useSearch.ts
+++ b/ui/src/hooks/useSearch.ts
@@ -14,12 +14,13 @@
 import { useState, useCallback, useEffect, useRef } from 'react'
 import { orchestratorClient } from '@/services/orchestrator'
 import { notifyClient } from '@/services/notify'
+import { memoryClient } from '@/services/memory'
 
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
 
-export type SearchCategory = 'agent' | 'notification' | 'action'
+export type SearchCategory = 'agent' | 'notification' | 'action' | 'memory'
 
 export interface SearchResult {
   id: string
@@ -33,6 +34,7 @@ export interface GroupedSearchResults {
   actions: SearchResult[]
   agents: SearchResult[]
   notifications: SearchResult[]
+  memories: SearchResult[]
   /** Total across all groups */
   total: number
 }
@@ -111,6 +113,13 @@ const QUICK_ACTIONS: SearchResult[] = [
     href: '/workflows',
   },
   {
+    id: 'action-memories',
+    category: 'action',
+    title: 'Go to Memories',
+    subtitle: 'Navigate to the memories page',
+    href: '/memories',
+  },
+  {
     id: 'action-monitoring',
     category: 'action',
     title: 'Go to Monitoring',
@@ -173,6 +182,7 @@ const EMPTY_RESULTS: GroupedSearchResults = {
   actions: [],
   agents: [],
   notifications: [],
+  memories: [],
   total: 0,
 }
 
@@ -218,9 +228,10 @@ export function useSearch(): UseSearchResult {
 
     async function doSearch() {
       try {
-        const [agentsResult, notifResult] = await Promise.allSettled([
+        const [agentsResult, notifResult, memoriesResult] = await Promise.allSettled([
           orchestratorClient.listAgents({ limit: 200 }),
           notifyClient.listNotifications({ limit: 200 }),
+          memoryClient.listMemories({ limit: 200 }),
         ])
 
         // --- Agents ---
@@ -262,19 +273,47 @@ export function useSearch(): UseSearchResult {
           notifResults.sort((a, b) => b._score - a._score)
         }
 
+        // --- Memories ---
+        const memoryResults: ScoredResult[] = []
+        if (memoriesResult.status === 'fulfilled') {
+          for (const memory of memoriesResult.value.items) {
+            const contentPreview = memory.content.length > 80
+              ? memory.content.slice(0, 80) + '…'
+              : memory.content
+            const score = Math.max(
+              scoreMatch(memory.content, q),
+              ...memory.tags.map((tag) => scoreMatch(tag, q)),
+              scoreMatch(memory.type, q),
+            )
+            if (score > 0) {
+              memoryResults.push({
+                id: `memory-${memory.id}`,
+                category: 'memory',
+                title: contentPreview,
+                subtitle: `${memory.type} — ${memory.tags.join(', ') || 'no tags'}`,
+                href: `/memories?highlight=${memory.id}`,
+                _score: score,
+              })
+            }
+          }
+          memoryResults.sort((a, b) => b._score - a._score)
+        }
+
         const agents = agentResults.slice(0, MAX_PER_CATEGORY)
         const notifications = notifResults.slice(0, MAX_PER_CATEGORY)
+        const memories = memoryResults.slice(0, MAX_PER_CATEGORY)
 
         setResults({
           actions: filteredActions,
           agents,
           notifications,
-          total: filteredActions.length + agents.length + notifications.length,
+          memories,
+          total: filteredActions.length + agents.length + notifications.length + memories.length,
         })
       } catch (err) {
         if (err instanceof Error && err.name === 'AbortError') return
         // On network error still show quick actions
-        setResults({ ...EMPTY_RESULTS, actions: filteredActions, total: filteredActions.length })
+        setResults({ ...EMPTY_RESULTS, actions: filteredActions, memories: [], total: filteredActions.length })
       } finally {
         setLoading(false)
       }

--- a/ui/src/hooks/useServiceHealth.ts
+++ b/ui/src/hooks/useServiceHealth.ts
@@ -9,12 +9,13 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import { orchestratorClient } from '@/services/orchestrator'
 import { notifyClient } from '@/services/notify'
 import { askClient } from '@/services/ask'
+import { memoryClient } from '@/services/memory'
 import type { HealthResponse } from '@/types/common'
 import type { ServiceStatus } from '@/components/common/StatusBadge'
 
 export interface ServiceHealth {
   name: string
-  key: 'orchestrator' | 'notify' | 'ask'
+  key: 'orchestrator' | 'notify' | 'ask' | 'memory'
   port: number
   status: ServiceStatus
   version?: string
@@ -72,6 +73,7 @@ export function useServiceHealth(): UseServiceHealthResult {
       fetchHealth('orchestrator', () => orchestratorClient.getHealth(), 17006),
       fetchHealth('notify', () => notifyClient.getHealth(), 17004),
       fetchHealth('ask', () => askClient.getHealth(), 17001),
+      fetchHealth('memory', () => memoryClient.getHealth(), 17008),
     ])
     setServices(results)
     setLoading(false)

--- a/ui/src/pages/DashboardPage.tsx
+++ b/ui/src/pages/DashboardPage.tsx
@@ -97,9 +97,9 @@ export function DashboardPage() {
         >
           Service Health
         </h2>
-        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
           {healthInit
-            ? Array.from({ length: 3 }).map((_, i) => <ServiceHealthCardSkeleton key={i} />)
+            ? Array.from({ length: 4 }).map((_, i) => <ServiceHealthCardSkeleton key={i} />)
             : services.map((svc) => <ServiceHealthCard key={svc.key} service={svc} />)}
         </div>
       </section>


### PR DESCRIPTION
## Summary
- Adds **"Go to Memories"** quick action to the global search palette so users can navigate to `/memories` from `Ctrl+K`
- Integrates **memory search results** into the search palette — searches memories by content, tags, and type with relevance ranking
- Adds **memory service health** to the dashboard service health cards (port 17008)
- Updates dashboard grid layout from 3 to 4 columns to accommodate the new health card
- Sidebar nav item and App router route were already in place from prior work

## Files Changed
- `ui/src/hooks/useSearch.ts` — added `memory` category, `memoryClient` search, and "Go to Memories" quick action
- `ui/src/hooks/useServiceHealth.ts` — added memory service health check
- `ui/src/components/search/SearchPalette.tsx` — include memories in keyboard-navigable results
- `ui/src/components/search/SearchResults.tsx` — render Memories result section with "View all" link
- `ui/src/pages/DashboardPage.tsx` — updated grid to 4-column layout with 4 skeleton cards

## Test plan
- [ ] Verify sidebar "Memories" link navigates to `/memories` and shows active state
- [ ] Open search palette (`Ctrl+K`), type "memo" — confirm "Go to Memories" quick action appears
- [ ] Search for a memory tag or content — confirm memory results appear in the Memories section
- [ ] Check dashboard loads 4 service health cards including Memory service
- [ ] Verify TypeScript compiles cleanly (`npx tsc --noEmit`)

Closes #382

🤖 Generated with [Claude Code](https://claude.com/claude-code)