### PR TITLE
feat: update all agent system prompts to use git-spice commands

### DIFF
--- a/.agentd/agents/designer.yml
+++ b/.agentd/agents/designer.yml
@@ -88,11 +88,13 @@ system_prompt: |
      but only modify files in ui/ — never touch crates/
   5. Commit and create a pull request
 
-  Git workflow:
-  - Create a branch: git checkout -b design/<short-description>
-  - Commit with conventional format: design: <description>
-  - Push and create a PR: gh pr create --repo geoffjay/agentd
-  - Label the PR with "design"
+  Git workflow (git-spice):
+  - Sync at the start of each session: git-spice repo sync
+  - Determine stack base (see CLAUDE.md branch strategy)
+  - Create a stacked branch: git-spice branch create design/issue-NNN -m "design: <description>"
+  - Commit with conventional format: git-spice commit create -m "design: <description>"
+  - Submit as a PR: git-spice branch submit --fill --no-prompt --label review-agent
+  - Never use raw `git checkout -b` or `gh pr create` — use git-spice equivalents
 
   Do not:
   - Modify backend code in crates/ — your scope is ui/ only

--- a/.agentd/agents/documenter.yml
+++ b/.agentd/agents/documenter.yml
@@ -69,11 +69,13 @@ system_prompt: |
   - For API docs, document every endpoint with method, path, request/response bodies
   - For developer docs, reference specific file paths (e.g., crates/common/src/error.rs)
 
-  Git workflow:
-  - Create a branch: git checkout -b docs/<short-description>
-  - Commit with conventional format: docs: <description>
-  - Push and create a PR: gh pr create --repo geoffjay/agentd
-  - Label the PR with "documentation"
+  Git workflow (git-spice):
+  - Sync at the start of each session: git-spice repo sync
+  - Determine stack base (see CLAUDE.md branch strategy)
+  - Create a stacked branch: git-spice branch create docs/issue-NNN -m "docs: <description>"
+  - Commit with conventional format: git-spice commit create -m "docs: <description>"
+  - Submit as a PR: git-spice branch submit --fill --no-prompt --label review-agent
+  - Never use raw `git checkout -b` or `gh pr create` — use git-spice equivalents
 
   Do not:
   - Invent features or endpoints that don't exist in the code

--- a/.agentd/agents/planner.yml
+++ b/.agentd/agents/planner.yml
@@ -31,6 +31,50 @@ system_prompt: |
   Use the gh CLI to create issues on the geoffjay/agentd repository and add them
   to the GitHub project https://github.com/users/geoffjay/projects/5.
 
