### PR TITLE
feat: create pipeline labels and define label-driven state machine

### DIFF
--- a/.agentd/agents/conductor.yml
+++ b/.agentd/agents/conductor.yml
@@ -28,20 +28,21 @@ system_prompt: |
 
   ## Pipeline State Machine
 
-  Each issue moves through the following states, driven by GitHub labels:
+  Each issue moves through the following states, driven by GitHub labels.
+  Full reference: `docs/public/pipeline-state-machine.md`
 
   ```
-  created → needs-triage → triaged → agent → in-review → merge-queue/needs-rework → merged → done
+  created → needs-triage → triaged → agent → in-review → merge-ready/needs-rework → merged → done
   ```
 
   | State          | Label(s)                     | Meaning                                       |
   |----------------|------------------------------|-----------------------------------------------|
   | created        | (none)                       | New issue, not yet triaged                    |
   | needs-triage   | needs-triage                 | Awaiting planner triage                       |
-  | triaged        | (no agent label)             | Triaged but not yet dispatched                |
+  | triaged        | triaged                      | Triaged, ready for planning or implementation |
   | agent          | agent                        | Dispatched to worker agent for implementation |
   | in-review      | review-agent                 | PR submitted, awaiting reviewer               |
-  | merge-queue    | merge-queue                  | Approved by reviewer, ready for merge         |
+  | merge-ready    | merge-ready                  | Approved by reviewer, ready for merge         |
   | needs-rework   | needs-rework                 | Reviewer requested changes                    |
   | needs-restack  | needs-restack                | Branch is behind parent; worker must restack  |
   | merged         | (PR merged, issue closed)    | Change merged into target branch              |
@@ -51,6 +52,12 @@ system_prompt: |
   - Apply `review-agent` → pull-request-reviewer workflow dispatches to reviewer
   - Apply `docs-agent` → docs-worker workflow dispatches to documenter
   - Apply `design-agent` → design-worker workflow dispatches to designer
+  - Apply `enrich-agent` → enrichment-worker workflow dispatches to enricher
+  - Apply `test-agent` → test-worker workflow dispatches to tester
+  - Apply `refactor-agent` → refactor-worker workflow dispatches to refactor agent
+  - Apply `research-agent` → research-worker workflow dispatches to research agent
+  - Apply `security-agent` → security-worker workflow dispatches to security agent
+  - Apply `conductor-sync` → manual trigger; conductor picks up and runs a pipeline sync
   - Remove `needs-rework`, re-apply `agent` → re-dispatches to worker for fixes
 
   ## Session Start
@@ -65,7 +72,7 @@ system_prompt: |
   git-spice log short
 
   # 3. Check current merge queue
-  gh pr list --repo geoffjay/agentd --label merge-queue \
+  gh pr list --repo geoffjay/agentd --label merge-ready \
     --json number,title,baseRefName,headRefName,reviews,statusCheckRollup
   ```
 
@@ -82,7 +89,7 @@ system_prompt: |
 
   ### Merge Ready Criteria
   A PR is ready to merge when ALL of the following are true:
-  1. Has the `merge-queue` label
+  1. Has the `merge-ready` label
   2. Has at least one approving review
   3. All CI checks pass (statusCheckRollup: all SUCCESS or SKIPPED)
   4. No open change request reviews
@@ -161,7 +168,7 @@ system_prompt: |
 
   ```bash
   # Gather state
-  MERGE_QUEUE=$(gh pr list --repo geoffjay/agentd --label merge-queue --json number,title | jq length)
+  MERGE_QUEUE=$(gh pr list --repo geoffjay/agentd --label merge-ready --json number,title | jq length)
   IN_REVIEW=$(gh pr list --repo geoffjay/agentd --label review-agent --json number,title | jq length)
   NEEDS_REWORK=$(gh pr list --repo geoffjay/agentd --label needs-rework --json number,title | jq length)
   ACTIVE_BRANCHES=$(git branch -r | grep -v HEAD | wc -l | tr -d ' ')

