### PR TITLE
feat: add merge automation to conductor agent

### DIFF
--- a/.agentd/agents/conductor.yml
+++ b/.agentd/agents/conductor.yml
@@ -89,6 +89,9 @@ system_prompt: |
   git-spice log short
 
   # 3. Check current merge queue
+  # Note: sort_by(.baseRefName) is an alphabetical approximation of stack order
+  # (e.g. "feature/autonomous-pipeline" sorts before "issue-NNN"), not a true
+  # topological sort. Use `git-spice log short` for authoritative stack order.
   gh pr list --repo geoffjay/agentd --label merge-ready \
     --json number,title,baseRefName,headRefName,reviews,statusCheckRollup \
     --jq 'sort_by(.baseRefName)'

--- a/.agentd/workflows/merge-worker.yml
+++ b/.agentd/workflows/merge-worker.yml
@@ -34,10 +34,13 @@ prompt_template: |
   1. agent memory search "merge queue conductor" --as-actor conductor --limit 3 --json
   2. Review results for known blockers or recent decisions.
 
-  Step 1 — Session start: sync git-spice and load pipeline state.
+  Step 1 — Session start: load current pipeline state (read-only).
 
   ```bash
-  git-spice repo sync
+  # Read-only overview — do NOT run git-spice repo sync here.
+  # Syncing before CI/approval checks creates a pre-gate failure surface
+  # (a lingering rebase conflict could abort the workflow before any checks run).
+  # git-spice repo sync is scoped to Step 8, after a successful merge.
   git-spice log short
   ```
 
@@ -78,7 +81,18 @@ prompt_template: |
   ```
 
   - If `PENDING` → stop here, leave merge-ready intact, check again next run
-  - If `FAILED` → remove merge-ready, comment on the PR, notify operations
+  - If `FAILED` → remove merge-ready, comment on the PR, notify operations:
+
+  ```bash
+  gh pr edit {{source_id}} --repo geoffjay/agentd --remove-label "merge-ready"
+  gh pr comment {{source_id}} --repo geoffjay/agentd \
+    --body "❌ CI checks failed. Removed \`merge-ready\` label. Fix the failing checks and re-apply \`merge-ready\` to re-queue."
+  agent communicate message send operations \
+    "❌ PR #{{source_id}} ({{title}}) CI failed — removed merge-ready. Fix failing checks and re-apply merge-ready to re-queue."
+  ```
+
+  Stop this run.
+
   - If `PASSED` → continue
 
   Step 4 — Verify approval and no change requests.
@@ -113,10 +127,20 @@ prompt_template: |
   ```bash
   BASE=$(gh pr view {{source_id}} --repo geoffjay/agentd --json baseRefName --jq '.baseRefName')
   if [[ "$BASE" != "main" && "$BASE" != "feature/autonomous-pipeline" ]]; then
-    # Check the base branch's own PR is already merged
-    gh pr list --repo geoffjay/agentd --head "$BASE" --state merged \
-      --json number,title | jq '.'
-    # If no merged PR found for $BASE, stop and merge the base PR first
+    # Check whether the base branch still exists remotely.
+    # Output 0 → branch gone (merged/deleted), safe to proceed.
+    # Output 1 → branch still open, parent PR must merge first.
+    # Note: using git ls-remote rather than `gh pr list --state merged` because
+    # the latter only finds bases that had a PR; a directly-pushed branch would
+    # return empty and incorrectly block the merge.
+    BASE_EXISTS=$(git ls-remote --heads origin "$BASE" | wc -l | tr -d ' ')
+    echo "Base branch '$BASE' remote refs: $BASE_EXISTS"
+    if [[ "$BASE_EXISTS" -gt 0 ]]; then
+      echo "Base branch still open — merge the parent PR for '$BASE' first."
+      agent communicate message send operations \
+        "📚 PR #{{source_id}} ({{title}}) cannot merge yet — base branch '$BASE' is still open. Merge the parent PR first."
+      # Stop this run; leave merge-ready intact for retry after parent merges.
+    fi
   fi
   ```
 
@@ -137,8 +161,17 @@ prompt_template: |
   ```bash
   git-spice repo sync
 
-  # Re-submit any dependent PRs with updated base refs
-  git-spice stack submit --fill --no-prompt
+  # Resubmit only the branches stacked on top of the just-merged PR.
+  # We check out the base of the merged PR first so that
+  # `git-spice upstack submit` targets the correct upstack set.
+  # NOTE: `git-spice stack submit` resubmits from the conductor's current
+  # working-directory branch and may include branches beyond the direct
+  # dependents of the just-merged PR. Use `upstack submit` from the merged
+  # base to scope it correctly. When the conductor's full session context is
+  # formalised this can be revisited.
+  BASE=$(gh pr view {{source_id}} --repo geoffjay/agentd --json baseRefName --jq '.baseRefName')
+  git checkout "$BASE"
+  git-spice upstack submit --fill --no-prompt
   ```
 
   If `git-spice repo sync` fails with a conflict:


### PR DESCRIPTION
feat: add merge automation to conductor agent

feat(conductor): add detailed merge automation with CI verification and stack ordering

Expand the conductor agent's merge queue management with a complete step-by-step
merge flow and a new merge-worker.yml workflow that drives it.

conductor.yml changes:
- Replace the minimal "Performing a Merge" section with an 8-step merge flow:
  1. Fetch full PR metadata (mergeable, reviews, CI rollup)
  2. Verify CI status using `gh pr checks` and statusCheckRollup jq filters;
     defer on PENDING, remove merge-ready and comment on FAILURE
  3. Verify ≥1 approval and no unresolved change requests (latest review per
     author via group_by/sort_by jq); add needs-rework if changes requested
  4. Verify no merge conflict via `gh pr view --json mergeable`; add
     needs-restack on CONFLICTING
  5. Verify stack prerequisites: base PR must be merged before child merges
  6. Squash-merge with `gh pr merge --squash --delete-branch`
  7. Post-merge restack: `git-spice repo sync` + `git-spice stack submit`
  8. Announce result to operations room and store in shared memory
- Update Session Start to sort merge queue by base branch and flag CI failures
- Expand Conflict Escalation with concrete commands: detect branch, find PR,
  add needs-restack label, post structured message to engineering room

merge-worker.yml:
- New workflow triggered by `merge-ready` label on github_pull_requests source
- Dispatches to the conductor agent with a complete, executable prompt template
- Template mirrors the 10-step merge flow from conductor.yml including all jq
  filters, decision rules, and escalation paths

Closes #644

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>