### PR TITLE
Add DB migration to rename source_type/source_config to trigger_type/trigger_config

### DIFF
--- a/crates/orchestrator/src/entity/workflow.rs
+++ b/crates/orchestrator/src/entity/workflow.rs
@@ -4,7 +4,7 @@ use sea_orm::entity::prelude::*;
 
 /// SeaORM model for the `workflows` table.
 ///
-/// JSON columns (`source_config`, `tool_policy`) are stored as TEXT and
+/// JSON columns (`trigger_config`, `tool_policy`) are stored as TEXT and
 /// deserialized manually in the storage layer.
 #[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
 #[sea_orm(table_name = "workflows")]
@@ -14,9 +14,9 @@ pub struct Model {
     #[sea_orm(unique)]
     pub name: String,
     pub agent_id: String,
-    pub source_type: String,
-    /// JSON-serialized [`crate::scheduler::types::TaskSourceConfig`].
-    pub source_config: String,
+    pub trigger_type: String,
+    /// JSON-serialized [`crate::scheduler::types::TriggerConfig`].
+    pub trigger_config: String,
     pub prompt_template: String,
     pub poll_interval_secs: i64,
     /// Stored as INTEGER (0/1); mapped to `bool` in the domain layer.

--- a/crates/orchestrator/src/migration/m20260316_000007_rename_trigger_columns.rs
+++ b/crates/orchestrator/src/migration/m20260316_000007_rename_trigger_columns.rs
@@ -1,0 +1,99 @@
+//! Migration: rename `source_type` / `source_config` columns in the
+//! `workflows` table to `trigger_type` / `trigger_config`.
+//!
+//! SQLite does not support `ALTER TABLE … RENAME COLUMN` before 3.25.0,
+//! so we use the copy-to-new-table approach for maximum compatibility:
+//!
+//! 1. Create `workflows_new` with the updated column names.
+//! 2. Copy all rows, mapping old columns to new names.
+//! 3. Drop the old `workflows` table.
+//! 4. Rename `workflows_new` → `workflows`.
+//! 5. Re-create the unique index on `name`.
+//!
+//! The `down()` migration reverses the rename.
+
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+/// SQL to copy the workflows table with renamed columns (old → new).
+const UP_SQL: &[&str] = &[
+    // 1. Create the replacement table with new column names.
+    "CREATE TABLE IF NOT EXISTS workflows_new (
+        id TEXT NOT NULL PRIMARY KEY,
+        name TEXT NOT NULL UNIQUE,
+        agent_id TEXT NOT NULL,
+        trigger_type TEXT NOT NULL,
+        trigger_config TEXT NOT NULL,
+        prompt_template TEXT NOT NULL,
+        poll_interval_secs INTEGER NOT NULL DEFAULT 60,
+        enabled INTEGER NOT NULL DEFAULT 1,
+        tool_policy TEXT NOT NULL DEFAULT '{\"mode\":\"allow_all\"}',
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+    )",
+    // 2. Copy data from old table → new table.
+    "INSERT INTO workflows_new (
+        id, name, agent_id, trigger_type, trigger_config,
+        prompt_template, poll_interval_secs, enabled, tool_policy,
+        created_at, updated_at
+    )
+    SELECT
+        id, name, agent_id, source_type, source_config,
+        prompt_template, poll_interval_secs, enabled, tool_policy,
+        created_at, updated_at
+    FROM workflows",
+    // 3. Drop the old table.
+    "DROP TABLE workflows",
+    // 4. Rename the new table.
+    "ALTER TABLE workflows_new RENAME TO workflows",
+];
+
+/// SQL to reverse the rename (new → old).
+const DOWN_SQL: &[&str] = &[
+    "CREATE TABLE IF NOT EXISTS workflows_old (
+        id TEXT NOT NULL PRIMARY KEY,
+        name TEXT NOT NULL UNIQUE,
+        agent_id TEXT NOT NULL,
+        source_type TEXT NOT NULL,
+        source_config TEXT NOT NULL,
+        prompt_template TEXT NOT NULL,
+        poll_interval_secs INTEGER NOT NULL DEFAULT 60,
+        enabled INTEGER NOT NULL DEFAULT 1,
+        tool_policy TEXT NOT NULL DEFAULT '{\"mode\":\"allow_all\"}',
+        created_at TEXT NOT NULL,
+        updated_at TEXT NOT NULL
+    )",
+    "INSERT INTO workflows_old (
+        id, name, agent_id, source_type, source_config,
+        prompt_template, poll_interval_secs, enabled, tool_policy,
+        created_at, updated_at
+    )
+    SELECT
+        id, name, agent_id, trigger_type, trigger_config,
+        prompt_template, poll_interval_secs, enabled, tool_policy,
+        created_at, updated_at
+    FROM workflows",
+    "DROP TABLE workflows",
+    "ALTER TABLE workflows_old RENAME TO workflows",
+];
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let db = manager.get_connection();
+        for stmt in UP_SQL {
+            db.execute_unprepared(stmt).await?;
+        }
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let db = manager.get_connection();
+        for stmt in DOWN_SQL {
+            db.execute_unprepared(stmt).await?;
+        }
+        Ok(())
+    }
+}

