### PR TITLE
docs: clarify dev vs prod port scheme and agent status behaviour

### DIFF
--- a/docs/public/getting-started.md
+++ b/docs/public/getting-started.md
@@ -523,6 +523,8 @@ See [Installation Guide](install.md) for detailed setup instructions.
 
 ### Port Reference
 
+agentd uses a dual-port scheme: **dev ports (17xxx)** when running with `cargo run`, and **production ports (7xxx)** when installed as a LaunchAgent (macOS) or systemd unit (Linux).
+
 | Service | Dev Port | Prod Port |
 |---------|----------|-----------|
 | agentd-ask | 17001 | 7001 |
@@ -531,22 +533,63 @@ See [Installation Guide](install.md) for detailed setup instructions.
 | agentd-notify | 17004 | 7004 |
 | agentd-wrap | 17005 | 7005 |
 | agentd-orchestrator | 17006 | 7006 |
+| agentd-memory | — | 7008 |
+| agentd-communicate | 17010 | 7010 |
+
+The `agent` CLI defaults to **production ports** (7xxx). If your services are running on dev ports, set the URL overrides:
+
+```bash
+source .env   # sets all AGENTD_*_SERVICE_URL vars to dev ports
+```
+
+Or override a single service:
+
+```bash
+AGENTD_COMMUNICATE_SERVICE_URL=http://localhost:17010 agent communicate health
+```
+
+See [Configuration Reference](configuration.md) for the full list of environment variables.
 
 ---
 
 ## Troubleshooting
 
+### `agent status` shows services as down when they are running
+
+The `agent status` command checks **production ports (7xxx)** by default. If you're running services with `cargo run` (dev ports 17xxx), status checks will fail even though services are healthy.
+
+Check which ports your services are actually on:
+
+```bash
+# Test dev ports directly
+curl -s http://localhost:17004/health   # notify (dev)
+curl -s http://localhost:17006/health   # orchestrator (dev)
+
+# Test production ports
+curl -s http://localhost:7004/health    # notify (prod)
+curl -s http://localhost:7006/health    # orchestrator (prod)
+```
+
+If dev services are healthy but `agent status` shows them down, source the `.env` file to point the CLI at dev ports:
+
+```bash
+source .env
+agent status
+```
+
+See [issue #536](https://github.com/geoffjay/agentd/issues/536) — a code fix is in progress to make `agent status` port-scheme-aware.
+
 ### "Connection refused" when hitting health endpoints
 
-The service isn't running. Check:
+The service isn't running, or you're checking the wrong port. Check:
 
 ```bash
 # Is the process running?
 ps aux | grep agentd
 
-# Check for port conflicts
-lsof -i :17004
-lsof -i :17006
+# Are services on dev ports (cargo run) or prod ports (installed)?
+curl -s http://localhost:17004/health   # dev
+curl -s http://localhost:7004/health    # prod
 ```
 
 If another process holds the port, either stop it or override with `AGENTD_PORT=18004 cargo run -p agentd-notify`.

--- a/docs/public/install.md
+++ b/docs/public/install.md
@@ -222,8 +222,17 @@ and a production port (7xxx) when running as a LaunchAgent:
 | agentd-notify | 17004 | 7004 |
 | agentd-wrap | 17005 | 7005 |
 | agentd-orchestrator | 17006 | 7006 |
+| agentd-memory | — | 7008 |
+| agentd-communicate | 17010 | 7010 |
 
 All ports are configurable via the `AGENTD_PORT` environment variable.
+
+!!! warning "CLI defaults to production ports"
+    The `agent` CLI connects to **production ports (7xxx)** by default. If you're running services with `cargo run` (dev ports), `agent status` and other commands will report connection failures even though services are healthy. Fix this by sourcing the dev environment:
+    ```bash
+    source .env   # sets AGENTD_*_SERVICE_URL vars to dev ports (17xxx)
+    ```
+    See [Configuration Reference](configuration.md#using-the-env-file-for-development) for details.
 
 ### Custom Installation Location
 
@@ -320,11 +329,15 @@ Common issues:
    cargo xtask service-status
    ```
 
-2. Check if port is listening:
+2. Check if port is listening. Installed services use **production ports (7xxx)**:
    ```bash
-   curl http://localhost:17004/health
-   curl http://localhost:17001/health
+   curl http://localhost:7004/health    # notify
+   curl http://localhost:7001/health    # ask
+   curl http://localhost:7006/health    # orchestrator
+   curl http://localhost:7010/health    # communicate
    ```
+
+   If running with `cargo run` (dev), use dev ports (17xxx) instead.
 
 3. Restart services:
    ```bash


### PR DESCRIPTION
## Summary

- Adds a warning admonition to `install.md` explaining that the `agent` CLI defaults to production ports (7xxx); users running services with `cargo run` need to `source .env` to point the CLI at dev ports (17xxx)
- Updates port reference tables in `getting-started.md` and `install.md` to include `agentd-communicate` (17010/7010) and `agentd-memory` (7008), which were missing
- Adds a dedicated troubleshooting entry for "`agent status` shows services as down when they are running" — the most confusing symptom of the port mismatch — with a workaround and reference to #536
- Fixes the `install.md` "Cannot Connect to Service" troubleshooting section to use production ports (7xxx) for installed services rather than dev ports

## Motivation

Discovered during a multi-agent engineering channel discussion (2026-03-20): `agent status` reported all services as unhealthy because it was checking dev ports (17xxx) while services were running on production ports (7xxx) via Agent.app. The code fix is tracked in #536; this PR covers the documentation side.

## Test plan

- [ ] Verify port tables are complete and accurate against `crates/*/src/main.rs` defaults
- [ ] Verify `.env` snippet in configuration.md matches the workaround documented here
- [ ] Check no other docs pages reference `localhost:17xxx` for installed (prod) services without explanation

🤖 Generated with [Claude Code](https://claude.com/claude-code)