### PR TITLE
feat(orchestrator,ui): persist agent log history and surface thinking blocks

### DIFF
--- a/crates/orchestrator/src/websocket.rs
+++ b/crates/orchestrator/src/websocket.rs
@@ -342,13 +342,17 @@ fn summarize_tool_input(tool_name: &str, input: &Value) -> String {
 /// Extract displayable text lines from a Claude Code `assistant` message.
 ///
 /// The `message` object may have a `content` field that is either a plain
-/// string or an array of content blocks (text blocks, tool_use blocks, etc.).
+/// string or an array of content blocks (text blocks, tool_use blocks,
+/// thinking blocks, etc.).
 ///
-/// Returns a tuple of (text_lines, tool_use_blocks) where tool_use_blocks
-/// carries structured tool use data for broadcasting as separate events.
-fn extract_assistant_content(message: &Value) -> (Vec<String>, Vec<Value>) {
+/// Returns a tuple of (text_lines, tool_use_blocks, thinking_lines) where
+/// tool_use_blocks carries structured tool use data for broadcasting as
+/// separate events, and thinking_lines holds reasoning text from thinking
+/// blocks.
+fn extract_assistant_content(message: &Value) -> (Vec<String>, Vec<Value>, Vec<String>) {
     let mut lines = Vec::new();
     let mut tool_uses = Vec::new();
+    let mut thinking_lines = Vec::new();
     if let Some(content) = message.get("content") {
         if let Some(text) = content.as_str() {
             lines.push(text.to_string());
@@ -361,13 +365,20 @@ fn extract_assistant_content(message: &Value) -> (Vec<String>, Vec<Value>) {
                             lines.push(text.to_string());
                         }
                     }
+                    "thinking" => {
+                        if let Some(thinking) = block.get("thinking").and_then(|v| v.as_str()) {
+                            thinking_lines.push(thinking.to_string());
+                        }
+                    }
                     "tool_use" => {
                         let tool_name =
                             block.get("name").and_then(|v| v.as_str()).unwrap_or("unknown");
                         let tool_id =
                             block.get("id").and_then(|v| v.as_str()).unwrap_or("").to_string();
-                        let tool_input =
-                            block.get("input").cloned().unwrap_or(Value::Object(Default::default()));
+                        let tool_input = block
+                            .get("input")
+                            .cloned()
+                            .unwrap_or(Value::Object(Default::default()));
                         let summary = summarize_tool_input(tool_name, &tool_input);
                         tool_uses.push(serde_json::json!({
                             "tool_name": tool_name,
@@ -381,7 +392,7 @@ fn extract_assistant_content(message: &Value) -> (Vec<String>, Vec<Value>) {
             }
         }
     }
-    (lines, tool_uses)
+    (lines, tool_uses, thinking_lines)
 }
 
 /// Broadcast a single `agent:output` event on the multiplexed stream.
@@ -430,9 +441,9 @@ async fn handle_incoming_message(agent_id: &Uuid, text: &str, registry: &Connect
             }
             "assistant" => {
                 debug!(%agent_id, "Assistant response received");
-                // Extract text content and tool use blocks; broadcast both.
+                // Extract text content, tool use blocks, and thinking lines; broadcast all.
                 if let Some(message) = msg.get("message") {
-                    let (texts, tool_uses) = extract_assistant_content(message);
+                    let (texts, tool_uses, thinking_lines) = extract_assistant_content(message);
                     for text in texts {
                         broadcast_output(agent_id, &text, registry);
                     }
@@ -445,6 +456,16 @@ async fn handle_incoming_message(agent_id: &Uuid, text: &str, registry: &Connect
                             "tool_id": tool_use["tool_id"],
                             "tool_input": tool_use["tool_input"],
                             "summary": tool_use["summary"],
+                            "timestamp": Utc::now().to_rfc3339(),
+                        });
+                        let _ = registry.stream_tx.send(event.to_string());
+                    }
+                    for thinking in thinking_lines {
+                        let event = serde_json::json!({
+                            "type": "agent:thinking",
+                            "agent_id": agent_id.to_string(),
+                            "agentId": agent_id.to_string(),
+                            "text": thinking,
                             "timestamp": Utc::now().to_rfc3339(),
                         });
                         let _ = registry.stream_tx.send(event.to_string());
@@ -869,6 +890,92 @@ mod tests {
         // Token fields always come from the nested usage object.
         assert_eq!(usage.input_tokens, 100);
         assert_eq!(usage.output_tokens, 50);
+    }
+
+    #[test]
+    fn test_extract_assistant_content_thinking_block() {
+        let message = json!({
+            "role": "assistant",
+            "content": [
+                {
+                    "type": "thinking",
+                    "thinking": "Let me reason about this step by step."
+                },
+                {
+                    "type": "text",
+                    "text": "Here is my answer."
+                }
+            ]
+        });
+
+        let (texts, tool_uses, thinking_lines) = extract_assistant_content(&message);
+        assert_eq!(texts, vec!["Here is my answer."]);
+        assert!(tool_uses.is_empty());
+        assert_eq!(thinking_lines, vec!["Let me reason about this step by step."]);
+    }
+
+    #[test]
+    fn test_extract_assistant_content_no_thinking_block() {
+        let message = json!({
+            "role": "assistant",
+            "content": [
+                {
+                    "type": "text",
+                    "text": "Plain response."
+                }
+            ]
+        });
+
+        let (texts, tool_uses, thinking_lines) = extract_assistant_content(&message);
+        assert_eq!(texts, vec!["Plain response."]);
+        assert!(tool_uses.is_empty());
+        assert!(thinking_lines.is_empty());
+    }
+
+    #[test]
+    fn test_extract_assistant_content_multiple_thinking_blocks() {
+        let message = json!({
+            "role": "assistant",
+            "content": [
+                {
+                    "type": "thinking",
+                    "thinking": "First thought."
+                },
+                {
+                    "type": "thinking",
+                    "thinking": "Second thought."
+                },
+                {
+                    "type": "text",
+                    "text": "Conclusion."
+                }
+            ]
+        });
+
+        let (texts, _tool_uses, thinking_lines) = extract_assistant_content(&message);
+        assert_eq!(texts, vec!["Conclusion."]);
+        assert_eq!(thinking_lines, vec!["First thought.", "Second thought."]);
+    }
+
+    #[test]
+    fn test_extract_assistant_content_thinking_block_missing_field() {
+        // A thinking block with no "thinking" field should be silently ignored.
+        let message = json!({
+            "role": "assistant",
+            "content": [
+                {
+                    "type": "thinking"
+                },
+                {
+                    "type": "text",
+                    "text": "Answer."
+                }
+            ]
+        });
+
+        let (texts, _tool_uses, thinking_lines) = extract_assistant_content(&message);
+        assert_eq!(texts, vec!["Answer."]);
+        assert!(thinking_lines.is_empty());
     }
 
     #[test]

--- a/ui/src/components/agents/AgentLogView.tsx
+++ b/ui/src/components/agents/AgentLogView.tsx
@@ -9,10 +9,12 @@
  * - Timestamp prefix on each line
  * - Connection status indicator
  * - Clear button
+ * - Thinking/reasoning line display (toggleable, persisted to localStorage)
+ * - Reconnection gap separator lines
  */
 
 import { useCallback, useEffect, useRef, useState } from 'react'
-import { ArrowDown, ChevronDown, ChevronRight, Eraser, Wifi, WifiOff, Loader2 } from 'lucide-react'
+import { ArrowDown, ChevronDown, ChevronRight, Eraser, Eye, EyeOff, Wifi, WifiOff, Loader2 } from 'lucide-react'
 import type { LogLine, StreamStatus } from '@/hooks/useAgentStream'
 
 // ---------------------------------------------------------------------------
@@ -25,6 +27,12 @@ const ANSI_RE = /\x1b\[[0-9;]*[A-Za-z]/g
 function stripAnsi(text: string): string {
   return text.replace(ANSI_RE, '')
 }
+
+// ---------------------------------------------------------------------------
+// localStorage key for thinking toggle preference
+// ---------------------------------------------------------------------------
+
+const THINKING_PREF_KEY = 'agentd:show-thinking'
 
 // ---------------------------------------------------------------------------
 // Status indicator
@@ -123,6 +131,22 @@ export function AgentLogView({ lines, status, onClear }: AgentLogViewProps) {
   const containerRef = useRef<HTMLDivElement>(null)
   const [scrollLocked, setScrollLocked] = useState(false)
 
+  // Thinking toggle — persisted to localStorage
+  const [showThinking, setShowThinking] = useState<boolean>(
+    () => localStorage.getItem(THINKING_PREF_KEY) === 'true',
+  )
+
+  const toggleThinking = useCallback(() => {
+    setShowThinking((prev) => {
+      const next = !prev
+      localStorage.setItem(THINKING_PREF_KEY, String(next))
+      return next
+    })
+  }, [])
+
+  // Filter lines based on showThinking preference
+  const visibleLines = showThinking ? lines : lines.filter((l) => !l.isThinking)
+
   // Auto-scroll to bottom when new lines arrive (unless scroll-locked)
   useEffect(() => {
     if (scrollLocked) return
@@ -130,7 +154,7 @@ export function AgentLogView({ lines, status, onClear }: AgentLogViewProps) {
     if (el) {
       el.scrollTop = el.scrollHeight
     }
-  }, [lines, scrollLocked])
+  }, [visibleLines, scrollLocked])
 
   // Detect when user scrolls up — engage scroll lock
   const handleScroll = useCallback(() => {
@@ -171,6 +195,19 @@ export function AgentLogView({ lines, status, onClear }: AgentLogViewProps) {
           )}
           <button
             type="button"
+            aria-label={showThinking ? 'Hide thinking' : 'Show thinking'}
+            onClick={toggleThinking}
+            className="flex items-center gap-1 rounded px-2 py-0.5 text-xs text-gray-400 hover:bg-gray-700 hover:text-white"
+          >
+            {showThinking ? (
+              <EyeOff size={12} aria-hidden="true" />
+            ) : (
+              <Eye size={12} aria-hidden="true" />
+            )}
+            {showThinking ? 'Hide thinking' : 'Show thinking'}
+          </button>
+          <button
+            type="button"
             aria-label="Clear log"
             onClick={onClear}
             className="flex items-center gap-1 rounded px-2 py-0.5 text-xs text-gray-400 hover:bg-gray-700 hover:text-white"
@@ -190,7 +227,7 @@ export function AgentLogView({ lines, status, onClear }: AgentLogViewProps) {
         aria-atomic="false"
         aria-relevant="additions"
       >
-        {lines.length === 0 ? (
+        {visibleLines.length === 0 ? (
           <p className="text-gray-600 italic select-none">
             {status === 'connecting'
               ? 'Connecting to agent stream…'
@@ -199,13 +236,34 @@ export function AgentLogView({ lines, status, onClear }: AgentLogViewProps) {
                 : 'Waiting for agent output…'}
           </p>
         ) : (
-          lines.map((line) => {
+          visibleLines.map((line) => {
             const ts = new Date(line.timestamp).toLocaleTimeString([], {
               hour: '2-digit',
               minute: '2-digit',
               second: '2-digit',
               hour12: false,
             })
+
+            if (line.isSeparator) {
+              return (
+                <div key={line.id} className="my-1 flex items-center gap-2 select-none">
+                  <div className="flex-1 border-t border-dashed border-gray-700" />
+                  <span className="text-xs text-gray-500 italic">{line.text}</span>
+                  <div className="flex-1 border-t border-dashed border-gray-700" />
+                </div>
+              )
+            }
+
+            if (line.isThinking) {
+              return (
+                <div key={line.id} className="flex gap-2 whitespace-pre-wrap break-all italic text-blue-300/70">
+                  <span className="flex-shrink-0 select-none text-gray-600">{ts}</span>
+                  <span className="flex-shrink-0 select-none">💭</span>
+                  <span>{stripAnsi(line.text)}</span>
+                </div>
+              )
+            }
+
             if (line.toolUse) {
               return (
                 <ToolUseLine
@@ -217,6 +275,7 @@ export function AgentLogView({ lines, status, onClear }: AgentLogViewProps) {
                 />
               )
             }
+
             return (
               <div key={line.id} className="flex gap-2 whitespace-pre-wrap break-all">
                 <span className="flex-shrink-0 select-none text-gray-600">{ts}</span>

--- a/ui/src/hooks/useAgentStream.ts
+++ b/ui/src/hooks/useAgentStream.ts
@@ -6,14 +6,16 @@
  * and message buffering.
  *
  * Returns a capped circular buffer of up to MAX_LINES log lines plus
- * a connection status indicator.
+ * a connection status indicator. Log history is persisted to sessionStorage
+ * so it survives component remounts within the same browser tab. A separator
+ * line is injected when history is rehydrated to mark any gap in output.
  */
 
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { WebSocketManager } from '@/services/websocket'
 import { serviceConfig } from '@/services/config'
 import { agentEventBus } from '@/services/eventBus'
-import type { AgentEvent, UsageUpdateEvent, ContextClearedEvent, AgentToolUseEvent } from '@/types/orchestrator'
+import type { AgentEvent, UsageUpdateEvent, ContextClearedEvent, AgentToolUseEvent, AgentThinkingEvent } from '@/types/orchestrator'
 
 // ---------------------------------------------------------------------------
 // Types
@@ -33,6 +35,10 @@ export interface LogLine {
     tool_input: Record<string, unknown>
     summary: string
   }
+  /** When true, this line is a thinking/reasoning block */
+  isThinking?: boolean
+  /** When true, this line is a reconnection gap separator */
+  isSeparator?: boolean
 }
 
 /** Callback invoked when a real-time usage update event arrives */
@@ -60,6 +66,45 @@ export interface UseAgentStreamResult {
 // ---------------------------------------------------------------------------
 
 const MAX_LINES = 5_000
+const MAX_STORED_LINES = 1_000
+
+// ---------------------------------------------------------------------------
+// sessionStorage helpers
+// ---------------------------------------------------------------------------
+
+const LOG_STORAGE_KEY = (agentId: string) => `agentd:log-history:${agentId}`
+
+interface StoredLogHistory {
+  lines: LogLine[]
+  lastTimestamp: string
+}
+
+function loadLogHistory(agentId: string): StoredLogHistory | null {
+  try {
+    const raw = sessionStorage.getItem(LOG_STORAGE_KEY(agentId))
+    if (!raw) return null
+    return JSON.parse(raw) as StoredLogHistory
+  } catch {
+    return null
+  }
+}
+
+function saveLogHistory(agentId: string, lines: LogLine[], lastTimestamp: string): void {
+  try {
+    const stored: StoredLogHistory = { lines, lastTimestamp }
+    sessionStorage.setItem(LOG_STORAGE_KEY(agentId), JSON.stringify(stored))
+  } catch {
+    // sessionStorage may be full or unavailable — silently ignore
+  }
+}
+
+function clearLogHistory(agentId: string): void {
+  try {
+    sessionStorage.removeItem(LOG_STORAGE_KEY(agentId))
+  } catch {
+    // ignore
+  }
+}
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -89,6 +134,26 @@ function makeToolUseLine(event: AgentToolUseEvent): LogLine {
   }
 }
 
+function makeThinkingLine(text: string, timestamp: string): LogLine {
+  return {
+    id: ++globalLineId,
+    text,
+    timestamp,
+    isThinking: true,
+  }
+}
+
+function makeSeparatorLine(fromTs: string, toTs: string): LogLine {
+  const fmt = (ts: string) =>
+    new Date(ts).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', second: '2-digit', hour12: false })
+  return {
+    id: ++globalLineId,
+    text: `─── Reconnected · missed output from ${fmt(fromTs)} to ${fmt(toTs)} ───`,
+    timestamp: toTs,
+    isSeparator: true,
+  }
+}
+
 function capLines(prev: LogLine[], incoming: LogLine[]): LogLine[] {
   const combined = [...prev, ...incoming]
   if (combined.length <= MAX_LINES) return combined
@@ -111,6 +176,13 @@ export function useAgentStream(
   const [lines, setLines] = useState<LogLine[]>([])
   const [status, setStatus] = useState<StreamStatus>('connecting')
 
+  // linesRef stays in sync with lines state for use in cleanup
+  const linesRef = useRef<LogLine[]>([])
+
+  // Stores the last stored timestamp when history is rehydrated; cleared
+  // after the first new message arrives (so we can insert a separator)
+  const pendingSeparatorRef = useRef<string | null>(null)
+
   // Store callbacks in refs so the WebSocket effect doesn't re-run when
   // callbacks change.
   const onUsageUpdateRef = useRef(options.onUsageUpdate)
@@ -121,6 +193,17 @@ export function useAgentStream(
   const managerRef = useRef<WebSocketManager | null>(null)
 
   useEffect(() => {
+    // Rehydrate persisted log history on mount
+    const stored = loadLogHistory(agentId)
+    if (stored && stored.lines.length > 0) {
+      setLines((prev) => {
+        const next = capLines(prev, stored.lines)
+        linesRef.current = next
+        return next
+      })
+      pendingSeparatorRef.current = stored.lastTimestamp
+    }
+
     const manager = new WebSocketManager(agentStreamUrl(agentId), {
       // Disable heartbeat — agent output arrives irregularly; a ping
       // would be noise in the log stream
@@ -169,15 +252,50 @@ export function useAgentStream(
 
         // For agent:output events, extract the line text
         if (parsed.type === 'agent:output') {
-          const incoming = [makeLogLine(parsed.line)]
-          setLines((prev) => capLines(prev, incoming))
+          const newLine = makeLogLine(parsed.line)
+          const separator = pendingSeparatorRef.current
+          pendingSeparatorRef.current = null
+          setLines((prev) => {
+            const incoming = separator
+              ? [makeSeparatorLine(separator, newLine.timestamp), newLine]
+              : [newLine]
+            const next = capLines(prev, incoming)
+            linesRef.current = next
+            return next
+          })
           return
         }
 
         // For agent:tool_use events, add a structured tool call line
         if (parsed.type === 'agent:tool_use') {
-          const incoming = [makeToolUseLine(parsed)]
-          setLines((prev) => capLines(prev, incoming))
+          const newLine = makeToolUseLine(parsed)
+          const separator = pendingSeparatorRef.current
+          pendingSeparatorRef.current = null
+          setLines((prev) => {
+            const incoming = separator
+              ? [makeSeparatorLine(separator, newLine.timestamp), newLine]
+              : [newLine]
+            const next = capLines(prev, incoming)
+            linesRef.current = next
+            return next
+          })
+          return
+        }
+
+        // For agent:thinking events, add a thinking log line
+        if (parsed.type === 'agent:thinking') {
+          const thinkingEvent = parsed as AgentThinkingEvent
+          const newLine = makeThinkingLine(thinkingEvent.text, thinkingEvent.timestamp)
+          const separator = pendingSeparatorRef.current
+          pendingSeparatorRef.current = null
+          setLines((prev) => {
+            const incoming = separator
+              ? [makeSeparatorLine(separator, newLine.timestamp), newLine]
+              : [newLine]
+            const next = capLines(prev, incoming)
+            linesRef.current = next
+            return next
+          })
           return
         }
 
@@ -187,8 +305,17 @@ export function useAgentStream(
       }
 
       // Plain text fallback
-      const incoming = rawText.split('\n').filter(Boolean).map(makeLogLine)
-      setLines((prev) => capLines(prev, incoming))
+      const separator = pendingSeparatorRef.current
+      pendingSeparatorRef.current = null
+      setLines((prev) => {
+        const newLines = rawText.split('\n').filter(Boolean).map(makeLogLine)
+        const incoming = separator && newLines.length > 0
+          ? [makeSeparatorLine(separator, newLines[0].timestamp), ...newLines]
+          : newLines
+        const next = capLines(prev, incoming)
+        linesRef.current = next
+        return next
+      })
     })
 
     manager.connect()
@@ -198,10 +325,23 @@ export function useAgentStream(
       unsubMsg()
       manager.disconnect()
       managerRef.current = null
+
+      // Persist log history (excluding separator lines) on unmount
+      const currentLines = linesRef.current.filter((l) => !l.isSeparator)
+      const trimmed = currentLines.slice(-MAX_STORED_LINES)
+      if (trimmed.length > 0) {
+        const lastTimestamp = trimmed[trimmed.length - 1].timestamp
+        saveLogHistory(agentId, trimmed, lastTimestamp)
+      }
     }
   }, [agentId])
 
-  const clear = useCallback(() => setLines([]), [])
+  const clear = useCallback(() => {
+    linesRef.current = []
+    pendingSeparatorRef.current = null
+    setLines([])
+    clearLogHistory(agentId)
+  }, [agentId])
 
   return { lines, status, clear }
 }

--- a/ui/src/types/orchestrator.ts
+++ b/ui/src/types/orchestrator.ts
@@ -358,6 +358,14 @@ export interface AgentToolUseEvent {
   timestamp: string
 }
 
+/** Agent emitted a thinking/reasoning block */
+export interface AgentThinkingEvent {
+  type: 'agent:thinking'
+  agentId: string
+  text: string
+  timestamp: string
+}
+
 /** Union of all agent-related WebSocket events */
 export type AgentEvent =
   | AgentOutputEvent
@@ -369,6 +377,7 @@ export type AgentEvent =
   | UsageUpdateEvent
   | ContextClearedEvent
   | AgentToolUseEvent
+  | AgentThinkingEvent
 
 // ---------------------------------------------------------------------------
 // Query params


### PR DESCRIPTION
## Summary

- **Backend**: `extract_assistant_content()` in `websocket.rs` now handles `thinking` content blocks (from Claude's extended thinking feature) and broadcasts them as `agent:thinking` events; 4 new unit tests added
- **Types**: Added `AgentThinkingEvent` interface and included it in the `AgentEvent` discriminated union
- **Hook (`useAgentStream`)**: Log lines are persisted to `sessionStorage` on unmount (keyed by agent ID, capped at 1,000 lines); on mount, history is rehydrated and a visual gap separator line is inserted showing the missed time window; `agent:thinking` events are handled as thinking log lines; `clear()` also wipes sessionStorage
- **Component (`AgentLogView`)**: Separator lines render as centered dashed dividers; thinking lines render with a 💭 prefix in italic blue-gray; a Show/Hide thinking toggle is added to the toolbar with preference persisted to `localStorage`

## Test plan

- [ ] Run `cargo test -p orchestrator --lib websocket` — all 10 tests pass (6 usage + 4 new thinking block tests)
- [ ] Run `cargo clippy -p orchestrator` — no warnings
- [ ] Navigate to an agent detail page, observe some log output, navigate away and return — previously buffered lines should rehydrate with a gap separator showing the missed time window
- [ ] Clear the log — sessionStorage entry is removed; returning to the page shows no rehydrated history
- [ ] With an agent using extended thinking (Claude model with thinking enabled), observe 💭-prefixed italic lines in the log
- [ ] Toggle "Show thinking" / "Hide thinking" in the toolbar — thinking lines appear/disappear; preference survives page refresh

Closes #386

🤖 Generated with [Claude Code](https://claude.com/claude-code)