### PR TITLE
feat(orchestrator,ui): enhance agent log tool call display with tool details

### DIFF
--- a/crates/orchestrator/src/websocket.rs
+++ b/crates/orchestrator/src/websocket.rs
@@ -296,12 +296,59 @@ fn extract_usage(msg: &Value) -> Option<UsageSnapshot> {
     })
 }
 
+/// Generate a human-readable one-line summary of a tool call input.
+fn summarize_tool_input(tool_name: &str, input: &Value) -> String {
+    let truncate = |s: &str, max: usize| -> String {
+        if s.len() <= max {
+            s.to_string()
+        } else {
+            format!("{}…", &s[..max])
+        }
+    };
+
+    match tool_name {
+        "Bash" => {
+            let cmd = input.get("command").and_then(|v| v.as_str()).unwrap_or("");
+            truncate(cmd, 100)
+        }
+        "Read" => {
+            let path = input.get("file_path").and_then(|v| v.as_str()).unwrap_or("");
+            truncate(path, 100)
+        }
+        "Edit" | "Write" => {
+            let path = input.get("file_path").and_then(|v| v.as_str()).unwrap_or("");
+            truncate(path, 100)
+        }
+        "Grep" => {
+            let pattern = input.get("pattern").and_then(|v| v.as_str()).unwrap_or("");
+            let path = input.get("path").and_then(|v| v.as_str()).unwrap_or("");
+            truncate(&format!("{} in {}", pattern, path), 100)
+        }
+        "Glob" => {
+            let pattern = input.get("pattern").and_then(|v| v.as_str()).unwrap_or("");
+            truncate(pattern, 100)
+        }
+        "WebFetch" => {
+            let url = input.get("url").and_then(|v| v.as_str()).unwrap_or("");
+            truncate(url, 100)
+        }
+        _ => {
+            let serialized = serde_json::to_string(input).unwrap_or_default();
+            truncate(&serialized, 100)
+        }
+    }
+}
+
 /// Extract displayable text lines from a Claude Code `assistant` message.
 ///
 /// The `message` object may have a `content` field that is either a plain
 /// string or an array of content blocks (text blocks, tool_use blocks, etc.).
-fn extract_assistant_text(message: &Value) -> Vec<String> {
+///
+/// Returns a tuple of (text_lines, tool_use_blocks) where tool_use_blocks
+/// carries structured tool use data for broadcasting as separate events.
+fn extract_assistant_content(message: &Value) -> (Vec<String>, Vec<Value>) {
     let mut lines = Vec::new();
+    let mut tool_uses = Vec::new();
     if let Some(content) = message.get("content") {
         if let Some(text) = content.as_str() {
             lines.push(text.to_string());
@@ -315,15 +362,26 @@ fn extract_assistant_text(message: &Value) -> Vec<String> {
                         }
                     }
                     "tool_use" => {
-                        let tool = block.get("name").and_then(|v| v.as_str()).unwrap_or("unknown");
-                        lines.push(format!("[Tool: {}]", tool));
+                        let tool_name =
+                            block.get("name").and_then(|v| v.as_str()).unwrap_or("unknown");
+                        let tool_id =
+                            block.get("id").and_then(|v| v.as_str()).unwrap_or("").to_string();
+                        let tool_input =
+                            block.get("input").cloned().unwrap_or(Value::Object(Default::default()));
+                        let summary = summarize_tool_input(tool_name, &tool_input);
+                        tool_uses.push(serde_json::json!({
+                            "tool_name": tool_name,
+                            "tool_id": tool_id,
+                            "tool_input": tool_input,
+                            "summary": summary,
+                        }));
                     }
                     _ => {}
                 }
             }
         }
     }
-    lines
+    (lines, tool_uses)
 }
 
 /// Broadcast a single `agent:output` event on the multiplexed stream.
