### PR TITLE
Fix clippy warnings and pin chrono to avoid arrow-arith conflict

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -77,6 +77,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1244,16 +1250,17 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.39"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "7e36cc9d416881d2e24f9a963be5fb1cd90966419ac844274161d10488b3e825"
 dependencies = [
+ "android-tzdata",
  "iana-time-zone",
  "js-sys",
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-link 0.2.1",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -1498,9 +1505,9 @@ dependencies = [
 
 [[package]]
 name = "croner"
-version = "3.0.1"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4aa42bcd3d846ebf66e15bd528d1087f75d1c6c1c66ebff626178a106353c576"
+checksum = "4c007081651a19b42931f86f7d4f74ee1c2a7d0cd2c6636a81695b5ffd4e9990"
 dependencies = [
  "chrono",
  "derive_builder",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,4 +39,5 @@ metrics = "0.24"
 metrics-exporter-prometheus = { version = "0.16", default-features = false }
 sea-orm = { version = "1.1", features = ["sqlx-sqlite", "runtime-tokio-rustls", "macros"] }
 sea-orm-migration = { version = "1.1" }
+chrono = { version = ">=0.4.38, <0.4.40", features = ["serde"] }
 croner = "3.0"

--- a/crates/ask/Cargo.toml
+++ b/crates/ask/Cargo.toml
@@ -22,7 +22,7 @@ axum = { workspace = true }
 tower-http = { workspace = true }
 reqwest = { version = "0.12", features = ["json"] }
 uuid = { version = "1.0", features = ["serde", "v4"] }
-chrono = { version = "0.4", features = ["serde"] }
+chrono = { workspace = true }
 tmux_interface = "0.3"
 notify = { path = "../notify" }
 agentd-common = { path = "../common" }

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -17,7 +17,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 reqwest = { version = "0.12", features = ["json"] }
 colored = "2.1"
-chrono = { version = "0.4", features = ["serde"] }
+chrono = { workspace = true }
 uuid = { version = "1.11", features = ["serde", "v4"] }
 prettytable-rs = "0.10"
 tokio-tungstenite = { version = "0.26", features = ["connect", "handshake"] }

--- a/crates/cli/src/commands/orchestrator.rs
+++ b/crates/cli/src/commands/orchestrator.rs
@@ -3539,24 +3539,24 @@ mod tests {
     }
 
     #[test]
-    fn test_trigger_config_is_poll_based() {
+    fn test_trigger_config_is_implemented() {
         assert!(TriggerConfig::GithubIssues {
             owner: "a".into(),
             repo: "b".into(),
             labels: vec![],
             state: "open".into(),
         }
-        .is_poll_based());
+        .is_implemented());
         assert!(TriggerConfig::GithubPullRequests {
             owner: "a".into(),
             repo: "b".into(),
             labels: vec![],
             state: "open".into(),
         }
-        .is_poll_based());
-        assert!(!TriggerConfig::Cron { expression: "* * * * *".into() }.is_poll_based());
-        assert!(!TriggerConfig::Delay { run_at: "2026-01-01T00:00:00Z".into() }.is_poll_based());
-        assert!(!TriggerConfig::Webhook { secret: None }.is_poll_based());
-        assert!(!TriggerConfig::Manual {}.is_poll_based());
+        .is_implemented());
+        assert!(TriggerConfig::Cron { expression: "* * * * *".into() }.is_implemented());
+        assert!(TriggerConfig::Delay { run_at: "2026-01-01T00:00:00Z".into() }.is_implemented());
+        assert!(!TriggerConfig::Webhook { secret: None }.is_implemented());
+        assert!(!TriggerConfig::Manual {}.is_implemented());
     }
 }

--- a/crates/common/Cargo.toml
+++ b/crates/common/Cargo.toml
@@ -16,7 +16,7 @@ thiserror = { workspace = true }
 axum = { workspace = true }
 tower-http = { workspace = true }
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
-chrono = { version = "0.4", features = ["serde"] }
+chrono = { workspace = true }
 uuid = { version = "1.11", features = ["v4", "serde"] }
 sea-orm = { workspace = true }
 sea-orm-migration = { workspace = true }

--- a/crates/hook/Cargo.toml
+++ b/crates/hook/Cargo.toml
@@ -23,7 +23,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 axum = { workspace = true }
 tower-http = { workspace = true }
