### PR TITLE
feat: add dispatch_result source_id propagation and wire pipeline chaining workflows

### DIFF
--- a/.agentd/workflows/review-merge-chain.yml
+++ b/.agentd/workflows/review-merge-chain.yml
@@ -1,0 +1,103 @@
+# Review → Merge chain workflow.
+#
+# Triggered when any workflow dispatch completes successfully. The conductor
+# reads `{{original_source_id}}` (the GitHub PR number from the parent
+# dispatch) and checks whether the PR is ready to merge. If it is approved
+# and CI is passing it applies the `merge-ready` label.
+#
+# Chaining setup:
+#
+#   1. Deploy pull-request-reviewer and this workflow via `agent apply`.
+#   2. After deployment, look up the pull-request-reviewer workflow UUID:
+#        agent orchestrator list-workflows | grep pull-request-reviewer
+#   3. Optionally scope this workflow to only react to reviewer completions by
+#      patching the source_workflow_id via the API:
+#        curl -s -X PATCH http://127.0.0.1:17006/workflows/<THIS_WORKFLOW_ID> \
+#          -H "Content-Type: application/json" \
+#          -d '{"source": {"source_workflow_id": "<REVIEWER_WORKFLOW_UUID>"}}'
+#
+# Without a source_workflow_id filter this workflow fires on *every* successful
+# dispatch. In a multi-pipeline deployment set source_workflow_id to the
+# pull-request-reviewer UUID so the chain is tightly scoped.
+#
+# IMPORTANT: This workflow ships as `enabled: false` to prevent noisy firing.
+# Without source_workflow_id set, enabling it would cause the chain to check
+# the GitHub API on every dispatch completion in the system, regardless of
+# source. Always complete step 3 above before setting `enabled: true`.
+#
+# Usage:
+#   agent apply .agentd/workflows/review-merge-chain.yml
+#   agent apply .agentd/  # creates all agents + workflows together
+#   # Then patch source_workflow_id and set enabled: true via the API
+
+name: review-merge-chain
+agent: conductor
+
+source:
+  type: dispatch_result
+  # source_workflow_id: "<REVIEWER_WORKFLOW_UUID>"  # uncomment and fill in after deployment
+  status: completed
+
+poll_interval: 60
+enabled: false
+
+prompt_template: |
+  A workflow dispatch has completed and you need to check whether the pull
+  request is ready to merge.
+
+  Dispatch context:
+  - Source workflow: {{source_workflow_id}}
+  - Dispatch ID:     {{dispatch_id}}
+  - Status:          {{status}}
+  - Completed at:    {{timestamp}}
+  - Original PR:     {{original_source_id}}
+
+  Step 1 — Fetch the PR's current state:
+
+  ```bash
+  gh pr view {{original_source_id}} --repo geoffjay/agentd \
+    --json number,title,state,labels,reviews,statusCheckRollup,baseRefName \
+    --jq '{
+      number: .number,
+      title: .title,
+      state: .state,
+      labels: [.labels[].name],
+      base: .baseRefName,
+      ci_states: [.statusCheckRollup[]?.state] | unique,
+      approved: ([.reviews[] | select(.state == "APPROVED")] | length),
+      changes_requested: ([.reviews[] | select(.state == "CHANGES_REQUESTED")] | length)
+    }'
+  ```
+
+  Step 2 — Evaluate merge readiness:
+
+  The PR is **NOT** ready if any of the following are true:
+  - The PR is already merged or closed
+  - It already has `merge-ready` or `merge-queue` label
+  - It has `needs-rework` or `needs-restack` label
+  - CI has any FAILURE or ERROR states
+  - `changes_requested` > 0
+  - `approved` == 0
+
+  If any of those conditions apply, stop here — no action needed.
+
+  Step 3 — If ready, apply the `merge-ready` label:
+
+  ```bash
+  gh pr edit {{original_source_id}} --repo geoffjay/agentd \
+    --add-label "merge-ready"
+  ```
+
+  Step 4 — Announce in the operations room:
+
+  ```bash
+  agent communicate message send operations \
+    "🔗 Chain triggered: PR #{{original_source_id}} advancing to merge-ready after review (dispatch {{dispatch_id}})."
+  ```
+
+  If the PR is not ready, announce why:
+
+  ```bash
+  agent communicate message send operations \
+    "🔗 Chain triggered: PR #{{original_source_id}} not yet merge-ready — <reason>."
+  ```