@@ -372,10 +430,24 @@ async fn handle_incoming_message(agent_id: &Uuid, text: &str, registry: &Connect
             }
             "assistant" => {
                 debug!(%agent_id, "Assistant response received");
-                // Extract text content and broadcast as agent:output events.
+                // Extract text content and tool use blocks; broadcast both.
                 if let Some(message) = msg.get("message") {
-                    for text in extract_assistant_text(message) {
+                    let (texts, tool_uses) = extract_assistant_content(message);
+                    for text in texts {
                         broadcast_output(agent_id, &text, registry);
+                    }
+                    for tool_use in tool_uses {
+                        let event = serde_json::json!({
+                            "type": "agent:tool_use",
+                            "agent_id": agent_id.to_string(),
+                            "agentId": agent_id.to_string(),
+                            "tool_name": tool_use["tool_name"],
+                            "tool_id": tool_use["tool_id"],
+                            "tool_input": tool_use["tool_input"],
+                            "summary": tool_use["summary"],
+                            "timestamp": Utc::now().to_rfc3339(),
+                        });
+                        let _ = registry.stream_tx.send(event.to_string());
                     }
                 }
             }

--- a/ui/src/components/agents/AgentLogView.tsx
+++ b/ui/src/components/agents/AgentLogView.tsx
@@ -12,7 +12,7 @@
  */
 
 import { useCallback, useEffect, useRef, useState } from 'react'
-import { ArrowDown, Eraser, Wifi, WifiOff, Loader2 } from 'lucide-react'
+import { ArrowDown, ChevronDown, ChevronRight, Eraser, Wifi, WifiOff, Loader2 } from 'lucide-react'
 import type { LogLine, StreamStatus } from '@/hooks/useAgentStream'
 
 // ---------------------------------------------------------------------------
@@ -61,6 +61,51 @@ function StreamStatusBadge({ status }: { status: StreamStatus }) {
       <WifiOff size={12} aria-hidden="true" />
       Disconnected
     </span>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// Tool use line (expandable)
+// ---------------------------------------------------------------------------
+
+interface ToolUseLineProps {
+  ts: string
+  toolName: string
+  summary: string
+  toolInput: Record<string, unknown>
+}
+
+function ToolUseLine({ ts, toolName, summary, toolInput }: ToolUseLineProps) {
+  const [expanded, setExpanded] = useState(false)
+
+  return (
+    <div className="my-0.5">
+      <button
+        type="button"
+        onClick={() => setExpanded((v) => !v)}
+        className="flex w-full items-start gap-2 rounded px-1 text-left hover:bg-gray-800"
+      >
+        <span className="flex-shrink-0 select-none text-gray-600">{ts}</span>
+        <span className="flex-shrink-0 text-purple-400">
+          {expanded ? (
+            <ChevronDown size={12} aria-hidden="true" className="mt-0.5" />
+          ) : (
+            <ChevronRight size={12} aria-hidden="true" className="mt-0.5" />
+          )}
+        </span>
+        <span className="flex items-baseline gap-1.5">
+          <span className="rounded bg-purple-900/40 px-1.5 py-0.5 text-xs font-semibold text-purple-300">
+            {toolName}
+          </span>
+          <span className="text-gray-300">{summary}</span>
+        </span>
+      </button>
+      {expanded && (
+        <div className="ml-24 mt-1 mb-2 rounded border border-gray-700 bg-gray-900 p-2 text-xs text-gray-300">
+          <pre className="whitespace-pre-wrap break-all">{JSON.stringify(toolInput, null, 2)}</pre>
+        </div>
+      )}
+    </div>
   )
 }
 
@@ -161,6 +206,17 @@ export function AgentLogView({ lines, status, onClear }: AgentLogViewProps) {
               second: '2-digit',
               hour12: false,
             })
+            if (line.toolUse) {
+              return (
+                <ToolUseLine
+                  key={line.id}
+                  ts={ts}
+                  toolName={line.toolUse.tool_name}
+                  summary={line.toolUse.summary}
+                  toolInput={line.toolUse.tool_input}
+                />
+              )
+            }
             return (
               <div key={line.id} className="flex gap-2 whitespace-pre-wrap break-all">
                 <span className="flex-shrink-0 select-none text-gray-600">{ts}</span>

--- a/ui/src/hooks/useAgentStream.ts
+++ b/ui/src/hooks/useAgentStream.ts
@@ -13,7 +13,7 @@ import { useCallback, useEffect, useRef, useState } from 'react'
 import { WebSocketManager } from '@/services/websocket'
 import { serviceConfig } from '@/services/config'
 import { agentEventBus } from '@/services/eventBus'
-import type { AgentEvent, UsageUpdateEvent, ContextClearedEvent } from '@/types/orchestrator'
+import type { AgentEvent, UsageUpdateEvent, ContextClearedEvent, AgentToolUseEvent } from '@/types/orchestrator'
 
 // ---------------------------------------------------------------------------
 // Types
@@ -26,6 +26,13 @@ export interface LogLine {
   /** Raw text (may contain ANSI escape sequences) */
   text: string
   timestamp: string
+  /** When set, this line represents a tool call rather than plain output */
+  toolUse?: {
+    tool_name: string
+    tool_id: string
+    tool_input: Record<string, unknown>
+    summary: string
+  }
 }
 
 /** Callback invoked when a real-time usage update event arrives */
@@ -65,6 +72,20 @@ function makeLogLine(text: string): LogLine {
     id: ++globalLineId,
     text,
     timestamp: new Date().toISOString(),
+  }
+}
+
+function makeToolUseLine(event: AgentToolUseEvent): LogLine {
+  return {
+    id: ++globalLineId,
+    text: `[${event.tool_name}] ${event.summary}`,
+    timestamp: event.timestamp,
+    toolUse: {
+      tool_name: event.tool_name,
+      tool_id: event.tool_id,
+      tool_input: event.tool_input,
+      summary: event.summary,
+    },
   }
 }
 
@@ -149,6 +170,13 @@ export function useAgentStream(
         // For agent:output events, extract the line text
         if (parsed.type === 'agent:output') {
           const incoming = [makeLogLine(parsed.line)]
+          setLines((prev) => capLines(prev, incoming))
+          return
+        }
+
+        // For agent:tool_use events, add a structured tool call line
+        if (parsed.type === 'agent:tool_use') {
+          const incoming = [makeToolUseLine(parsed)]
           setLines((prev) => capLines(prev, incoming))
           return
         }

--- a/ui/src/types/orchestrator.ts
+++ b/ui/src/types/orchestrator.ts
@@ -347,6 +347,17 @@ export interface ContextClearedEvent {
   timestamp: string
 }
 
+/** Agent invoked a tool — carries full input and a human-readable summary */
+export interface AgentToolUseEvent {
+  type: 'agent:tool_use'
+  agentId: string
+  tool_name: string
+  tool_id: string
+  tool_input: Record<string, unknown>
+  summary: string
+  timestamp: string
+}
+
 /** Union of all agent-related WebSocket events */
 export type AgentEvent =
   | AgentOutputEvent
@@ -357,6 +368,7 @@ export type AgentEvent =
   | WorkflowTaskCompletedEvent
   | UsageUpdateEvent
   | ContextClearedEvent
+  | AgentToolUseEvent
 
 // ---------------------------------------------------------------------------
 // Query params


### PR DESCRIPTION
## Summary

Enhances the agent log display to show tool call details instead of just `[Tool: Bash]`. Tool use lines are now visually distinct and expandable to show the full tool input as formatted JSON.

## Changes

### Backend (`crates/orchestrator/src/websocket.rs`)
- Added `summarize_tool_input()` helper that generates human-readable one-liners per tool type (Bash shows command, Read/Write/Edit show file path, Grep shows pattern, WebFetch shows URL, etc.)
- `extract_assistant_text()` now also broadcasts `agent:tool_use` events with `tool_name`, `tool_id`, `tool_input`, and `summary` fields

### Frontend
- Added `AgentToolUseEvent` type to `ui/src/types/orchestrator.ts`
- Updated `useAgentStream` hook to parse `agent:tool_use` events and add them to the log buffer with tool use metadata
- Updated `AgentLogView` to render tool call lines with a distinct purple badge style and expand/collapse interaction for full JSON input

## Before / After

**Before:** `[Tool: Bash]`
**After:** `[Bash] cargo test --workspace` (expandable to show full JSON input)

## Notes

The diagnostic errors flagged by the LSP (`Property 'span' does not exist on JSX.IntrinsicElements`) are false positives caused by the isolated git worktree environment lacking symlinked `node_modules` for LSP resolution. Running `tsc --noEmit` directly against the project produces zero errors for these files.

Closes #385