### PR TITLE
feat(communicate): implement room management REST API

### DIFF
--- a/crates/communicate/src/api.rs
+++ b/crates/communicate/src/api.rs
@@ -1,27 +1,174 @@
 //! REST API router for the communicate service.
+//!
+//! # Endpoints
+//!
+//! - `GET /health` — liveness check
+//! - `POST /rooms` — create a room (201 Created)
+//! - `GET /rooms` — list rooms (paginated, optional `room_type` filter)
+//! - `GET /rooms/{id}` — get room by ID
+//! - `PUT /rooms/{id}` — update room topic/description
+//! - `DELETE /rooms/{id}` — delete room
+//! - `GET /rooms/{id}/participants` — list participants in a room (paginated)
 
-use axum::{routing::get, Json, Router};
+use axum::{
+    extract::{Path, Query, State},
+    http::StatusCode,
+    routing::{get, post},
+    Json, Router,
+};
+use serde::Deserialize;
 use std::sync::Arc;
+use uuid::Uuid;
 
 use crate::storage::CommunicateStorage;
+use crate::types::{
+    CreateRoomRequest, PaginatedResponse, ParticipantResponse, RoomResponse, RoomType,
+    UpdateRoomRequest,
+};
+
+pub use agentd_common::error::ApiError;
 
 /// Shared application state injected into all route handlers.
 #[derive(Clone)]
 pub struct ApiState {
-    // Storage will be accessed by route handlers added in subsequent issues.
-    #[allow(dead_code)]
     pub storage: Arc<CommunicateStorage>,
 }
 
 /// Build the Axum router with all communicate API routes.
 pub fn create_router(state: ApiState) -> Router {
-    Router::new().route("/health", get(health)).with_state(state)
+    let rooms_router = Router::new()
+        .route("/", post(create_room).get(list_rooms))
+        .route("/{id}", get(get_room).put(update_room).delete(delete_room))
+        .route("/{id}/participants", get(list_participants));
+
+    Router::new().route("/health", get(health)).nest("/rooms", rooms_router).with_state(state)
 }
 
 /// `GET /health` — liveness check.
 async fn health() -> Json<agentd_common::types::HealthResponse> {
     Json(agentd_common::types::HealthResponse::ok("agentd-communicate", env!("CARGO_PKG_VERSION")))
 }