--- a/.agentd/workflows/triage-enrich-chain.yml
+++ b/.agentd/workflows/triage-enrich-chain.yml
@@ -1,0 +1,81 @@
+# Triage → Enrich chain workflow.
+#
+# Triggered when any workflow dispatch completes successfully. The conductor
+# reads `{{original_source_id}}` (the GitHub issue number from the parent
+# dispatch) and applies the `enrich-agent` label so the enrichment-worker
+# picks it up next.
+#
+# Chaining setup:
+#
+#   1. Deploy triage-worker and this workflow via `agent apply`.
+#   2. After deployment, look up the triage-worker workflow UUID:
+#        agent orchestrator list-workflows | grep triage-worker
+#   3. Optionally scope this workflow to only react to triage completions by
+#      patching the source_workflow_id via the API:
+#        curl -s -X PATCH http://127.0.0.1:17006/workflows/<THIS_WORKFLOW_ID> \
+#          -H "Content-Type: application/json" \
+#          -d '{"source": {"source_workflow_id": "<TRIAGE_WORKER_UUID>"}}'
+#
+# Without a source_workflow_id filter this workflow fires on *every* successful
+# dispatch. In a multi-pipeline deployment you should set source_workflow_id to
+# the triage-worker UUID so the chain is tightly scoped.
+#
+# IMPORTANT: This workflow ships as `enabled: false` to prevent feedback loops.
+# Without source_workflow_id set, enabling it would cause the chain to fire on
+# every dispatch completion in the system — including its own — which would
+# re-apply `enrich-agent` indefinitely. Always complete step 3 above before
+# setting `enabled: true`.
+#
+# Usage:
+#   agent apply .agentd/workflows/triage-enrich-chain.yml
+#   agent apply .agentd/  # creates all agents + workflows together
+#   # Then patch source_workflow_id and set enabled: true via the API
+
+name: triage-enrich-chain
+agent: conductor
+
+source:
+  type: dispatch_result
+  # source_workflow_id: "<TRIAGE_WORKER_UUID>"  # uncomment and fill in after deployment
+  status: completed
+
+poll_interval: 60
+enabled: false
+
+prompt_template: |
+  A workflow dispatch has completed and you need to advance the issue to the
+  enrichment stage.
+
+  Dispatch context:
+  - Source workflow: {{source_workflow_id}}
+  - Dispatch ID:     {{dispatch_id}}
+  - Status:          {{status}}
+  - Completed at:    {{timestamp}}
+  - Original issue:  {{original_source_id}}
+
+  Step 1 — Verify the issue still needs enrichment:
+
+  ```bash
+  gh issue view {{original_source_id}} --repo geoffjay/agentd \
+    --json number,title,labels,state \
+    --jq '{number: .number, title: .title, state: .state, labels: [.labels[].name]}'
+  ```
+
+  If the issue is closed, already has `enrich-agent`, or already has a
+  downstream agent label (`agent`, `work-agent`), stop here — no action needed.
+  Note: the presence of `triaged` is the signal that enrichment is appropriate,
+  not a reason to stop.
+
+  Step 2 — Apply the `enrich-agent` label to trigger enrichment:
+
+  ```bash
+  gh issue edit {{original_source_id}} --repo geoffjay/agentd \
+    --add-label "enrich-agent"
+  ```
+
+  Step 3 — Announce in the engineering room:
+
+  ```bash
+  agent communicate message send engineering \
+    "🔗 Chain triggered: issue #{{original_source_id}} advancing from triage → enrich (dispatch {{dispatch_id}})."
+  ```

--- a/crates/orchestrator/src/scheduler/events.rs
+++ b/crates/orchestrator/src/scheduler/events.rs
@@ -23,7 +23,16 @@ pub enum SystemEvent {
     /// An agent's conversation context was cleared.
     ContextCleared { agent_id: Uuid },
     /// A workflow dispatch completed (succeeded or failed).
-    DispatchCompleted { workflow_id: Uuid, dispatch_id: Uuid, status: DispatchStatus },
+    ///
+    /// `source_id` is the original task identifier (e.g. a GitHub issue or PR number)
+    /// that triggered the dispatch. It is `None` when the dispatch originated from a
+    /// trigger type that does not carry a task-level source identifier (rare).
+    DispatchCompleted {
+        workflow_id: Uuid,
+        dispatch_id: Uuid,
+        status: DispatchStatus,
+        source_id: Option<String>,
+    },
     /// An agent joined a communicate room.
     AgentJoinedRoom { agent_id: Uuid, room_id: Uuid },
 }
