### PR TITLE
feat: add operations and security communication rooms

### DIFF
--- a/.agentd/rooms/operations.yml
+++ b/.agentd/rooms/operations.yml
@@ -1,0 +1,32 @@
+# .agentd/rooms/operations.yml
+#
+# Operations room for pipeline status digests, merge results, conflict
+# escalations, and stale work alerts posted by the conductor agent.
+# Created during `agent apply .agentd/` — agents auto-join on first connect.
+name: operations
+topic: "Pipeline operations and status"
+description: "Conductor posts pipeline status digests, merge results, conflict escalations, and stale work alerts."
+type: group
+participants:
+  - identifier: conductor
+    kind: agent
+    role: admin
+  - identifier: worker
+    kind: agent
+    role: observer
+  - identifier: reviewer
+    kind: agent
+    role: observer
+  - identifier: planner
+    kind: agent
+    role: observer
+  - identifier: documenter
+    kind: agent
+    role: observer
+  - identifier: designer
+    kind: agent
+    role: observer
+  - identifier: geoff
+    kind: human
+    role: admin
+    display_name: "Geoff"

--- a/.agentd/rooms/security.yml
+++ b/.agentd/rooms/security.yml
@@ -1,0 +1,20 @@
+# .agentd/rooms/security.yml
+#
+# Security room for audit findings, RUSTSEC advisories, and vulnerability
+# reports posted by the security agent.
+# Created during `agent apply .agentd/` — agents auto-join on first connect.
+name: security
+topic: "Security audits and vulnerability reports"
+description: "Security agent posts audit findings, RUSTSEC advisories, and vulnerability reports."
+type: group
+participants:
+  - identifier: security
+    kind: agent
+    role: admin
+  - identifier: reviewer
+    kind: agent
+    role: member
+  - identifier: geoff
+    kind: human
+    role: admin
+    display_name: "Geoff"


### PR DESCRIPTION
## Summary

- Adds `.agentd/rooms/operations.yml` — conductor (admin) posts pipeline status digests, merge results, conflict escalations, and stale work alerts; all agents as observers; geoff as admin
- Adds `.agentd/rooms/security.yml` — security agent (admin) posts audit findings, RUSTSEC advisories, and vulnerability reports; reviewer as member; geoff as admin
- Both files follow the existing pattern from `engineering.yml` and `announcements.yml`

## Test plan

- [x] `.agentd/rooms/operations.yml` exists with correct participant roles
- [x] `.agentd/rooms/security.yml` exists with correct participant roles
- [x] Both files follow the `engineering.yml` YAML structure pattern

Closes #635

🤖 Generated with [Claude Code](https://claude.com/claude-code)