### PR TITLE
docs: document TriggerStrategy abstraction and source_config migration

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -73,7 +73,7 @@ curl -s -X POST http://127.0.0.1:17006/workflows \
   -d '{
     "name": "issue-worker",
     "agent_id": "<agent-id-from-step-1>",
-    "source_config": {
+    "trigger_config": {
       "type": "github_issues",
       "owner": "your-org",
       "repo": "your-repo",

--- a/docs/public/getting-started.md
+++ b/docs/public/getting-started.md
@@ -390,7 +390,7 @@ curl -s -X POST http://localhost:17006/workflows \
   -d '{
     "name": "auto-issues",
     "agent_id": "'$AGENT_ID'",
-    "source_config": {
+    "trigger_config": {
       "type": "github_issues",
       "owner": "YOUR_ORG",
       "repo": "YOUR_REPO",

--- a/docs/public/migration-trigger.md
+++ b/docs/public/migration-trigger.md
@@ -1,0 +1,204 @@
+# Migration: `source_config` → `trigger_config`
+
+Phase 1 of the workflow refactor (#326) introduced the `TriggerStrategy` trait and renamed the workflow configuration fields to reflect the new abstraction. This page documents what changed and how to update existing installations and integrations.
+
+---
+
+## What Changed
+
+| Before (≤ Phase 0) | After (Phase 1+) |
+|--------------------|-----------------|
+| `source_config` field in JSON | `trigger_config` |
+| `source_type` column in DB | `trigger_type` |
+| `TaskSourceConfig` Rust type | `TriggerConfig` |
+
+The semantics are identical — only the names changed.
+
+---
+
+## JSON Payload Changes
+
+### Create Workflow Request
+
+=== "New (trigger_config)"
+
+    ```json
+    {
+      "name": "issue-worker",
+      "agent_id": "550e8400-e29b-41d4-a716-446655440000",
+      "trigger_config": {
+        "type": "github_issues",
+        "owner": "myorg",
+        "repo": "myrepo",
+        "labels": ["agent"],
+        "state": "open"
+      },
+      "prompt_template": "Work on issue #{{source_id}}: {{title}}\n\n{{body}}",
+      "poll_interval_secs": 60,
+      "enabled": true
+    }
+    ```
+
+=== "Old (source_config) — still accepted"
+
+    ```json
+    {
+      "name": "issue-worker",
+      "agent_id": "550e8400-e29b-41d4-a716-446655440000",
+      "source_config": {
+        "type": "github_issues",
+        "owner": "myorg",
+        "repo": "myrepo",
+        "labels": ["agent"],
+        "state": "open"
+      },
+      "prompt_template": "Work on issue #{{source_id}}: {{title}}\n\n{{body}}",
+      "poll_interval_secs": 60,
+      "enabled": true
+    }
+    ```
+
+### Workflow Response
+
+The response from `GET /workflows/{id}` and `POST /workflows` now uses `trigger_config`:
+
+```json
+{
+  "id": "550e8400-e29b-41d4-a716-446655440001",
+  "name": "issue-worker",
+  "agent_id": "550e8400-e29b-41d4-a716-446655440000",
+  "trigger_config": {
+    "type": "github_issues",
+    "owner": "myorg",
+    "repo": "myrepo",
+    "labels": ["agent"],
+    "state": "open"
+  },
+  "prompt_template": "Work on issue #{{source_id}}: {{title}}\n\n{{body}}",
+  "poll_interval_secs": 60,
+  "enabled": true,
+  "tool_policy": { "mode": "auto" },
+  "created_at": "2026-03-14T10:00:00Z",
+  "updated_at": "2026-03-14T10:00:00Z"
+}
+```
+
+---
+
+## Backwards Compatibility
+
+The Rust structs for `CreateWorkflowRequest`, `WorkflowResponse`, and `WorkflowConfig` all carry a `#[serde(alias = "source_config")]` attribute:
+
+```rust
+#[serde(alias = "source_config")]
+pub trigger_config: TriggerConfig,
+```
+
+This means:
+
+- **Existing API clients sending `source_config`** continue to work without any changes.
+- **Existing stored workflow JSON** (e.g. in `.agentd/` template files) that uses `source_config` is still deserialised correctly.
+- **Responses** always use `trigger_config` — if your client parses response bodies by field name, update it.
+
+---
+
+## Database Migration
+
+Migration `m20260316_000007_rename_trigger_columns` runs automatically when the orchestrator starts. It renames the two affected columns in the `workflows` table:
+
+| Old column | New column |
+|------------|------------|
+| `source_type` | `trigger_type` |
+| `source_config` | `trigger_config` |
+
+**SQLite note:** SQLite before version 3.25.0 does not support `ALTER TABLE … RENAME COLUMN`. The migration uses a copy-to-new-table approach:
+
+1. Create `workflows_new` with the renamed columns.
+2. Copy all rows from `workflows`, mapping `source_type` → `trigger_type` and `source_config` → `trigger_config`.
+3. Drop `workflows`.
+4. Rename `workflows_new` → `workflows`.
+
+### Verifying the migration ran
+
+```bash
+sqlite3 ~/Library/Application\ Support/agentd-orchestrator/orchestrator.db \
+  ".schema workflows"
+```
+
+The output should show `trigger_type` and `trigger_config` (not `source_type` / `source_config`).
+
+### Manual rollback
+
+The migration includes a `DOWN` path that reverses the rename. To trigger it you would need to roll back via the SeaORM migration CLI (`sea-orm-cli migrate down`) — this is not exposed as a regular `agentd` command and should only be used during development.
+
+!!! warning
+    Rolling back the migration on an installation that has already upgraded will cause the orchestrator to fail to start until the migration is re-applied.
+
+---
+
+## YAML Template Files
+
+If you have `.agentd/workflows/*.yml` template files using `source_config`, they are still accepted. To adopt the new naming, update them:
+
+=== "New"
+
+    ```yaml
+    name: issue-worker
+    agent: worker
+    trigger_config:
+      type: github_issues
+      owner: myorg
+      repo: myrepo
+      labels:
+        - agent
+    prompt_template: |
+      Work on issue #{{source_id}}: {{title}}
+
+      {{body}}
+    poll_interval_secs: 60
+    ```
+
+=== "Old (still works)"
+
+    ```yaml
+    name: issue-worker
+    agent: worker
+    source_config:
+      type: github_issues
+      owner: myorg
+      repo: myrepo
+      labels:
+        - agent
+    prompt_template: |
+      Work on issue #{{source_id}}: {{title}}
+
+      {{body}}
+    poll_interval_secs: 60
+    ```
+
+---
+
+## CLI
+
+The CLI `create-workflow` command already uses the new naming — it passes `trigger_config` in the JSON body it sends to the orchestrator. No CLI changes are required.
+
+```bash
+agent orchestrator create-workflow \
+  --name issue-worker \
+  --agent-name worker \
+  --trigger-type github-issues \
+  --owner myorg \
+  --repo myrepo \
+  --labels agent \
+  --prompt-template "Work on #{{source_id}}: {{title}}\n\n{{body}}"
+```
+
+---
+
+## Summary Checklist
+
+- [x] API responses use `trigger_config` — update any response-parsing code
+- [x] `source_config` in request bodies still works — no urgent client changes needed
+- [x] DB migration runs automatically on orchestrator startup
+- [x] `.agentd/` YAML templates using `source_config` still load correctly
+- [ ] Optionally rename `source_config` → `trigger_config` in your YAML templates for consistency

--- a/docs/public/services/orchestrator.md
+++ b/docs/public/services/orchestrator.md
@@ -435,7 +435,7 @@ websocat ws://127.0.0.1:17006/stream/{agent_id}
 
 ### Workflow Endpoints
 
-Workflows pair a long-running agent with a GitHub issue source. The scheduler polls for new issues and dispatches them to the agent one at a time.
+Workflows pair a long-running agent with a trigger source. The scheduler runs the trigger strategy and dispatches tasks to the agent one at a time. See [Trigger Strategies](../trigger-strategies.md) for architecture details.
 
 #### Create Workflow
 
@@ -450,12 +450,16 @@ Content-Type: application/json
 |-------|------|----------|---------|-------------|
 | `name` | string | yes | | Unique workflow name |
 | `agent_id` | UUID | yes | | Agent to dispatch tasks to (must be Running) |
-| `source_config` | object | yes | | Task source configuration (see below) |
+| `trigger_config` | object | yes | | Trigger configuration (see below) |
 | `prompt_template` | string | yes | | Template with `{{placeholders}}` for task data |
-| `poll_interval_secs` | integer | no | `60` | Seconds between poll cycles |
+| `poll_interval_secs` | integer | no | `60` | Seconds between poll cycles (poll-based triggers only) |
 | `enabled` | bool | no | `true` | Whether the workflow is active |
+| `tool_policy` | object | no | `{"mode":"auto"}` | Tool policy applied when dispatching tasks |
 
-**Source config (GitHub Issues):**
+!!! note "Backwards compatibility"
+    The field name `source_config` is accepted as an alias for `trigger_config`. New integrations should use `trigger_config`.
+
+**`trigger_config` — GitHub Issues:**
 ```json
 {
   "type": "github_issues",
@@ -466,9 +470,41 @@ Content-Type: application/json
 }
 ```
 
+**`trigger_config` — GitHub Pull Requests:**
+```json
+{
+  "type": "github_pull_requests",
+  "owner": "org-or-user",
+  "repo": "repo-name",
+  "labels": [],
+  "state": "open"
+}
+```
+
 **Template placeholders:** `{{title}}`, `{{body}}`, `{{url}}`, `{{labels}}`, `{{assignee}}`, `{{source_id}}`, `{{metadata}}`
 
 **Response:** `201 Created` with workflow object.
+
+```json
+{
+  "id": "550e8400-e29b-41d4-a716-446655440001",
+  "name": "issue-worker",
+  "agent_id": "550e8400-e29b-41d4-a716-446655440000",
+  "trigger_config": {
+    "type": "github_issues",
+    "owner": "myorg",
+    "repo": "myrepo",
+    "labels": ["agent"],
+    "state": "open"
+  },
+  "prompt_template": "Work on issue #{{source_id}}: {{title}}\n\n{{body}}",
+  "poll_interval_secs": 60,
+  "enabled": true,
+  "tool_policy": { "mode": "auto" },
+  "created_at": "2026-03-14T10:00:00Z",
+  "updated_at": "2026-03-14T10:00:00Z"
+}
+```
 
 #### List Workflows
 

--- a/docs/public/trigger-strategies.md
+++ b/docs/public/trigger-strategies.md
@@ -1,0 +1,186 @@
+# Trigger Strategies
+
+Trigger strategies define *when* a workflow runs and *what tasks* it produces. They decouple the scheduling mechanism from the dispatch logic, making it straightforward to add new trigger types without touching the runner loop.
+
+## Architecture
+
+```mermaid
+graph LR
+    Runner -->|calls next_tasks()| Strategy
+    Strategy -->|returns Vec<Task>| Runner
+    Runner -->|renders prompt + dispatches| Agent
+
+    subgraph "Trigger Layer"
+        Strategy["TriggerStrategy"]
+        Polling["PollingStrategy"]
+        TaskSrc["TaskSource (e.g. GithubIssueSource)"]
+        Polling -->|delegates to| TaskSrc
+        Strategy -.->|implemented by| Polling
+    end
+```
+
+The **trigger layer** answers: *"Is there work to do right now?"*
+The **dispatch layer** answers: *"How do I send that work to an agent?"*
+
+Source code lives in `crates/orchestrator/src/scheduler/`.
+
+---
+
+## `TriggerStrategy` Trait
+
+**File:** `crates/orchestrator/src/scheduler/strategy.rs`
+
+```rust
+#[async_trait]
+pub trait TriggerStrategy: Send + Sync {
+    /// Wait for the next trigger event and return tasks to dispatch.
+    ///
+    /// Implementations should respect the `shutdown` receiver and return
+    /// promptly (with an empty vec or an error) when the signal fires.
+    ///
+    /// Returning an empty `Vec<Task>` is valid and indicates that no work
+    /// is available at this time — the runner may call `next_tasks` again.
+    async fn next_tasks(&mut self, shutdown: &watch::Receiver<bool>) -> anyhow::Result<Vec<Task>>;
+}
+```
+
+### Contract
+
+| Aspect | Behaviour |
+|--------|-----------|
+| **Return: tasks** | A non-empty `Vec<Task>` — the runner dispatches each task to the agent in sequence |
+| **Return: empty vec** | No work available; the runner calls `next_tasks()` again on the next iteration |
+| **Return: `Err`** | Transient failure; the runner logs the error, applies backoff, and retries |
+| **Shutdown** | When `*shutdown.borrow() == true` the implementation must return promptly — `Ok(vec![])` is the correct response |
+| **Thread safety** | Implementors must be `Send + Sync` so they can be boxed and moved across task boundaries |
+
+### Runner loop integration
+
+The runner holds a `Box<dyn TriggerStrategy>` and drives it in a loop:
+
+```rust
+loop {
+    let tasks = strategy.next_tasks(&shutdown_rx).await?;
+    for task in tasks {
+        dispatch(task, &config, &registry).await?;
+    }
+}
+```
+
+The loop exits when the shutdown channel fires or `next_tasks` returns an unrecoverable error.
+
+---
+
+## `PollingStrategy` — Reference Implementation
+
+`PollingStrategy` is the built-in implementation used by all poll-based workflows (currently GitHub Issues and GitHub Pull Requests).
+
+**File:** `crates/orchestrator/src/scheduler/strategy.rs`
+
+### How it works
+
+1. Sleep for `poll_interval_secs` (interruptible by shutdown signal).
+2. Call `TaskSource::fetch_tasks()` on the underlying source.
+3. Return the tasks, or apply backoff and propagate the error on failure.
+
+### Exponential backoff
+
+When `fetch_tasks()` fails, `PollingStrategy` adds a linear backoff on top of the regular interval:
+
+```
+sleep_duration = poll_interval_secs + min(consecutive_errors × 2, 30)
+```
+
+`consecutive_errors` resets to `0` on the first successful fetch. The maximum additional delay is **30 seconds**.
+
+### Shutdown handling
+
+`PollingStrategy` uses `tokio::select!` to make the sleep interruptible:
+
+```rust
+tokio::select! {
+    _ = tokio::time::sleep(sleep_dur) => {}
+    _ = shutdown.changed() => {
+        if *shutdown.borrow() { return Ok(vec![]); }
+    }
+}
+```
+
+A workflow that is disabled or deleted responds to shutdown within milliseconds regardless of how long the configured poll interval is.
+
+---
+
+## `TriggerConfig` Enum
+
+`TriggerConfig` is the serialisable description of which strategy to use for a workflow. It is stored as JSON in the `trigger_config` column of the `workflows` table.
+
+**File:** `crates/orchestrator/src/scheduler/types.rs`
+
+```rust
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum TriggerConfig {
+    GithubIssues {
+        owner: String,
+        repo: String,
+        labels: Vec<String>,   // default: []
+        state: String,         // default: "open"
+    },
+    GithubPullRequests {
+        owner: String,
+        repo: String,
+        labels: Vec<String>,   // default: []
+        state: String,         // default: "open"
+    },
+    Cron { expression: String },       // Phase 2
+    Delay { run_at: String },          // Phase 2 — ISO 8601
+    Webhook { secret: Option<String> }, // Phase 4
+    Manual {},
+}
+```
+
+!!! info "Implementation status"
+    Only `github_issues` and `github_pull_requests` are currently runnable. Attempting to create a workflow with `cron`, `delay`, `webhook`, or `manual` returns `400 Invalid Input`.
+
+### JSON tagged-union format
+
+`TriggerConfig` uses `#[serde(tag = "type")]` — the discriminant is the `type` key:
+
+```json
+{ "type": "github_issues", "owner": "myorg", "repo": "myrepo", "labels": ["agent"] }
+{ "type": "github_pull_requests", "owner": "myorg", "repo": "myrepo", "state": "open" }
+```
+
+---
+
+## `TaskSource` Trait
+
+`TriggerStrategy` and `TaskSource` are two distinct abstractions:
+
+| Trait | Responsibility |
+|-------|---------------|
+| `TriggerStrategy` | *When* to run — owns timing, backoff, shutdown |
+| `TaskSource` | *What* to fetch — owns the external API call |
+
+```rust
+#[async_trait]
+pub trait TaskSource: Send + Sync {
+    async fn fetch_tasks(&self) -> anyhow::Result<Vec<Task>>;
+    fn source_type(&self) -> &'static str;
+}
+```
+
+Implemented by `GithubIssueSource` and `GithubPullRequestSource` in `crates/orchestrator/src/scheduler/github.rs`. Both call the `gh` CLI to list issues/PRs and map them to `Task` structs.
+
+---
+
+## Adding a New Trigger Type
+
+To add a new trigger type (e.g. `Cron`):
+
+1. **Add a variant** to `TriggerConfig` in `scheduler/types.rs`.
+2. **Implement `TriggerStrategy`** (or a new `TaskSource` if it's poll-based) in `scheduler/strategy.rs` or a new file.
+3. **Wire it** in `create_strategy()` in `scheduler/runner.rs`.
+4. **Add CLI support** in the `TriggerType` enum in `crates/cli/src/commands/orchestrator.rs`.
+5. **Remove the "not yet implemented" guard** in `scheduler/api.rs` for the new variant.
+
+See [Trigger Migration Guide](../migration-trigger.md) for the history of the `source_*` → `trigger_*` rename.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -93,6 +93,9 @@ nav:
       - Notify: public/services/notify.md
       - Ask: public/services/ask.md
       - Wrap: public/services/wrap.md
+  - Workflows:
+      - Trigger Strategies: public/trigger-strategies.md
+      - Migration (source_config → trigger_config): public/migration-trigger.md
   - Development:
       - Error Handling & Logging: public/error-handling.md
       - Storage Patterns: storage.md


### PR DESCRIPTION
Closes #349

## Summary

- **New page** `docs/public/trigger-strategies.md` — documents the `TriggerStrategy` trait contract, `PollingStrategy` backoff/shutdown behaviour, the `TriggerConfig` tagged-union enum, and a guide for adding new trigger types
- **New page** `docs/public/migration-trigger.md` — covers the `source_config` → `trigger_config` rename with before/after JSON examples, serde alias backwards-compatibility, DB migration steps, and YAML template updates
- **Updated** `docs/public/services/orchestrator.md` — workflow API section uses `trigger_config`, adds full response body example and `tool_policy` field
- **Updated** `docs/index.md` and `docs/public/getting-started.md` — quick-start examples use `trigger_config`
- **Updated** `mkdocs.yml` — added Workflows nav section

## Test plan

- [ ] `mkdocs serve` renders both new pages without errors
- [ ] Nav shows the Workflows section with both links
- [ ] Mermaid diagram and tabbed code blocks render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)