@@ -147,6 +156,7 @@ mod tests {
             workflow_id,
             dispatch_id,
             status: DispatchStatus::Completed,
+            source_id: Some("123".to_string()),
         });
 
         // Verify all four events arrive in order.
@@ -155,10 +165,16 @@ mod tests {
         assert!(matches!(rx.recv().await.unwrap(), SystemEvent::ContextCleared { .. }));
 
         match rx.recv().await.unwrap() {
-            SystemEvent::DispatchCompleted { workflow_id: wf, dispatch_id: d, status } => {
+            SystemEvent::DispatchCompleted {
+                workflow_id: wf,
+                dispatch_id: d,
+                status,
+                source_id,
+            } => {
                 assert_eq!(wf, workflow_id);
                 assert_eq!(d, dispatch_id);
                 assert_eq!(status, DispatchStatus::Completed);
+                assert_eq!(source_id, Some("123".to_string()));
             }
             other => panic!("Unexpected event: {:?}", other),
         }
@@ -244,6 +260,7 @@ mod tests {
             workflow_id,
             dispatch_id,
             status: DispatchStatus::Failed,
+            source_id: None,
         });
 
         match rx.recv().await.unwrap() {

--- a/crates/orchestrator/src/scheduler/mod.rs
+++ b/crates/orchestrator/src/scheduler/mod.rs
@@ -161,9 +161,9 @@ impl Scheduler {
                 continue;
             }
 
-            let dispatch_id = {
+            let (dispatch_id, source_id) = {
                 let busy = running.busy.lock().await;
-                busy.active_dispatch_id
+                (busy.active_dispatch_id, busy.active_source_id.clone())
             };
             if let Some(dispatch_id) = dispatch_id {
                 notify_complete(&running.busy, &self.storage, is_error).await;
@@ -176,6 +176,7 @@ impl Scheduler {
                         workflow_id: running.workflow_id,
                         dispatch_id,
                         status,
+                        source_id,
                     });
                 }
 
@@ -356,6 +357,7 @@ impl Scheduler {
             if let Some(running) = runners.get(workflow_id) {
                 let mut busy = running.busy.lock().await;
                 busy.active_dispatch_id = Some(record.id);
+                busy.active_source_id = Some(task.source_id.clone());
             }
         }
 

--- a/crates/orchestrator/src/scheduler/runner.rs
+++ b/crates/orchestrator/src/scheduler/runner.rs
@@ -21,6 +21,10 @@ use uuid::Uuid;
 pub struct BusyState {
     /// The dispatch record ID of the currently active task.
     pub(crate) active_dispatch_id: Option<Uuid>,
+    /// The source identifier (e.g. GitHub issue/PR number) of the currently active task.
+    /// Populated alongside `active_dispatch_id` so callers can include it in
+    /// `DispatchCompleted` events without an extra storage lookup.
+    pub(crate) active_source_id: Option<String>,
 }
 
 /// Runs the trigger-dispatch loop for a single workflow.
@@ -64,7 +68,10 @@ impl WorkflowRunner {
             storage,
             registry,
             strategy,
-            busy: Arc::new(Mutex::new(BusyState { active_dispatch_id: None })),
+            busy: Arc::new(Mutex::new(BusyState {
+                active_dispatch_id: None,
+                active_source_id: None,
+            })),
             shutdown_tx,
             shutdown_rx,
         }
@@ -189,6 +196,7 @@ impl WorkflowRunner {
             {
                 let mut busy = self.busy.lock().await;
                 busy.active_dispatch_id = Some(record.id);
+                busy.active_source_id = Some(task.source_id.clone());
             }
 
             // Apply the workflow's tool policy to the agent before dispatching.
@@ -209,6 +217,7 @@ impl WorkflowRunner {
                     .await;
                 let mut busy = self.busy.lock().await;
                 busy.active_dispatch_id = None;
+                busy.active_source_id = None;
                 return Err(e);
             }
 
@@ -234,6 +243,7 @@ pub async fn notify_complete(
 ) {
     let dispatch_id = {
         let mut busy = busy.lock().await;
+        busy.active_source_id = None;
         busy.active_dispatch_id.take()
     };
 

--- a/crates/orchestrator/src/scheduler/strategy.rs
+++ b/crates/orchestrator/src/scheduler/strategy.rs
@@ -462,7 +462,7 @@ impl EventStrategy {
                     source_workflow_id: filter_wf,
                     status: filter_status,
                 },
-                SystemEvent::DispatchCompleted { workflow_id, dispatch_id, status },
+                SystemEvent::DispatchCompleted { workflow_id, dispatch_id, status, source_id },
             ) => {
                 // Filter by source workflow ID if configured.
                 if let Some(expected_wf) = filter_wf {
@@ -476,7 +476,12 @@ impl EventStrategy {
                         return None;
                     }
                 }
-                Some(self.build_dispatch_task(workflow_id, dispatch_id, status))
+                Some(self.build_dispatch_task(
+                    workflow_id,
+                    dispatch_id,
+                    status,
+                    source_id.as_deref(),
+                ))
             }
 
             _ => None,
@@ -503,11 +508,16 @@ impl EventStrategy {
     }
 
     /// Build a task for a dispatch completion event.
+    ///
+    /// `original_source_id` is forwarded from the [`SystemEvent::DispatchCompleted`] event
+    /// so that chained workflows can reference the originating GitHub issue or PR number
+    /// via `{{original_source_id}}` in their prompt templates.
     fn build_dispatch_task(
         &self,
         workflow_id: &Uuid,
         dispatch_id: &Uuid,
         status: &DispatchStatus,
+        original_source_id: Option<&str>,
     ) -> Task {
         let timestamp = Utc::now().to_rfc3339();
         let mut metadata = HashMap::new();
@@ -515,6 +525,9 @@ impl EventStrategy {
         metadata.insert("dispatch_id".to_string(), dispatch_id.to_string());
         metadata.insert("status".to_string(), status.to_string());
         metadata.insert("timestamp".to_string(), timestamp.clone());
+        if let Some(sid) = original_source_id {
+            metadata.insert("original_source_id".to_string(), sid.to_string());
+        }
 
         Task {
             source_id: format!("event:dispatch:{}:{}", dispatch_id, timestamp),
@@ -1201,6 +1214,7 @@ mod tests {
             workflow_id,
             dispatch_id,
             status: DispatchStatus::Completed,
+            source_id: Some("101".to_string()),
         });
 
         let result = strategy.next_tasks(&rx).await.unwrap();
@@ -1210,6 +1224,7 @@ mod tests {
         assert_eq!(result[0].metadata.get("source_workflow_id"), Some(&workflow_id.to_string()));
         assert_eq!(result[0].metadata.get("dispatch_id"), Some(&dispatch_id.to_string()));
         assert_eq!(result[0].metadata.get("status"), Some(&"completed".to_string()));
+        assert_eq!(result[0].metadata.get("original_source_id"), Some(&"101".to_string()));
     }
 
     #[tokio::test]
@@ -1227,6 +1242,7 @@ mod tests {
             workflow_id: other_wf,
             dispatch_id: Uuid::new_v4(),
             status: DispatchStatus::Completed,
+            source_id: None,
         });
         // Publish for correct workflow — should match.
         let expected_dispatch = Uuid::new_v4();
@@ -1234,6 +1250,7 @@ mod tests {
             workflow_id: target_wf,
             dispatch_id: expected_dispatch,
             status: DispatchStatus::Failed,
+            source_id: None,
         });
 
         let result = strategy.next_tasks(&rx).await.unwrap();
@@ -1257,6 +1274,7 @@ mod tests {
             workflow_id,
             dispatch_id: Uuid::new_v4(),
             status: DispatchStatus::Completed,
+            source_id: None,
         });
         // Publish a Failed event — should match.
         let expected_dispatch = Uuid::new_v4();
@@ -1264,6 +1282,7 @@ mod tests {
             workflow_id,
             dispatch_id: expected_dispatch,
             status: DispatchStatus::Failed,
+            source_id: None,
         });
 
         let result = strategy.next_tasks(&rx).await.unwrap();
@@ -1283,6 +1302,7 @@ mod tests {
             workflow_id: Uuid::new_v4(),
             dispatch_id: Uuid::new_v4(),
             status: DispatchStatus::Completed,
+            source_id: None,
         });
 
         let result = strategy.next_tasks(&rx).await.unwrap();