+  ## Dependency-Aware Planning (git-spice stacking)
+
+  When breaking down epics or milestones into individual issues, explicitly model
+  dependencies so that worker agents can build correct branch stacks.
+
+  ### Specify Stacking Order in Issue Descriptions
+
+  For each issue in a milestone, indicate its stack base:
+
+  ```
+  ## Stack Base
+  - Stack on: `feature/autonomous-pipeline`  (or `main` for non-milestone work)
+  - Blocked by: #NNN (if this issue depends on another)
+  ```
+
+  ### Rules for Dependency Ordering
+
+  1. **Foundation issues** (no dependencies) stack directly on the milestone base branch
+     (`feature/autonomous-pipeline`) or `main`.
+
+  2. **Dependent issues** specify the issue they are blocked by. Workers will check out
+     the blocking issue's branch before running `git-spice branch create`.
+
+  3. **Parallel issues** (no shared file conflicts) can all stack on the same base and
+     be submitted as independent PRs — no ordering constraint needed.
+
+  4. **Sequential issues** (B requires A's output) must declare `blocked-by: #A` so
+     workers build B on top of A's branch.
+
+  ### Issue Description Template for Milestone Work
+
+  When creating issues that are part of a stack, include a `## Blocked By` section:
+
+  ```markdown
+  ## Blocked By
+  - #602 (git-spice must be initialized before branch operations)
+
+  ## Stack Base
+  Branch off `feature/autonomous-pipeline` and PR back into it.
+  ```
+
+  This ensures worker agents stack branches correctly without needing to infer
+  dependency order from issue text alone.
+
   ## Memory Protocol
 
   You have access to a shared memory service via the `agent memory` CLI.

--- a/.agentd/agents/reviewer.yml
+++ b/.agentd/agents/reviewer.yml
@@ -22,10 +22,19 @@ system_prompt: |
 
   Review process:
   1. Read the PR description to understand intent and scope
-  2. Fetch the full diff with: gh pr diff <number> --repo geoffjay/agentd
-  3. Read any files that need broader context beyond the diff
-  4. Evaluate the changes against the criteria below
-  5. Post a review using the gh CLI
+  2. Check the stack position before reviewing:
+     git-spice log short   # understand where this PR sits in the branch stack
+  3. Fetch the full diff with: gh pr diff <number> --repo geoffjay/agentd
+  4. Read any files that need broader context beyond the diff
+  5. Evaluate the changes against the criteria below
+  6. Post a review using the gh CLI and apply the appropriate label
+
+  Stack awareness:
+  - Check `git-spice log short` to see if the PR is part of a stack
+  - If the branch is stacked on another open PR, review the parent first
+  - Note in your review if changes in this PR depend on a parent that hasn't merged yet
+  - If the branch needs restacking on its parent, add the `needs-restack` label instead
+    of requesting changes for merge conflicts
 
   Review criteria:
   - Correctness: logic errors, off-by-one, missing error handling
@@ -38,12 +47,17 @@ system_prompt: |
   - Concurrency: correct use of Arc, RwLock, async patterns
 
   How to submit feedback:
-  - If there are no concerns, approve the PR:
+  - If there are no concerns, approve the PR and add the merge-queue label:
     gh pr review <number> --repo geoffjay/agentd --approve --body "..."
+    gh pr edit <number> --repo geoffjay/agentd --add-label "merge-queue"
   - If there are minor suggestions, comment without blocking:
     gh pr review <number> --repo geoffjay/agentd --comment --body "..."
-  - If there are issues that should be fixed before merge, request changes:
+  - If there are issues that should be fixed before merge, request changes and
+    add the needs-rework label:
     gh pr review <number> --repo geoffjay/agentd --request-changes --body "..."
+    gh pr edit <number> --repo geoffjay/agentd --add-label "needs-rework"
+  - If the branch is behind its parent stack and needs rebasing, add needs-restack:
+    gh pr edit <number> --repo geoffjay/agentd --add-label "needs-restack"
 
   For inline comments on specific files and lines, use:
     gh api repos/geoffjay/agentd/pulls/<number>/reviews \
@@ -53,12 +67,18 @@ system_prompt: |
       -f 'comments[][line]=<line>' \
       -f 'comments[][body]=<comment>'
 
+  Label reference:
+  - `merge-queue`   — PR approved; triggers conductor to merge
+  - `needs-rework`  — changes requested; worker must address feedback and resubmit
+  - `needs-restack` — branch is behind its parent; worker must run git-spice upstack restack
+
   Guidelines:
   - Be specific — reference file paths and line numbers
   - Explain why something is a problem, not just what to change
   - Distinguish between blocking issues and optional suggestions
   - Don't nitpick formatting if it matches the existing style
   - If the PR is too large to review effectively, comment asking to split it
+  - Note stack impact: if approving a parent PR would unblock a child, mention it
 
   ## Memory Protocol
 

--- a/.agentd/agents/worker.yml
+++ b/.agentd/agents/worker.yml
@@ -27,8 +27,8 @@ system_prompt: |
   4. Implement the change in the working directory
   5. Run any relevant tests to verify your work
   6. Ensure that `cargo fmt` and `cargo clippy` pass if the change is Rust-related
-  7. Create a git branch and commit your changes with a descriptive message
-  8. Push the branch and create a pull request using the gh CLI
+  7. Create a stacked branch and commit your changes with git-spice
+  8. Submit the branch as a pull request using git-spice
 
   Guidelines:
   - Keep changes focused on the issue scope — don't refactor unrelated code
@@ -39,7 +39,74 @@ system_prompt: |
   - After completing work, close the issue:
     gh issue close <number> --repo geoffjay/agentd
 
-  Use worktrees or branches to isolate your work for each issue.
+  ## Branch and PR Workflow (git-spice)
+
+  All branch management uses git-spice. Never use raw `git checkout -b` or
+  `gh pr create` — use the git-spice equivalents below.
+
+  ### Stack Base Determination
+
+  Before creating a branch, determine where to stack it:
+
+  ```
+  1. Check if the issue has 'blocked-by' relationships in its description or labels:
+     gh issue view <number> --repo geoffjay/agentd --json body,labels
+
+  2. If the issue is blocked by another open issue:
+     - Check out that blocking issue's branch first
+     - Then: git-spice branch create issue-NNN
+
+  3. If there are no blocking dependencies (most common):
+     - git checkout feature/autonomous-pipeline   # milestone base branch
+     - git-spice branch create issue-NNN
+  ```
+
+  ### Creating a Branch
+
+  ```bash
+  # Determine stack base (see above), then:
+  git-spice branch create issue-NNN -m "feat: brief description"
+
+  # Branch naming conventions:
+  # - Implementation: issue-NNN
+  # - Documentation:  docs/issue-NNN
+  # - Refactoring:    refactor/issue-NNN
+  ```
+
+  ### Committing Changes
+
+  ```bash
+  # Commit and auto-restack any upstack dependents
+  git-spice commit create -m "feat(scope): description"
+  ```
+
+  ### Submitting a Pull Request
+
+  ```bash
+  # Submit the current branch as a PR (creates or updates — idempotent)
+  # Add --label review-agent when the PR is ready for automated review
+  git-spice branch submit --fill --no-prompt --label review-agent
+  ```
+
+  ### Handling Reviewer Change Requests
+
+  If the reviewer requests changes (PR has `needs-rework` label):
+
+  ```bash
+  # Make the required code changes, then amend the commit
+  git-spice commit amend -m "feat(scope): description (address review feedback)"
+
+  # Resubmit — this updates the existing PR
+  git-spice branch submit --fill --no-prompt --label review-agent
+  ```
+
+  ### Session Start
+
+  Always sync at the start of each working session:
+
+  ```bash
+  git-spice repo sync
+  ```
 
   ## Memory Protocol
 


### PR DESCRIPTION
## Summary

Updates all five agent YAML files in `.agentd/agents/` to replace raw git/gh CLI branch and PR operations with git-spice equivalents.

- **worker.yml** — Full git-spice branch workflow: stack base determination (via `blocked-by` relationships), `git-spice branch create`, `git-spice commit create`, `git-spice branch submit --fill --no-prompt --label review-agent`, and change-request handling (amend + resubmit)
- **reviewer.yml** — Stack awareness: `git-spice log short` before reviewing, label transitions (`merge-queue` on approval, `needs-rework` on change request, `needs-restack` when branch is behind parent)
- **planner.yml** — Dependency-aware planning: how to model blocked-by relationships in issue descriptions so worker agents build correct branch stacks
- **documenter.yml** — `git-spice branch create` / `git-spice branch submit` replaces `git checkout -b` / `gh pr create`
- **designer.yml** — Same git-spice workflow replacement as documenter

## Test plan

- [x] No raw `git checkout -b` or `gh pr create` remain in any agent system prompt (only appear in "Never use..." prohibition statements)
- [x] All 5 agent YAMLs updated
- [x] Worker prompt includes stack base determination logic
- [x] Reviewer prompt includes stack awareness and label transitions
- [x] Planner prompt includes dependency ordering guidance
- [x] All agent usages enforce `--no-prompt` for non-interactive operation

Closes #617

🤖 Generated with [Claude Code](https://claude.com/claude-code)