--- a/crates/orchestrator/src/migration/mod.rs
+++ b/crates/orchestrator/src/migration/mod.rs
@@ -17,6 +17,7 @@ mod m20250310_000003_rename_tmux_session;
 mod m20250311_000004_add_network_policy;
 mod m20250311_000006_add_additional_dirs;
 mod m20250312_000005_add_docker_config;
+mod m20260316_000007_rename_trigger_columns;
 
 /// The migration runner — applies all known migrations in order.
 pub struct Migrator;
@@ -31,6 +32,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20250311_000004_add_network_policy::Migration),
             Box::new(m20250312_000005_add_docker_config::Migration),
             Box::new(m20250311_000006_add_additional_dirs::Migration),
+            Box::new(m20260316_000007_rename_trigger_columns::Migration),
         ]
     }
 }

--- a/crates/orchestrator/src/scheduler/storage.rs
+++ b/crates/orchestrator/src/scheduler/storage.rs
@@ -39,15 +39,15 @@ impl SchedulerStorage {
 
     /// Inserts a workflow and returns its UUID.
     pub async fn add_workflow(&self, workflow: &WorkflowConfig) -> Result<Uuid> {
-        let source_config_json = serde_json::to_string(&workflow.trigger_config)?;
+        let trigger_config_json = serde_json::to_string(&workflow.trigger_config)?;
         let tool_policy_json = serde_json::to_string(&workflow.tool_policy).unwrap_or_default();
 
         let model = workflow_entity::ActiveModel {
             id: Set(workflow.id.to_string()),
             name: Set(workflow.name.clone()),
             agent_id: Set(workflow.agent_id.to_string()),
-            source_type: Set(workflow.trigger_config.trigger_type().to_string()),
-            source_config: Set(source_config_json),
+            trigger_type: Set(workflow.trigger_config.trigger_type().to_string()),
+            trigger_config: Set(trigger_config_json),
             prompt_template: Set(workflow.prompt_template.clone()),
             poll_interval_secs: Set(workflow.poll_interval_secs as i64),
             enabled: Set(if workflow.enabled { 1 } else { 0 }),
@@ -290,7 +290,7 @@ fn model_to_workflow(model: workflow_entity::Model) -> Result<WorkflowConfig> {
         id: Uuid::parse_str(&model.id)?,
         name: model.name,
         agent_id: Uuid::parse_str(&model.agent_id)?,
-        trigger_config: serde_json::from_str(&model.source_config)?,
+        trigger_config: serde_json::from_str(&model.trigger_config)?,
         prompt_template: model.prompt_template,
         poll_interval_secs: model.poll_interval_secs as u64,
         enabled: model.enabled != 0,


### PR DESCRIPTION
## Summary

- Add SeaORM migration `m20260316_000007` to rename `source_type` → `trigger_type` and `source_config` → `trigger_config` columns in the `workflows` table
- Update the SeaORM entity (`entity/workflow.rs`) to use new column names
- Update `SchedulerStorage` methods to reference new entity fields

## Migration Approach

SQLite has limited `ALTER TABLE` support, so the migration uses the copy-table strategy:

1. Create `workflows_new` with the renamed columns
2. Copy all existing data from old table to new
3. Drop the old `workflows` table
4. Rename `workflows_new` → `workflows`

The `down()` migration reverses the process for rollback safety.

## Key Files Changed

- `crates/orchestrator/src/migration/m20260316_000007_rename_trigger_columns.rs` — new migration
- `crates/orchestrator/src/migration/mod.rs` — register migration
- `crates/orchestrator/src/entity/workflow.rs` — entity field renames
- `crates/orchestrator/src/scheduler/storage.rs` — storage layer field updates

## Test plan

- [x] `cargo check` passes with no errors or warnings
- [x] All 3 scheduler storage tests pass (CRUD, dispatch log, fail-inflight)
- [x] All 50 CLI orchestrator command tests pass
- [x] All 125 orchestrator tests pass (3 pre-existing sandbox failures unrelated)
- [x] Migration preserves existing data during column rename
- [x] `down()` migration reverses the rename

Closes #336

🤖 Generated with [Claude Code](https://claude.com/claude-code)