@@ -1407,12 +1427,72 @@ mod tests {
         let strategy = EventStrategy::new(bus, filter);
         let wf_id = Uuid::new_v4();
         let dispatch_id = Uuid::new_v4();
-        let task = strategy.build_dispatch_task(&wf_id, &dispatch_id, &DispatchStatus::Completed);
+        let task =
+            strategy.build_dispatch_task(&wf_id, &dispatch_id, &DispatchStatus::Completed, None);
 
         assert!(task.source_id.starts_with("event:dispatch:"));
         assert!(task.source_id.contains(&dispatch_id.to_string()));
         assert!(task.title.contains(&dispatch_id.to_string()));
         assert!(task.title.contains("completed"));
+        // Without source_id, original_source_id should not appear in metadata.
+        assert!(!task.metadata.contains_key("original_source_id"));
+    }
+
+    #[test]
+    fn event_filter_dispatch_task_with_original_source_id() {
+        let bus = EventBus::shared(16);
+        let filter = EventFilter::DispatchResult { source_workflow_id: None, status: None };
+        let strategy = EventStrategy::new(bus, filter);
+        let wf_id = Uuid::new_v4();
+        let dispatch_id = Uuid::new_v4();
+        let task = strategy.build_dispatch_task(
+            &wf_id,
+            &dispatch_id,
+            &DispatchStatus::Completed,
+            Some("99"),
+        );
+
+        assert_eq!(task.metadata.get("original_source_id"), Some(&"99".to_string()));
+        assert_eq!(task.metadata.get("source_workflow_id"), Some(&wf_id.to_string()));
+        assert_eq!(task.metadata.get("status"), Some(&"completed".to_string()));
+    }
+
+    #[tokio::test]
+    async fn event_strategy_dispatch_result_propagates_original_source_id() {
+        let bus = EventBus::shared(16);
+        let filter = EventFilter::DispatchResult { source_workflow_id: None, status: None };
+        let mut strategy = EventStrategy::new(bus.clone(), filter);
+        let (_tx, rx) = watch::channel(false);
+
+        bus.publish(SystemEvent::DispatchCompleted {
+            workflow_id: Uuid::new_v4(),
+            dispatch_id: Uuid::new_v4(),
+            status: DispatchStatus::Completed,
+            source_id: Some("77".to_string()),
+        });
+
+        let result = strategy.next_tasks(&rx).await.unwrap();
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].metadata.get("original_source_id"), Some(&"77".to_string()));
+    }
+
+    #[tokio::test]
+    async fn event_strategy_dispatch_result_no_original_source_id_when_none() {
+        let bus = EventBus::shared(16);
+        let filter = EventFilter::DispatchResult { source_workflow_id: None, status: None };
+        let mut strategy = EventStrategy::new(bus.clone(), filter);
+        let (_tx, rx) = watch::channel(false);
+
+        bus.publish(SystemEvent::DispatchCompleted {
+            workflow_id: Uuid::new_v4(),
+            dispatch_id: Uuid::new_v4(),
+            status: DispatchStatus::Completed,
+            source_id: None,
+        });
+
+        let result = strategy.next_tasks(&rx).await.unwrap();
+        assert_eq!(result.len(), 1);
+        assert!(!result[0].metadata.contains_key("original_source_id"));
     }
 
     // ── WebhookStrategy tests ─────────────────────────────────────────

