### PR TITLE
feat: initialize git-spice and configure project defaults

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# git-spice state is stored in refs/spice/data — treat as binary to avoid merge conflicts
+refs/spice/data -merge
+
+# Default line endings
+* text=auto

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,134 @@
+# agentd — Claude Code Guide
+
+This file provides guidance for Claude Code and AI agents working on the agentd repository.
+
+## Repository Overview
+
+agentd is a Rust workspace containing multiple services. See `README.md` for the full overview.
+
+## Branch Strategy
+
+All feature work branches off `feature/autonomous-pipeline` and PRs back into it — **never directly to `main`**.
+
+```bash
+git checkout feature/autonomous-pipeline
+git checkout -b issue-<number>
+# ... implement changes ...
+git-spice branch submit
+```
+
+## git-spice (Branch Stacking)
+
+git-spice (`git-spice`) is **required** for branch management in this project. It manages stacked branches, pull request navigation comments, and change request status tracking.
+
+### Installation
+
+```bash
+# macOS
+brew install abhinav/tap/git-spice
+
+# Verify
+git-spice --version
+```
+
+### One-Time Setup (per clone)
+
+```bash
+# Initialize git-spice (trunk = main)
+git-spice repo init --trunk main
+```
+
+> [!IMPORTANT]
+> **Human-only step:** `git-spice auth login` is an interactive OAuth flow that requires a human to complete. Run this once before any `git-spice branch submit` operations. Agents cannot perform this step.
+>
+> ```bash
+> git-spice auth login
+> ```
+
+### Project Config Defaults
+
+These are stored in `.git/config` and should be present after initialization:
+
+```gitconfig
+[spice]
+    submit.navigationComment = true
+    submit.navigationComment.downstack = true
+    log.all = true
+    log.crStatus = true
+```
+
+If these are missing in a fresh clone, restore them with:
+
+```bash
+git config spice.submit.navigationComment true
+git config spice.submit.navigationComment.downstack true
+git config spice.log.all true
+git config spice.log.crStatus true
+```
+
+### Common Workflows
+
+```bash
+# Check stacked branch status
+git-spice log short
+
+# Create a new branch on top of current
+git-spice branch create <branch-name>
+
+# Submit branch as a pull request
+git-spice branch submit
+
+# Submit with the review-agent label (when ready for review)
+git-spice branch submit --label review-agent
+
+# Sync with upstream changes
+git-spice branch sync
+
+# Restack after upstream changes
+git-spice branch restack
+```
+
+> [!NOTE]
+> Do **not** set `spice.submit.label = review-agent` as a project default. Agents should pass `--label review-agent` explicitly only when the PR is ready for review (e.g., not for draft PRs).
+
+### Verifying git-spice State
+
+```bash
+# Verify the spice data ref exists
+git log --oneline refs/spice/data | head -5
+
+# Check clean log state against main
+git-spice log short
+```
+
+### References
+
+- [git-spice documentation](https://abhinav.github.io/git-spice/)
+- git-spice skill: use the `agent-memory` skill for agent workflows
+
+## Development Commands
+
+```bash
+# Build all crates
+cargo build
+
+# Run tests
+cargo test
+
+# Format code
+cargo fmt
+
+# Lint
+cargo clippy
+
+# Run a specific service
+cargo run -p agentd-orchestrator
+```
+
+## Code Conventions
+
+- Follow existing Rust idioms and patterns in each crate
+- Use `anyhow` for error handling in binaries, `thiserror` for library errors
+- Write tests for new functionality
+- Keep changes focused on the issue scope — don't refactor unrelated code
+- Run `cargo fmt` and `cargo clippy` before committing


### PR DESCRIPTION
## Summary

- Runs `git-spice repo init --trunk main --remote origin` to initialize git-spice state in `refs/spice/data`
- Sets project-level git config defaults (`spice.submit.navigationComment`, `spice.log.all`, `spice.log.crStatus`)
- Adds `CLAUDE.md` with git-spice setup guide, branch strategy, contributor conventions, and documentation of the human-only `git-spice auth login` step
- Adds `.gitattributes` for consistent line endings

## Test plan

- [x] `git log --oneline refs/spice/data` shows initialized store commit
- [x] `git-spice log short` returns `main` (clean state)
- [x] `git config --list | grep spice` shows all four project defaults
- [x] `CLAUDE.md` documents initialization, human auth step, and common workflows

## Notes

The `git-spice auth login` step is an interactive OAuth flow that must be performed once by a human. This is documented in `CLAUDE.md`. All other initialization steps are automated in this PR.

Closes #615

🤖 Generated with [Claude Code](https://claude.com/claude-code)