### PR TITLE
feat(communicate): scaffold communicate crate with Axum server and SeaORM storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1387,6 +1387,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "communicate"
+version = "0.2.0"
+dependencies = [
+ "agentd-common",
+ "anyhow",
+ "async-trait",
+ "axum",
+ "chrono",
+ "directories",
+ "metrics",
+ "metrics-exporter-prometheus",
+ "reqwest",
+ "sea-orm",
+ "sea-orm-migration",
+ "serde",
+ "serde_json",
+ "tempfile",
+ "thiserror 2.0.17",
+ "tokio",
+ "tower",
+ "tower-http",
+ "tracing",
+ "tracing-subscriber",
+ "uuid",
+]
+
+[[package]]
 name = "compression-codecs"
 version = "0.4.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ members = [
     "crates/baml",
     "crates/cli",
     "crates/common",
+    "crates/communicate",
     "crates/hook",
     "crates/memory",
     "crates/monitor",

--- a/crates/communicate/Cargo.toml
+++ b/crates/communicate/Cargo.toml
@@ -1,0 +1,42 @@
+[package]
+name = "communicate"
+version.workspace = true
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+
+[[bin]]
+name = "agentd-communicate"
+path = "src/main.rs"
+
+[dependencies]
+tokio = { workspace = true }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true }
+anyhow = { workspace = true }
+thiserror = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+
+# HTTP API server
+axum = { workspace = true }
+tower = "0.5"
+tower-http = { workspace = true, features = ["cors"] }
+
+# HTTP client
+reqwest = { version = "0.12", features = ["json"] }
+
+sea-orm = { workspace = true }
+sea-orm-migration = { workspace = true }
+async-trait = "0.1"
+
+# Additional utilities
+uuid = { version = "1.11", features = ["v4", "serde"] }
+chrono = { workspace = true }
+directories = "6.0.0"
+agentd-common = { path = "../common" }
+metrics = { workspace = true }
+metrics-exporter-prometheus = { workspace = true }
+
+[dev-dependencies]
+tempfile = "3.14"

--- a/crates/communicate/src/api.rs
+++ b/crates/communicate/src/api.rs
@@ -1,0 +1,63 @@
+//! REST API router for the communicate service.
+//!
+//! Exposes a `GET /health` endpoint and serves as the extension point for
+//! rooms, messages, and other inter-agent communication endpoints.
+
+use axum::{routing::get, Json, Router};
+use std::sync::Arc;
+
+use crate::storage::CommunicateStorage;
+
+/// Shared application state injected into all route handlers.
+#[derive(Clone)]
+pub struct ApiState {
+    // Storage will be accessed by route handlers added in subsequent issues.
+    #[allow(dead_code)]
+    pub storage: Arc<CommunicateStorage>,
+}
+
+/// Build the Axum router with all communicate API routes.
+pub fn create_router(state: ApiState) -> Router {
+    Router::new().route("/health", get(health)).with_state(state)
+}
+
+/// `GET /health` — liveness check.
+async fn health() -> Json<agentd_common::types::HealthResponse> {
+    Json(agentd_common::types::HealthResponse::ok("agentd-communicate", env!("CARGO_PKG_VERSION")))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::{
+        body::Body,
+        http::{Request, StatusCode},
+    };
+    use tempfile::TempDir;
+    use tower::ServiceExt;
+
+    async fn build_test_app() -> (Router, TempDir) {
+        let temp_dir = TempDir::new().unwrap();
+        let db_path = temp_dir.path().join("test.db");
+        let storage = Arc::new(CommunicateStorage::with_path(&db_path).await.unwrap());
+        let state = ApiState { storage };
+        (create_router(state), temp_dir)
+    }
+
+    #[tokio::test]
+    async fn test_health_endpoint() {
+        let (app, _temp) = build_test_app().await;
+
+        let response = app
+            .oneshot(Request::builder().uri("/health").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+
+        let body = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["status"], "ok");
+        assert_eq!(json["service"], "agentd-communicate");
+    }
+}

--- a/crates/communicate/src/entity/mod.rs
+++ b/crates/communicate/src/entity/mod.rs
@@ -1,0 +1,5 @@
+//! SeaORM entity modules.
+//!
+//! Entity modules are generated from the database schema using `sea-orm-cli`.
+//! As tables are added via migrations, run:
+//!   `cargo xtask generate-entities --service communicate`

