### PR TITLE
feat(wrap): add SIGINT support to execution backends

### DIFF
--- a/crates/wrap/src/backend.rs
+++ b/crates/wrap/src/backend.rs
@@ -191,6 +191,20 @@ pub trait ExecutionBackend: Send + Sync {
         Ok(None)
     }
 
+    /// Sends an interrupt signal (SIGINT / Ctrl-C) to a running session.
+    ///
+    /// For tmux backends this sends `C-c` via `send-keys`; for Docker backends
+    /// this sends `SIGINT` to the container via `docker kill --signal=SIGINT`.
+    ///
+    /// This interrupts the currently running process (e.g., an in-flight
+    /// Claude Code prompt) without terminating the session or container.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the session/container does not exist or the
+    /// underlying signal delivery fails.
+    async fn send_interrupt(&self, session_id: &str) -> anyhow::Result<()>;
+
     /// Stops all sessions managed by this backend.
     ///
     /// Used during graceful shutdown to clean up all running sessions.
@@ -303,6 +317,13 @@ impl ExecutionBackend for TmuxBackend {
         let tmux = self.tmux.clone();
 
         tokio::task::spawn_blocking(move || tmux.list_sessions()).await?
+    }
+
+    async fn send_interrupt(&self, session_id: &str) -> anyhow::Result<()> {
+        let tmux = self.tmux.clone();
+        let name = session_id.to_string();
+
+        tokio::task::spawn_blocking(move || tmux.send_interrupt(&name)).await?
     }
 
     fn prefix(&self) -> &str {
@@ -547,5 +568,25 @@ mod tests {
         let backend = TmuxBackend::new("test");
         let exit_info = backend.session_exit_info("nonexistent").await.unwrap();
         assert!(exit_info.is_none());
+    }
+
+    // -- send_interrupt tests --
+
+    /// `TmuxBackend::send_interrupt` must return `Err` for a session that does
+    /// not exist (either because tmux is not installed or the session is absent).
+    #[tokio::test]
+    async fn tmux_backend_send_interrupt_nonexistent_session_returns_err() {
+        let backend = TmuxBackend::new("test");
+        let result = backend.send_interrupt("definitely-does-not-exist-xyzzy").await;
+        assert!(result.is_err(), "Expected Err for non-existent session, got Ok");
+    }
+
+    /// Verify that `TmuxBackend` satisfies the `ExecutionBackend` trait including
+    /// the new `send_interrupt` method.
+    #[test]
+    fn tmux_backend_implements_send_interrupt_in_trait() {
+        fn _assert_object_safe(_: &dyn ExecutionBackend) {}
+        let backend = TmuxBackend::new("agentd");
+        _assert_object_safe(&backend);
     }
 }

--- a/crates/wrap/src/docker.rs
+++ b/crates/wrap/src/docker.rs
@@ -40,8 +40,8 @@
 use crate::backend::{ExecutionBackend, SessionConfig, SessionExitInfo, SessionHealth};
 use async_trait::async_trait;
 use bollard::container::{
-    Config, CreateContainerOptions, ListContainersOptions, RemoveContainerOptions,
-    StartContainerOptions, StopContainerOptions,
+    Config, CreateContainerOptions, KillContainerOptions, ListContainersOptions,
+    RemoveContainerOptions, StartContainerOptions, StopContainerOptions,
 };
 use bollard::exec::CreateExecOptions;
 use bollard::models::{ContainerStateStatusEnum, HealthStatusEnum};
@@ -781,6 +781,36 @@ impl ExecutionBackend for DockerBackend {
         }
     }
 
+    /// Sends SIGINT to a running Docker container.
+    ///
+    /// Uses `docker kill --signal=SIGINT` to deliver SIGINT to PID 1
+    /// of the container. This interrupts the currently running process
+    /// (e.g., an in-flight Claude Code prompt) without stopping the container.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the container does not exist or is not running.
+    async fn send_interrupt(&self, session_id: &str) -> anyhow::Result<()> {
+        debug!(session = %session_id, "Sending SIGINT to Docker container");
+
+        self.docker
+            .kill_container(session_id, Some(KillContainerOptions { signal: "SIGINT" }))
+            .await
+            .map_err(|e| {
+                if is_not_found(&e) {
+                    anyhow::anyhow!(
+                        "Cannot send interrupt: container '{}' does not exist",
+                        session_id
+                    )
+                } else {
+                    anyhow::anyhow!("Failed to send SIGINT to container '{}': {}", session_id, e)
+                }
+            })?;
+
+        debug!(session = %session_id, "SIGINT delivered to Docker container");
+        Ok(())
+    }
+
     /// Stops all containers managed by this Docker backend.
     ///
     /// Lists all containers with the matching prefix label and stops + removes
@@ -1232,5 +1262,31 @@ mod tests {
             "Bridge mode should use host.docker.internal"
         );
         assert!(url.contains("/ws/myid"), "URL should contain agent ID");
