### PR TITLE
docs: autonomous pipeline architecture planning documents

### DIFF
--- a/docs/planning/autonomous-pipeline-gates.md
+++ b/docs/planning/autonomous-pipeline-gates.md
@@ -1,0 +1,146 @@
+# Autonomous Pipeline — Human Interaction Gates
+
+> **Status:** Design phase. Tracked in [#611](https://github.com/geoffjay/agentd/issues/611).
+> See [autonomous-pipeline.md](autonomous-pipeline.md) for the full architecture.
+
+This document defines exactly where the autonomous pipeline pauses for human input. Three categories of gates exist: operations that are always human, gates that are configurable, and operations that are always autonomous.
+
+---
+
+## Gate Categories
+
+### Always Human
+
+These operations cannot be delegated to an agent under any configuration:
+
+| Operation | Reason |
+|---|---|
+| `gs auth login` | Interactive OAuth flow — one-time per environment, requires browser |
+| Production deployments | Risk threshold requires explicit human sign-off |
+| Security-critical dependency changes | Flagged by the security-auditor; requires human judgment |
+| Merge conflict resolution when conductor escalates | Requires understanding of intent, not just syntax |
+| Adding new external service integrations | Architectural impact beyond a single issue |
+| Removing or deprecating a public API | Downstream consumers may be affected |
+
+When the conductor encounters an always-human situation it cannot proceed past, it:
+
+1. Posts to the `engineering` channel with a description of what is blocked and why
+2. Applies the `needs-human` label to the relevant issue or PR
+3. Skips all downstream work in the same stack
+4. Resumes automatically once the `needs-human` label is removed
+
+### Configurable Gates
+
+These operations are **allowed by default** but can be overridden in individual agent YAML files via `tool_policies`. A project can tighten these gates without modifying agent logic.
+
+| Gate | Default | Config Key | Effect when `ask` |
+|---|---|---|---|
+| PR auto-merge | `allow` | `conductor.auto_merge` | Conductor posts intent to engineering and waits for a reaction before merging |
+| Issue auto-close after PR merge | `allow` | `conductor.auto_close_issues` | Conductor leaves issue open; human closes manually |
+| Planner creating issues autonomously | `allow` | `planner.autonomous_creation` | Planner posts proposed issue list to engineering for review |
+| New Cargo dependency additions | `ask` | `worker.new_dependencies` | Worker pauses and asks via `agent ask` before adding to `Cargo.toml` |
+| Bulk file deletion | `ask` | `worker.bulk_delete` | Worker pauses and asks before deleting multiple files |
+
+#### Configuring a Gate
+
+Gates are expressed as `tool_policies` in agent YAML files. The orchestrator enforces them at dispatch time.
+
+```yaml
+# .agentd/agents/conductor.yml (excerpt)
+tool_policies:
+  - pattern: "gh pr merge *"
+    policy: allow          # default: autonomous merge
+  - pattern: "gh issue close *"
+    policy: allow          # default: auto-close after merge
+
+# To require human approval for merges, change to:
+  - pattern: "gh pr merge *"
+    policy: ask
+```
+
+```yaml
+# .agentd/agents/worker.yml (excerpt)
+tool_policies:
+  - pattern: "cargo add *"
+    policy: ask            # always ask before adding new dependencies
+  - pattern: "rm -rf *"
+    policy: deny           # never bulk-delete
+```
+
+!!! note "Policy DSL"
+    See the [tool policies documentation](../public/tool-policies.md) for the full policy DSL reference including wildcard patterns, environment-specific overrides, and the `deny` policy.
+
+### Always Autonomous
+
+These operations never require human approval, regardless of configuration:
+
+- Branch creation, deletion, and navigation via git-spice
+- PR submission and force-push after restack
+- Code review comments and approval
+- Test writing and test file updates
+- Documentation writing and updates
+- Memory read and write operations (`agent memory remember/search`)
+- Posting messages to communication channels
+- Reading GitHub issues, PRs, and repository files
+- Applying and removing labels (except `needs-human`)
+- Closing issues that are direct results of a completed PR
+
+---
+
+## Escalation Path
+
+When the conductor cannot proceed:
+
+```mermaid
+flowchart LR
+    A[Conductor blocked] --> B{Gate type?}
+    B -- always-human --> C[Post to engineering channel\napply needs-human label\nskip stack]
+    B -- configurable ask --> D[Post intent to engineering\nwait for approval\ntimeout after 24h]
+    D -- approved --> E[Proceed autonomously]
+    D -- timeout --> C
+    C --> F{Human resolves}
+    F -- removes needs-human --> G[Conductor resumes\non next 15-min tick]
+```
+
+### Engineering Channel Escalation Format
+
+The conductor uses a consistent format when escalating to the `engineering` channel:
+
+```
+🚨 Human action needed — [brief description]
+
+Issue/PR: #<N> <title>
+Blocked by: <reason>
+What to do: <specific instruction>
+
+After resolving, remove the `needs-human` label from #<N> to resume the pipeline.
+```
+
+---
+
+## CLAUDE.md Reference
+
+The always-human list must also appear in `CLAUDE.md` so that any agent operating outside a formal workflow respects these boundaries:
+
+```markdown
+## Human-Only Operations
+
+The following must never be performed autonomously — always ask or escalate:
+
+- gs auth login (interactive OAuth)
+- Deploying to production environments
+- Adding new external service integrations
+- Resolving git merge conflicts that the conductor has escalated
+- Removing or deprecating a public API surface
+```
+
+---
+
+## Related Issues
+
+| Issue | Title |
+|---|---|
+| [#611](https://github.com/geoffjay/agentd/issues/611) | Define human interaction gates and tool policies |
+| [#642](https://github.com/geoffjay/agentd/issues/642) | Add agent file-path scoping |
+| [#643](https://github.com/geoffjay/agentd/issues/643) | Define and enforce human approval gates |
+| [#603](https://github.com/geoffjay/agentd/issues/603) | Create conductor agent YAML (implements escalation) |

--- a/docs/planning/autonomous-pipeline.md
+++ b/docs/planning/autonomous-pipeline.md
@@ -1,0 +1,437 @@
+# Autonomous Development Pipeline — Architecture
+
+> **Status:** Design phase. Implementation tracked in [v0.10.0 milestone](https://github.com/geoffjay/agentd/milestone/20) and [v0.9.0 milestone](https://github.com/geoffjay/agentd/milestone/18).
+>
+> This document captures design decisions. Update it as implementation diverges from the design.
+
+---
+
+## Vision
+
+A complete software development lifecycle running with minimal human interaction:
+
+```
+Issue Created → Enriched → Planned → Implemented → Reviewed → Merged → Restacked
+```
+
+Human interaction is reduced to: one-time environment setup, configurable approval gates, and conflict escalation handling. The goal is a proof-of-concept demonstrating agentd as a complete autonomous development platform.
+
+---
+
+## Pipeline Stages
+
+```mermaid
+flowchart TD
+    A([Issue Created]) --> B{needs-triage?}
+    B -- yes --> C[Triage Agent\nroutes & labels]
+    B -- no --> D{enrich-agent?}
+    C --> D
+    D -- yes --> E[Enricher Agent\nadds context & AC]
+    D -- no --> F{plan-agent?}
+    E --> F
+    F -- yes --> G[Planner Agent\nbreaks down & orders]
+    F -- no --> H{agent label?}
+    G --> H
+    H -- yes --> I[Worker Agent\nimplements on branch]
+    I --> J[git-spice branch create\n+ git-spice branch submit]
+    J --> K{PR opened\nreview-agent label}
+    K --> L[Reviewer Agent\nreviews diff]
+    L --> M{Decision}
+    M -- request changes --> N[Worker fixes\ngit-spice branch submit]
+    N --> L
+    M -- approve --> O[merge-queue label\napplied to PR]
+    O --> P[Conductor Agent\n15-min cron]
+    P --> Q{CI green +\napproved?}
+    Q -- no --> R[Wait / escalate\nif stuck]
+    Q -- yes --> S[gh pr merge\nin dep order]
+    S --> T[git-spice repo sync]
+    T --> U{Dependents\nexist?}
+    U -- yes --> V[git-spice upstack restack\nneeds-restack label on PRs]
+    V --> L
+    U -- no --> W([Issue Closed])
+```
+
+### Stage 1 — Triage
+
+**Trigger:** `needs-triage` label applied to an issue
+**Agent:** triage
+**Workflow:** `triage-worker.yml`
+
+The triage agent reads the issue and applies appropriate routing labels (`agent`, `plan-agent`, `enrich-agent`, `docs-agent`, etc.), estimates complexity, and optionally adds `enrich-agent` if the issue lacks sufficient detail. Issues that are clearly out of scope or duplicates are commented on and closed.
+
+### Stage 2 — Enrich
+
+**Trigger:** `enrich-agent` label
+**Agent:** enricher
+**Workflow:** `enricher-worker.yml`
+
+The enricher agent expands sparse issues into actionable work items. It adds:
+
+- Acceptance criteria as a checklist
+- Technical context (relevant files, dependencies, patterns)
+- Complexity estimate (S / M / L / XL)
+- Suggested labels for downstream routing
+
+After enrichment the issue is ready for implementation or planning.
+
+### Stage 3 — Plan
+
+**Trigger:** `plan-agent` label
+**Agent:** planner
+**Workflow:** `plan-worker.yml`
+
+The planner handles epics and complex issues. It:
+
+- Breaks the parent issue into sub-issues
+- Creates GitHub sub-issue relationships via the API
+- Adds `blocked-by` relationships to encode implementation order
+- Applies the `agent` label to leaf issues (ready to implement)
+- Determines the stack base: the planner uses existing `blocked-by` relationships to establish which issues must land first, creating a linear or tree-shaped stack
+
+### Stage 4 — Implement
+
+**Trigger:** `agent` label on an issue
+**Agent:** worker
+**Workflow:** `issue-worker.yml`
+
+The worker agent implements the issue on a stacked branch:
+
+```bash
+# Determine stack base from blocked-by relationships
+# If issue is blocked by #123, base the branch on #123's branch
+gs branch create issue-<N> --base <blocking-branch-or-main>
+
+# Implement the change, then submit
+gs branch submit --fill
+```
+
+After pushing the PR, the worker applies the `review-agent` label to trigger the reviewer.
+
+### Stage 5 — Review
+
+**Trigger:** `review-agent` label on a PR
+**Agent:** reviewer
+**Workflow:** `pull-request-reviewer.yml`
+
+The reviewer fetches the diff, evaluates correctness, safety, and consistency, then either approves or requests changes. On approval it:
+
+1. Removes the `review-agent` label
+2. Applies the `merge-queue` label to hand off to the conductor
+
+### Stage 6 — Merge
+
+**Trigger:** `merge-queue` label on a PR (scanned by conductor's cron)
+**Agent:** conductor
+**Workflow:** `conductor-sync.yml`
+
+The conductor runs every 15 minutes and:
+
+1. Collects all PRs with `merge-queue` label
+2. Sorts them by dependency order (deepest/blocking branches first)
+3. Checks each PR: CI must be green and at least one approval
+4. Merges eligible PRs in order: `gh pr merge <N> --squash --repo geoffjay/agentd`
+5. After each merge: `gs repo sync` to update git-spice state
+6. Restacks dependent branches: `gs upstack restack`
+7. Applies `needs-restack` to any PRs whose base has changed
+8. Escalates unresolvable conflicts to the engineering channel
+
+### Stage 7 — Restack
+
+**Trigger:** Post-merge restack by conductor, or `needs-restack` label on a PR
+
+After a merge, the conductor calls `gs upstack restack` to rebase all branches that stacked on the merged branch. If a rebase produces conflicts the conductor cannot resolve, it:
+
+1. Posts to the `engineering` channel with the conflict details
+2. Applies a `needs-human` label
+3. Waits for human resolution before continuing the queue
+
+---
+
+## Agent Roster
+
+| Agent | Label Trigger | Scope | Room Membership |
+|---|---|---|---|
+| **triage** | `needs-triage` (issue) | Routes and labels incoming issues | engineering, announcements (observer) |
+| **enricher** | `enrich-agent` (issue) | Adds AC, context, complexity to issues | engineering, announcements (observer) |
+| **planner** | `plan-agent` (issue) | Breaks down epics, sets `blocked-by` order | engineering, announcements (observer) |
+| **worker** | `agent` (issue) | Implements on stacked git-spice branches | engineering, announcements (observer) |
+| **reviewer** | `review-agent` (PR) | Reviews diffs, approves or requests changes | engineering, announcements (observer) |
+| **conductor** | cron every 15 min | Manages merge queue, restacks, escalates | engineering, announcements (observer) |
+| **documenter** | `docs-agent` (issue) | Writes and updates documentation | engineering, announcements (observer) |
+| **architect** | `architecture` (issue) | ADRs, design review, architectural changes | engineering, announcements (observer) |
+| **security-auditor** | `security-agent` (issue) | Security audits and vulnerability review | engineering, announcements (observer) |
+| **tester** | `test-agent` (issue) | Test coverage for undertested areas | engineering, announcements (observer) |
+| **refactor** | `refactor-agent` (issue) | Code quality and refactoring | engineering, announcements (observer) |
+| **researcher** | `research-agent` (issue) | Technical research and investigation | engineering, announcements (observer) |
+| **release-manager** | `release` (issue) | Release preparation and changelog | engineering, announcements (observer) |
+
+---
+
+## Label-Driven State Machine
+
+Issues and PRs move through the pipeline via GitHub labels. The orchestrator's workflow engine polls for labelled items and dispatches them to the appropriate agent.
+
+```mermaid
+stateDiagram-v2
+    [*] --> Inbox : Issue created
+
+    Inbox --> Triaging : needs-triage applied
+    Triaging --> Enriching : enrich-agent applied by triage agent
+    Triaging --> Planning : plan-agent applied by triage agent
+    Triaging --> Ready : agent applied by triage agent
+
+    Enriching --> Planning : plan-agent applied by enricher
+    Enriching --> Ready : agent applied by enricher
+
+    Planning --> Ready : agent applied to sub-issues by planner
+
+    Ready --> InProgress : worker picks up issue
+    InProgress --> InReview : review-agent applied to PR
+
+    InReview --> NeedsRework : reviewer requests changes
+    NeedsRework --> InReview : worker resubmits
+    InReview --> MergeQueue : reviewer approves, merge-queue applied
+
+    MergeQueue --> Merging : conductor picks up PR (CI green)
+    Merging --> Restacking : merge completes, dependents exist
+    Restacking --> InReview : needs-restack on dependent PRs
+
+    Merging --> [*] : issue auto-closed
+
+    MergeQueue --> Escalated : stuck (CI failing, conflict)
+    Escalated --> MergeQueue : human resolves, removes needs-human
+```
+
+### Labels Reference
+
+| Label | Applied To | Applied By | Triggers |
+|---|---|---|---|
+| `needs-triage` | Issue | Human or any agent | triage-worker workflow |
+| `enrich-agent` | Issue | Triage agent | enricher-worker workflow |
+| `plan-agent` | Issue | Triage or enricher | plan-worker workflow |
+| `agent` | Issue | Triage, enricher, or planner | issue-worker workflow |
+| `review-agent` | PR | Worker agent | pull-request-reviewer workflow |
+| `merge-queue` | PR | Reviewer agent | Conductor's cron scan |
+| `needs-restack` | PR | Conductor | Worker or conductor restack |
+| `needs-human` | PR or Issue | Conductor | Human notification in engineering channel |
+| `docs-agent` | Issue | Any agent or human | docs-worker workflow |
+| `architecture` | Issue | Any agent or human | architect workflow |
+| `security-agent` | Issue | Any agent or human | security-audit workflow |
+
+---
+
+## git-spice Integration
+
+### Why Stacked Branches
+
+The autonomous pipeline implements work in dependency order. When issue B is blocked by issue A, the worker implementing B must build on A's branch — not main. git-spice manages this stacked branch graph, ensures PRs target the right base, and restacks all dependents after a merge without manual rebasing.
+
+### git-spice State
+
+git-spice stores its state in `refs/spice/data` within the repository. This is a lightweight JSON blob tracking the branch stack relationships. It is safe to push alongside regular commits.
+
+### One-Time Setup (human required)
+
+```bash
+# Authenticate with GitHub (interactive OAuth — cannot be automated)
+gs auth login
+
+# Initialize git-spice in the repository
+gs repo init
+```
+
+After `gs repo init`, commit the resulting configuration and push. See [#602](https://github.com/geoffjay/agentd/issues/602).
+
+### Commands by Agent Role
+
+=== "Worker"
+
+    ```bash
+    # Create a new branch stacked on the blocking issue's branch.
+    # If issue #42 is blocked by #38, and #38's branch is issue-38:
+    gs branch create issue-42 --base issue-38
+
+    # If not blocked by anything, stack on main:
+    gs branch create issue-42
+
+    # After committing work, create or update the PR:
+    gs branch submit --fill
+    # --fill uses the branch name and commit message to populate PR title/body
+
+    # If reviewer requests changes, amend and resubmit:
+    git add -p && git commit --amend --no-edit
+    gs branch submit
+    ```
+
+=== "Reviewer"
+
+    ```bash
+    # Understand the stack context before reviewing
+    gs log short
+
+    # The reviewer does not need to run git-spice commands directly.
+    # It reviews the PR diff via gh pr diff <N> as normal.
+    # Stack context is visible in the PR description generated by gs branch submit.
+    ```
+
+=== "Conductor"
+
+    ```bash
+    # After merging a PR, sync git-spice state:
+    gs repo sync
+    # Marks merged branches as landed, updates dependent branch bases.
+
+    # Restack all branches that depended on the merged branch:
+    gs upstack restack --branch <merged-branch>
+    # Rebases dependent branches onto the updated base.
+
+    # Force-push the restacked branches to update their PRs:
+    gs branch submit --force
+    ```
+
+=== "Planner"
+
+    ```bash
+    # View current stack to understand what is in flight:
+    gs log
+
+    # The planner uses blocked-by issue relationships to determine
+    # stack ordering. It does not manipulate git-spice directly.
+    # Stack structure follows from the blocked-by graph on issues.
+    ```
+
+### Stack Dependency Model
+
+The mapping from issue dependencies to branch stacks:
+
+```
+Issue graph (blocked-by):          Branch stack:
+  #42 blocked by #38                 main
+  #43 blocked by #38                   └── issue-38   (PR #101)
+  #44 blocked by #43                         ├── issue-42  (PR #102)
+                                             └── issue-43  (PR #103)
+                                                   └── issue-44  (PR #104)
+```
+
+The conductor merges in this order: `#101 → #102 → #103 → #104`. After merging `#101` it runs `gs repo sync` and `gs upstack restack`, which rebases `issue-42`, `issue-43`, and `issue-44` onto the updated main.
+
+---
+
+## Conductor Behavior
+
+The conductor is the pipeline's air-traffic controller. It runs as a scheduled workflow (`conductor-sync.yml`) every 15 minutes.
+
+### Cron Cycle
+
+```
+Every 15 minutes:
+  1. gs repo sync                          # refresh git-spice state
+  2. Fetch all PRs with merge-queue label
+  3. Sort by dependency order (deepest-in-stack first)
+  4. For each PR in order:
+       a. Check: CI passing? At least one approval?
+       b. If yes: gh pr merge <N> --squash
+                  gs repo sync
+                  gs upstack restack --branch <merged>
+                  gs branch submit --force  (update restacked PR bases)
+                  gh issue close <N>        (if conductor.auto_close_issues = allow)
+       c. If CI failing: skip, include in status digest
+       d. If conflict: post to engineering channel, apply needs-human label
+  5. Post status digest to announcements channel
+```
+
+### Merge Queue Ordering
+
+The conductor sorts `merge-queue` PRs using git-spice stack depth: branches closer to main merge first. Ties are broken by PR creation time (oldest first).
+
+### Conflict Escalation
+
+When `gs upstack restack` encounters a merge conflict:
+
+1. Conductor records the conflict details (files, branches involved)
+2. Posts to `engineering` channel with the conflict and instructions
+3. Applies `needs-human` label to the affected PR
+4. Skips all downstream branches in this stack (they depend on the conflicted branch)
+5. Continues processing independent stacks
+
+### Status Digest
+
+After each cron cycle, the conductor posts a digest to the `announcements` channel:
+
+```
+🔄 Pipeline digest (15:00 UTC)
+Merged:       #102 (issue-42), #103 (issue-43)
+Waiting CI:   #105 (issue-46)
+Needs human:  #104 (issue-44) — restack conflict
+Queue depth:  3 PRs
+```
+
+---
+
+## Workflow Chaining
+
+The pipeline uses label application as the inter-workflow communication mechanism. When an agent completes its stage, it applies the next stage's label, which the orchestrator's poller picks up within `poll_interval` seconds.
+
+```
+Worker completes → applies review-agent label to PR
+→ pull-request-reviewer workflow fires within 60 s
+→ Reviewer approves → applies merge-queue label to PR
+→ Conductor picks it up on next 15-min tick
+```
+
+There is no direct workflow-to-workflow call. The label graph is the message bus.
+
+### Future: `dispatch_result` Trigger
+
+Issue [#641](https://github.com/geoffjay/agentd/issues/641) proposes a `dispatch_result` trigger type that fires when a specific workflow completes with a given result. This would enable lower-latency chaining without the 15-minute conductor tick. Until #641 is implemented, all chaining goes through labels.
+
+---
+
+## Human Interaction Gates
+
+See [autonomous-pipeline-gates.md](autonomous-pipeline-gates.md) for the full gate reference.
+
+Summary:
+
+| Category | Examples |
+|---|---|
+| **Always human** | `gs auth login`, production deploys, conflict resolution |
+| **Configurable** | PR auto-merge, issue auto-close, new Cargo dependencies |
+| **Always autonomous** | Branch ops, PR submission, code review, docs, tests |
+
+---
+
+## Known Limitations and Open Questions
+
+### Limitations (at design phase)
+
+- **Single repository:** The pipeline assumes all work is in `geoffjay/agentd`. Cross-repo stacks are not supported by this design.
+- **Linear merge queue:** The conductor processes one stack at a time. Parallel independent stacks are supported but the 15-minute tick is shared.
+- **No rollback:** The pipeline has no automated rollback if a merged PR breaks main. A human must revert.
+- **git-spice auth is one-time-per-machine:** Cloud agents running in fresh containers need a persistent credential store or a service account token.
+
+### Open Questions
+
+- **Stack discovery:** How does the worker know which branch to base on when the blocking issue may not yet have a branch? Proposal: worker checks if the blocking issue's PR exists; if not, it waits and comments on the issue.
+- **Conductor identity:** Should the conductor merge under its own GitHub token or a shared bot token? Affects the audit trail.
+- **PR target validation:** git-spice sets the PR base automatically. If a blocking branch is force-pushed after restack, GitHub may show the PR as targeting an outdated commit. Does `gs repo sync` handle this?
+- **Parallel workers on the same stack:** If two workers both branch off `issue-38` simultaneously, who wins? The second `gs branch create` will succeed, but `gs upstack restack` may produce conflicts.
+
+---
+
+## Related Issues
+
+| Issue | Title |
+|---|---|
+| [#597](https://github.com/geoffjay/agentd/issues/597) | Epic: git-spice integration |
+| [#598](https://github.com/geoffjay/agentd/issues/598) | Epic: Conductor agent |
+| [#599](https://github.com/geoffjay/agentd/issues/599) | Epic: Agent template updates |
+| [#601](https://github.com/geoffjay/agentd/issues/601) | Create git-spice skill |
+| [#602](https://github.com/geoffjay/agentd/issues/602) | Initialize git-spice in repository |
+| [#603](https://github.com/geoffjay/agentd/issues/603) | Create conductor agent YAML |
+| [#604](https://github.com/geoffjay/agentd/issues/604) | Create conductor-sync workflow |
+| [#610](https://github.com/geoffjay/agentd/issues/610) | Create pipeline labels |
+| [#611](https://github.com/geoffjay/agentd/issues/611) | Define human interaction gates |
+| [#612](https://github.com/geoffjay/agentd/issues/612) | Document autonomous pipeline |
+| [#613](https://github.com/geoffjay/agentd/issues/613) | End-to-end PoC validation |
+| [#641](https://github.com/geoffjay/agentd/issues/641) | Add `dispatch_result` trigger type |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -108,6 +108,9 @@ nav:
   - Development:
       - Error Handling & Logging: public/error-handling.md
       - Storage Patterns: storage.md
+  - Planning:
+      - Autonomous Pipeline Architecture: planning/autonomous-pipeline.md
+      - Human Interaction Gates: planning/autonomous-pipeline-gates.md
 
 extra:
   social:


### PR DESCRIPTION
## Summary

- Add `docs/planning/autonomous-pipeline.md` — full architecture design for the v0.10.0 autonomous development pipeline: stage-by-stage breakdown, agent roster, label-driven state machine, git-spice integration (commands per agent role), stack dependency model, conductor behavior, workflow chaining, open questions, and mermaid diagrams
- Add `docs/planning/autonomous-pipeline-gates.md` — three-tier human interaction gate model (always-human, configurable, always-autonomous), `tool_policies` config examples for conductor and worker, conductor escalation path diagram, and `CLAUDE.md` reference block
- Update `mkdocs.yml` nav to expose both pages under a new **Planning** section

These are design documents. They capture decisions made during the engineering channel sessions and will be updated as implementation proceeds (v0.10.0, milestone #20).

## Test plan

- [ ] Verify mermaid diagrams render: `mkdocs serve` and check both pages
- [ ] Confirm all issue cross-links resolve to real GitHub issues
- [ ] Review gate categories against implemented `tool_policies` once #643 lands
- [ ] Update open questions section as implementation answers them

## Related issues

Closes #612. Related: #611, #646.

🤖 Generated with [Claude Code](https://claude.com/claude-code)