### PR TITLE
feat: update workflow prompt templates to use git-spice commands

### DIFF
--- a/.agentd/workflows/design-worker.yml
+++ b/.agentd/workflows/design-worker.yml
@@ -34,22 +34,27 @@ prompt_template: |
   3. Review results to maintain consistency with prior design work.
 
   Instructions:
-  1. Read the issue carefully to understand what design work is needed
-  2. Check the current state of ui/design/ .pen files and ui/src/ components
-  3. If the task involves new UI, create or update .pen designs using the Pencil
+  1. Sync with upstream at the start of the session:
+     git-spice repo sync
+  2. Determine stack base — check for blocked-by relationships:
+     gh issue view {{source_id}} --repo geoffjay/agentd --json body,labels
+     If blocked by another open issue, check out that branch first.
+     Otherwise: git checkout feature/autonomous-pipeline
+  3. Create a stacked branch:
+     git-spice branch create design/issue-{{source_id}} -m "design: <brief description>"
+  4. Read the issue carefully to understand what design work is needed
+  5. Check the current state of ui/design/ .pen files and ui/src/ components
+  6. If the task involves new UI, create or update .pen designs using the Pencil
      MCP tools (get_editor_state, open_document, batch_design, get_screenshot)
-  4. If the task involves design tokens, update tokens in the .pen file and
+  7. If the task involves design tokens, update tokens in the .pen file and
      document the corresponding CSS custom property changes needed in ui/src/index.css
-  5. If the task involves a design-to-code sync audit, compare .pen files against
+  8. If the task involves a design-to-code sync audit, compare .pen files against
      implemented components and report discrepancies
-  6. Create a feature branch from main: git checkout -b design/issue-{{source_id}}
-  7. Commit your changes: git commit with a "design: ..." message referencing #{{source_id}}
-  8. Push and create a pull request:
-     gh pr create --repo geoffjay/agentd \
-       --title "design: <short description>" \
-       --body "Closes #{{source_id}}" \
-       --label design
-  9. Store any design decisions or findings for future reference:
-     agent memory remember "<what you decided>" --created-by designer --type information --tags designer,issue-{{source_id}} --visibility public
-  10. Move the issue to In Progress on the project board:
+  9. Commit with a design: message referencing the issue:
+     git-spice commit create -m "design: <description> (closes #{{source_id}})"
+  10. Submit the branch as a PR (creates or updates — idempotent):
+      git-spice branch submit --fill --no-prompt --label review-agent
+  11. Store any design decisions or findings for future reference:
+      agent memory remember "<what you decided>" --created-by designer --type information --tags designer,issue-{{source_id}} --visibility public
+  12. Move the issue to In Progress on the project board:
       gh issue edit {{source_id}} --repo geoffjay/agentd --add-project "https://github.com/users/geoffjay/projects/5"

--- a/.agentd/workflows/docs-worker.yml
+++ b/.agentd/workflows/docs-worker.yml
@@ -34,18 +34,23 @@ prompt_template: |
   3. Review results to understand prior documentation decisions and known gaps.
 
   Instructions:
-  1. Read the issue carefully to understand what documentation is needed
-  2. Check the current state of docs/ and the relevant source code in crates/
-  3. Write or update the documentation to address the issue
-  4. Update mkdocs.yml nav if you added new pages
-  5. Create a feature branch from main: git checkout -b docs/issue-{{source_id}}
-  6. Commit your changes: git commit with a "docs: ..." message referencing #{{source_id}}
-  7. Push and create a pull request:
-     gh pr create --repo geoffjay/agentd \
-       --title "docs: <short description>" \
-       --body "Closes #{{source_id}}" \
-       --label documentation
-  8. Store any documentation decisions or discovered gaps for future reference:
-     agent memory remember "<what you learned>" --created-by documenter --type information --tags documenter,issue-{{source_id}} --visibility public
-  9. Move the issue to In Progress on the project board:
-     gh issue edit {{source_id}} --repo geoffjay/agentd --add-project "https://github.com/users/geoffjay/projects/5"
+  1. Sync with upstream at the start of the session:
+     git-spice repo sync
+  2. Determine stack base — check for blocked-by relationships:
+     gh issue view {{source_id}} --repo geoffjay/agentd --json body,labels
+     If blocked by another open issue, check out that branch first.
+     Otherwise: git checkout feature/autonomous-pipeline
+  3. Create a stacked branch:
+     git-spice branch create docs/issue-{{source_id}} -m "docs: <brief description>"
+  4. Read the issue carefully to understand what documentation is needed
+  5. Check the current state of docs/ and the relevant source code in crates/
+  6. Write or update the documentation to address the issue
+  7. Update mkdocs.yml nav if you added new pages
+  8. Commit with a docs: message referencing the issue:
+     git-spice commit create -m "docs: <description> (closes #{{source_id}})"
+  9. Submit the branch as a PR (creates or updates — idempotent):
+     git-spice branch submit --fill --no-prompt --label review-agent
+  10. Store any documentation decisions or discovered gaps for future reference:
+      agent memory remember "<what you learned>" --created-by documenter --type information --tags documenter,issue-{{source_id}} --visibility public
+  11. Move the issue to In Progress on the project board:
+      gh issue edit {{source_id}} --repo geoffjay/agentd --add-project "https://github.com/users/geoffjay/projects/5"