--- a/crates/communicate/src/main.rs
+++ b/crates/communicate/src/main.rs
@@ -1,0 +1,108 @@
+//! agentd-communicate service entry point.
+//!
+//! This is the main executable for the inter-agent communication service. It
+//! initializes the storage backend, sets up the REST API server, and starts
+//! listening for HTTP requests.
+//!
+//! # Features
+//!
+//! - SQLite-based persistent storage
+//! - REST API on `http://127.0.0.1:17010` (dev default)
+//! - Structured logging with tracing
+//! - Prometheus metrics endpoint
+//! - CORS support
+//!
+//! # Running the Service
+//!
+//! ```bash
+//! # Run with default INFO logging
+//! cargo run -p agentd-communicate
+//!
+//! # Run with DEBUG logging
+//! RUST_LOG=debug cargo run -p agentd-communicate
+//! ```
+//!
+//! # Environment Variables
+//!
+//! - `RUST_LOG` — Controls logging level (e.g., `debug`, `info`, `warn`, `error`).
+//!   Defaults to `info` if not set.
+//! - `AGENTD_PORT` — Override the listening port. Defaults to `17010`.
+//!
+//! # API Endpoints
+//!
+//! - `GET /health` — Health check
+//! - `GET /metrics` — Prometheus metrics
+//!
+//! # Database Location
+//!
+//! The SQLite database is stored at a platform-specific location:
+//! - Linux: `~/.local/share/agentd-communicate/communicate.db`
+//! - macOS: `~/Library/Application Support/agentd-communicate/communicate.db`
+
+mod api;
+mod entity;
+mod migration;
+mod storage;
+mod types;
+
+use api::{create_router, ApiState};
+use axum::{extract::State, response::IntoResponse, routing::get};
+use metrics_exporter_prometheus::PrometheusHandle;
+use std::env;
+use std::sync::Arc;
+use storage::CommunicateStorage;
+use tracing::info;
+
+fn init_metrics() -> PrometheusHandle {
+    let builder = metrics_exporter_prometheus::PrometheusBuilder::new();
+    let handle = builder.install_recorder().expect("failed to install metrics recorder");
+    metrics::gauge!(
+        "service_info",
+        "version" => env!("CARGO_PKG_VERSION"),
+        "service" => "communicate"
+    )
+    .set(1.0);
+    handle
+}
+
+async fn metrics_handler(State(handle): State<PrometheusHandle>) -> impl IntoResponse {
+    handle.render()
+}
+
+/// Main entry point for the agentd-communicate service.
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    agentd_common::server::init_tracing();
+
+    info!("Starting agentd-communicate service...");
+
+    // Initialize SQLite storage
+    let storage = CommunicateStorage::new().await?;
+    info!("Communicate storage initialized at: {:?}", CommunicateStorage::get_db_path()?);
+
+    let storage = Arc::new(storage);
+
+    // Initialize Prometheus metrics
+    let metrics_handle = init_metrics();
+
+    // Create API state and router with metrics endpoint and tracing middleware
+    let api_state = ApiState { storage };
+    let metrics_router =
+        axum::Router::new().route("/metrics", get(metrics_handler)).with_state(metrics_handle);
+
+    let app = create_router(api_state)
+        .merge(metrics_router)
+        .layer(agentd_common::server::trace_layer())
+        .layer(agentd_common::server::cors_layer());
+
+    // Bind to address (use AGENTD_PORT env var, default 17010 for dev, 7010 for production)
+    let port = env::var("AGENTD_PORT").unwrap_or_else(|_| "17010".to_string());
+    let addr = format!("127.0.0.1:{port}");
+    let listener = tokio::net::TcpListener::bind(&addr).await?;
+    info!("Communicate API server listening on http://{}", addr);
+
+    // Start the HTTP server
+    axum::serve(listener, app).await?;
+
+    Ok(())
+}

--- a/crates/communicate/src/migration/mod.rs
+++ b/crates/communicate/src/migration/mod.rs
@@ -1,0 +1,10 @@
+pub use sea_orm_migration::prelude::*;
+
+pub struct Migrator;
+
+#[async_trait::async_trait]
+impl MigratorTrait for Migrator {
+    fn migrations() -> Vec<Box<dyn MigrationTrait>> {
+        vec![]
+    }
+}