--- a/.github/labels.yml
+++ b/.github/labels.yml
@@ -1,0 +1,185 @@
+# GitHub label definitions for the agentd repository.
+#
+# This file serves as the authoritative source for label configuration.
+# Labels are grouped by purpose.
+#
+# To sync labels from this file, use:
+#   gh label import .github/labels.yml
+
+# ── Default GitHub labels ───────────────────────────────────────────────────
+
+- name: bug
+  description: Something isn't working
+  color: "d73a4a"
+
+- name: documentation
+  description: Improvements or additions to documentation
+  color: "0075ca"
+
+- name: duplicate
+  description: This issue or pull request already exists
+  color: "cfd3d7"
+
+- name: enhancement
+  description: New feature or request
+  color: "a2eeef"
+
+- name: good first issue
+  description: Good for newcomers
+  color: "7057ff"
+
+- name: help wanted
+  description: Extra attention is needed
+  color: "008672"
+
+- name: invalid
+  description: This doesn't seem right
+  color: "e4e669"
+
+- name: question
+  description: Further information is requested
+  color: "d876e3"
+
+- name: wontfix
+  description: This will not be worked on
+  color: "ffffff"
+
+# ── Classification ───────────────────────────────────────────────────────────
+
+- name: agent
+  description: Related to agent definitions or agent behaviour
+  color: "aaaaaa"
+
+- name: architecture
+  description: Cross-service architectural design or review
+  color: "5319e7"
+
+- name: frontend
+  description: Frontend application code
+  color: "1D76DB"
+
+- name: plan
+  description: Plan issue for future work
+  color: "c5def5"
+
+- name: refactor
+  description: Code improvement without changing behavior
+  color: "fbca04"
+
+- name: release
+  description: Release preparation, changelog, and versioning
+  color: "0e8a16"
+
+- name: research
+  description: Research and investigation tasks
+  color: "0075ca"
+
+- name: security
+  description: Security vulnerability, audit, or hardening
+  color: "ee0701"
+
+- name: ui
+  description: User interface and frontend
+  color: "1D76DB"
+
+# ── Pipeline state labels ─────────────────────────────────────────────────────
+#
+# Blue family. These labels encode the current state of an issue or PR in the
+# autonomous pipeline. The conductor agent reads and sets these labels to drive
+# state transitions. See docs/public/pipeline-state-machine.md for the full
+# state machine.
+
+- name: needs-triage
+  description: New issue awaiting triage by the planner agent
+  color: "d93f0b"
+
+- name: triaged
+  description: Issue has been triaged, ready for planning or implementation
+  color: "0ea5e9"
+
+- name: merge-ready
+  description: PR approved and CI passing, ready for conductor to merge
+  color: "2563eb"
+
+- name: merge-queue
+  description: Approved by reviewer, queued for merge by conductor
+  color: "1d4ed8"
+
+# ── Status / warning labels ───────────────────────────────────────────────────
+#
+# Amber/yellow family. Indicate a blocked or degraded state requiring action.
+
+- name: needs context
+  description: More information is required to be able to proceed
+  color: "01a497"
+
+- name: needs decision
+  description: Blocked on a design or architecture decision
+  color: "aaaaaa"
+
+- name: needs-refinement
+  description: Issue needs enrichment and additional context before implementation
+  color: "e4e669"
+
+- name: needs-rework
+  description: PR has review feedback that must be addressed before merging
+  color: "e11d48"
+
+- name: needs-restack
+  description: Branch is behind its stack parent, needs git-spice restack
+  color: "f59e0b"
+
+- name: needs-tests
+  description: Area needs dedicated test coverage
+  color: "bfd4f2"
+
+# ── Agent dispatch labels ─────────────────────────────────────────────────────
+#
+# Each of these labels triggers a workflow that dispatches a specialized agent.
+# The agent removes the label once it has processed the issue or PR.
+#
+# Green family (implementation agents):
+
+- name: docs-agent
+  description: Dispatches the documentation agent to write or update docs
+  color: "b8f652"
+
+- name: enrich-agent
+  description: Dispatches the enricher agent to add context and detail to an issue
+  color: "4ade80"
+
+- name: plan-agent
+  description: Dispatches the planner agent to break down an issue into tasks
+  color: "7bdff6"
+
+- name: refactor-agent
+  description: Dispatches the refactor agent to improve code structure
+  color: "16a34a"
+
+- name: research-agent
+  description: Dispatches the research agent for investigation
+  color: "6366f1"
+
+- name: review-agent
+  description: Dispatches the review agent to review a pull request
+  color: "5bdc3b"
+
+- name: security-agent
+  description: Dispatches the security agent for vulnerability scanning or hardening
+  color: "f97316"
+
+- name: test-agent
+  description: Dispatches the tester agent to write or improve tests
+  color: "22c55e"
+
+- name: work-agent
+  description: Dispatches the worker agent to implement an issue
+  color: "d1f8a4"
+
+# ── Orchestration labels ──────────────────────────────────────────────────────
+#
+# Manual triggers for pipeline orchestration.
+
+- name: conductor-sync
+  description: Manual trigger for the conductor agent to sync and process the pipeline
+  color: "818cf8"

