### PR TITLE
feat(.agentd): update room memberships for all new agents

### DIFF
--- a/.agentd/agents/conductor.yml
+++ b/.agentd/agents/conductor.yml
@@ -15,7 +15,8 @@ model: claude-sonnet-4-6
 
 rooms:
   - engineering
-  - operations
+  - name: operations
+    role: admin
   - name: announcements
     role: observer
 

--- a/.agentd/agents/designer.yml
+++ b/.agentd/agents/designer.yml
@@ -11,6 +11,7 @@ worktree: true
 model: claude-sonnet-4-6
 
 rooms:
+  - engineering
   - name: announcements
     role: observer
 

--- a/.agentd/agents/release-manager.yml
+++ b/.agentd/agents/release-manager.yml
@@ -18,9 +18,9 @@ worktree: true
 model: claude-sonnet-4-6
 
 rooms:
-  - name: announcements
-    role: member
   - engineering
+  - name: announcements
+    role: observer
 
 system_prompt: |
   You are the release manager agent for the agentd project — a Rust workspace

--- a/.agentd/agents/security.yml
+++ b/.agentd/agents/security.yml
@@ -16,7 +16,8 @@ model: claude-sonnet-4-6
 
 rooms:
   - engineering
-  - security
+  - name: security
+    role: admin
   - name: announcements
     role: observer
 

--- a/.agentd/rooms/engineering.yml
+++ b/.agentd/rooms/engineering.yml
@@ -7,6 +7,9 @@ topic: "Engineering team coordination"
 description: "General channel for engineering agents and humans"
 type: group
 participants:
+  - identifier: conductor
+    kind: agent
+    role: member
   - identifier: geoff
     kind: human
     role: admin


### PR DESCRIPTION
## Summary

- Add `conductor` as a `member` participant in `engineering.yml` room definition
- Give conductor's `operations` room entry an explicit `admin` role
- Give security's `security` room entry an explicit `admin` role
- Add missing `engineering` room membership to `designer.yml`
- Fix `release-manager.yml`: change `announcements` role `member` → `observer`, reorder so `engineering` comes first (consistent with all other agents)

## Test plan

- [x] All 5 files diff as expected (YAML-only changes, no Rust)
- [x] `cargo test` passes (pre-existing doctest failure in `hook` crate is unrelated)
- [x] `agent apply .agentd/` creates all rooms and agents without errors
- [x] Conductor joins `engineering` and `operations` (admin), observes `announcements`
- [x] Security agent joins `engineering` and `security` (admin), observes `announcements`
- [x] Designer joins `engineering`, observes `announcements`
- [x] Release manager joins `engineering`, observes `announcements`

Closes #636

🤖 Generated with [Claude Code](https://claude.com/claude-code)