--- a/crates/orchestrator/src/scheduler/template.rs
+++ b/crates/orchestrator/src/scheduler/template.rs
@@ -7,13 +7,18 @@ use crate::scheduler::types::Task;
 /// by schedule-based triggers. Which metadata variables are present depends
 /// on the trigger type:
 ///
-/// | Variable          | Trigger types          | Description                        |
-/// |-------------------|------------------------|------------------------------------|
-/// | `fire_time`       | cron                   | RFC 3339 timestamp of the firing   |
-/// | `cron_expression` | cron                   | The cron expression that fired     |
-/// | `trigger_type`    | cron, delay            | The trigger type name              |
-/// | `run_at`          | delay                  | The scheduled run-at datetime      |
-/// | `workflow_id`     | delay                  | The workflow UUID                  |
+/// | Variable             | Trigger types          | Description                                    |
+/// |----------------------|------------------------|------------------------------------------------|
+/// | `fire_time`          | cron                   | RFC 3339 timestamp of the firing               |
+/// | `cron_expression`    | cron                   | The cron expression that fired                 |
+/// | `trigger_type`       | cron, delay            | The trigger type name                          |
+/// | `run_at`             | delay                  | The scheduled run-at datetime                  |
+/// | `workflow_id`        | delay                  | The workflow UUID                              |
+/// | `source_workflow_id` | dispatch_result        | UUID of the workflow whose dispatch completed  |
+/// | `dispatch_id`        | dispatch_result        | UUID of the completed dispatch record          |
+/// | `status`             | dispatch_result        | Completion status (`completed` or `failed`)    |
+/// | `timestamp`          | dispatch_result        | RFC 3339 timestamp of the completion event     |
+/// | `original_source_id` | dispatch_result        | Source ID from the parent dispatch (if any)    |
 pub const KNOWN_VARIABLES: &[&str] = &[
     // Top-level task fields
     "title",
@@ -29,6 +34,12 @@ pub const KNOWN_VARIABLES: &[&str] = &[
     "trigger_type",
     "run_at",
     "workflow_id",
+    // Metadata-backed (dispatch_result triggers)
+    "source_workflow_id",
+    "dispatch_id",
+    "status",
+    "timestamp",
+    "original_source_id",
 ];
 
 /// Validate a prompt template, returning any warnings or errors.
@@ -318,6 +329,53 @@ mod tests {
         let warnings = validate_template("{{fire_time}} {{totally_fake}}");
         assert_eq!(warnings.len(), 1);
         assert!(warnings[0].contains("totally_fake"));
+    }
+
+    // ── dispatch_result trigger variable tests ───────────────────────
+
+    #[test]
+    fn test_validate_dispatch_result_variables_accepted() {
+        let template = "{{source_workflow_id}} {{dispatch_id}} {{status}} {{timestamp}} {{original_source_id}}";
+        let warnings = validate_template(template);
+        assert!(warnings.is_empty(), "Expected no warnings, got: {:?}", warnings);
+    }
+
+    #[test]
+    fn test_render_dispatch_result_variables() {
+        let mut task = sample_task();
+        task.metadata.insert("source_workflow_id".to_string(), "wf-uuid-123".to_string());
+        task.metadata.insert("dispatch_id".to_string(), "dispatch-uuid-456".to_string());
+        task.metadata.insert("status".to_string(), "completed".to_string());
+        task.metadata.insert("timestamp".to_string(), "2025-06-01T10:00:00Z".to_string());
+        task.metadata.insert("original_source_id".to_string(), "42".to_string());
+
+        let template = "Workflow {{source_workflow_id}} dispatch {{dispatch_id}} finished with status {{status}} at {{timestamp}}. Original issue: {{original_source_id}}";
+        let result = render_template(template, &task);
+        assert_eq!(
+            result,
+            "Workflow wf-uuid-123 dispatch dispatch-uuid-456 finished with status completed at 2025-06-01T10:00:00Z. Original issue: 42"
+        );
+    }
+
+    #[test]
+    fn test_render_dispatch_result_without_original_source_id() {
+        // When original_source_id is absent (source_id was None in the event),
+        // the placeholder is preserved as-is.
+        let mut task = sample_task();
+        task.metadata.insert("source_workflow_id".to_string(), "wf-uuid-123".to_string());
+        task.metadata.insert("status".to_string(), "failed".to_string());
+
+        let result = render_template("Status: {{status}}, Origin: {{original_source_id}}", &task);
+        assert_eq!(result, "Status: failed, Origin: {{original_source_id}}");
+    }
+
+    #[test]
+    fn test_validate_all_variables_including_dispatch_result() {
+        let template = "{{title}} {{body}} {{url}} {{labels}} {{assignee}} {{source_id}} {{metadata}} \
+                        {{fire_time}} {{cron_expression}} {{trigger_type}} {{run_at}} {{workflow_id}} \
+                        {{source_workflow_id}} {{dispatch_id}} {{status}} {{timestamp}} {{original_source_id}}";
+        let warnings = validate_template(template);
+        assert!(warnings.is_empty(), "Expected no warnings, got: {:?}", warnings);
     }
 
     #[test]

--- a/docs/public/event-triggers.md
+++ b/docs/public/event-triggers.md
@@ -9,8 +9,8 @@ Event-driven triggers fire workflows in response to internal orchestrator events
 
 Both types are backed by the internal [Event Bus](#event-bus-architecture) and implemented via `EventStrategy`.
 
-!!! note "API-only configuration"
-    `agent_lifecycle` and `dispatch_result` triggers are created via the REST API directly (e.g. `curl`). The `agent orchestrator create-workflow` CLI and `.agentd/` YAML templates do not yet expose these trigger types.
+!!! tip "YAML template support"
+    `dispatch_result` and `agent_lifecycle` triggers can be configured in `.agentd/` workflow YAML files (see [Pipeline chaining with YAML templates](#pipeline-chaining-with-yaml-templates)) as well as via the REST API.
 
 ---
 
@@ -56,7 +56,7 @@ graph LR
 | `AgentConnected { agent_id }` | `ConnectionRegistry` | An agent establishes a WebSocket connection |
 | `AgentDisconnected { agent_id }` | `ConnectionRegistry` | An agent's WebSocket connection is closed |
 | `ContextCleared { agent_id }` | `AgentManager` | An agent's conversation context is cleared (`/clear`) |
-| `DispatchCompleted { workflow_id, dispatch_id, status }` | `Scheduler` | A workflow dispatch finishes (success or failure) |
+| `DispatchCompleted { workflow_id, dispatch_id, status, source_id }` | `Scheduler` | A workflow dispatch finishes (success or failure). `source_id` is the original task identifier (e.g. GitHub issue or PR number). |
 
 ### Broadcast channel model
 
@@ -216,8 +216,11 @@ In practice, `dispatch_result` workflows are most useful filtering on `"complete
 | `dispatch_id` | UUID of the specific dispatch record | `a1b2c3d4-...` |
 | `status` | Completion status | `completed` |
 | `timestamp` | RFC 3339 timestamp | `2026-04-01T09:05:00Z` |
+| `original_source_id` | Source ID from the parent dispatch (e.g. GitHub issue or PR number). Present only when the parent workflow had a task-level source identifier. | `42` |
 
 `source_id` includes both the dispatch UUID and the timestamp, so it is unique per event.
+
+Use `{{original_source_id}}` in a chained workflow's prompt template to reference the GitHub issue or PR number that triggered the parent workflow. This is the key variable that makes triage→enrich and review→merge pipeline chains practical.
 
 ### Workflow chaining
 
@@ -240,13 +243,89 @@ Each downstream workflow uses `{{source_workflow_id}}` and `{{dispatch_id}}` in 
 ```
 Workflow {{source_workflow_id}} completed with status {{status}} at {{timestamp}}.
 Dispatch ID: {{dispatch_id}}.
+Original issue/PR: {{original_source_id}}.
 
 Run the next pipeline stage.
 ```
 
+All `dispatch_result` variables are also listed in the [template variable reference](templates.md).
+
 ---
 
-## Creating Event-Driven Workflows
+## Pipeline Chaining with YAML Templates
+
+Workflow chaining can be configured in `.agentd/` YAML files using `type: dispatch_result` in the `source` block. The orchestrator serialises the trigger configuration from YAML using the same `TriggerConfig` enum as the REST API.
+
+### triage → enrich example
+
+When the triage workflow completes, the conductor applies the `enrich-agent` label so the enrichment-worker picks up the issue next.
+
+```yaml
+name: triage-enrich-chain
+agent: conductor
+
+source:
+  type: dispatch_result
+  # source_workflow_id: "<TRIAGE_WORKER_UUID>"  # fill in after deployment
+  status: completed
+
+poll_interval: 60
+enabled: true
+
+prompt_template: |
+  Workflow {{source_workflow_id}} completed. Advance issue #{{original_source_id}}
+  to the enrichment stage by applying the enrich-agent label:
+
+    gh issue edit {{original_source_id}} --repo geoffjay/agentd --add-label "enrich-agent"
+```
+
+The ready-to-deploy version is at `.agentd/workflows/triage-enrich-chain.yml`.
+
+### review → merge example
+
+When the reviewer workflow completes, the conductor checks whether the PR is approved and CI is passing, then applies `merge-ready` if so.
+
+```yaml
+name: review-merge-chain
+agent: conductor
+
+source:
+  type: dispatch_result
+  # source_workflow_id: "<REVIEWER_WORKFLOW_UUID>"  # fill in after deployment
+  status: completed
+
+poll_interval: 60
+enabled: true
+
+prompt_template: |
+  Workflow {{source_workflow_id}} completed. Check PR #{{original_source_id}}
+  for merge readiness and apply merge-ready if all criteria are met.
+```
+
+The ready-to-deploy version is at `.agentd/workflows/review-merge-chain.yml`.
+
+### Setting `source_workflow_id` after deployment
+
+YAML templates cannot know workflow UUIDs before deployment. After running `agent apply`, retrieve the UUID and patch the workflow:
+
+```bash
+# 1. Find the triage-worker UUID
+agent orchestrator list-workflows | grep triage-worker
+# Example output: triage-worker  550e8400-e29b-41d4-a716-446655440001  enabled
+
+# 2. Find the chain workflow UUID
+agent orchestrator list-workflows | grep triage-enrich-chain
+# Example output: triage-enrich-chain  a1b2c3d4-e29b-41d4-a716-446655440002  enabled
+
+# 3. Update the chain workflow via the API
+curl -s -X PATCH http://127.0.0.1:17006/workflows/a1b2c3d4-e29b-41d4-a716-446655440002 \
+  -H "Content-Type: application/json" \
+  -d '{"source": {"type": "dispatch_result", "source_workflow_id": "550e8400-e29b-41d4-a716-446655440001", "status": "completed"}}'
+```
+
+---
+
+## Creating Event-Driven Workflows via REST API
 
 Event-driven triggers are created via the orchestrator REST API. Use `curl` or any HTTP client.
 

--- a/docs/public/templates.md
+++ b/docs/public/templates.md
@@ -303,6 +303,7 @@ Available `{{placeholders}}` in prompt templates:
 | `{{source_workflow_id}}` | `dispatch_result` | UUID of the workflow that completed | `a1b2c3d4-...` |
 | `{{dispatch_id}}` | `dispatch_result` | UUID of the dispatch record | `b2c3d4e5-...` |
 | `{{status}}` | `dispatch_result` | Completion status | `completed` |
+| `{{original_source_id}}` | `dispatch_result` | Source ID from the parent dispatch (e.g. GitHub issue or PR number). Absent when the parent had no task-level source identifier. | `42` |
 
 !!! note
     Schedule and event trigger variables are stored in the task's `metadata` map and resolved during template rendering. If a variable is referenced but not present for the trigger type (e.g. `{{fire_time}}` in a delay workflow), the placeholder is left as-is in the rendered prompt.


### PR DESCRIPTION
feat: add dispatch_result source_id propagation and wire pipeline chaining workflows

feat(scheduler): propagate source_id through DispatchCompleted event for workflow chaining

- Add `source_id: Option<String>` to `SystemEvent::DispatchCompleted` so
  chained workflows can reference the originating GitHub issue or PR number
- Add `active_source_id: Option<String>` to `BusyState` and populate it
  alongside `active_dispatch_id` in `dispatch_tasks` and `trigger_workflow`
- Pass `source_id` from `BusyState` when publishing `DispatchCompleted` in
  `notify_task_complete`
- Add `original_source_id` metadata key in `build_dispatch_task` so chained
  prompt templates can use `{{original_source_id}}`
- Add `source_workflow_id`, `dispatch_id`, `status`, `timestamp`, and
  `original_source_id` to `KNOWN_VARIABLES` in template.rs to eliminate
  validation warnings for dispatch_result workflows
- Add `.agentd/workflows/triage-enrich-chain.yml` and
  `review-merge-chain.yml` as ready-to-deploy pipeline chaining examples
- Update `docs/public/event-triggers.md` and `docs/public/templates.md` with
  `original_source_id`, YAML chaining examples, and updated system event docs

Closes #641

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>