### PR TITLE
Support ${VAR} substitution in env values in agent YAML templates

### DIFF
--- a/crates/cli/src/commands/apply.rs
+++ b/crates/cli/src/commands/apply.rs
@@ -1101,10 +1101,7 @@ env: {}
         let mut env = HashMap::new();
         env.insert("API_KEY".to_string(), "${AGENTD_TEST_MAP_VAL}".to_string());
         env.insert("STATIC".to_string(), "no-change".to_string());
-        env.insert(
-            "WITH_DEFAULT".to_string(),
-            "${AGENTD_TEST_NONEXIST:-default_val}".to_string(),
-        );
+        env.insert("WITH_DEFAULT".to_string(), "${AGENTD_TEST_NONEXIST:-default_val}".to_string());
 
         expand_env_vars(&mut env).unwrap();
 


### PR DESCRIPTION
## Summary
- Add `expand_env_in_value()` function that handles `${VAR}` (required, errors if unset) and `${VAR:-default}` (optional with fallback) syntax in env value strings
- Apply substitution as a post-parse step in `parse_agent_template()` so all env values are expanded before agent creation
- Add 14 unit tests covering required vars, defaults, missing vars, multiple vars, edge cases (unclosed braces, empty names, dollar without brace)

## Test plan
- [x] All 14 new env substitution tests pass
- [x] All 29 existing apply module tests still pass
- [ ] Manual test: create an agent YAML with `${HOME}` in env and verify it expands correctly

Closes #159

🤖 Generated with [Claude Code](https://claude.com/claude-code)