### PR TITLE
Implement DelayStrategy for one-shot timed execution

### DIFF
--- a/crates/orchestrator/src/scheduler/api.rs
+++ b/crates/orchestrator/src/scheduler/api.rs
@@ -85,6 +85,15 @@ async fn create_workflow(
                     "Delay trigger requires a non-empty 'run_at' datetime".to_string(),
                 ));
             }
+            // Validate the datetime is parseable as ISO 8601 / RFC 3339.
+            if chrono::DateTime::parse_from_rfc3339(run_at).is_err()
+                && run_at.parse::<chrono::DateTime<Utc>>().is_err()
+            {
+                return Err(ApiError::InvalidInput(format!(
+                    "Invalid run_at datetime '{}': expected ISO 8601 format (e.g., 2025-01-01T09:00:00Z)",
+                    run_at
+                )));
+            }
         }
         TriggerConfig::Webhook { .. } | TriggerConfig::Manual {} => {}
     }
@@ -92,7 +101,7 @@ async fn create_workflow(
     // Reject trigger types that are not yet implemented.
     if !req.trigger_config.is_implemented() {
         return Err(ApiError::InvalidInput(format!(
-            "Trigger type '{}' is not yet implemented. Currently supported: github_issues, github_pull_requests, cron",
+            "Trigger type '{}' is not yet implemented. Currently supported: github_issues, github_pull_requests, cron, delay",
             req.trigger_config.trigger_type()
         )));
     }

--- a/crates/orchestrator/src/scheduler/mod.rs
+++ b/crates/orchestrator/src/scheduler/mod.rs
@@ -8,7 +8,7 @@ pub mod template;
 pub mod types;
 
 use crate::websocket::ConnectionRegistry;
-use runner::{create_strategy, notify_complete, WorkflowRunner};
+use runner::{create_strategy, notify_complete, RunOutcome, WorkflowRunner};
 use std::collections::HashMap;
 use std::sync::Arc;
 use storage::SchedulerStorage;
@@ -61,9 +61,21 @@ impl Scheduler {
         let shutdown_tx = runner.shutdown_handle();
         let busy = runner.busy_handle();
 
-        // Spawn the runner.
+        // Spawn the runner. If it returns AutoDisable, update the workflow
+        // in storage and remove the runner from the active set.
+        let storage = self.storage.clone();
         tokio::spawn(async move {
-            runner.run().await;
+            let outcome = runner.run().await;
+            if outcome == RunOutcome::AutoDisable {
+                info!(%workflow_id, "Auto-disabling one-shot workflow");
+                if let Ok(Some(mut wf)) = storage.get_workflow(&workflow_id).await {
+                    wf.enabled = false;
+                    wf.updated_at = chrono::Utc::now();
+                    if let Err(e) = storage.update_workflow(&wf).await {
+                        error!(%workflow_id, %e, "Failed to auto-disable workflow");
+                    }
+                }
+            }
         });
 
         // Track the runner.

--- a/crates/orchestrator/src/scheduler/runner.rs
+++ b/crates/orchestrator/src/scheduler/runner.rs
@@ -1,7 +1,7 @@
 use crate::scheduler::github::{GithubIssueSource, GithubPullRequestSource};
 use crate::scheduler::source::TaskSource;
 use crate::scheduler::storage::SchedulerStorage;
-use crate::scheduler::strategy::{CronStrategy, PollingStrategy, TriggerStrategy};
+use crate::scheduler::strategy::{CronStrategy, DelayStrategy, PollingStrategy, TriggerStrategy};
 use crate::scheduler::template::render_template;
 use crate::scheduler::types::{
     DispatchRecord, DispatchStatus, Task, TriggerConfig, WorkflowConfig,
@@ -25,6 +25,17 @@ pub struct BusyState {
 /// The runner delegates trigger timing to a [`TriggerStrategy`] and focuses
 /// on dispatch logic: dedup checking, template rendering, and sending prompts
 /// to the connected agent.
+/// Returned by the runner to indicate whether the workflow should be
+/// auto-disabled after the run loop exits (used by one-shot strategies).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RunOutcome {
+    /// Normal shutdown (e.g., explicit stop or service shutdown).
+    Shutdown,
+    /// The strategy completed its one-shot execution and the workflow
+    /// should be auto-disabled.
+    AutoDisable,
+}
+
 pub struct WorkflowRunner {
     config: WorkflowConfig,
     storage: SchedulerStorage,
@@ -71,11 +82,17 @@ impl WorkflowRunner {
     /// The loop calls [`TriggerStrategy::next_tasks()`] to wait for tasks,
     /// then dispatches the first undispatched task to the connected agent.
     /// The strategy handles interval timing, backoff, and shutdown detection.
-    pub async fn run(mut self) {
+    ///
+    /// Returns [`RunOutcome::AutoDisable`] if the strategy is a one-shot
+    /// type (e.g., delay) that has completed its execution.
+    pub async fn run(mut self) -> RunOutcome {
         let workflow_id = self.config.id;
         let agent_id = self.config.agent_id;
+        let is_one_shot = self.config.trigger_config.is_one_shot();
 
         info!(%workflow_id, %agent_id, "Workflow runner started");
+
+        let mut dispatched_one_shot = false;
 
         loop {
             // Wait for the strategy to produce tasks (includes interval/backoff).
@@ -91,10 +108,15 @@ impl WorkflowRunner {
             // Check for shutdown signal — strategy returns Ok(vec![]) on shutdown.
             if *self.shutdown_rx.borrow() {
                 info!(%workflow_id, "Shutdown signal received, stopping runner");
-                break;
+                return RunOutcome::Shutdown;
             }
 
             if tasks.is_empty() {
+                // For one-shot strategies, empty after dispatch means we're done.
+                if is_one_shot && dispatched_one_shot {
+                    info!(%workflow_id, "One-shot strategy completed, auto-disabling");
+                    return RunOutcome::AutoDisable;
+                }
                 debug!(%workflow_id, "No new tasks from strategy");
                 continue;
             }
@@ -118,6 +140,9 @@ impl WorkflowRunner {
                 Ok(dispatched) => {
                     if dispatched {
                         info!(%workflow_id, "Task dispatched to agent");
+                        if is_one_shot {
+                            dispatched_one_shot = true;
+                        }
                     } else {
                         debug!(%workflow_id, "All tasks already dispatched");
                     }
@@ -127,8 +152,6 @@ impl WorkflowRunner {
                 }
             }
         }
-
-        info!(%workflow_id, "Workflow runner stopped");
     }
 
     /// Find the first undispatched task and send it to the agent.
@@ -246,12 +269,22 @@ fn create_source(config: &TriggerConfig) -> anyhow::Result<Box<dyn TaskSource>> 
 /// Create the appropriate [`TriggerStrategy`] for a workflow configuration.
 ///
 /// Poll-based workflows (GitHub triggers) use [`PollingStrategy`].
-/// Cron workflows use [`CronStrategy`]. Returns an error for trigger types
-/// that are not yet implemented.
+/// Cron workflows use [`CronStrategy`]. Delay workflows use [`DelayStrategy`].
+/// Returns an error for trigger types that are not yet implemented.
 pub fn create_strategy(config: &WorkflowConfig) -> anyhow::Result<Box<dyn TriggerStrategy>> {
     match &config.trigger_config {
         TriggerConfig::Cron { expression } => {
             let strategy = CronStrategy::new(expression)?;
+            Ok(Box::new(strategy))
+        }
+        TriggerConfig::Delay { run_at } => {
+            let dt = chrono::DateTime::parse_from_rfc3339(run_at)
+                .map(|dt| dt.with_timezone(&Utc))
+                .or_else(|_| run_at.parse::<chrono::DateTime<Utc>>())
+                .map_err(|e| {
+                    anyhow::anyhow!("Invalid run_at datetime '{}': {}", run_at, e)
+                })?;
+            let strategy = DelayStrategy::new(dt, config.id);
             Ok(Box::new(strategy))
         }
         _ => {

--- a/crates/orchestrator/src/scheduler/strategy.rs
+++ b/crates/orchestrator/src/scheduler/strategy.rs
@@ -252,6 +252,114 @@ impl TriggerStrategy for CronStrategy {
 }
 
 // ---------------------------------------------------------------------------
+// DelayStrategy
+// ---------------------------------------------------------------------------
+
+/// A [`TriggerStrategy`] that fires once at a specific datetime, then stops.
+///
+/// On the first call to `next_tasks()`, the strategy sleeps until `run_at`
+/// and produces a single synthetic [`Task`]. If `run_at` is in the past, it
+/// fires immediately. On subsequent calls, it returns an empty vec to signal
+/// that the one-shot execution is complete.
+///
+/// # Auto-disable
+///
+/// After the delay fires, the runner should auto-disable the workflow by
+/// updating `enabled = false` in storage and stopping the runner. This is
+/// signalled by the `fired` flag — the runner checks [`DelayStrategy::has_fired()`]
+/// after dispatch.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use orchestrator::scheduler::strategy::DelayStrategy;
+/// use chrono::{Utc, Duration};
+///
+/// let run_at = Utc::now() + Duration::seconds(30);
+/// let strategy = DelayStrategy::new(run_at, workflow_id);
+/// ```
+#[derive(Debug)]
+pub struct DelayStrategy {
+    run_at: chrono::DateTime<Utc>,
+    workflow_id: uuid::Uuid,
+    fired: bool,
+}
+
+impl DelayStrategy {
+    /// Create a new delay strategy.
+    ///
+    /// * `run_at` — the datetime at which to fire.
+    /// * `workflow_id` — used to generate a unique `source_id`.
+    pub fn new(run_at: chrono::DateTime<Utc>, workflow_id: uuid::Uuid) -> Self {
+        Self { run_at, workflow_id, fired: false }
+    }
+
+    /// Returns `true` after the delay has fired.
+    pub fn has_fired(&self) -> bool {
+        self.fired
+    }
+
+    /// Build the synthetic task for the delay firing.
+    fn build_task(&self) -> Task {
+        let mut metadata = HashMap::new();
+        metadata.insert("run_at".to_string(), self.run_at.to_rfc3339());
+        metadata.insert("workflow_id".to_string(), self.workflow_id.to_string());
+
+        Task {
+            source_id: format!("delay:{}", self.workflow_id),
+            title: format!("Delay trigger: {}", self.run_at.to_rfc3339()),
+            body: String::new(),
+            url: String::new(),
+            labels: vec![],
+            assignee: None,
+            metadata,
+        }
+    }
+}
+
+#[async_trait]
+impl TriggerStrategy for DelayStrategy {
+    async fn next_tasks(&mut self, shutdown: &watch::Receiver<bool>) -> anyhow::Result<Vec<Task>> {
+        // Already fired — signal done by returning empty.
+        if self.fired {
+            // Sleep briefly to avoid busy-spinning before the runner stops us.
+            tokio::time::sleep(Duration::from_secs(1)).await;
+            return Ok(vec![]);
+        }
+
+        let now = Utc::now();
+        let wait_duration = if self.run_at > now {
+            (self.run_at - now).to_std().unwrap_or(Duration::ZERO)
+        } else {
+            Duration::ZERO
+        };
+
+        info!(
+            run_at = %self.run_at,
+            wait_secs = wait_duration.as_secs(),
+            workflow_id = %self.workflow_id,
+            "Delay strategy waiting for fire time"
+        );
+
+        // Sleep until the fire time, respecting shutdown.
+        let mut shutdown = shutdown.clone();
+        tokio::select! {
+            _ = tokio::time::sleep(wait_duration) => {
+                self.fired = true;
+                let task = self.build_task();
+                Ok(vec![task])
+            }
+            _ = shutdown.changed() => {
+                if *shutdown.borrow() {
+                    return Ok(vec![]);
+                }
+                Ok(vec![])
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
@@ -550,5 +658,118 @@ mod tests {
         for expr in expressions {
             assert!(CronStrategy::new(expr).is_ok(), "Failed to parse: {}", expr);
         }
+    }
+
+    // ── DelayStrategy tests ─────────────────────────────────────────
+
+    #[test]
+    fn delay_strategy_build_task_has_correct_fields() {
+        let wf_id = uuid::Uuid::new_v4();
+        let run_at = Utc::now() + chrono::Duration::hours(1);
+        let strategy = DelayStrategy::new(run_at, wf_id);
+        let task = strategy.build_task();
+
+        assert_eq!(task.source_id, format!("delay:{}", wf_id));
+        assert!(task.title.contains("Delay trigger:"));
+        assert_eq!(task.metadata.get("run_at"), Some(&run_at.to_rfc3339()));
+        assert_eq!(task.metadata.get("workflow_id"), Some(&wf_id.to_string()));
+    }
+
+    #[test]
+    fn delay_strategy_not_fired_initially() {
+        let wf_id = uuid::Uuid::new_v4();
+        let strategy = DelayStrategy::new(Utc::now(), wf_id);
+        assert!(!strategy.has_fired());
+    }
+
+    #[tokio::test]
+    async fn delay_strategy_fires_immediately_for_past_time() {
+        let wf_id = uuid::Uuid::new_v4();
+        let past = Utc::now() - chrono::Duration::hours(1);
+        let mut strategy = DelayStrategy::new(past, wf_id);
+        let (_tx, rx) = watch::channel(false);
+
+        let start = tokio::time::Instant::now();
+        let result = strategy.next_tasks(&rx).await.unwrap();
+        let elapsed = start.elapsed();
+
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].source_id, format!("delay:{}", wf_id));
+        assert!(elapsed < Duration::from_secs(1));
+        assert!(strategy.has_fired());
+    }
+
+    #[tokio::test]
+    async fn delay_strategy_fires_at_future_time() {
+        let wf_id = uuid::Uuid::new_v4();
+        // Fire 100ms in the future
+        let run_at = Utc::now() + chrono::Duration::milliseconds(100);
+        let mut strategy = DelayStrategy::new(run_at, wf_id);
+        let (_tx, rx) = watch::channel(false);
+
+        let result = strategy.next_tasks(&rx).await.unwrap();
+        assert_eq!(result.len(), 1);
+        assert!(strategy.has_fired());
+    }
+
+    #[tokio::test]
+    async fn delay_strategy_returns_empty_after_firing() {
+        let wf_id = uuid::Uuid::new_v4();
+        let past = Utc::now() - chrono::Duration::hours(1);
+        let mut strategy = DelayStrategy::new(past, wf_id);
+        let (_tx, rx) = watch::channel(false);
+
+        // First call fires.
+        let result = strategy.next_tasks(&rx).await.unwrap();
+        assert_eq!(result.len(), 1);
+
+        // Second call returns empty.
+        let result = strategy.next_tasks(&rx).await.unwrap();
+        assert!(result.is_empty());
+    }
+
+    #[tokio::test]
+    async fn delay_strategy_respects_shutdown() {
+        let wf_id = uuid::Uuid::new_v4();
+        // Use a far-future time so it would block forever.
+        let run_at = Utc::now() + chrono::Duration::hours(24);
+        let mut strategy = DelayStrategy::new(run_at, wf_id);
+        let (tx, rx) = watch::channel(false);
+
+        // Fire shutdown after a short delay.
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(50)).await;
+            let _ = tx.send(true);
+        });
+
+        let start = tokio::time::Instant::now();
+        let result = strategy.next_tasks(&rx).await.unwrap();
+        let elapsed = start.elapsed();
+
+        assert!(elapsed < Duration::from_secs(2));
+        assert!(result.is_empty());
+        assert!(!strategy.has_fired());
+    }
+
+    #[tokio::test]
+    async fn delay_strategy_is_object_safe() {
+        let wf_id = uuid::Uuid::new_v4();
+        let past = Utc::now() - chrono::Duration::seconds(1);
+        let strategy: Box<dyn TriggerStrategy> = Box::new(DelayStrategy::new(past, wf_id));
+        let (_tx, rx) = watch::channel(false);
+
+        let mut strategy = strategy;
+        let result = strategy.next_tasks(&rx).await.unwrap();
+        assert_eq!(result.len(), 1);
+    }
+
+    #[test]
+    fn delay_strategy_source_id_uses_workflow_id() {
+        let wf_id = uuid::Uuid::new_v4();
+        let strategy = DelayStrategy::new(Utc::now(), wf_id);
+        let task = strategy.build_task();
+
+        // source_id should be deterministic based on workflow_id for dedup.
+        assert_eq!(task.source_id, format!("delay:{}", wf_id));
     }
 }

--- a/crates/orchestrator/src/scheduler/types.rs
+++ b/crates/orchestrator/src/scheduler/types.rs
@@ -124,7 +124,14 @@ impl TriggerConfig {
             TriggerConfig::GithubIssues { .. }
                 | TriggerConfig::GithubPullRequests { .. }
                 | TriggerConfig::Cron { .. }
+                | TriggerConfig::Delay { .. }
         )
+    }
+
+    /// Returns `true` for one-shot trigger types that should auto-disable
+    /// the workflow after firing.
+    pub fn is_one_shot(&self) -> bool {
+        matches!(self, TriggerConfig::Delay { .. })
     }
 }
 


### PR DESCRIPTION
## Summary
- Add `DelayStrategy` that sleeps until a specific `run_at` datetime and produces a single synthetic `Task` with `source_id = "delay:{workflow_id}"` for deduplication
- If `run_at` is in the past, fires immediately on first call
- After firing, returns empty `Vec` on subsequent calls to signal completion
- Add `RunOutcome` enum (`Shutdown` / `AutoDisable`) — the runner detects one-shot completion and the scheduler auto-disables the workflow (`enabled = false`) in storage
- Validate `run_at` as ISO 8601 datetime on workflow creation in the API
- Add `is_one_shot()` to `TriggerConfig` and update `is_implemented()` to include `Delay`

## Test plan
- [x] 8 new DelayStrategy unit tests pass (past-time fires immediately, future-time fires correctly, empty after firing, shutdown interrupts, object safety, task fields, source_id determinism)
- [x] All 17 existing strategy tests (polling + cron) still pass
- [x] Build succeeds with no errors
- [ ] Manual: create a delay workflow with `run_at` 30s in the future and verify it fires once then auto-disables

Closes #339

🤖 Generated with [Claude Code](https://claude.com/claude-code)