+
+// ---------------------------------------------------------------------------
+// Query parameter types
+// ---------------------------------------------------------------------------
+
+/// Query parameters for `GET /rooms`.
+#[derive(Debug, Deserialize)]
+struct ListRoomsParams {
+    limit: Option<usize>,
+    offset: Option<usize>,
+    room_type: Option<String>,
+}
+
+/// Query parameters for paginated list endpoints.
+#[derive(Debug, Deserialize)]
+struct PaginationParams {
+    limit: Option<usize>,
+    offset: Option<usize>,
+}
+
+fn clamp_limit(limit: Option<usize>) -> usize {
+    limit.unwrap_or(50).min(200)
+}
+
+// ---------------------------------------------------------------------------
+// Room handlers
+// ---------------------------------------------------------------------------
+
+/// `POST /rooms` — create a new room.
+async fn create_room(
+    State(state): State<ApiState>,
+    Json(req): Json<CreateRoomRequest>,
+) -> Result<(StatusCode, Json<RoomResponse>), ApiError> {
+    let room = state.storage.create_room(&req).await?;
+
+    metrics::counter!("rooms_created_total").increment(1);
+
+    let active = state.storage.count_rooms().await?;
+    metrics::gauge!("rooms_active").set(active as f64);
+
+    Ok((StatusCode::CREATED, Json(RoomResponse::from(room))))
+}
+
+/// `GET /rooms` — list all rooms, with optional type filter and pagination.
+async fn list_rooms(
+    State(state): State<ApiState>,
+    Query(params): Query<ListRoomsParams>,
+) -> Result<Json<PaginatedResponse<RoomResponse>>, ApiError> {
+    let limit = clamp_limit(params.limit);
+    let offset = params.offset.unwrap_or(0);
+
+    let (rooms, total) = if let Some(type_str) = params.room_type {
+        let rt = type_str.parse::<RoomType>().map_err(|e| ApiError::InvalidInput(e.to_string()))?;
+        state.storage.list_rooms_by_type(&rt, limit, offset).await?
+    } else {
+        state.storage.list_rooms(limit, offset).await?
+    };
+
+    let items = rooms.into_iter().map(RoomResponse::from).collect();
+    Ok(Json(PaginatedResponse { items, total, limit, offset }))
+}
+
+/// `GET /rooms/{id}` — get a room by ID.
+async fn get_room(
+    State(state): State<ApiState>,
+    Path(id): Path<Uuid>,
+) -> Result<Json<RoomResponse>, ApiError> {
+    let room = state.storage.get_room(&id).await?.ok_or(ApiError::NotFound)?;
+    Ok(Json(RoomResponse::from(room)))
+}
+
+/// `PUT /rooms/{id}` — update a room's topic and/or description.
+async fn update_room(
+    State(state): State<ApiState>,
+    Path(id): Path<Uuid>,
+    Json(req): Json<UpdateRoomRequest>,
+) -> Result<Json<RoomResponse>, ApiError> {
+    let room = state
+        .storage
+        .update_room(&id, req.topic, req.description)
+        .await?
+        .ok_or(ApiError::NotFound)?;
+    Ok(Json(RoomResponse::from(room)))
+}
+
+/// `DELETE /rooms/{id}` — delete a room.
+async fn delete_room(
+    State(state): State<ApiState>,
+    Path(id): Path<Uuid>,
+) -> Result<StatusCode, ApiError> {
+    let deleted = state.storage.delete_room(&id).await?;
+    if deleted {
+        let active = state.storage.count_rooms().await?;
+        metrics::gauge!("rooms_active").set(active as f64);
+        Ok(StatusCode::NO_CONTENT)
+    } else {
+        Err(ApiError::NotFound)
+    }
+}
+
+/// `GET /rooms/{id}/participants` — list participants in a room.
+async fn list_participants(
+    State(state): State<ApiState>,
+    Path(id): Path<Uuid>,
+    Query(params): Query<PaginationParams>,
+) -> Result<Json<PaginatedResponse<ParticipantResponse>>, ApiError> {
+    // Verify room exists first.
+    state.storage.get_room(&id).await?.ok_or(ApiError::NotFound)?;
+
+    let limit = clamp_limit(params.limit);
+    let offset = params.offset.unwrap_or(0);
+
+    let (participants, total) = state.storage.list_participants_in_room(&id, limit, offset).await?;
+
+    let items = participants.into_iter().map(ParticipantResponse::from).collect();
+    Ok(Json(PaginatedResponse { items, total, limit, offset }))
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
 
 #[cfg(test)]
 mod tests {
@@ -30,6 +177,7 @@ mod tests {
         body::Body,
         http::{Request, StatusCode},
     };
+    use serde_json::{json, Value};
     use tempfile::TempDir;
     use tower::ServiceExt;
 
@@ -39,6 +187,21 @@ mod tests {
         let storage = Arc::new(CommunicateStorage::with_path(&db_path).await.unwrap());
         let state = ApiState { storage };
         (create_router(state), temp_dir)
+    }
+
+    async fn body_json(body: axum::body::Body) -> Value {
+        let bytes = axum::body::to_bytes(body, usize::MAX).await.unwrap();
+        serde_json::from_slice(&bytes).unwrap()
+    }
+
+    fn create_room_body(name: &str) -> Body {
+        Body::from(
+            serde_json::to_vec(&json!({
+                "name": name,
+                "created_by": "test-agent"
+            }))
+            .unwrap(),
+        )
     }
 
     #[tokio::test]
@@ -51,10 +214,212 @@ mod tests {
             .unwrap();
 
         assert_eq!(response.status(), StatusCode::OK);
-
-        let body = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
-        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let json = body_json(response.into_body()).await;
         assert_eq!(json["status"], "ok");
         assert_eq!(json["service"], "agentd-communicate");
+    }
+
+    #[tokio::test]
+    async fn test_create_room_returns_201() {
+        let (app, _temp) = build_test_app().await;
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/rooms")
+                    .header("content-type", "application/json")
+                    .body(create_room_body("general"))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::CREATED);
+        let json = body_json(response.into_body()).await;
+        assert_eq!(json["name"], "general");
+        assert!(json["id"].as_str().is_some());
+    }
+
+    #[tokio::test]
+    async fn test_create_duplicate_name_returns_409() {
+        let (app, _temp) = build_test_app().await;
+
+        // First creation succeeds.
+        let resp1 = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/rooms")
+                    .header("content-type", "application/json")
+                    .body(create_room_body("dup-room"))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp1.status(), StatusCode::CREATED);
+
+        // Second creation with same name returns 409.
+        let resp2 = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/rooms")
+                    .header("content-type", "application/json")
+                    .body(create_room_body("dup-room"))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp2.status(), StatusCode::CONFLICT);
+    }
+
+    #[tokio::test]
+    async fn test_get_nonexistent_room_returns_404() {
+        let (app, _temp) = build_test_app().await;
+        let missing_id = Uuid::new_v4();
+
+        let response = app
+            .oneshot(
+                Request::builder().uri(format!("/rooms/{missing_id}")).body(Body::empty()).unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn test_list_rooms_paginated() {
+        let (app, _temp) = build_test_app().await;
+
+        // Create 3 rooms.
+        for name in ["alpha", "beta", "gamma"] {
+            app.clone()
+                .oneshot(
+                    Request::builder()
+                        .method("POST")
+                        .uri("/rooms")
+                        .header("content-type", "application/json")
+                        .body(create_room_body(name))
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+        }
+
+        let response = app
+            .oneshot(Request::builder().uri("/rooms?limit=2&offset=0").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let json = body_json(response.into_body()).await;
+        assert_eq!(json["total"], 3);
+        assert_eq!(json["items"].as_array().unwrap().len(), 2);
+        assert_eq!(json["limit"], 2);
+        assert_eq!(json["offset"], 0);
+    }
+
+    #[tokio::test]
+    async fn test_delete_room() {
+        let (app, _temp) = build_test_app().await;
+
+        // Create room.
+        let create_resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/rooms")
+                    .header("content-type", "application/json")
+                    .body(create_room_body("to-delete"))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(create_resp.status(), StatusCode::CREATED);
+        let room_json = body_json(create_resp.into_body()).await;
+        let id = room_json["id"].as_str().unwrap();
+
+        // Delete room.
+        let del_resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("DELETE")
+                    .uri(format!("/rooms/{id}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(del_resp.status(), StatusCode::NO_CONTENT);
+
+        // Verify gone.
+        let get_resp = app
+            .oneshot(Request::builder().uri(format!("/rooms/{id}")).body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(get_resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn test_update_room() {
+        let (app, _temp) = build_test_app().await;
+
+        // Create room.
+        let create_resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/rooms")
+                    .header("content-type", "application/json")
+                    .body(create_room_body("updateable"))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(create_resp.status(), StatusCode::CREATED);
+        let room_json = body_json(create_resp.into_body()).await;
+        let id = room_json["id"].as_str().unwrap();
+
+        // Update topic.
+        let update_body =
+            Body::from(serde_json::to_vec(&json!({ "topic": "Updated topic" })).unwrap());
+        let update_resp = app
+            .oneshot(
+                Request::builder()
+                    .method("PUT")
+                    .uri(format!("/rooms/{id}"))
+                    .header("content-type", "application/json")
+                    .body(update_body)
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(update_resp.status(), StatusCode::OK);
+        let updated = body_json(update_resp.into_body()).await;
+        assert_eq!(updated["topic"], "Updated topic");
+    }
+
+    #[tokio::test]
+    async fn test_list_participants_returns_404_for_missing_room() {
+        let (app, _temp) = build_test_app().await;
+        let missing_id = Uuid::new_v4();
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .uri(format!("/rooms/{missing_id}/participants"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
     }
 }

--- a/crates/communicate/src/storage.rs
+++ b/crates/communicate/src/storage.rs
@@ -3,16 +3,22 @@
 //! - Linux: `~/.local/share/agentd-communicate/communicate.db`
 //! - macOS: `~/Library/Application Support/agentd-communicate/communicate.db`
 
+use crate::entity;
 use crate::migration::Migrator;
+use crate::types::{
+    CreateRoomRequest, Participant, ParticipantKind, ParticipantRole, Room, RoomType,
+};
+use agentd_common::error::ApiError;
 use anyhow::Result;
-use sea_orm::DatabaseConnection;
+use sea_orm::prelude::*;
+use sea_orm::{ColumnTrait, DatabaseConnection, QueryFilter, QueryOrder, QuerySelect, Set};
 use sea_orm_migration::prelude::MigratorTrait;
 use std::path::{Path, PathBuf};
+use uuid::Uuid;
 
 /// Persistent storage backend for the communicate service using SeaORM + SQLite.
 #[derive(Clone)]
 pub struct CommunicateStorage {
-    #[allow(dead_code)]
     pub(crate) db: DatabaseConnection,
 }
 
@@ -35,11 +41,265 @@ impl CommunicateStorage {
         Migrator::up(&db, None).await?;
         Ok(Self { db })
     }
+
+    // -----------------------------------------------------------------------
+    // Room operations
+    // -----------------------------------------------------------------------
+
+    /// Creates a new room from the given request.
+    ///
+    /// Returns a `409 Conflict` (`ApiError::Conflict`) if a room with the same
+    /// name already exists.
+    pub async fn create_room(&self, req: &CreateRoomRequest) -> Result<Room, ApiError> {
+        if req.name.trim().is_empty() {
+            return Err(ApiError::InvalidInput("room name must not be empty".to_string()));
+        }
+
+        // Check for duplicate name.
+        let existing = entity::room::Entity::find()
+            .filter(entity::room::Column::Name.eq(req.name.as_str()))
+            .one(&self.db)
+            .await
+            .map_err(|e| ApiError::Internal(e.into()))?;
+
+        if existing.is_some() {
+            return Err(ApiError::Conflict(format!("a room named '{}' already exists", req.name)));
+        }
+
+        let now = chrono::Utc::now();
+        let id = Uuid::new_v4();
+
+        let model = entity::room::ActiveModel {
+            id: Set(id.to_string()),
+            name: Set(req.name.clone()),
+            topic: Set(req.topic.clone()),
+            description: Set(req.description.clone()),
+            room_type: Set(req.room_type.to_string()),
+            created_by: Set(req.created_by.clone()),
+            created_at: Set(now.to_rfc3339()),
+            updated_at: Set(now.to_rfc3339()),
+        };
+
+        model.insert(&self.db).await.map_err(|e| ApiError::Internal(e.into()))?;
+
+        let inserted = entity::room::Entity::find_by_id(id.to_string())
+            .one(&self.db)
+            .await
+            .map_err(|e| ApiError::Internal(e.into()))?
+            .ok_or_else(|| ApiError::Internal(anyhow::anyhow!("room not found after insert")))?;
+
+        model_to_room(inserted).map_err(ApiError::Internal)
+    }
+
+    /// Retrieves a room by its UUID.
+    pub async fn get_room(&self, id: &Uuid) -> Result<Option<Room>, ApiError> {
+        let row = entity::room::Entity::find_by_id(id.to_string())
+            .one(&self.db)
+            .await
+            .map_err(|e| ApiError::Internal(e.into()))?;
+
+        row.map(|m| model_to_room(m).map_err(ApiError::Internal)).transpose()
+    }
+
+    /// Retrieves a room by its unique name.
+    #[allow(dead_code)]
+    pub async fn get_room_by_name(&self, name: &str) -> Result<Option<Room>, ApiError> {
+        let row = entity::room::Entity::find()
+            .filter(entity::room::Column::Name.eq(name))
+            .one(&self.db)
+            .await
+            .map_err(|e| ApiError::Internal(e.into()))?;
+
+        row.map(|m| model_to_room(m).map_err(ApiError::Internal)).transpose()
+    }
+
+    /// Returns a paginated list of all rooms and the total count.
+    pub async fn list_rooms(
+        &self,
+        limit: usize,
+        offset: usize,
+    ) -> Result<(Vec<Room>, usize), ApiError> {
+        let total = entity::room::Entity::find()
+            .count(&self.db)
+            .await
+            .map_err(|e| ApiError::Internal(e.into()))? as usize;
+
+        let rows = entity::room::Entity::find()
+            .order_by_asc(entity::room::Column::Name)
+            .limit(limit as u64)
+            .offset(offset as u64)
+            .all(&self.db)
+            .await
+            .map_err(|e| ApiError::Internal(e.into()))?;
+
+        let rooms = rows
+            .into_iter()
+            .map(model_to_room)
+            .collect::<Result<Vec<_>>>()
+            .map_err(ApiError::Internal)?;
+
+        Ok((rooms, total))
+    }
+
+    /// Returns a paginated list of rooms filtered by type, and the total count
+    /// of rooms matching the filter.
+    pub async fn list_rooms_by_type(
+        &self,
+        room_type: &RoomType,
+        limit: usize,
+        offset: usize,
+    ) -> Result<(Vec<Room>, usize), ApiError> {
+        let type_str = room_type.to_string();
+
+        let total = entity::room::Entity::find()
+            .filter(entity::room::Column::RoomType.eq(type_str.as_str()))
+            .count(&self.db)
+            .await
+            .map_err(|e| ApiError::Internal(e.into()))? as usize;
+
+        let rows = entity::room::Entity::find()
+            .filter(entity::room::Column::RoomType.eq(type_str.as_str()))
+            .order_by_asc(entity::room::Column::Name)
+            .limit(limit as u64)
+            .offset(offset as u64)
+            .all(&self.db)
+            .await
+            .map_err(|e| ApiError::Internal(e.into()))?;
+
+        let rooms = rows
+            .into_iter()
+            .map(model_to_room)
+            .collect::<Result<Vec<_>>>()
+            .map_err(ApiError::Internal)?;
+
+        Ok((rooms, total))
+    }
+
+    /// Updates the mutable fields of a room (topic and/or description).
+    ///
+    /// Returns `None` if the room does not exist.
+    pub async fn update_room(
+        &self,
+        id: &Uuid,
+        topic: Option<String>,
+        description: Option<String>,
+    ) -> Result<Option<Room>, ApiError> {
+        use sea_orm::IntoActiveModel;
+
+        let row = entity::room::Entity::find_by_id(id.to_string())
+            .one(&self.db)
+            .await
+            .map_err(|e| ApiError::Internal(e.into()))?;
+
+        let row = match row {
+            Some(r) => r,
+            None => return Ok(None),
+        };
+
+        let mut active = row.into_active_model();
+        if topic.is_some() {
+            active.topic = Set(topic);
+        }
+        if description.is_some() {
+            active.description = Set(description);
+        }
+        active.updated_at = Set(chrono::Utc::now().to_rfc3339());
+
+        let updated = active.update(&self.db).await.map_err(|e| ApiError::Internal(e.into()))?;
+
+        let room = model_to_room(updated).map_err(ApiError::Internal)?;
+        Ok(Some(room))
+    }
+
+    /// Deletes a room by ID. Returns `true` if deleted, `false` if not found.
+    pub async fn delete_room(&self, id: &Uuid) -> Result<bool, ApiError> {
+        let result = entity::room::Entity::delete_by_id(id.to_string())
+            .exec(&self.db)
+            .await
+            .map_err(|e| ApiError::Internal(e.into()))?;
+
+        Ok(result.rows_affected > 0)
+    }
+
+    /// Returns the total number of rooms in the database.
+    pub async fn count_rooms(&self) -> Result<usize, ApiError> {
+        let count = entity::room::Entity::find()
+            .count(&self.db)
+            .await
+            .map_err(|e| ApiError::Internal(e.into()))?;
+        Ok(count as usize)
+    }
+
+    /// Returns a paginated list of participants in the given room and the total
+    /// count.
+    pub async fn list_participants_in_room(
+        &self,
+        room_id: &Uuid,
+        limit: usize,
+        offset: usize,
+    ) -> Result<(Vec<Participant>, usize), ApiError> {
+        let id_str = room_id.to_string();
+
+        let total = entity::participant::Entity::find()
+            .filter(entity::participant::Column::RoomId.eq(id_str.as_str()))
+            .count(&self.db)
+            .await
+            .map_err(|e| ApiError::Internal(e.into()))? as usize;
+
+        let rows = entity::participant::Entity::find()
+            .filter(entity::participant::Column::RoomId.eq(id_str.as_str()))
+            .order_by_asc(entity::participant::Column::JoinedAt)
+            .limit(limit as u64)
+            .offset(offset as u64)
+            .all(&self.db)
+            .await
+            .map_err(|e| ApiError::Internal(e.into()))?;
+
+        let participants = rows
+            .into_iter()
+            .map(model_to_participant)
+            .collect::<Result<Vec<_>>>()
+            .map_err(ApiError::Internal)?;
+
+        Ok((participants, total))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Model conversion helpers
+// ---------------------------------------------------------------------------
+
+/// Converts a SeaORM room model into the domain `Room` type.
+pub fn model_to_room(m: entity::room::Model) -> Result<Room> {
+    Ok(Room {
+        id: m.id.parse::<Uuid>()?,
+        name: m.name,
+        topic: m.topic,
+        description: m.description,
+        room_type: m.room_type.parse::<RoomType>()?,
+        created_by: m.created_by,
+        created_at: m.created_at.parse::<chrono::DateTime<chrono::Utc>>()?,
+        updated_at: m.updated_at.parse::<chrono::DateTime<chrono::Utc>>()?,
+    })
+}
+
+/// Converts a SeaORM participant model into the domain `Participant` type.
+pub fn model_to_participant(m: entity::participant::Model) -> Result<Participant> {
+    Ok(Participant {
+        id: m.id.parse::<Uuid>()?,
+        room_id: m.room_id.parse::<Uuid>()?,
+        identifier: m.identifier,
+        kind: m.kind.parse::<ParticipantKind>()?,
+        display_name: m.display_name,
+        role: m.role.parse::<ParticipantRole>()?,
+        joined_at: m.joined_at.parse::<chrono::DateTime<chrono::Utc>>()?,
+    })
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::types::RoomType;
     use tempfile::TempDir;
 
     async fn create_test_storage() -> (CommunicateStorage, TempDir) {
@@ -47,6 +307,16 @@ mod tests {
         let db_path = temp_dir.path().join("test.db");
         let storage = CommunicateStorage::with_path(&db_path).await.unwrap();
         (storage, temp_dir)
+    }
+
+    fn make_create_req(name: &str) -> CreateRoomRequest {
+        CreateRoomRequest {
+            name: name.to_string(),
+            topic: Some("Test topic".to_string()),
+            description: Some("Test description".to_string()),
+            room_type: RoomType::Group,
+            created_by: "agent-test".to_string(),
+        }
     }
 
     #[tokio::test]
@@ -58,5 +328,175 @@ mod tests {
     async fn test_storage_clone() {
         let (storage, _temp) = create_test_storage().await;
         let _clone = storage.clone();
+    }
+
+    #[tokio::test]
+    async fn test_create_and_get_room() {
+        let (storage, _temp) = create_test_storage().await;
+
+        let req = make_create_req("general");
+        let room = storage.create_room(&req).await.unwrap();
+
+        assert_eq!(room.name, "general");
+        assert_eq!(room.room_type, RoomType::Group);
+        assert_eq!(room.created_by, "agent-test");
+
+        let fetched = storage.get_room(&room.id).await.unwrap().unwrap();
+        assert_eq!(fetched.id, room.id);
+        assert_eq!(fetched.name, room.name);
+    }
+
+    #[tokio::test]
+    async fn test_create_duplicate_room_name() {
+        let (storage, _temp) = create_test_storage().await;
+
+        let req = make_create_req("duplicate");
+        storage.create_room(&req).await.unwrap();
+
+        let result = storage.create_room(&req).await;
+        assert!(matches!(result, Err(ApiError::Conflict(_))));
+    }
+
+    #[tokio::test]
+    async fn test_create_room_empty_name() {
+        let (storage, _temp) = create_test_storage().await;
+
+        let req = CreateRoomRequest {
+            name: "   ".to_string(),
+            topic: None,
+            description: None,
+            room_type: RoomType::Group,
+            created_by: "agent-test".to_string(),
+        };
+        let result = storage.create_room(&req).await;
+        assert!(matches!(result, Err(ApiError::InvalidInput(_))));
+    }
+
+    #[tokio::test]
+    async fn test_list_rooms_paginated() {
+        let (storage, _temp) = create_test_storage().await;
+
+        for i in 0..5 {
+            let req = make_create_req(&format!("room-{i:02}"));
+            storage.create_room(&req).await.unwrap();
+        }
+
+        let (first_page, total) = storage.list_rooms(3, 0).await.unwrap();
+        assert_eq!(total, 5);
+        assert_eq!(first_page.len(), 3);
+
+        let (second_page, total2) = storage.list_rooms(3, 3).await.unwrap();
+        assert_eq!(total2, 5);
+        assert_eq!(second_page.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_get_room_by_name() {
+        let (storage, _temp) = create_test_storage().await;
+
+        let req = make_create_req("by-name");
+        let created = storage.create_room(&req).await.unwrap();
+
+        let found = storage.get_room_by_name("by-name").await.unwrap().unwrap();
+        assert_eq!(found.id, created.id);
+
+        let missing = storage.get_room_by_name("no-such-room").await.unwrap();
+        assert!(missing.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_update_room() {
+        let (storage, _temp) = create_test_storage().await;
+
+        let req = make_create_req("updateable");
+        let room = storage.create_room(&req).await.unwrap();
+
+        let updated = storage
+            .update_room(&room.id, Some("New topic".to_string()), None)
+            .await
+            .unwrap()
+            .unwrap();
+
+        assert_eq!(updated.topic, Some("New topic".to_string()));
+        // description unchanged
+        assert_eq!(updated.description, room.description);
+    }
+
+    #[tokio::test]
+    async fn test_update_room_not_found() {
+        let (storage, _temp) = create_test_storage().await;
+
+        let missing_id = Uuid::new_v4();
+        let result = storage.update_room(&missing_id, None, None).await.unwrap();
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_delete_room_cascades() {
+        let (storage, _temp) = create_test_storage().await;
+
+        let req = make_create_req("to-delete");
+        let room = storage.create_room(&req).await.unwrap();
+
+        let deleted = storage.delete_room(&room.id).await.unwrap();
+        assert!(deleted);
+
+        let fetched = storage.get_room(&room.id).await.unwrap();
+        assert!(fetched.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_delete_room_not_found() {
+        let (storage, _temp) = create_test_storage().await;
+
+        let missing_id = Uuid::new_v4();
+        let deleted = storage.delete_room(&missing_id).await.unwrap();
+        assert!(!deleted);
+    }
+
+    #[tokio::test]
+    async fn test_count_rooms() {
+        let (storage, _temp) = create_test_storage().await;
+
+        assert_eq!(storage.count_rooms().await.unwrap(), 0);
+
+        storage.create_room(&make_create_req("r1")).await.unwrap();
+        storage.create_room(&make_create_req("r2")).await.unwrap();
+        assert_eq!(storage.count_rooms().await.unwrap(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_list_rooms_by_type() {
+        let (storage, _temp) = create_test_storage().await;
+
+        let mut req = make_create_req("direct-room");
+        req.room_type = RoomType::Direct;
+        storage.create_room(&req).await.unwrap();
+
+        storage.create_room(&make_create_req("group-room")).await.unwrap();
+
+        let (direct_rooms, direct_total) =
+            storage.list_rooms_by_type(&RoomType::Direct, 10, 0).await.unwrap();
+        assert_eq!(direct_total, 1);
+        assert_eq!(direct_rooms.len(), 1);
+        assert_eq!(direct_rooms[0].name, "direct-room");
+
+        let (group_rooms, group_total) =
+            storage.list_rooms_by_type(&RoomType::Group, 10, 0).await.unwrap();
+        assert_eq!(group_total, 1);
+        assert_eq!(group_rooms.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_list_participants_in_room_empty() {
+        let (storage, _temp) = create_test_storage().await;
+
+        let req = make_create_req("empty-room");
+        let room = storage.create_room(&req).await.unwrap();
+
+        let (participants, total) =
+            storage.list_participants_in_room(&room.id, 10, 0).await.unwrap();
+        assert_eq!(total, 0);
+        assert!(participants.is_empty());
     }
 }

--- a/crates/communicate/src/types.rs
+++ b/crates/communicate/src/types.rs
@@ -245,6 +245,13 @@ impl From<Room> for RoomResponse {
     }
 }
 
+/// Request body for updating an existing room's mutable fields.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UpdateRoomRequest {
+    pub topic: Option<String>,
+    pub description: Option<String>,
+}
+
 /// Request body for adding a participant to a room.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct AddParticipantRequest {


### PR DESCRIPTION
## Summary

- Implements full room CRUD storage methods on `CommunicateStorage` (`create_room`, `get_room`, `get_room_by_name`, `list_rooms`, `list_rooms_by_type`, `update_room`, `delete_room`, `count_rooms`, `list_participants_in_room`)
- Adds `model_to_room` and `model_to_participant` conversion helpers in `storage.rs`
- Expands `api.rs` router with 6 new room endpoints: `POST /rooms`, `GET /rooms`, `GET /rooms/{id}`, `PUT /rooms/{id}`, `DELETE /rooms/{id}`, `GET /rooms/{id}/participants`
- Adds `UpdateRoomRequest` type to `types.rs`
- Prometheus metrics: `rooms_created_total` counter and `rooms_active` gauge maintained on create/delete

## HTTP Behaviour

| Method | Path | Status codes |
|--------|------|-------------|
| POST | /rooms | 201 Created, 400 empty name, 409 duplicate name |
| GET | /rooms | 200 OK (paginated, optional `room_type` query param) |
| GET | /rooms/{id} | 200 OK, 404 Not Found |
| PUT | /rooms/{id} | 200 OK, 404 Not Found |
| DELETE | /rooms/{id} | 204 No Content, 404 Not Found |
| GET | /rooms/{id}/participants | 200 OK, 404 if room missing |

## Test plan

- [x] `test_create_and_get_room` — create a room, retrieve by ID
- [x] `test_create_duplicate_room_name` — returns `Conflict` error
- [x] `test_create_room_empty_name` — returns `InvalidInput` error
- [x] `test_list_rooms_paginated` — pagination with total count
- [x] `test_get_room_by_name` — lookup by name, missing returns None
- [x] `test_update_room` — topic updated, description unchanged
- [x] `test_update_room_not_found` — returns None
- [x] `test_delete_room_cascades` — room gone after delete
- [x] `test_delete_room_not_found` — returns false
- [x] `test_count_rooms` — count increments correctly
- [x] `test_list_rooms_by_type` — filters by room type
- [x] `test_list_participants_in_room_empty` — empty list for new room
- [x] `test_create_room_returns_201` — HTTP 201 with body
- [x] `test_create_duplicate_name_returns_409` — HTTP 409
- [x] `test_get_nonexistent_room_returns_404` — HTTP 404
- [x] `test_list_rooms_paginated` (API) — total/items/limit/offset correct
- [x] `test_delete_room` — 204 then 404
- [x] `test_update_room` (API) — topic updated in response
- [x] `test_list_participants_returns_404_for_missing_room` — HTTP 404

All 32 tests pass (`cargo test -p communicate`), clippy clean.

Closes #491

🤖 Generated with [Claude Code](https://claude.com/claude-code)