### PR TITLE
feat(orchestrator): track agent busy/idle activity state in ConnectionRegistry

### DIFF
--- a/crates/cli/src/commands/orchestrator.rs
+++ b/crates/cli/src/commands/orchestrator.rs
@@ -2547,6 +2547,7 @@ mod tests {
             id: Uuid::new_v4(),
             name: "test-agent".to_string(),
             status: AgentStatus::Running,
+            activity: Default::default(),
             config: AgentConfig {
                 working_dir: "/tmp/test".to_string(),
                 user: None,
@@ -3393,6 +3394,7 @@ mod tests {
             id: Uuid::new_v4(),
             name: "docker-agent".to_string(),
             status: AgentStatus::Running,
+            activity: Default::default(),
             config: AgentConfig {
                 working_dir: "/workspace".to_string(),
                 user: None,

--- a/crates/orchestrator/src/api.rs
+++ b/crates/orchestrator/src/api.rs
@@ -93,7 +93,13 @@ async fn list_agents(
     let offset = query.offset.unwrap_or(0);
 
     let (agents, total) = state.manager.list_agents_paginated(status_filter, limit, offset).await?;
-    let items: Vec<AgentResponse> = agents.into_iter().map(AgentResponse::from).collect();
+    let mut items: Vec<AgentResponse> = Vec::with_capacity(agents.len());
+    for agent in agents {
+        let id = agent.id;
+        let mut response = AgentResponse::from(agent);
+        response.activity = state.registry.get_activity_state(&id).await;
+        items.push(response);
+    }
 
     Ok(Json(PaginatedResponse { items, total, limit, offset }))
 }
@@ -133,8 +139,10 @@ async fn get_agent(
     Path(id): Path<Uuid>,
 ) -> Result<impl IntoResponse, ApiError> {
     let agent = state.manager.get_agent(&id).await?.ok_or(ApiError::NotFound)?;
+    let mut response = AgentResponse::from(agent);
+    response.activity = state.registry.get_activity_state(&id).await;
 
-    Ok(Json(AgentResponse::from(agent)))
+    Ok(Json(response))
 }
 
 async fn terminate_agent(

--- a/crates/orchestrator/src/types.rs
+++ b/crates/orchestrator/src/types.rs
@@ -57,6 +57,21 @@ impl std::fmt::Display for AgentStatus {
     }
 }
 
+/// Activity state of a connected agent — whether it is currently processing a
+/// prompt or waiting for input.
+///
+/// This is tracked in memory by the [`ConnectionRegistry`] and is not
+/// persisted to the database. A newly connected agent defaults to `Idle`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "snake_case")]
+pub enum ActivityState {
+    /// Agent is waiting for input — no prompt is currently being processed.
+    #[default]
+    Idle,
+    /// Agent is actively processing a prompt.
+    Busy,
+}
+
 impl std::str::FromStr for AgentStatus {
     type Err = anyhow::Error;
 
@@ -365,6 +380,12 @@ pub struct AgentResponse {
     pub id: Uuid,
     pub name: String,
     pub status: AgentStatus,
+    /// Current activity state of the agent (idle or busy).
+    ///
+    /// This reflects whether the agent is currently processing a prompt.
+    /// Defaults to `idle` for agents that are not connected via WebSocket.
+    #[serde(default)]
+    pub activity: ActivityState,
     pub config: AgentConfig,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub session_id: Option<String>,
@@ -384,6 +405,7 @@ impl From<Agent> for AgentResponse {
             id: agent.id,
             name: agent.name,
             status: agent.status,
+            activity: ActivityState::default(),
             config,
             session_id: agent.session_id,
             backend_type: agent.backend_type,
@@ -1296,5 +1318,58 @@ mod tests {
         assert!(policy.evaluate("Bash", Some(&make_input("rm -rf /"))));
         assert!(policy.evaluate("Read", None));
         assert!(!policy.evaluate("Write", None));
+    }
+
+    #[test]
+    fn test_activity_state_default_is_idle() {
+        let state: ActivityState = Default::default();
+        assert_eq!(state, ActivityState::Idle);
+    }
+
+    #[test]
+    fn test_activity_state_serializes_as_snake_case() {
+        let idle = serde_json::to_string(&ActivityState::Idle).unwrap();
+        let busy = serde_json::to_string(&ActivityState::Busy).unwrap();
+        assert_eq!(idle, "\"idle\"");
+        assert_eq!(busy, "\"busy\"");
+    }
+
+    #[test]
+    fn test_activity_state_deserializes_from_snake_case() {
+        let idle: ActivityState = serde_json::from_str("\"idle\"").unwrap();
+        let busy: ActivityState = serde_json::from_str("\"busy\"").unwrap();
+        assert_eq!(idle, ActivityState::Idle);
+        assert_eq!(busy, ActivityState::Busy);
+    }
+
+    #[test]
+    fn test_agent_response_includes_activity_field() {
+        let config = AgentConfig {
+            working_dir: "/tmp".to_string(),
+            user: None,
+            shell: "zsh".to_string(),
+            interactive: false,
+            prompt: None,
+            worktree: false,
+            system_prompt: None,
+            tool_policy: ToolPolicy::default(),
+            model: None,
+            env: Default::default(),
+            auto_clear_threshold: None,
+            network_policy: None,
+            docker_image: None,
+            extra_mounts: None,
+            resource_limits: None,
+            additional_dirs: vec![],
+        };
+        let agent = Agent::new("test".to_string(), config);
+        let response = AgentResponse::from(agent);
+
+        // Default from the From<Agent> impl is Idle.
+        assert_eq!(response.activity, ActivityState::Idle);
+
+        // The JSON representation should contain the activity field.
+        let json = serde_json::to_string(&response).unwrap();
+        assert!(json.contains("\"activity\":\"idle\""));
     }
 }

--- a/crates/orchestrator/src/websocket.rs
+++ b/crates/orchestrator/src/websocket.rs
@@ -1,6 +1,6 @@
 use crate::approvals::ApprovalRegistry;
 use crate::scheduler::events::{EventBus, SystemEvent};
-use crate::types::{ApprovalDecision, ResultInfo, ToolPolicy, UsageSnapshot};
+use crate::types::{ActivityState, ApprovalDecision, ResultInfo, ToolPolicy, UsageSnapshot};
 use axum::{
     extract::{
         ws::{Message, WebSocket},
@@ -34,6 +34,8 @@ pub struct ConnectionRegistry {
     result_callbacks: Arc<RwLock<Vec<ResultCallback>>>,
     /// Per-agent tool policies (set during agent creation).
     policies: Arc<RwLock<HashMap<Uuid, ToolPolicy>>>,
+    /// Per-agent activity state (idle or busy).
+    activity_states: Arc<RwLock<HashMap<Uuid, ActivityState>>>,
     /// Broadcast channel for the multiplexed agent stream.
     stream_tx: broadcast::Sender<String>,
     /// Notifies waiters when any agent connects.
@@ -57,6 +59,7 @@ impl ConnectionRegistry {
             connections: Arc::new(RwLock::new(HashMap::new())),
             result_callbacks: Arc::new(RwLock::new(Vec::new())),
             policies: Arc::new(RwLock::new(HashMap::new())),
+            activity_states: Arc::new(RwLock::new(HashMap::new())),
             stream_tx,
             connect_notify: Arc::new(tokio::sync::Notify::new()),
             approvals: ApprovalRegistry::new(300), // 5-minute default timeout
@@ -87,6 +90,7 @@ impl ConnectionRegistry {
 
     pub async fn register(&self, agent_id: Uuid, conn: AgentConnection) {
         self.connections.write().await.insert(agent_id, conn);
+        self.activity_states.write().await.insert(agent_id, ActivityState::Idle);
         self.connect_notify.notify_waiters();
         if let Some(bus) = &self.event_bus {
             bus.publish(SystemEvent::AgentConnected { agent_id });
@@ -121,6 +125,7 @@ impl ConnectionRegistry {
     pub async fn unregister(&self, agent_id: &Uuid) {
         self.connections.write().await.remove(agent_id);
         self.policies.write().await.remove(agent_id);
+        self.activity_states.write().await.remove(agent_id);
         if let Some(bus) = &self.event_bus {
             bus.publish(SystemEvent::AgentDisconnected { agent_id: *agent_id });
         }
@@ -137,10 +142,20 @@ impl ConnectionRegistry {
         self.policies.read().await.get(agent_id).cloned().unwrap_or_default()
     }
 
+    /// Get the current activity state for an agent.
+    ///
+    /// Returns `Idle` for agents that are not connected (no entry in the map).
+    pub async fn get_activity_state(&self, agent_id: &Uuid) -> ActivityState {
+        self.activity_states.read().await.get(agent_id).cloned().unwrap_or_default()
+    }
+
     /// Send a user message (prompt) to a connected agent.
     ///
     /// Uses the Claude Code SDK `stream-json` input format:
     /// `{"type": "user", "message": {"role": "user", "content": "..."}}`
+    ///
+    /// Transitions the agent's activity state to `Busy` and broadcasts an
+    /// `agent:activity_changed` event on the stream.
     pub async fn send_user_message(&self, agent_id: &Uuid, content: &str) -> anyhow::Result<()> {
         let connections = self.connections.read().await;
         let conn = connections
@@ -157,6 +172,19 @@ impl ConnectionRegistry {
         conn.tx
             .send(serde_json::to_string(&msg)? + "\n")
             .map_err(|e| anyhow::anyhow!("Failed to send to agent: {}", e))?;
+
+        drop(connections);
+
+        // Transition to Busy and broadcast activity change.
+        self.activity_states.write().await.insert(*agent_id, ActivityState::Busy);
+        let event = serde_json::json!({
+            "type": "agent:activity_changed",
+            "agent_id": agent_id.to_string(),
+            "agentId": agent_id.to_string(),
+            "activity": "busy",
+            "timestamp": chrono::Utc::now().to_rfc3339(),
+        });
+        let _ = self.stream_tx.send(event.to_string());
 
         Ok(())
     }
@@ -479,6 +507,17 @@ async fn handle_incoming_message(agent_id: &Uuid, text: &str, registry: &Connect
                 } else {
                     info!(%agent_id, "Agent query completed successfully");
                 }
+
+                // Transition to Idle and broadcast activity change.
+                registry.activity_states.write().await.insert(*agent_id, ActivityState::Idle);
+                let activity_event = serde_json::json!({
+                    "type": "agent:activity_changed",
+                    "agent_id": agent_id.to_string(),
+                    "agentId": agent_id.to_string(),
+                    "activity": "idle",
+                    "timestamp": Utc::now().to_rfc3339(),
+                });
+                let _ = registry.stream_tx.send(activity_event.to_string());
 
                 // Broadcast result text as agent:output
                 if let Some(result_text) = msg.get("result").and_then(|v| v.as_str()) {
@@ -998,5 +1037,143 @@ mod tests {
         assert_eq!(usage.num_turns, 2);
         assert_eq!(usage.duration_ms, 300);
         assert_eq!(usage.duration_api_ms, 250);
+    }
+
+    // ---------------------------------------------------------------------------
+    // Activity state tests
+    // ---------------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_new_connection_defaults_to_idle() {
+        let registry = ConnectionRegistry::new();
+        let agent_id = Uuid::new_v4();
+
+        // Before connection: unknown agent should default to Idle.
+        assert_eq!(registry.get_activity_state(&agent_id).await, ActivityState::Idle);
+    }
+
+    #[tokio::test]
+    async fn test_register_sets_idle() {
+        let registry = ConnectionRegistry::new();
+        let agent_id = Uuid::new_v4();
+        let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
+        registry.register(agent_id, AgentConnection { tx }).await;
+
+        assert_eq!(registry.get_activity_state(&agent_id).await, ActivityState::Idle);
+    }
+
+    #[tokio::test]
+    async fn test_unregister_removes_activity_state() {
+        let registry = ConnectionRegistry::new();
+        let agent_id = Uuid::new_v4();
+        let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
+        registry.register(agent_id, AgentConnection { tx }).await;
+
+        // Manually set Busy to verify unregister clears it.
+        registry.activity_states.write().await.insert(agent_id, ActivityState::Busy);
+        registry.unregister(&agent_id).await;
+
+        // After unregister: defaults back to Idle (no entry in map).
+        assert_eq!(registry.get_activity_state(&agent_id).await, ActivityState::Idle);
+    }
+
+    #[tokio::test]
+    async fn test_send_user_message_transitions_to_busy() {
+        let registry = ConnectionRegistry::new();
+        let agent_id = Uuid::new_v4();
+        let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
+        registry.register(agent_id, AgentConnection { tx }).await;
+
+        assert_eq!(registry.get_activity_state(&agent_id).await, ActivityState::Idle);
+
+        registry.send_user_message(&agent_id, "hello").await.unwrap();
+
+        assert_eq!(registry.get_activity_state(&agent_id).await, ActivityState::Busy);
+    }
+
+    #[tokio::test]
+    async fn test_result_message_transitions_to_idle() {
+        let registry = ConnectionRegistry::new();
+        let agent_id = Uuid::new_v4();
+        let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
+        registry.register(agent_id, AgentConnection { tx }).await;
+
+        // Simulate busy state.
+        registry.activity_states.write().await.insert(agent_id, ActivityState::Busy);
+        assert_eq!(registry.get_activity_state(&agent_id).await, ActivityState::Busy);
+
+        // Simulate receiving a result message.
+        let result_msg = json!({
+            "type": "result",
+            "is_error": false,
+            "result": "done",
+            "usage": {
+                "input_tokens": 10,
+                "output_tokens": 5,
+            }
+        });
+        handle_incoming_message(&agent_id, &result_msg.to_string(), &registry).await;
+
+        assert_eq!(registry.get_activity_state(&agent_id).await, ActivityState::Idle);
+    }
+
+    #[tokio::test]
+    async fn test_result_message_broadcasts_activity_changed_event() {
+        let registry = ConnectionRegistry::new();
+        let agent_id = Uuid::new_v4();
+        let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
+        registry.register(agent_id, AgentConnection { tx }).await;
+
+        let mut stream_rx = registry.subscribe_stream();
+
+        // Set busy then receive result.
+        registry.activity_states.write().await.insert(agent_id, ActivityState::Busy);
+        let result_msg = json!({
+            "type": "result",
+            "is_error": false,
+            "result": "",
+            "usage": { "input_tokens": 1, "output_tokens": 1 }
+        });
+        handle_incoming_message(&agent_id, &result_msg.to_string(), &registry).await;
+
+        // Drain broadcast messages looking for the activity_changed event.
+        let mut found = false;
+        while let Ok(msg) = stream_rx.try_recv() {
+            if let Ok(v) = serde_json::from_str::<serde_json::Value>(&msg) {
+                if v.get("type").and_then(|t| t.as_str()) == Some("agent:activity_changed")
+                    && v.get("activity").and_then(|a| a.as_str()) == Some("idle")
+                {
+                    found = true;
+                    break;
+                }
+            }
+        }
+        assert!(found, "Expected agent:activity_changed (idle) event on stream");
+    }
+
+    #[tokio::test]
+    async fn test_send_user_message_broadcasts_activity_changed_event() {
+        let registry = ConnectionRegistry::new();
+        let agent_id = Uuid::new_v4();
+        let (tx, _rx) = tokio::sync::mpsc::unbounded_channel();
+        registry.register(agent_id, AgentConnection { tx }).await;
+
+        let mut stream_rx = registry.subscribe_stream();
+
+        registry.send_user_message(&agent_id, "test prompt").await.unwrap();
+
+        // Drain looking for the busy activity_changed event.
+        let mut found = false;
+        while let Ok(msg) = stream_rx.try_recv() {
+            if let Ok(v) = serde_json::from_str::<serde_json::Value>(&msg) {
+                if v.get("type").and_then(|t| t.as_str()) == Some("agent:activity_changed")
+                    && v.get("activity").and_then(|a| a.as_str()) == Some("busy")
+                {
+                    found = true;
+                    break;
+                }
+            }
+        }
+        assert!(found, "Expected agent:activity_changed (busy) event on stream");
     }
 }


### PR DESCRIPTION
## Summary

- Adds `ActivityState` enum (`Idle`/`Busy`) to `types.rs` with snake_case serialization and `Idle` as the default
- Tracks per-agent activity state in `ConnectionRegistry` — initialised to `Idle` on connect, removed on disconnect
- `send_user_message()` transitions state to `Busy` and broadcasts an `agent:activity_changed` event on the stream WebSocket
- `handle_incoming_message()` transitions state to `Idle` when a `result` message is received and broadcasts the corresponding event
- Adds `get_activity_state(&self, agent_id) -> ActivityState` method to `ConnectionRegistry`
- Exposes `activity` field (`"idle"` or `"busy"`) in `AgentResponse` for both `GET /agents` and `GET /agents/{id}`
- Adds 7 new unit tests covering state transitions and event broadcasting

## Test plan

- [x] All new activity state tests pass
- [x] `cargo fmt` and `cargo clippy` clean

Closes #403

🤖 Generated with [Claude Code](https://claude.com/claude-code)