+    }
+
+    // -- send_interrupt --
+
+    /// `DockerBackend::send_interrupt` must return `Err` when the container
+    /// does not exist. If Docker is not available the test is skipped.
+    #[tokio::test]
+    async fn docker_backend_send_interrupt_nonexistent_container_returns_err() {
+        let Some(backend) = test_backend() else { return };
+        let result = backend.send_interrupt("definitely-does-not-exist-xyzzy").await;
+        assert!(result.is_err(), "Expected Err for non-existent container, got Ok");
+        let msg = result.unwrap_err().to_string();
+        // The error should mention the container name or come from Docker.
+        assert!(
+            msg.contains("definitely-does-not-exist-xyzzy") || msg.contains("No such container"),
+            "Unexpected error message: {msg}"
+        );
+    }
+
+    /// Verify that `DockerBackend` satisfies the `ExecutionBackend` trait including
+    /// the new `send_interrupt` method.
+    #[test]
+    fn docker_backend_implements_send_interrupt_in_trait() {
+        fn _assert_object_safe(_: &dyn ExecutionBackend) {}
+        let Some(backend) = test_backend() else { return };
+        _assert_object_safe(&backend);
     }
 }

--- a/crates/wrap/src/tmux.rs
+++ b/crates/wrap/src/tmux.rs
@@ -338,6 +338,61 @@ impl TmuxManager {
         Ok(())
     }
 
+    /// Sends an interrupt signal (Ctrl-C / SIGINT) to a tmux session.
+    ///
+    /// Uses `tmux send-keys -t {session} C-c` to deliver SIGINT to the
+    /// foreground process without killing the session itself.
+    ///
+    /// # Arguments
+    ///
+    /// * `session_name` - Name of the tmux session to interrupt
+    ///
+    /// # Returns
+    ///
+    /// Returns `Ok(())` if the signal was sent successfully.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - The session does not exist
+    /// - The tmux command fails
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use wrap::tmux::TmuxManager;
+    ///
+    /// let tmux = TmuxManager::new("agentd");
+    /// tmux.send_interrupt("my-session")?;
+    /// # Ok::<(), anyhow::Error>(())
+    /// ```
+    pub fn send_interrupt(&self, session_name: &str) -> anyhow::Result<()> {
+        debug!("Sending interrupt to tmux session: {}", session_name);
+
+        // Verify the session exists before attempting to send the signal.
+        if !self.session_exists(session_name)? {
+            return Err(anyhow::anyhow!(
+                "Cannot send interrupt: tmux session '{}' does not exist",
+                session_name
+            ));
+        }
+
+        let output = Command::new(get_tmux_command())
+            .args(["send-keys", "-t", session_name, "C-c", ""])
+            .output()?;
+
+        if !output.status.success() {
+            let stderr = String::from_utf8_lossy(&output.stderr);
+            return Err(anyhow::anyhow!(
+                "Failed to send interrupt to session '{}': {}",
+                session_name,
+                stderr
+            ));
+        }
+
+        Ok(())
+    }
+
     /// Lists all active tmux sessions.
     ///
     /// Returns a list of all currently running tmux sessions.
@@ -403,5 +458,41 @@ mod tests {
         let timestamp = chrono::Local::now().format("%Y%m%d-%H%M%S");
         let session_name = format!("{}-my-project-{}", tmux.prefix(), timestamp);
         assert!(session_name.starts_with("agentd-my-project-"));
+    }
+
+    /// Verify that `send_interrupt` returns an error for a non-existent session.
+    ///
+    /// This test relies on `session_exists` returning `false` for an unknown
+    /// session, which is the case when:
+    /// - tmux is not installed (the `output()` call fails with an OS error), OR
+    /// - tmux is installed but no session with this name exists.
+    ///
+    /// In either case the method must return `Err`.
+    #[test]
+    fn test_send_interrupt_nonexistent_session() {
+        let tmux = TmuxManager::new("test");
+        // "definitely-does-not-exist-xyzzy" is guaranteed not to be a live session.
+        let result = tmux.send_interrupt("definitely-does-not-exist-xyzzy");
+        assert!(result.is_err(), "Expected error for non-existent session, got Ok");
+    }
+
+    /// Verify that the error message for a missing session contains the session name.
+    ///
+    /// If tmux is installed and reachable the error comes from our existence check.
+    /// If tmux is not installed at all the OS error is propagated instead — this
+    /// assertion is only checked when tmux is available.
+    #[test]
+    fn test_send_interrupt_error_message_contains_session_name() {
+        let tmux = TmuxManager::new("test");
+        let session = "definitely-does-not-exist-xyzzy";
+        if let Err(e) = tmux.send_interrupt(session) {
+            let msg = e.to_string();
+            // The error should mention the session name OR be an OS-level error
+            // (tmux not installed). Either is acceptable.
+            assert!(
+                msg.contains(session) || msg.contains("tmux") || msg.contains("No such file"),
+                "Unexpected error message: {msg}"
+            );
+        }
     }
 }


### PR DESCRIPTION
## Summary

- Extends `ExecutionBackend` trait with a new required `async fn send_interrupt(&self, session_id: &str) -> Result<()>` method
- `TmuxBackend` implements via `tmux send-keys -t {session} C-c` (sends Ctrl-C / SIGINT to the foreground process without killing the session)
- `DockerBackend` implements via bollard's `kill_container` with `SIGINT` signal (`docker kill --signal=SIGINT`)
- Both backends return clear errors for non-existent sessions/containers
- Unit tests added for all three affected files covering error cases and trait object-safety

## Test plan

- [x] `cargo build -p wrap` passes
- [x] `cargo clippy -p wrap` passes
- [x] `cargo test -p wrap` — all new tests pass
- [x] Non-existent tmux session returns a meaningful error
- [x] Non-existent Docker container returns a meaningful error

Closes #404

🤖 Generated with [Claude Code](https://claude.com/claude-code)