### PR TITLE
fix(orchestrator): persist and restore agent room memberships

### DIFF
--- a/crates/orchestrator/src/entity/agent.rs
+++ b/crates/orchestrator/src/entity/agent.rs
@@ -47,6 +47,9 @@ pub struct Model {
     /// JSON-serialized `Vec<String>` of additional directory paths.
     /// Maps to Claude Code's `--add-dir` flag.
     pub additional_dirs: String,
+    /// JSON-serialized `Vec<String>` of communicate room names.
+    /// The agent is auto-joined to these rooms when it connects to the orchestrator.
+    pub rooms: String,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/crates/orchestrator/src/migration/m20260319_000008_add_rooms_to_agents.rs
+++ b/crates/orchestrator/src/migration/m20260319_000008_add_rooms_to_agents.rs
@@ -1,0 +1,36 @@
+//! Migration: add `rooms` column to the `agents` table.
+//!
+//! Adds one column:
+//! - `rooms` (TEXT NOT NULL DEFAULT '[]'): JSON-serialized `Vec<String>`
+//!   of communicate room names the agent should auto-join on connect.
+//!
+//! Existing rows default to an empty JSON array (`[]`), preserving
+//! backwards compatibility (agents without rooms configured).
+
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let db = manager.get_connection();
+
+        let stmt = "ALTER TABLE agents ADD COLUMN rooms TEXT NOT NULL DEFAULT '[]'";
+        if let Err(e) = db.execute_unprepared(stmt).await {
+            // Idempotent: ignore if column already exists (e.g., re-run).
+            if !e.to_string().contains("duplicate column name") {
+                return Err(e);
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn down(&self, _manager: &SchemaManager) -> Result<(), DbErr> {
+        // SQLite < 3.35.0 does not support DROP COLUMN, so we leave
+        // the column in place on rollback for simplicity.
+        Ok(())
+    }
+}

--- a/crates/orchestrator/src/migration/mod.rs
+++ b/crates/orchestrator/src/migration/mod.rs
@@ -18,6 +18,7 @@ mod m20250311_000004_add_network_policy;
 mod m20250311_000006_add_additional_dirs;
 mod m20250312_000005_add_docker_config;
 mod m20260316_000007_rename_trigger_columns;
+mod m20260319_000008_add_rooms_to_agents;
 
 /// The migration runner — applies all known migrations in order.
 pub struct Migrator;
@@ -33,6 +34,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20250312_000005_add_docker_config::Migration),
             Box::new(m20250311_000006_add_additional_dirs::Migration),
             Box::new(m20260316_000007_rename_trigger_columns::Migration),
+            Box::new(m20260319_000008_add_rooms_to_agents::Migration),
         ]
     }
 }

--- a/crates/orchestrator/src/storage.rs
+++ b/crates/orchestrator/src/storage.rs
@@ -98,6 +98,9 @@ impl AgentStorage {
                 .map(|r| serde_json::to_string(r).unwrap_or_else(|_| "{}".to_string()))),
             additional_dirs: Set(serde_json::to_string(&agent.config.additional_dirs)
                 .unwrap_or_else(|_| "[]".to_string())),
+            rooms: Set(
+                serde_json::to_string(&agent.config.rooms).unwrap_or_else(|_| "[]".to_string())
+            ),
         };
 
         agent_entity::Entity::insert(model).exec(&self.db).await?;
@@ -543,7 +546,7 @@ fn model_to_agent(model: agent_entity::Model) -> Result<Agent> {
                 .as_deref()
                 .and_then(|s| serde_json::from_str(s).ok()),
             additional_dirs: serde_json::from_str(&model.additional_dirs).unwrap_or_default(),
-            rooms: vec![],
+            rooms: serde_json::from_str(&model.rooms).unwrap_or_default(),
         },
         session_id: model.session_id,
         backend_type: model.backend_type,


### PR DESCRIPTION
## Summary

- The `rooms` field in `AgentConfig` was never written to or read from the database — the `agents` table had no `rooms` column and `model_to_agent()` always returned `rooms: vec![]`
- This caused the `AgentConnected` auto-join handler in `main.rs` to see empty rooms for every agent and skip room joining entirely
- All human↔agent communication via the communicate service was silently broken

## Changes

- **New migration** `m20260319_000008_add_rooms_to_agents`: adds `rooms TEXT NOT NULL DEFAULT '[]'` column to the `agents` table (idempotent, existing rows get `[]`)
- **`entity/agent.rs`**: added `rooms: String` field to the SeaORM `Model`
- **`storage.rs`**: serialize rooms to JSON on `add()`, deserialize from JSON in `model_to_agent()` (was hardcoded `vec![]`)

## Test plan

- [ ] All 257 existing orchestrator tests pass (`cargo test -p orchestrator`)
- [ ] `cargo fmt` and `cargo clippy` clean
- [ ] `agent apply .agentd/` creates rooms, then agents join them on connect
- [ ] `agent communicate members engineering` shows agent participants after startup
- [ ] `agent communicate watch engineering` receives agent messages

Fixes #532

🤖 Generated with [Claude Code](https://claude.com/claude-code)