-chrono = { version = "0.4", features = ["serde"] }
+chrono = { workspace = true }
 uuid = { version = "1.0", features = ["serde", "v4"] }
 reqwest = { workspace = true, features = ["json"] }
 agentd-common = { path = "../common" }

--- a/crates/memory/Cargo.toml
+++ b/crates/memory/Cargo.toml
@@ -46,7 +46,7 @@ futures = "0.3"
 
 # Additional utilities
 uuid = { version = "1.11", features = ["v4", "serde"] }
-chrono = { version = "0.4", features = ["serde"] }
+chrono = { workspace = true }
 directories = "6.0.0"
 agentd-common = { path = "../common" }
 metrics = { workspace = true }

--- a/crates/monitor/Cargo.toml
+++ b/crates/monitor/Cargo.toml
@@ -23,7 +23,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 axum = { workspace = true }
 tower-http = { workspace = true }
-chrono = { version = "0.4", features = ["serde"] }
+chrono = { workspace = true }
 uuid = { version = "1.0", features = ["serde", "v4"] }
 sysinfo = "0.33"
 reqwest = { workspace = true, features = ["json"] }

--- a/crates/notify/Cargo.toml
+++ b/crates/notify/Cargo.toml
@@ -32,7 +32,7 @@ async-trait = "0.1"
 
 # Additional utilities
 uuid = { version = "1.11", features = ["v4", "serde"] }
-chrono = { version = "0.4", features = ["serde"] }
+chrono = { workspace = true }
 directories = "6.0.0"
 agentd-common = { path = "../common" }
 metrics = { workspace = true }

--- a/crates/orchestrator/Cargo.toml
+++ b/crates/orchestrator/Cargo.toml
@@ -32,7 +32,7 @@ async-trait = "0.1"
 
 # Additional utilities
 uuid = { version = "1.11", features = ["v4", "serde"] }
-chrono = { version = "0.4", features = ["serde"] }
+chrono = { workspace = true }
 directories = "6.0.0"
 futures = "0.3"
 agentd-common = { path = "../common" }

--- a/crates/orchestrator/src/scheduler/strategy.rs
+++ b/crates/orchestrator/src/scheduler/strategy.rs
@@ -295,6 +295,7 @@ impl DelayStrategy {
     }
 
     /// Returns `true` after the delay has fired.
+    #[cfg(test)]
     pub fn has_fired(&self) -> bool {
         self.fired
     }

--- a/crates/orchestrator/src/scheduler/types.rs
+++ b/crates/orchestrator/src/scheduler/types.rs
@@ -109,14 +109,6 @@ impl TriggerConfig {
         }
     }
 
-    /// Returns `true` for trigger types that use poll-based task fetching.
-    pub fn is_poll_based(&self) -> bool {
-        matches!(
-            self,
-            TriggerConfig::GithubIssues { .. } | TriggerConfig::GithubPullRequests { .. }
-        )
-    }
-
     /// Returns `true` for trigger types that have a working implementation.
     pub fn is_implemented(&self) -> bool {
         matches!(

--- a/crates/wrap/Cargo.toml
+++ b/crates/wrap/Cargo.toml
@@ -20,7 +20,7 @@ tracing-subscriber = { workspace = true }
 
 axum = { workspace = true }
 tower-http = { workspace = true }
-chrono = "0.4"
+chrono = { workspace = true }
 uuid = { version = "1.11", features = ["v4", "serde"] }
 reqwest = { version = "0.12", features = ["json"] }
 agentd-common = { path = "../common" }


### PR DESCRIPTION
## Summary
- Pin `chrono` to `>=0.4.38, <0.4.40` as a workspace dependency to fix `error[E0034]` build failure caused by chrono 0.4.40+ adding `Datelike::quarter()` which conflicts with `arrow-arith 53.4.0`'s `ChronoDateExt::quarter()`
- Centralize `chrono` as a workspace dependency (with `serde` feature) across all 9 crates
- Remove unused `is_poll_based()` method (superseded by `is_implemented()`) and update corresponding test
- Gate `DelayStrategy::has_fired()` with `#[cfg(test)]` to eliminate dead code warning

## Test plan
- [x] `cargo clippy --all-targets -- -D warnings` passes cleanly
- [x] All workspace tests pass (one pre-existing doctest failure in `hook/config.rs` unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)