### PR TITLE
feat(communicate): add real-time WebSocket message streaming (#494)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1396,6 +1396,7 @@ dependencies = [
  "axum",
  "chrono",
  "directories",
+ "futures",
  "metrics",
  "metrics-exporter-prometheus",
  "reqwest",

--- a/crates/communicate/Cargo.toml
+++ b/crates/communicate/Cargo.toml
@@ -18,10 +18,11 @@ thiserror = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 
-# HTTP API server
-axum = { workspace = true }
+# HTTP API server + WebSocket
+axum = { workspace = true, features = ["ws"] }
 tower = "0.5"
 tower-http = { workspace = true, features = ["cors"] }
+futures = "0.3"
 
 # HTTP client
 reqwest = { version = "0.12", features = ["json"] }

--- a/crates/communicate/src/api.rs
+++ b/crates/communicate/src/api.rs
@@ -36,6 +36,7 @@ use crate::types::{
     PaginatedResponse, ParticipantResponse, RoomResponse, RoomType, UpdateParticipantRoleRequest,
     UpdateRoomRequest,
 };
+use crate::websocket::{ws_handler, ConnectionManager, RoomEvent};
 
 pub use agentd_common::error::ApiError;
 
@@ -43,6 +44,7 @@ pub use agentd_common::error::ApiError;
 #[derive(Clone)]
 pub struct ApiState {
     pub storage: Arc<CommunicateStorage>,
+    pub connection_manager: Arc<ConnectionManager>,
 }
 
 /// Build the Axum router with all communicate API routes.
@@ -70,6 +72,7 @@ pub fn create_router(state: ApiState) -> Router {
 
     Router::new()
         .route("/health", get(health))
+        .route("/ws", get(ws_handler))
         .nest("/rooms", rooms_router)
         .nest("/participants", participants_router)
         .nest("/messages", messages_router)
@@ -230,7 +233,15 @@ async fn add_participant(
     let count = state.storage.count_participants_in_room(&id).await?;
     metrics::gauge!("participants_total", "room_id" => id.to_string()).set(count as f64);
 
-    Ok((StatusCode::CREATED, Json(ParticipantResponse::from(participant))))
+    let response = ParticipantResponse::from(participant);
+
+    // Broadcast participant joined event to WebSocket subscribers
+    state
+        .connection_manager
+        .broadcast_to_room(id, RoomEvent::ParticipantJoined(response.clone()))
+        .await;
+
+    Ok((StatusCode::CREATED, Json(response)))
 }
 
 /// `GET /rooms/{id}/participants/{identifier}` — get a specific participant.
@@ -269,6 +280,16 @@ async fn remove_participant(
     if removed {
         let count = state.storage.count_participants_in_room(&id).await?;
         metrics::gauge!("participants_total", "room_id" => id.to_string()).set(count as f64);
+
+        // Broadcast participant left event to WebSocket subscribers
+        state
+            .connection_manager
+            .broadcast_to_room(
+                id,
+                RoomEvent::ParticipantLeft { room_id: id, identifier: identifier.clone() },
+            )
+            .await;
+
         Ok(StatusCode::NO_CONTENT)
     } else {
         Err(ApiError::NotFound)
@@ -308,7 +329,12 @@ async fn send_message(
     let count = state.storage.get_room_message_count(&id).await?;
     metrics::histogram!("messages_per_room", "room_id" => id.to_string()).record(count as f64);
 
-    Ok((StatusCode::CREATED, Json(MessageResponse::from(message))))
+    let response = MessageResponse::from(message);
+
+    // Broadcast message to WebSocket subscribers
+    state.connection_manager.broadcast_to_room(id, RoomEvent::Message(response.clone())).await;
+
+    Ok((StatusCode::CREATED, Json(response)))
 }
 
 /// `GET /rooms/{id}/messages` — list messages in a room (paginated, filterable).
@@ -403,7 +429,8 @@ mod tests {
         let temp_dir = TempDir::new().unwrap();
         let db_path = temp_dir.path().join("test.db");
         let storage = Arc::new(CommunicateStorage::with_path(&db_path).await.unwrap());
-        let state = ApiState { storage };
+        let connection_manager = Arc::new(ConnectionManager::new());
+        let state = ApiState { storage, connection_manager };
         (create_router(state), temp_dir)
     }
 

--- a/crates/communicate/src/main.rs
+++ b/crates/communicate/src/main.rs
@@ -8,6 +8,7 @@ mod entity;
 mod migration;
 mod storage;
 mod types;
+mod websocket;
 
 use api::{create_router, ApiState};
 use axum::{extract::State, response::IntoResponse, routing::get};
@@ -16,6 +17,7 @@ use std::env;
 use std::sync::Arc;
 use storage::CommunicateStorage;
 use tracing::info;
+use websocket::ConnectionManager;
 
 fn init_metrics() -> PrometheusHandle {
     let builder = metrics_exporter_prometheus::PrometheusBuilder::new();
@@ -43,9 +45,10 @@ async fn main() -> anyhow::Result<()> {
     info!("Communicate storage initialized at: {:?}", CommunicateStorage::get_db_path()?);
 
     let storage = Arc::new(storage);
+    let connection_manager = Arc::new(ConnectionManager::new());
     let metrics_handle = init_metrics();
 
-    let api_state = ApiState { storage };
+    let api_state = ApiState { storage, connection_manager };
     let metrics_router =
         axum::Router::new().route("/metrics", get(metrics_handler)).with_state(metrics_handle);
 

--- a/crates/communicate/src/websocket.rs
+++ b/crates/communicate/src/websocket.rs
@@ -1,0 +1,412 @@
+//! WebSocket support for real-time message streaming.
+//!
+//! This module provides a `ConnectionManager` that tracks active WebSocket
+//! connections and broadcasts room events (messages, participant join/leave)
+//! to subscribed clients.
+
+use crate::storage::CommunicateStorage;
+use crate::types::{MessageResponse, ParticipantResponse};
+use axum::{
+    extract::{
+        ws::{Message, WebSocket, WebSocketUpgrade},
+        Query, State,
+    },
+    response::IntoResponse,
+};
+use futures::{SinkExt, StreamExt};
+use serde::{Deserialize, Serialize};
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+use tokio::sync::{broadcast, mpsc, RwLock};
+use tracing::{debug, error, info, warn};
+use uuid::Uuid;
+
+use agentd_common::error::ApiError;
+
+/// Unique identifier for a WebSocket connection.
+type ConnectionId = Uuid;
+
+/// A connection entry containing the connection ID and message sender.
+type ConnectionEntry = (ConnectionId, mpsc::UnboundedSender<ServerMessage>);
+
+/// Events that can occur in a room and should be broadcast to subscribers.
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub enum RoomEvent {
+    Message(MessageResponse),
+    ParticipantJoined(ParticipantResponse),
+    ParticipantLeft { room_id: Uuid, identifier: String },
+}
+
+/// Manages active WebSocket connections and room subscriptions.
+#[derive(Clone)]
+pub struct ConnectionManager {
+    /// Maps participant identifier to their active connection senders.
+    connections: Arc<RwLock<HashMap<String, Vec<ConnectionEntry>>>>,
+    /// Maps room ID to broadcast channel for that room.
+    room_broadcasts: Arc<RwLock<HashMap<Uuid, broadcast::Sender<RoomEvent>>>>,
+    /// Maps connection ID to the set of rooms they're subscribed to.
+    subscriptions: Arc<RwLock<HashMap<ConnectionId, HashSet<Uuid>>>>,
+    /// Maps connection ID to participant identifier.
+    connection_participants: Arc<RwLock<HashMap<ConnectionId, String>>>,
+}
+
+impl ConnectionManager {
+    /// Creates a new connection manager.
+    pub fn new() -> Self {
+        Self {
+            connections: Arc::new(RwLock::new(HashMap::new())),
+            room_broadcasts: Arc::new(RwLock::new(HashMap::new())),
+            subscriptions: Arc::new(RwLock::new(HashMap::new())),
+            connection_participants: Arc::new(RwLock::new(HashMap::new())),
+        }
+    }
+
+    /// Registers a new WebSocket connection.
+    pub async fn connect(
+        &self,
+        participant_id: String,
+        sender: mpsc::UnboundedSender<ServerMessage>,
+    ) -> ConnectionId {
+        let conn_id = Uuid::new_v4();
+
+        self.connections
+            .write()
+            .await
+            .entry(participant_id.clone())
+            .or_insert_with(Vec::new)
+            .push((conn_id, sender));
+
+        self.connection_participants.write().await.insert(conn_id, participant_id.clone());
+
+        info!(%conn_id, %participant_id, "WebSocket connection registered");
+        conn_id
+    }
+
+    /// Subscribes a connection to a room's events.
+    ///
+    /// Verifies that the participant is actually in the room before allowing subscription.
+    pub async fn subscribe(
+        &self,
+        conn_id: ConnectionId,
+        room_id: Uuid,
+        storage: &CommunicateStorage,
+    ) -> Result<broadcast::Receiver<RoomEvent>, ApiError> {
+        // Get the participant identifier for this connection
+        let participant_id = {
+            let conn_participants = self.connection_participants.read().await;
+            conn_participants.get(&conn_id).cloned().ok_or(ApiError::NotFound)?
+        };
+
+        // Verify participant is in the room
+        let participant = storage
+            .get_participant(&room_id, &participant_id)
+            .await
+            .map_err(|_| ApiError::NotFound)?;
+
+        if participant.is_none() {
+            return Err(ApiError::Forbidden("You are not a participant in this room".to_string()));
+        }
+
+        // Get or create the broadcast channel for this room
+        let sender = {
+            let mut room_broadcasts = self.room_broadcasts.write().await;
+            room_broadcasts.entry(room_id).or_insert_with(|| broadcast::channel(1024).0).clone()
+        };
+
+        // Record the subscription
+        self.subscriptions
+            .write()
+            .await
+            .entry(conn_id)
+            .or_insert_with(HashSet::new)
+            .insert(room_id);
+
+        info!(%conn_id, %room_id, %participant_id, "Subscribed to room");
+        Ok(sender.subscribe())
+    }
+
+    /// Unsubscribes a connection from a room's events.
+    pub async fn unsubscribe(&self, conn_id: ConnectionId, room_id: Uuid) {
+        if let Some(subs) = self.subscriptions.write().await.get_mut(&conn_id) {
+            subs.remove(&room_id);
+            info!(%conn_id, %room_id, "Unsubscribed from room");
+        }
+    }
+
+    /// Disconnects and cleans up a WebSocket connection.
+    pub async fn disconnect(&self, conn_id: ConnectionId) {
+        // Get participant ID before removing
+        let participant_id = self.connection_participants.write().await.remove(&conn_id);
+
+        // Remove subscriptions
+        self.subscriptions.write().await.remove(&conn_id);
+
+        // Remove from connections list
+        if let Some(ref pid) = participant_id {
+            if let Some(conns) = self.connections.write().await.get_mut(pid) {
+                conns.retain(|(id, _)| *id != conn_id);
+                if conns.is_empty() {
+                    self.connections.write().await.remove(pid);
+                }
+            }
+        }
+
+        info!(%conn_id, participant_id = ?participant_id, "WebSocket connection disconnected");
+    }
+
+    /// Broadcasts an event to all subscribers of a room.
+    pub async fn broadcast_to_room(&self, room_id: Uuid, event: RoomEvent) {
+        let room_broadcasts = self.room_broadcasts.read().await;
+        if let Some(sender) = room_broadcasts.get(&room_id) {
+            // broadcast::send returns Err if there are no receivers, which is fine
+            let _ = sender.send(event);
+        }
+    }
+
+    /// Gets the broadcast sender for a room, creating one if it doesn't exist.
+    #[allow(dead_code)]
+    pub async fn get_room_sender(&self, room_id: Uuid) -> broadcast::Sender<RoomEvent> {
+        let mut room_broadcasts = self.room_broadcasts.write().await;
+        room_broadcasts.entry(room_id).or_insert_with(|| broadcast::channel(1024).0).clone()
+    }
+}
+
+impl Default for ConnectionManager {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// WebSocket Protocol Messages
+// ---------------------------------------------------------------------------
+
+/// Parameters for establishing a WebSocket connection.
+#[derive(Debug, Deserialize)]
+pub struct WsConnectParams {
+    /// Unique identifier for the participant (e.g., agent ID or username).
+    pub identifier: String,
+    /// Type of participant: "agent" or "human".
+    pub kind: String,
+    /// Human-readable display name.
+    pub display_name: String,
+}
+
+/// Messages sent from the client to the server.
+#[derive(Debug, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+enum ClientMessage {
+    /// Subscribe to receive events from a room.
+    Subscribe { room_id: Uuid },
+    /// Unsubscribe from a room's events.
+    Unsubscribe { room_id: Uuid },
+    /// Send a message to a room.
+    Send {
+        room_id: Uuid,
+        content: String,
+        #[serde(default)]
+        metadata: HashMap<String, String>,
+    },
+    /// Ping to keep connection alive.
+    Ping,
+}
+
+/// Messages sent from the server to the client.
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+pub(crate) enum ServerMessage {
+    /// A new message in a subscribed room.
+    Message { room_id: Uuid, message: MessageResponse },
+    /// A participant joined or left a room.
+    ParticipantEvent {
+        room_id: Uuid,
+        event: String, // "joined" or "left"
+        participant: Option<ParticipantResponse>,
+        identifier: Option<String>, // For left events
+    },
+    /// An error occurred.
+    Error { message: String },
+    /// Pong response to ping.
+    Pong,
+}
+
+/// WebSocket upgrade handler.
+pub async fn ws_handler(
+    ws: WebSocketUpgrade,
+    State(state): State<crate::api::ApiState>,
+    Query(params): Query<WsConnectParams>,
+) -> Result<impl IntoResponse, ApiError> {
+    // Validate participant kind
+    if params.kind != "agent" && params.kind != "human" {
+        return Err(ApiError::InvalidInput("kind must be 'agent' or 'human'".to_string()));
+    }
+
+    Ok(ws.on_upgrade(move |socket| handle_socket(socket, state, params)))
+}
+
+/// Handles an individual WebSocket connection.
+async fn handle_socket(socket: WebSocket, state: crate::api::ApiState, params: WsConnectParams) {
+    let (mut ws_sender, mut ws_receiver) = socket.split();
+
+    // Create a channel for sending messages to this connection
+    let (tx, mut rx) = mpsc::unbounded_channel::<ServerMessage>();
+
+    // Register the connection
+    let conn_id = state.connection_manager.connect(params.identifier.clone(), tx.clone()).await;
+
+    // Spawn a task to forward messages from our channel to the WebSocket
+    let send_task = tokio::spawn(async move {
+        while let Some(msg) = rx.recv().await {
+            match serde_json::to_string(&msg) {
+                Ok(json) => {
+                    if ws_sender.send(Message::Text(json.into())).await.is_err() {
+                        break;
+                    }
+                }
+                Err(e) => {
+                    error!("Failed to serialize message: {}", e);
+                }
+            }
+        }
+    });
+
+    // Track active subscription tasks
+    let mut subscription_tasks: HashMap<Uuid, tokio::task::JoinHandle<()>> = HashMap::new();
+
+    // Handle incoming messages
+    while let Some(msg) = ws_receiver.next().await {
+        match msg {
+            Ok(Message::Text(text)) => {
+                match serde_json::from_str::<ClientMessage>(&text) {
+                    Ok(ClientMessage::Subscribe { room_id }) => {
+                        debug!(%conn_id, %room_id, "Subscribe request");
+
+                        match state
+                            .connection_manager
+                            .subscribe(conn_id, room_id, &state.storage)
+                            .await
+                        {
+                            Ok(mut room_rx) => {
+                                // Spawn a task to forward room events to this connection
+                                let tx_clone = tx.clone();
+                                let task = tokio::spawn(async move {
+                                    while let Ok(event) = room_rx.recv().await {
+                                        let server_msg = match event {
+                                            RoomEvent::Message(msg) => {
+                                                ServerMessage::Message { room_id, message: msg }
+                                            }
+                                            RoomEvent::ParticipantJoined(p) => {
+                                                ServerMessage::ParticipantEvent {
+                                                    room_id,
+                                                    event: "joined".to_string(),
+                                                    participant: Some(p),
+                                                    identifier: None,
+                                                }
+                                            }
+                                            RoomEvent::ParticipantLeft {
+                                                room_id: _,
+                                                identifier,
+                                            } => ServerMessage::ParticipantEvent {
+                                                room_id,
+                                                event: "left".to_string(),
+                                                participant: None,
+                                                identifier: Some(identifier),
+                                            },
+                                        };
+
+                                        if tx_clone.send(server_msg).is_err() {
+                                            break;
+                                        }
+                                    }
+                                });
+
+                                subscription_tasks.insert(room_id, task);
+                            }
+                            Err(e) => {
+                                warn!(%conn_id, %room_id, error = %e, "Subscribe failed");
+                                let _ = tx.send(ServerMessage::Error { message: e.to_string() });
+                            }
+                        }
+                    }
+                    Ok(ClientMessage::Unsubscribe { room_id }) => {
+                        debug!(%conn_id, %room_id, "Unsubscribe request");
+                        state.connection_manager.unsubscribe(conn_id, room_id).await;
+
+                        // Cancel the subscription task
+                        if let Some(task) = subscription_tasks.remove(&room_id) {
+                            task.abort();
+                        }
+                    }
+                    Ok(ClientMessage::Send { room_id, content, metadata }) => {
+                        debug!(%conn_id, %room_id, "Send message request");
+
+                        // Use the storage layer to send the message
+                        use crate::types::{CreateMessageRequest, ParticipantKind};
+                        let req = CreateMessageRequest {
+                            sender_id: params.identifier.clone(),
+                            sender_name: params.display_name.clone(),
+                            sender_kind: if params.kind == "agent" {
+                                ParticipantKind::Agent
+                            } else {
+                                ParticipantKind::Human
+                            },
+                            content,
+                            metadata,
+                            reply_to: None,
+                        };
+
+                        match state.storage.send_message(&room_id, &req).await {
+                            Ok(msg) => {
+                                // Convert to response
+                                let msg_response = MessageResponse::from(msg);
+
+                                // Broadcast to all subscribers
+                                state
+                                    .connection_manager
+                                    .broadcast_to_room(room_id, RoomEvent::Message(msg_response))
+                                    .await;
+                            }
+                            Err(e) => {
+                                warn!(%conn_id, %room_id, error = %e, "Send message failed");
+                                let _ = tx.send(ServerMessage::Error {
+                                    message: format!("Failed to send message: {}", e),
+                                });
+                            }
+                        }
+                    }
+                    Ok(ClientMessage::Ping) => {
+                        let _ = tx.send(ServerMessage::Pong);
+                    }
+                    Err(e) => {
+                        warn!(%conn_id, error = %e, "Invalid message format");
+                        let _ = tx.send(ServerMessage::Error {
+                            message: format!("Invalid message format: {}", e),
+                        });
+                    }
+                }
+            }
+            Ok(Message::Close(_)) => {
+                debug!(%conn_id, "Client closed connection");
+                break;
+            }
+            Ok(Message::Ping(_)) | Ok(Message::Pong(_)) => {
+                // Axum handles ping/pong automatically
+            }
+            Ok(Message::Binary(_)) => {
+                warn!(%conn_id, "Unexpected binary message");
+            }
+            Err(e) => {
+                error!(%conn_id, error = %e, "WebSocket error");
+                break;
+            }
+        }
+    }
+
+    // Cleanup
+    send_task.abort();
+    for (_, task) in subscription_tasks {
+        task.abort();
+    }
+    state.connection_manager.disconnect(conn_id).await;
+}


### PR DESCRIPTION
## Summary

Implements real-time WebSocket message streaming for the communicate service, enabling clients (agents and humans) to receive instant notifications of room events.

- New WebSocket endpoint at `GET /ws?identifier=<id>&kind=<agent|human>&display_name=<name>`
- ConnectionManager tracks active connections and manages room subscriptions
- Real-time broadcasting of messages, participant joins/leaves to all room subscribers
- Authorization enforcement: only participants can subscribe to rooms
- Bidirectional protocol: clients can subscribe, send messages, and receive events

## Implementation Details

### ConnectionManager
- Manages WebSocket connections indexed by participant identifier
- Per-room broadcast channels (tokio::sync::broadcast) for efficient event distribution
- Tracks subscriptions: which connections are subscribed to which rooms
- Authorization: verifies participant membership before allowing room subscriptions

### WebSocket Protocol

**Client → Server messages:**
- `subscribe`: Subscribe to a room's events (requires participant membership)
- `unsubscribe`: Unsubscribe from a room
- `send`: Send a message to a room (persisted and broadcast)
- `ping`: Keep-alive

**Server → Client messages:**
- `message`: New message in subscribed room
- `participant_event`: Participant joined or left event
- `error`: Error response
- `pong`: Ping response

### Integration Points
- REST API `POST /rooms/{id}/messages` now broadcasts to WebSocket subscribers
- REST API `POST /rooms/{id}/participants` broadcasts participant joined events
- REST API `DELETE /rooms/{id}/participants/{identifier}` broadcasts participant left events
- Messages sent via WebSocket are persisted and broadcast the same way

### Dependencies Added
- `axum` with `ws` feature for WebSocket support
- `futures` for stream/sink utilities

## Testing

- All existing tests pass (55 tests)
- WebSocket functionality can be tested with a WebSocket client
- Consider adding integration tests for WebSocket in future work

## Example Usage

```bash
# Connect to WebSocket
wscat -c "ws://localhost:17010/ws?identifier=agent-1&kind=agent&display_name=Agent%20One"

# Subscribe to a room (must be a participant)
{"type": "subscribe", "room_id": "<room-uuid>"}

# Send a message
{"type": "send", "room_id": "<room-uuid>", "content": "Hello!", "metadata": {}}

# Receive events
{"type": "message", "room_id": "<room-uuid>", "message": {...}}
{"type": "participant_event", "room_id": "<room-uuid>", "event": "joined", "participant": {...}}
```

## Closes

Closes #494

Generated with [Claude Code](https://claude.com/claude-code)