--- a/.agentd/workflows/issue-worker.yml
+++ b/.agentd/workflows/issue-worker.yml
@@ -38,11 +38,27 @@ prompt_template: |
 
   Instructions:
   1. Move the issue to "In Progress" by assigning it using the status field
-  2. Create a feature branch from the main branch: git checkout -b issue-{{source_id}}
-  3. Implement the changes described in the issue
-  4. Run tests to verify: cargo test
-  5. Commit with a descriptive message referencing the issue
-  6. Push and create a PR: gh pr create --repo geoffjay/agentd --title "{{title}}" --body "Closes #{{source_id}}"
-  7. Store any significant findings or decisions made during implementation:
+  2. Sync with upstream and determine stack base:
+     a. git-spice repo sync
+     b. Check if this issue has 'blocked-by' relationships:
+        gh issue view {{source_id}} --repo geoffjay/agentd --json body,labels
+     c. If blocked by another open issue, check out that branch first.
+        Otherwise: git checkout feature/autonomous-pipeline
+  3. Create a stacked branch:
+     git-spice branch create issue-{{source_id}} -m "feat: <brief description>"
+  4. Implement the changes described in the issue
+  5. Run tests to verify: cargo test
+  6. Ensure cargo fmt and cargo clippy pass for Rust changes
+  7. Commit with a descriptive message referencing the issue:
+     git-spice commit create -m "feat: <description> (closes #{{source_id}})"
+  8. Submit the branch as a PR (creates or updates — idempotent):
+     git-spice branch submit --fill --no-prompt --label review-agent
+  9. Store any significant findings or decisions made during implementation:
      agent memory remember "<what you learned>" --created-by worker --type information --tags worker,issue-{{source_id}} --visibility public
-  8. Close the issue: gh issue close {{source_id}} --repo geoffjay/agentd
+  10. Close the issue: gh issue close {{source_id}} --repo geoffjay/agentd
+
+  Handling needs-rework (reviewer requested changes):
+  If this issue's PR has the "needs-rework" label, the reviewer found issues.
+  Fetch the review comments, address the feedback, then:
+     git-spice commit amend -m "feat: <description> (address review feedback)"
+     git-spice branch submit --fill --no-prompt --label review-agent

--- a/.agentd/workflows/plan-worker.yml
+++ b/.agentd/workflows/plan-worker.yml
@@ -62,7 +62,7 @@ prompt_template: |
     hard requirement and larger plans will require more issues
   - If a planning task has already been broken down into phases these phases should have an
     associated epic issue created for them, with each epic broken down into multiple issues
-  - Create relationships between issues as needed using blocked by, blocks, and aprent issues
+  - Create relationships between issues as needed using blocked by, blocks, and parent issues
   - Use gh issue-ext to add relationships and dependencies
 
   For each proposed issue, create it using:
@@ -74,7 +74,21 @@ prompt_template: |
   After adding the issue to the project board, assign the necessary relationships and dependencies.
   Skip this if the issue-ext extension is not available in the gh CLI:
     gh issue-ext sub add <parent> <child>         # parent/child relationship
-    gh issue-ext blocking add <blocked> <blocker> # blocking relationship
+    gh issue-ext blocking add <blocked> <blocker> # blocking relationship (use for git-spice stack ordering)
+
+  Dependency ordering for git-spice stacking:
+  When issues have sequential dependencies (B requires output from A), use blocking
+  relationships so worker agents know to stack B's branch on top of A's branch:
+    gh issue-ext blocking add <issue-B> <issue-A>   # A must merge before B
+
+  Include a "## Stack Base" section in each issue body specifying where to branch from:
+  - "Stack on: feature/autonomous-pipeline" for milestone work
+  - "Blocked by: #NNN" when this issue depends on another
+  - "Parallel: no ordering constraint" when issues can be implemented independently
+
+  Parallel issues (no shared file conflicts) can all branch from the same base and
+  be submitted as independent PRs — no ordering constraint needed. Only use blocking
+  relationships when there is a genuine sequential dependency.
 
   After the plan is complete:
 

