### PR TITLE
Add POST /workflows/{id}/trigger endpoint for manual dispatch

### DIFF
--- a/crates/cli/src/commands/orchestrator.rs
+++ b/crates/cli/src/commands/orchestrator.rs
@@ -55,7 +55,8 @@ use uuid::Uuid;
 
 use orchestrator::client::OrchestratorClient;
 use orchestrator::scheduler::types::{
-    CreateWorkflowRequest, DispatchResponse, TriggerConfig, UpdateWorkflowRequest, WorkflowResponse,
+    CreateWorkflowRequest, DispatchResponse, TriggerConfig, TriggerWorkflowRequest,
+    UpdateWorkflowRequest, WorkflowResponse,
 };
 use orchestrator::types::{
     AddDirResponse, AgentResponse, AgentStatus, AgentUsageStats, ApprovalStatus,
@@ -713,6 +714,32 @@ pub enum OrchestratorCommand {
         id: String,
     },
 
+    /// Manually trigger a workflow on demand.
+    ///
+    /// Dispatches the workflow immediately, bypassing its normal trigger strategy.
+    /// Useful for testing or ad-hoc automation. Works for `Manual` trigger type
+    /// workflows as well as any other trigger type.
+    ///
+    /// # Examples
+    ///
+    ///   agent orchestrator trigger-workflow <WORKFLOW_ID>
+    ///
+    ///   agent orchestrator trigger-workflow <WORKFLOW_ID> \
+    ///     --title "Deploy hotfix" \
+    ///     --body "Please review and merge PR #123"
+    TriggerWorkflow {
+        /// Workflow ID (UUID)
+        id: String,
+
+        /// Task title (defaults to "Manual trigger")
+        #[arg(long)]
+        title: Option<String>,
+
+        /// Task body / description
+        #[arg(long)]
+        body: Option<String>,
+    },
+
     /// Add an additional directory to an agent's accessible paths.
     ///
     /// The directory must exist on the local filesystem. The change takes
@@ -910,6 +937,9 @@ impl OrchestratorCommand {
             }
             OrchestratorCommand::DeleteWorkflow { id } => delete_workflow(client, id, json).await,
             OrchestratorCommand::WorkflowHistory { id } => workflow_history(client, id, json).await,
+            OrchestratorCommand::TriggerWorkflow { id, title, body } => {
+                trigger_workflow_cmd(client, id, title.as_deref(), body.as_deref(), json).await
+            }
             OrchestratorCommand::AddDir { id, path } => add_dir_cmd(client, id, path, json).await,
             OrchestratorCommand::RemoveDir { id, path } => {
                 remove_dir_cmd(client, id, path, json).await
@@ -2250,6 +2280,53 @@ async fn workflow_history(client: &OrchestratorClient, id: &str, json: bool) -> 
     Ok(())
 }
 
+async fn trigger_workflow_cmd(
+    client: &OrchestratorClient,
+    id: &str,
+    title: Option<&str>,
+    body: Option<&str>,
+    json: bool,
+) -> Result<()> {
+    let uuid = parse_uuid(id)?;
+
+    let request = TriggerWorkflowRequest {
+        title: title.map(|s| s.to_string()),
+        body: body.map(|s| s.to_string()),
+        metadata: std::collections::HashMap::new(),
+    };
+
+    let dispatch = client
+        .trigger_workflow(&uuid, &request)
+        .await
+        .map_err(|e| {
+            let msg = e.to_string();
+            if msg.contains("404") {
+                anyhow::anyhow!(
+                    "Workflow '{}' not found. Use 'agent orchestrator list-workflows' to see available workflows.",
+                    id
+                )
+            } else if msg.contains("400") {
+                anyhow::anyhow!("Workflow '{}' is disabled. Enable it first with update-workflow --enabled true.", id)
+            } else if msg.contains("409") {
+                anyhow::anyhow!("Workflow '{}' agent is currently busy processing another task.", id)
+            } else if msg.contains("503") {
+                anyhow::anyhow!("Agent for workflow '{}' is not connected.", id)
+            } else {
+                e.context("Failed to trigger workflow")
+            }
+        })?;
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&dispatch)?);
+    } else {
+        println!("{}", "Workflow triggered successfully.".green().bold());
+        println!("{}", "=".repeat(80).cyan());
+        display_dispatch(&dispatch);
+    }
+
+    Ok(())
+}
+
 // -- Helper functions --
 
 /// Parse a string as a UUID, providing a user-friendly error message.
@@ -3567,7 +3644,7 @@ mod tests {
         .is_implemented());
         assert!(TriggerConfig::Cron { expression: "* * * * *".into() }.is_implemented());
         assert!(TriggerConfig::Delay { run_at: "2026-01-01T00:00:00Z".into() }.is_implemented());