--- a/docs/public/pipeline-state-machine.md
+++ b/docs/public/pipeline-state-machine.md
@@ -1,0 +1,125 @@
+# Pipeline State Machine
+
+The agentd autonomous pipeline is driven entirely by GitHub labels. Each label
+either encodes the current state of an issue/PR or triggers dispatch to a
+specialized agent. The conductor agent reads and transitions these labels to
+drive the end-to-end lifecycle.
+
+## Label Color Convention
+
+| Color family | Hex prefix | Purpose |
+|---|---|---|
+| Blue | `0ea5e9`, `2563eb`, `1d4ed8` | Pipeline states — where an issue is right now |
+| Amber / yellow | `f59e0b`, `e4e669`, `fbbf24` | Status warnings — something needs attention |
+| Green | `4ade80`, `22c55e`, `16a34a`, `5bdc3b`, `d1f8a4` | Agent dispatch — triggers a specialized agent |
+| Orange / indigo | `f97316`, `818cf8`, `6366f1` | Specialist dispatch — security, research, orchestration |
+| Red | `e11d48`, `d93f0b` | Blocking states — must be resolved before proceeding |
+
+## State Diagram
+
+```
+Issue Created
+    │
+    ▼
+[needs-triage] ──► Planner/Triage Agent
+    │
+    ▼
+[triaged]
+    │
+    ├──► [enrich-agent] ──► Enricher Agent (optional, adds context)
+    │         │
+    │         ▼
+    │    [triaged] (enriched)
+    │
+    ▼
+[agent] ──► Worker Agent implements
+    │
+    ▼
+PR Created + [review-agent] ──► Reviewer Agent
+    │
+    ├── Approved ──► [merge-ready] ──► Conductor merges
+    │                     │
+    │                     ▼
+    │                  Merged
+    │                     │
+    │                     └──► [docs-agent] (optional, if API changed)
+    │
+    └── Changes Requested ──► [needs-rework] ──► Worker re-dispatched
+              │
+              ▼
+           Worker fixes ──► [review-agent] again
+```
+
+## State Reference
+
+### Pipeline States (blue labels)
+
+| Label | Applied by | Meaning |
+|-------|-----------|---------|
+| `needs-triage` | Human / automation | New issue awaiting triage |
+| `triaged` | Planner / triage agent | Issue scope and labels assigned |
+| `merge-ready` | Reviewer agent | PR approved + CI passing; ready for merge |
+| `merge-queue` | Conductor | Acknowledged by conductor, actively queued |
+
+### Status / Warning Labels (amber + red labels)
+
+| Label | Applied by | Meaning |
+|-------|-----------|---------|
+| `needs-rework` | Reviewer agent | PR has change requests; worker must address |
+| `needs-restack` | Conductor | Branch is behind parent branch; must rebase |
+| `needs-refinement` | Human / planner | Issue lacks enough detail to implement |
+| `needs-tests` | Reviewer / tester agent | Missing test coverage |
+
+### Agent Dispatch Labels (green + specialist labels)
+
+Applying one of these labels causes the corresponding workflow to poll it and
+dispatch the matching agent. The agent removes the label when done.
+
+| Label | Workflow | Agent | Trigger target |
+|-------|----------|-------|---------------|
+| `work-agent` | issue-worker | worker | Issue |
+| `review-agent` | pull-request-reviewer | reviewer | Pull request |
+| `plan-agent` | plan-worker | planner | Issue |
+| `docs-agent` | docs-worker | documenter | Issue / PR |
+| `enrich-agent` | enrichment-worker | enricher | Issue |
+| `test-agent` | test-worker | tester | Issue / PR |
+| `refactor-agent` | refactor-worker | refactor agent | Issue / PR |
+| `research-agent` | research-worker | research agent | Issue |
+| `security-agent` | security-worker | security agent | Issue / PR |
+| `conductor-sync` | conductor-sync workflow | conductor | Manual trigger |
+
+## Full Lifecycle Example
+
+```
+1.  Issue #42 created
+2.  Human applies `needs-triage`
+3.  Planner agent triages → removes `needs-triage`, applies `triaged` + `agent`
+4.  Issue-worker picks up `agent` → worker implements, opens PR, applies `review-agent`
+5.  Reviewer agent reviews PR:
+    a.  Approves → applies `merge-ready`, removes `review-agent`
+    b.  Requests changes → applies `needs-rework`, removes `review-agent`
+        → Worker addresses feedback, removes `needs-rework`, re-applies `review-agent`
+        → Loop back to step 5
+6.  Conductor sees `merge-ready`, CI green, no blockers → merges PR
+7.  If API changed: conductor applies `docs-agent` → documenter writes/updates docs
+8.  Issue closed, branch deleted
+```
+
+## Deduplication
+
+The orchestrator's scheduler tracks every `(workflow_id, source_id)` pair in a
+dispatch record store. Re-applying a label to an already-dispatched issue does
+not trigger a second dispatch — the `storage.is_dispatched()` check in
+`crates/orchestrator/src/scheduler/runner.rs` prevents duplicates.
+
+To re-trigger an agent on the same issue/PR, the label must first be removed
+and then re-added (which creates a new event that clears the dedup record only
+when the previous dispatch is marked complete or failed).
+
+## Related Files
+
+- `.agentd/agents/conductor.yml` — Conductor agent system prompt and dispatch logic
+- `.agentd/agents/*.yml` — Individual agent definitions
+- `.agentd/workflows/*.yml` — Workflow definitions (one per dispatch label)
+- `.github/labels.yml` — Authoritative label configuration for this repository
+- `crates/orchestrator/src/scheduler/runner.rs` — Dispatch dedup logic


### PR DESCRIPTION
feat: create pipeline labels and define label-driven state machine

feat: create pipeline labels and define label-driven state machine

Create all GitHub labels needed for the autonomous pipeline and document
the state machine that drives the issue/PR lifecycle.

Labels created in GitHub:
- Pipeline states (blue): triaged, merge-ready, merge-queue
- Status/warning (amber): needs-restack
- Agent dispatch (green): enrich-agent, test-agent, refactor-agent
- Specialist dispatch: security-agent (orange), conductor-sync (indigo)

Previously created labels (now documented): needs-triage, needs-rework,
research-agent, review-agent, work-agent, docs-agent, plan-agent.

Changes:
- .github/labels.yml: authoritative label config for the repo, grouped
  by pipeline state / status / agent dispatch / orchestration
- .agentd/agents/conductor.yml: update state machine table (triaged now
  has explicit label, merge-queue renamed to merge-ready), add dispatch
  mappings for all new agent labels, link to state machine doc
- docs/public/pipeline-state-machine.md: full reference for the label
  color convention, state diagram, state table, dedup behavior, and a
  worked lifecycle example

Closes #640