--- a/crates/communicate/src/storage.rs
+++ b/crates/communicate/src/storage.rs
@@ -1,0 +1,83 @@
+//! SeaORM-based persistent storage for the communicate service.
+//!
+//! Provides the [`CommunicateStorage`] backend that persists data to an SQLite
+//! database using SeaORM entities and a migration-managed schema.
+//!
+//! # Database Location
+//!
+//! - Linux: `~/.local/share/agentd-communicate/communicate.db`
+//! - macOS: `~/Library/Application Support/agentd-communicate/communicate.db`
+//!
+//! # Schema
+//!
+//! Managed by [`crate::migration::Migrator`].
+
+use crate::migration::Migrator;
+use anyhow::Result;
+use sea_orm::DatabaseConnection;
+use sea_orm_migration::prelude::MigratorTrait;
+use std::path::{Path, PathBuf};
+
+/// Persistent storage backend for the communicate service using SeaORM + SQLite.
+///
+/// [`DatabaseConnection`] is `Clone + Send + Sync`.
+#[derive(Clone)]
+pub struct CommunicateStorage {
+    #[allow(dead_code)]
+    db: DatabaseConnection,
+}
+
+impl CommunicateStorage {
+    /// Gets the platform-specific database file path.
+    ///
+    /// - **Linux**: `~/.local/share/agentd-communicate/communicate.db`
+    /// - **macOS**: `~/Library/Application Support/agentd-communicate/communicate.db`
+    pub fn get_db_path() -> Result<PathBuf> {
+        agentd_common::storage::get_db_path("agentd-communicate", "communicate.db")
+    }
+
+    /// Creates a new storage instance with the default database path.
+    pub async fn new() -> Result<Self> {
+        let db_path = Self::get_db_path()?;
+        Self::with_path(&db_path).await
+    }
+
+    /// Creates a new storage instance connected to `db_path`.
+    ///
+    /// The file is created if it does not exist, and all pending SeaORM
+    /// migrations are applied before returning.
+    pub async fn with_path(db_path: &Path) -> Result<Self> {
+        let db = agentd_common::storage::create_connection(db_path).await?;
+        Migrator::up(&db, None).await?;
+        Ok(Self { db })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    async fn create_test_storage() -> (CommunicateStorage, TempDir) {
+        let temp_dir = TempDir::new().unwrap();
+        let db_path = temp_dir.path().join("test.db");
+        let storage = CommunicateStorage::with_path(&db_path).await.unwrap();
+        (storage, temp_dir)
+    }
+
+    #[tokio::test]
+    async fn test_storage_init() {
+        let (_storage, _temp) = create_test_storage().await;
+        // Storage initializes without error and migrations run successfully.
+    }
+
+    #[tokio::test]
+    async fn test_storage_clone() {
+        let (storage, _temp) = create_test_storage().await;
+        let _clone = storage.clone();
+    }
+}

--- a/crates/communicate/src/types.rs
+++ b/crates/communicate/src/types.rs
@@ -1,0 +1,4 @@
+//! Domain types for the communicate service.
+//!
+//! This module will hold rooms, messages, and related types as inter-agent
+//! communication features are built out in subsequent issues.

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -146,6 +146,12 @@ const DB_SERVICES: &[DbService] = &[
         db_file: "orchestrator.db",
         entity_dir: "crates/orchestrator/src/entity",
     },
+    DbService {
+        name: "communicate",
+        project: "agentd-communicate",
+        db_file: "communicate.db",
+        entity_dir: "crates/communicate/src/entity",
+    },
 ];
 
 struct DbService {

--- a/crates/xtask/src/platform/mod.rs
+++ b/crates/xtask/src/platform/mod.rs
@@ -37,11 +37,12 @@ pub const SERVICES: &[ServiceInfo] = &[
     ServiceInfo { name: "wrap", binary: "agentd-wrap", port: 7005, extra_env: &[] },
     ServiceInfo { name: "orchestrator", binary: "agentd-orchestrator", port: 7006, extra_env: &[] },
     ServiceInfo { name: "memory", binary: "agentd-memory", port: 7008, extra_env: &[] },
+    ServiceInfo { name: "communicate", binary: "agentd-communicate", port: 7010, extra_env: &[] },
 ];
 
 /// All valid service names.
 pub const SERVICE_NAMES: &[&str] =
-    &["ask", "hook", "monitor", "notify", "wrap", "orchestrator", "memory"];
+    &["ask", "hook", "monitor", "notify", "wrap", "orchestrator", "memory", "communicate"];
 
 /// Look up a service by short name.
 #[cfg(test)]
@@ -94,8 +95,8 @@ mod tests {
 
     #[test]
     fn test_service_info_completeness() {
-        assert_eq!(SERVICES.len(), 7);
-        assert_eq!(SERVICE_NAMES.len(), 7);
+        assert_eq!(SERVICES.len(), 8);
+        assert_eq!(SERVICE_NAMES.len(), 8);
 
         // Every service name should have a corresponding ServiceInfo
         for name in SERVICE_NAMES {


### PR DESCRIPTION
## Summary

- Creates `crates/communicate/` following the established notify/memory service patterns
- `Cargo.toml` with workspace dependencies (axum, sea-orm, tokio, serde, tracing, uuid, chrono, metrics, metrics-exporter-prometheus, agentd-common)
- `src/main.rs` — Axum server on port `17010` (dev) / `7010` (production) with tracing, Prometheus metrics, CORS
- `src/api.rs` — Router with `GET /health` returning service name and version
- `src/types.rs` — Placeholder module for future room/message types
- `src/storage.rs` — `CommunicateStorage` backed by SeaORM + SQLite at `agentd-communicate/communicate.db`
- `src/entity/mod.rs` — Placeholder for sea-orm-cli generated entities
- `src/migration/mod.rs` — `Migrator` stub ready for future schema migrations
- Added `crates/communicate` to workspace `Cargo.toml` members
- Added `communicate` to `DB_SERVICES` in `crates/xtask/src/main.rs`
- Added `communicate` `ServiceInfo` (port 7010) and `SERVICE_NAMES` in `crates/xtask/src/platform/mod.rs`

## Test plan

- [x] `cargo build -p communicate` — clean, no warnings
- [x] `cargo clippy -p communicate` — clean
- [x] 3 communicate unit tests pass: `storage::tests::test_storage_init`, `test_storage_clone`, `api::tests::test_health_endpoint`
- [x] 12 xtask tests pass including updated `test_service_info_completeness` (8 services)

Closes #489

🤖 Generated with [Claude Code](https://claude.com/claude-code)