-        assert!(!TriggerConfig::Webhook { secret: None }.is_implemented());
-        assert!(!TriggerConfig::Manual {}.is_implemented());
+        assert!(TriggerConfig::Webhook { secret: None }.is_implemented());
+        assert!(TriggerConfig::Manual {}.is_implemented());
     }
 }

--- a/crates/orchestrator/src/client.rs
+++ b/crates/orchestrator/src/client.rs
@@ -29,7 +29,8 @@ use serde::Serialize;
 use uuid::Uuid;
 
 use crate::scheduler::types::{
-    CreateWorkflowRequest, DispatchResponse, UpdateWorkflowRequest, WorkflowResponse,
+    CreateWorkflowRequest, DispatchResponse, TriggerWorkflowRequest, UpdateWorkflowRequest,
+    WorkflowResponse,
 };
 use crate::types::{
     AddDirRequest, AddDirResponse, AgentResponse, AgentUsageStats, ApprovalActionRequest,
@@ -249,6 +250,15 @@ impl OrchestratorClient {
     /// Get the dispatch history for a workflow.
     pub async fn dispatch_history(&self, id: &Uuid) -> Result<PaginatedResponse<DispatchResponse>> {
         self.get(&format!("/workflows/{}/history", id)).await
+    }
+
+    /// Manually trigger a workflow on demand, bypassing its normal trigger strategy.
+    pub async fn trigger_workflow(
+        &self,
+        id: &Uuid,
+        request: &TriggerWorkflowRequest,
+    ) -> Result<DispatchResponse> {
+        self.post(&format!("/workflows/{}/trigger", id), request).await
     }
 
     // -- Private HTTP helpers --

--- a/crates/orchestrator/src/scheduler/api.rs
+++ b/crates/orchestrator/src/scheduler/api.rs
@@ -36,6 +36,7 @@ pub fn workflow_routes(state: WorkflowState) -> Router {
         .route("/workflows", get(list_workflows).post(create_workflow))
         .route("/workflows/{id}", get(get_workflow).put(update_workflow).delete(delete_workflow))
         .route("/workflows/{id}/history", get(dispatch_history))
+        .route("/workflows/{id}/trigger", post(trigger_workflow))
         .with_state(state)
 }
 
@@ -252,6 +253,68 @@ async fn dispatch_history(
         state.scheduler.storage().list_dispatches_paginated(&id, limit, offset).await?;
     let items: Vec<DispatchResponse> = dispatches.into_iter().map(DispatchResponse::from).collect();
     Ok(Json(PaginatedResponse { items, total, limit, offset }))
+}
+
+// ---------------------------------------------------------------------------
+// Manual trigger endpoint
+// ---------------------------------------------------------------------------
+
+/// Manually trigger a workflow on demand, bypassing its normal trigger strategy.
+///
+/// Accepts an optional JSON body:
+/// ```json
+/// { "title": "...", "body": "...", "metadata": { "key": "value" } }
+/// ```
+///
+/// Returns:
+/// - `200 OK` with the [`DispatchResponse`] on success
+/// - `400 Bad Request` if the workflow is disabled
+/// - `404 Not Found` if the workflow does not exist
+/// - `409 Conflict` if the agent is currently busy
+/// - `503 Service Unavailable` if the agent is not connected
+async fn trigger_workflow(
+    State(state): State<WorkflowState>,
+    Path(id): Path<Uuid>,
+    body: Option<Json<TriggerWorkflowRequest>>,
+) -> Result<impl IntoResponse, ApiError> {
+    // Verify workflow exists.
+    state.scheduler.storage().get_workflow(&id).await?.ok_or(ApiError::NotFound)?;
+
+    let req = body.map(|Json(r)| r).unwrap_or_default();
+
+    // Build a synthetic Task from the request body (or defaults).
+    let source_id = format!("manual:{}", Uuid::new_v4());
+    let task = Task {
+        source_id,
+        title: req.title.unwrap_or_else(|| "Manual trigger".to_string()),
+        body: req.body.unwrap_or_default(),
+        url: String::new(),
+        labels: vec![],
+        assignee: None,
+        metadata: req.metadata,
+    };
+
+    info!(
+        workflow_id = %id,
+        source_id = %task.source_id,
+        title = %task.title,
+        "Manual workflow trigger requested"
+    );
+
+    let record = state.scheduler.trigger_workflow(&id, task).await.map_err(|e| {
+        let msg = e.to_string();
+        if msg.contains("not enabled") {
+            ApiError::InvalidInput(msg)
+        } else if msg.contains("currently busy") {
+            ApiError::Conflict(msg)
+        } else if msg.contains("not connected") {
+            ApiError::ServiceUnavailable(msg)
+        } else {
+            ApiError::Internal(e)
+        }
+    })?;
+
+    Ok(Json(DispatchResponse::from(record)))
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/orchestrator/src/scheduler/mod.rs
+++ b/crates/orchestrator/src/scheduler/mod.rs
@@ -15,10 +15,10 @@ use runner::{create_strategy, notify_complete, RunOutcome, WorkflowRunner};
 use std::collections::HashMap;
 use std::sync::Arc;
 use storage::SchedulerStorage;
-use strategy::WebhookStrategy;
-use tokio::sync::{watch, Mutex, RwLock};
+use strategy::{ManualStrategy, WebhookStrategy};
+use tokio::sync::{mpsc, watch, Mutex, RwLock};
 use tracing::{error, info, warn};
-use types::{DispatchStatus, TriggerConfig, WorkflowConfig};
+use types::{DispatchRecord, DispatchStatus, Task, TriggerConfig, WorkflowConfig};
 use uuid::Uuid;
 use webhook::WebhookRegistry;
 
@@ -30,6 +30,9 @@ struct RunningWorkflow {
     agent_id: Uuid,
     shutdown_tx: watch::Sender<bool>,
     busy: Arc<Mutex<runner::BusyState>>,
+    /// Channel sender for Manual-type workflows.
+    /// Used by the `POST /workflows/{id}/trigger` API endpoint.
+    manual_tx: Option<mpsc::Sender<Task>>,
 }
 
 /// Manages all active WorkflowRunners.
@@ -83,13 +86,17 @@ impl Scheduler {
             }
         }
 
-        // Webhook triggers use a channel-based strategy with a shared registry;
-        // all other triggers use the standard factory.
+        // Build strategy and capture any channel sender for the workflow type.
+        let mut manual_tx: Option<mpsc::Sender<Task>> = None;
         let strategy: Box<dyn strategy::TriggerStrategy> =
             if let TriggerConfig::Webhook { ref secret } = config.trigger_config {
-                let (tx, rx) = tokio::sync::mpsc::channel(webhook::DEFAULT_CHANNEL_CAPACITY);
+                let (tx, rx) = mpsc::channel(webhook::DEFAULT_CHANNEL_CAPACITY);
                 self.webhook_registry.register(workflow_id, tx, secret.clone()).await;
                 Box::new(WebhookStrategy::new(rx))
+            } else if matches!(config.trigger_config, TriggerConfig::Manual {}) {
+                let (tx, rx) = mpsc::channel(webhook::DEFAULT_CHANNEL_CAPACITY);
+                manual_tx = Some(tx);
+                Box::new(ManualStrategy::new(rx))
             } else {
                 create_strategy(&config, self.event_bus.as_ref())?
             };
@@ -117,7 +124,10 @@ impl Scheduler {
 
         // Track the runner.
         let mut runners = self.runners.write().await;
-        runners.insert(workflow_id, RunningWorkflow { workflow_id, agent_id, shutdown_tx, busy });
+        runners.insert(
+            workflow_id,
+            RunningWorkflow { workflow_id, agent_id, shutdown_tx, busy, manual_tx },
+        );
 
         info!(%workflow_id, "Workflow started");
         Ok(())
@@ -240,6 +250,145 @@ impl Scheduler {
     /// Return the set of currently running workflow IDs and their assigned agent IDs.
     pub async fn running_workflows(&self) -> Vec<(Uuid, Uuid)> {
         self.runners.read().await.iter().map(|(wf_id, rw)| (*wf_id, rw.agent_id)).collect()
+    }
+
+    /// Manually trigger a workflow, bypassing its normal trigger strategy.
+    ///
+    /// Creates a synthetic [`Task`] from the provided data, renders the
+    /// workflow's prompt template, records the dispatch, and sends the prompt
+    /// to the workflow's agent.
+    ///
+    /// For `Manual`-type workflows, the task is pushed through the workflow's
+    /// dedicated `mpsc` channel so the running [`WorkflowRunner`] handles it
+    /// with full busy-state tracking.  For all other trigger types the task
+    /// is dispatched directly (bypassing the strategy), which is useful for
+    /// ad-hoc testing.
+    ///
+    /// Returns the created [`DispatchRecord`] on success.
+    pub async fn trigger_workflow(
+        &self,
+        workflow_id: &Uuid,
+        task: Task,
+    ) -> anyhow::Result<DispatchRecord> {
+        use crate::scheduler::template::render_template;
+
+        // Load workflow config (must exist and be enabled).
+        let workflow = self
+            .storage
+            .get_workflow(workflow_id)
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("Workflow not found"))?;
+
+        if !workflow.enabled {
+            anyhow::bail!("Workflow {} is not enabled", workflow_id);
+        }
+
+        // For Manual-type workflows with a running runner, send via the channel
+        // so the runner can apply its full dispatch logic (busy-state tracking, etc.).
+        {
+            let runners = self.runners.read().await;
+            if let Some(running) = runners.get(workflow_id) {
+                if let Some(ref tx) = running.manual_tx {
+                    // Check busy state before sending.
+                    let busy = running.busy.lock().await;
+                    if busy.active_dispatch_id.is_some() {
+                        anyhow::bail!("Agent is currently busy processing another task");
+                    }
+                    drop(busy);
+
+                    tx.try_send(task.clone()).map_err(|e| match e {
+                        mpsc::error::TrySendError::Full(_) => {
+                            anyhow::anyhow!("Manual trigger channel full")
+                        }
+                        mpsc::error::TrySendError::Closed(_) => {
+                            anyhow::anyhow!("Manual trigger channel closed")
+                        }
+                    })?;
+
+                    // Create the dispatch record immediately so we can return it.
+                    let prompt = render_template(&workflow.prompt_template, &task);
+                    let record = DispatchRecord {
+                        id: Uuid::new_v4(),
+                        workflow_id: *workflow_id,
+                        source_id: task.source_id.clone(),
+                        agent_id: workflow.agent_id,
+                        prompt_sent: prompt,
+                        status: DispatchStatus::Pending,
+                        dispatched_at: chrono::Utc::now(),
+                        completed_at: None,
+                    };
+                    self.storage.add_dispatch(&record).await?;
+
+                    info!(
+                        %workflow_id,
+                        source_id = %task.source_id,
+                        "Manual trigger queued via channel"
+                    );
+                    return Ok(record);
+                }
+            }
+        }
+
+        // Direct dispatch: render prompt, record, and send to agent.
+        // Works for any workflow type (bypasses normal trigger strategy).
+        let prompt = render_template(&workflow.prompt_template, &task);
+
+        // Verify the agent is connected.
+        if !self.registry.is_connected(&workflow.agent_id).await {
+            anyhow::bail!("Agent {} is not connected", workflow.agent_id);
+        }
+
+        let record = DispatchRecord {
+            id: Uuid::new_v4(),
+            workflow_id: *workflow_id,
+            source_id: task.source_id.clone(),
+            agent_id: workflow.agent_id,
+            prompt_sent: prompt.clone(),
+            status: DispatchStatus::Dispatched,
+            dispatched_at: chrono::Utc::now(),
+            completed_at: None,
+        };
+        self.storage.add_dispatch(&record).await?;
+
+        // Update the runner's busy state so completion is tracked correctly.
+        {
+            let runners = self.runners.read().await;
+            if let Some(running) = runners.get(workflow_id) {
+                let mut busy = running.busy.lock().await;
+                busy.active_dispatch_id = Some(record.id);
+            }
+        }
+
+        // Apply the workflow's tool policy.
+        self.registry.set_policy(workflow.agent_id, workflow.tool_policy.clone()).await;
+
+        // Send the prompt to the agent.
+        if let Err(e) = self.registry.send_user_message(&workflow.agent_id, &prompt).await {
+            // Best-effort: mark the dispatch as failed.
+            let _ = self
+                .storage
+                .update_dispatch_status(
+                    &record.id,
+                    DispatchStatus::Failed,
+                    Some(chrono::Utc::now()),
+                )
+                .await;
+            // Clear busy state.
+            let runners = self.runners.read().await;
+            if let Some(running) = runners.get(workflow_id) {
+                let mut busy = running.busy.lock().await;
+                busy.active_dispatch_id = None;
+            }
+            return Err(e);
+        }
+
+        info!(
+            %workflow_id,
+            source_id = %task.source_id,
+            "Manual trigger dispatched directly to agent"
+        );
+
+        Ok(record)
     }
 
     /// Shutdown all running workflows gracefully.

--- a/crates/orchestrator/src/scheduler/strategy.rs
+++ b/crates/orchestrator/src/scheduler/strategy.rs
@@ -622,6 +622,65 @@ impl TriggerStrategy for WebhookStrategy {
 }
 
 // ---------------------------------------------------------------------------
+// ManualStrategy
+// ---------------------------------------------------------------------------
+
+/// A [`TriggerStrategy`] that receives tasks from an explicit API trigger call
+/// via an `mpsc` channel.
+///
+/// Manual workflows do not poll or respond to events — they are triggered on
+/// demand via the `POST /workflows/{id}/trigger` API endpoint or the
+/// `agent orchestrator trigger-workflow` CLI command.
+///
+/// Each manual workflow gets a bounded `mpsc` channel. The HTTP endpoint
+/// pushes parsed [`Task`]s through the sender; this strategy receives them.
+/// When the sender is dropped (e.g., workflow stopped), `recv()` returns
+/// `None` and the strategy signals completion with an empty vec.
+///
+/// # Example
+///
+/// ```rust,ignore
+/// use tokio::sync::mpsc;
+/// use orchestrator::scheduler::strategy::ManualStrategy;
+///
+/// let (tx, rx) = mpsc::channel(64);
+/// let strategy = ManualStrategy::new(rx);
+/// // Register `tx` for access by the trigger API handler.
+/// ```
+pub struct ManualStrategy {
+    rx: mpsc::Receiver<Task>,
+}
+
+impl ManualStrategy {
+    /// Create a new manual strategy from a channel receiver.
+    pub fn new(rx: mpsc::Receiver<Task>) -> Self {
+        Self { rx }
+    }
+}
+
+#[async_trait]
+impl TriggerStrategy for ManualStrategy {
+    async fn next_tasks(&mut self, shutdown: &watch::Receiver<bool>) -> anyhow::Result<Vec<Task>> {
+        let mut shutdown = shutdown.clone();
+
+        tokio::select! {
+            task = self.rx.recv() => {
+                match task {
+                    Some(task) => Ok(vec![task]),
+                    None => Ok(vec![]),  // Sender dropped — workflow stopped.
+                }
+            }
+            _ = shutdown.changed() => {
+                if *shutdown.borrow() {
+                    return Ok(vec![]);
+                }
+                Ok(vec![])
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 

--- a/crates/orchestrator/src/scheduler/types.rs
+++ b/crates/orchestrator/src/scheduler/types.rs
@@ -145,6 +145,7 @@ impl TriggerConfig {
                 | TriggerConfig::AgentLifecycle { .. }
                 | TriggerConfig::DispatchResult { .. }
                 | TriggerConfig::Webhook { .. }
+                | TriggerConfig::Manual { .. }
         )
     }
 
@@ -203,6 +204,23 @@ impl std::str::FromStr for DispatchStatus {
             _ => Err(anyhow::anyhow!("Unknown dispatch status: {}", s)),
         }
     }
+}
+
+/// Request body for manually triggering a workflow via the API.
+///
+/// All fields are optional. Defaults are used when not provided:
+/// - `title`: "Manual trigger"
+/// - `body`: empty string
+/// - `metadata`: empty map
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct TriggerWorkflowRequest {
+    /// Task title (defaults to "Manual trigger").
+    pub title: Option<String>,
+    /// Task body / description.
+    pub body: Option<String>,
+    /// Arbitrary metadata key-value pairs.
+    #[serde(default)]
+    pub metadata: HashMap<String, String>,
 }
 
 /// Request body for creating a workflow.


### PR DESCRIPTION
## Summary

- Implements `POST /workflows/{id}/trigger` for on-demand workflow execution
- Adds `ManualStrategy` (mpsc channel-based, mirrors `WebhookStrategy`) used when trigger type is `Manual`
- Adds `Scheduler::trigger_workflow()` that routes through the manual channel for `Manual`-type workflows, or does a direct dispatch for any other trigger type (useful for testing)
- Adds `TriggerWorkflowRequest` with optional `title`, `body`, and `metadata` fields
- Adds `OrchestratorClient::trigger_workflow()` HTTP client method
- Adds `agent orchestrator trigger-workflow <id> [--title "..."] [--body "..."]` CLI command
- Updates `TriggerConfig::is_implemented()` to include `Manual` (and `Webhook` which was already implemented)
- Returns the `DispatchResponse` record on success with proper error mapping (400/404/409/503)

## Test plan

- [x] All existing tests pass (`cargo test -p orchestrator -p cli`)
- [x] `cargo fmt` and `cargo clippy -- -D warnings` pass clean
- [x] Updated `test_trigger_config_is_implemented` to reflect `Manual` and `Webhook` are now implemented
- [ ] Manual: `POST /workflows/{id}/trigger` with/without body for a Manual-type workflow
- [ ] Manual: `POST /workflows/{id}/trigger` for a non-Manual workflow (direct dispatch)
- [ ] Manual: `agent orchestrator trigger-workflow <id> --title "Test" --body "Details"`

Closes #346

🤖 Generated with [Claude Code](https://claude.com/claude-code)