--- a/.agentd/workflows/pull-request-reviewer.yml
+++ b/.agentd/workflows/pull-request-reviewer.yml
@@ -42,16 +42,34 @@ prompt_template: |
   3. Review results to inform your review — look for recurring issues or past decisions.
 
   Instructions:
-  1. Fetch the full diff: gh pr diff {{source_id}} --repo geoffjay/agentd
-  2. Read the diff carefully, noting each changed file and the nature of the changes
-  3. For any files where you need more context, read the full file
-  4. Check that the changes match what the PR description claims
-  5. Evaluate against your review criteria (correctness, safety, consistency, tests, scope)
-  6. Submit your review:
-     - Approve if the changes are good
-     - Comment if you have non-blocking suggestions
-     - Request changes if there are issues that need to be fixed
-  7. If you found a recurring pattern or notable issue worth tracking, store it:
+  1. Check the stack position of this PR before reviewing:
+     git-spice log short
+     This shows where the branch sits in the stack and whether it has a parent PR
+     that should be reviewed first.
+  2. Fetch the full diff: gh pr diff {{source_id}} --repo geoffjay/agentd
+  3. Read the diff carefully, noting each changed file and the nature of the changes
+  4. For any files where you need more context, read the full file
+  5. Check that the changes match what the PR description claims
+  6. Note any stack impact in your review: if this is a stacked PR, mention whether
+     approval of the parent branch would affect this branch
+  7. Evaluate against your review criteria (correctness, safety, consistency, tests, scope)
+  8. Submit your review and apply the appropriate label transition:
+     - If approved — approve and add merge-queue label:
+         gh pr review {{source_id}} --repo geoffjay/agentd --approve --body "..."
+         gh pr edit {{source_id}} --repo geoffjay/agentd --add-label "merge-queue"
+     - If non-blocking suggestions — comment only (no label change):
+         gh pr review {{source_id}} --repo geoffjay/agentd --comment --body "..."
+     - If changes required — request changes and add needs-rework label:
+         gh pr review {{source_id}} --repo geoffjay/agentd --request-changes --body "..."
+         gh pr edit {{source_id}} --repo geoffjay/agentd --add-label "needs-rework"
+     - If branch needs rebasing on its parent — add needs-restack label:
+         gh pr edit {{source_id}} --repo geoffjay/agentd --add-label "needs-restack"
+  9. If you found a recurring pattern or notable issue worth tracking, store it:
      agent memory remember "<finding>" --created-by reviewer --type information --tags reviewer,pr-{{source_id}} --visibility public
-  8. Remove the "review-agent" label after review:
-     gh pr edit {{source_id}} --repo geoffjay/agentd --remove-label review-agent
+  10. Remove the "review-agent" label after review:
+      gh pr edit {{source_id}} --repo geoffjay/agentd --remove-label review-agent
+
+  Label reference:
+  - merge-queue   — PR approved; triggers conductor to merge
+  - needs-rework  — changes requested; worker must address feedback and resubmit
+  - needs-restack — branch is behind its parent; worker must run git-spice upstack restack


### PR DESCRIPTION
## Summary

Updates all five workflow YAML prompt templates in `.agentd/workflows/` to replace raw git/gh CLI branch and PR operations with git-spice equivalents.

- **issue-worker.yml** — Session sync (`git-spice repo sync`), stack base determination (blocked-by check), `git-spice branch create`, `git-spice commit create`, `git-spice branch submit --fill --no-prompt --label review-agent`, and `needs-rework` re-dispatch handling (amend + resubmit)
- **plan-worker.yml** — Dependency ordering guidance: use `gh issue-ext blocking add` to express stack ordering, include `## Stack Base` section in each issue body, distinguish parallel vs sequential dependencies
- **pull-request-reviewer.yml** — `git-spice log short` stack position check before review, label transitions (`merge-queue` on approval, `needs-rework` on change request, `needs-restack` when branch is behind parent), label reference table
- **docs-worker.yml** — `git-spice repo sync`, stack base determination, `git-spice branch create docs/issue-NNN`, `git-spice commit create`, `git-spice branch submit` replacing `git checkout -b` and `gh pr create`
- **design-worker.yml** — Same git-spice workflow replacement as docs-worker

## Test plan

- [x] No raw `git checkout -b` or `gh pr create` remains in any workflow template (verified with grep)
- [x] All 5 workflow templates updated
- [x] `git-spice repo sync` is the first step in all implementation workflows (issue, docs, design)
- [x] issue-worker handles `needs-rework` re-dispatch
- [x] pull-request-reviewer adds label transitions
- [x] plan-worker includes stack ordering guidance for dependency relationships

Closes #618

🤖 Generated with [Claude Code](https://claude.com/claude-code)