### PR TITLE
feat: add PTY stream relay WebSocket endpoint to orchestrator

### DIFF
--- a/crates/orchestrator/src/api.rs
+++ b/crates/orchestrator/src/api.rs
@@ -3,7 +3,8 @@ use crate::scheduler::api::{webhook_routes, workflow_routes, WorkflowState};
 use crate::scheduler::Scheduler;
 use crate::types::*;
 use crate::websocket::{
-    ws_handler, ws_stream_agent_handler, ws_stream_all_handler, ConnectionRegistry,
+    ws_handler, ws_stream_agent_handler, ws_stream_all_handler, ws_terminal_handler,
+    ConnectionRegistry, TerminalRelayState,
 };
 use axum::{
     extract::{Path, Query, State},
@@ -43,6 +44,11 @@ pub fn create_router(state: ApiState) -> Router {
         .route("/stream/{agent_id}", get(ws_stream_agent_handler))
         .with_state(state.registry.clone());
 
+    // PTY terminal relay WebSocket — binary frames of raw terminal I/O.
+    let ws_terminal_routes = Router::new()
+        .route("/terminal/{agent_id}", get(ws_terminal_handler))
+        .with_state(TerminalRelayState { manager: state.manager.clone() });
+
     let wf_state =
         WorkflowState { scheduler: state.scheduler.clone(), manager: state.manager.clone() };
     let wf_routes = workflow_routes(wf_state.clone());
@@ -72,7 +78,12 @@ pub fn create_router(state: ApiState) -> Router {
         .route("/debug/agents", get(debug_agents))
         .with_state(state);
 
-    api_routes.merge(ws_agent_routes).merge(ws_stream_routes).merge(wf_routes).merge(wh_routes)
+    api_routes
+        .merge(ws_agent_routes)
+        .merge(ws_stream_routes)
+        .merge(ws_terminal_routes)
+        .merge(wf_routes)
+        .merge(wh_routes)
 }
 
 #[derive(Deserialize)]

--- a/crates/orchestrator/src/manager.rs
+++ b/crates/orchestrator/src/manager.rs
@@ -479,6 +479,50 @@ impl AgentManager {
         }
     }
 
+    /// Return the PTY output stream for an agent's session, if the backend
+    /// supports it.
+    ///
+    /// Returns `Ok(None)` when the agent does not have a session or when the
+    /// backend does not support PTY streaming (e.g., tmux or Docker backends).
+    /// Returns `Ok(Some(stream))` for PTY-backed sessions.
+    pub async fn get_agent_pty_stream(
+        &self,
+        agent_id: &Uuid,
+    ) -> anyhow::Result<Option<wrap::pty_stream::PtyOutputStream>> {
+        let agent =
+            self.storage.get(agent_id).await?.ok_or_else(|| anyhow::anyhow!("Agent not found"))?;
+
+        let session_name = match agent.session_id {
+            Some(s) => s,
+            None => return Ok(None),
+        };
+
+        self.backend.session_output_stream(&session_name).await
+    }
+
+    /// Resize the PTY terminal for an agent's session.
+    ///
+    /// No-ops silently for backends that do not support resize (tmux/Docker).
+    /// Returns `Ok(())` when the agent has no active session.
+    pub async fn resize_agent_pty(
+        &self,
+        agent_id: &Uuid,
+        cols: u16,
+        rows: u16,
+    ) -> anyhow::Result<()> {
+        let agent = match self.storage.get(agent_id).await? {
+            Some(a) => a,
+            None => return Ok(()),
+        };
+
+        let session_name = match agent.session_id {
+            Some(s) => s,
+            None => return Ok(()),
+        };
+
+        self.backend.resize_session(&session_name, cols, rows).await
+    }
+
     /// Restart a running agent: kill the current session and re-launch Claude.
     ///
     /// Preserves the agent's ID, name, and config. The prompt is NOT re-sent

--- a/crates/orchestrator/src/websocket.rs
+++ b/crates/orchestrator/src/websocket.rs
@@ -1,4 +1,5 @@
 use crate::approvals::ApprovalRegistry;
+use crate::manager::AgentManager;
 use crate::scheduler::events::{EventBus, SystemEvent};
 use crate::types::{ActivityState, ApprovalDecision, ResultInfo, ToolPolicy, UsageSnapshot};
 use axum::{
@@ -10,6 +11,7 @@ use axum::{
 };
 use chrono::Utc;
 use futures::{SinkExt, StreamExt};
+use serde::{Deserialize, Serialize};
 use serde_json::Value;
 use std::collections::HashMap;
 use std::sync::Arc;
@@ -833,6 +835,163 @@ async fn handle_stream_socket(
     info!(filter = %label, "Stream WebSocket connection ended");
 }
 
+// ---------------------------------------------------------------------------
+// Terminal relay WebSocket  (GET /terminal/{agent_id})
+// ---------------------------------------------------------------------------
+
+/// Control message sent from a terminal client to the server.
+///
+/// Binary frames are forwarded as-is to the PTY stdin.
+/// Text frames are parsed as JSON control messages (e.g., resize).
+#[derive(Debug, Deserialize, Serialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+enum TerminalControlMessage {
+    /// Resize the PTY to the given dimensions.
+    Resize { cols: u16, rows: u16 },
+}
+
+/// State passed to the terminal WebSocket handler.
+///
+/// Carries the `AgentManager` so the handler can resolve agent → session
+/// and obtain the `PtyOutputStream`.
+#[derive(Clone)]
+pub struct TerminalRelayState {
+    pub manager: Arc<AgentManager>,
+}
+
+/// Maximum byte length accepted for a single binary stdin frame forwarded to
+/// the PTY. Frames larger than this are dropped with a warning. This prevents
+/// a misbehaving client from holding the PTY writer mutex for an arbitrarily
+/// long write.
+const MAX_STDIN_FRAME_BYTES: usize = 64 * 1024; // 64 KiB
+
+/// Axum handler for the PTY terminal relay at `GET /terminal/{agent_id}`.
+///
+/// Upgrades the connection to a binary WebSocket relay:
+/// - **Server → Client**: raw PTY output bytes as binary frames
+/// - **Client → Server**: binary frames forwarded to PTY stdin;
+///   text frames parsed as JSON control messages (e.g. `{"type":"resize","cols":120,"rows":40}`)
+///
+/// Returns `404 Not Found` when the agent does not exist or the backend does
+/// not support PTY streaming.
+/// Returns `500 Internal Server Error` when the PTY stream lookup fails.
+pub async fn ws_terminal_handler(
+    Path(agent_id): Path<Uuid>,
+    ws: WebSocketUpgrade,
+    State(state): State<TerminalRelayState>,
+) -> impl IntoResponse {
+    info!(%agent_id, "Terminal WebSocket upgrade request");
+    // Resolve the PTY stream before upgrading so HTTP-level clients receive a
+    // proper status code (404/500) rather than a WebSocket-framed error message.
+    match state.manager.get_agent_pty_stream(&agent_id).await {
+        Ok(None) => {
+            warn!(%agent_id, "Terminal relay: no PTY stream available");
+            axum::http::StatusCode::NOT_FOUND.into_response()
+        }
+        Err(e) => {
+            error!(%agent_id, %e, "Terminal relay: failed to get PTY stream");
+            axum::http::StatusCode::INTERNAL_SERVER_ERROR.into_response()
+        }
+        Ok(Some(stream)) => ws
+            .on_upgrade(move |socket| {
+                handle_terminal_socket(socket, agent_id, stream, state.manager)
+            })
+            .into_response(),
+    }
+}
+
+async fn handle_terminal_socket(
+    socket: WebSocket,
+    agent_id: Uuid,
+    stream: wrap::pty_stream::PtyOutputStream,
+    manager: Arc<AgentManager>,
+) {
+    let (mut ws_sender, mut ws_receiver) = socket.split();
+
+    // Subscribe before sending history to avoid a race between replay and live.
+    let (history, mut pty_rx) = stream.subscribe();
+    info!(%agent_id, history_chunks = history.len(), "Terminal relay connected");
+
+    // Send history buffer as individual binary frames.
+    for chunk in history {
+        if ws_sender.send(Message::Binary(chunk)).await.is_err() {
+            return;
+        }
+    }
+
+    // Spawn a task that forwards live PTY output → WebSocket binary frames.
+    let send_task = tokio::spawn(async move {
+        loop {
+            match pty_rx.recv().await {
+                Ok(chunk) => {
+                    if ws_sender.send(Message::Binary(chunk)).await.is_err() {
+                        break;
+                    }
+                }
+                Err(broadcast::error::RecvError::Lagged(n)) => {
+                    warn!(%agent_id, skipped = n, "Terminal relay lagged, skipped PTY chunks");
+                    // Continue — we already lost these bytes; keep forwarding.
+                }
+                Err(broadcast::error::RecvError::Closed) => {
+                    info!(%agent_id, "PTY broadcast channel closed, terminal relay ending");
+                    break;
+                }
+            }
+        }
+    });
+
+    // Main loop: handle incoming client frames.
+    loop {
+        match ws_receiver.next().await {
+            None => break, // client closed the connection cleanly
+            Some(Err(e)) => {
+                warn!(%agent_id, %e, "Terminal relay: receive error");
+                break;
+            }
+            Some(Ok(msg)) => match msg {
+                Message::Binary(data) => {
+                    // Raw keyboard input — forward to PTY stdin.
+                    if data.len() > MAX_STDIN_FRAME_BYTES {
+                        warn!(
+                            %agent_id,
+                            bytes = data.len(),
+                            limit = MAX_STDIN_FRAME_BYTES,
+                            "Terminal relay: oversized stdin frame dropped"
+                        );
+                    } else if let Err(e) = stream.write_input(&data) {
+                        warn!(%agent_id, %e, "Terminal relay: failed to write input to PTY");
+                    }
+                }
+                Message::Text(text) => {
+                    // JSON control message — parse and dispatch.
+                    match serde_json::from_str::<TerminalControlMessage>(&text) {
+                        Ok(TerminalControlMessage::Resize { cols, rows }) => {
+                            debug!(%agent_id, cols, rows, "Terminal resize request");
+                            if let Err(e) = manager.resize_agent_pty(&agent_id, cols, rows).await {
+                                warn!(%agent_id, %e, "Terminal relay: resize failed");
+                            }
+                        }
+                        Err(e) => {
+                            warn!(%agent_id, %e, text = %text, "Terminal relay: unrecognised control message");
+                        }
+                    }
+                }
+                Message::Close(_) => {
+                    info!(%agent_id, "Terminal client disconnected");
+                    break;
+                }
+                Message::Ping(_) => {} // auto-pong by axum
+                _ => {}
+            },
+        }
+    }
+
+    send_task.abort();
+    // Wait for the send task to exit so its ws_sender is dropped before we return.
+    let _ = send_task.await;
+    info!(%agent_id, "Terminal WebSocket connection ended");
+}
+
 async fn send_raw(
     agent_id: &Uuid,
     msg: &Value,
@@ -1202,5 +1361,52 @@ mod tests {
             }
         }
         assert!(found, "Expected agent:activity_changed (busy) event on stream");
+    }
+
+    // -----------------------------------------------------------------------
+    // Terminal control message parsing tests
+    // -----------------------------------------------------------------------
+
+    #[test]
+    fn test_terminal_resize_message_deserialises() {
+        let json = r#"{"type":"resize","cols":120,"rows":40}"#;
+        let msg: TerminalControlMessage = serde_json::from_str(json).unwrap();
+        match msg {
+            TerminalControlMessage::Resize { cols, rows } => {
+                assert_eq!(cols, 120);
+                assert_eq!(rows, 40);
+            }
+        }
+    }
+
+    #[test]
+    fn test_terminal_resize_message_serialises() {
+        let msg = TerminalControlMessage::Resize { cols: 80, rows: 24 };
+        let json = serde_json::to_string(&msg).unwrap();
+        assert!(json.contains(r#""type":"resize""#));
+        assert!(json.contains(r#""cols":80"#));
+        assert!(json.contains(r#""rows":24"#));
+    }
+
+    #[test]
+    fn test_terminal_unknown_message_type_errors() {
+        let json = r#"{"type":"unknown_action","data":"foo"}"#;
+        let result = serde_json::from_str::<TerminalControlMessage>(json);
+        assert!(result.is_err(), "Unknown type should fail to deserialise");
+    }
+
+    #[test]
+    fn test_terminal_resize_missing_fields_errors() {
+        // Missing `rows` — should fail.
+        let json = r#"{"type":"resize","cols":80}"#;
+        let result = serde_json::from_str::<TerminalControlMessage>(json);
+        assert!(result.is_err(), "Resize missing rows should fail");
+    }
+
+    #[test]
+    fn test_terminal_relay_state_is_clone() {
+        // Verifies the TerminalRelayState can be cloned (required by axum State).
+        fn assert_clone<T: Clone>() {}
+        assert_clone::<TerminalRelayState>();
     }
 }

--- a/crates/wrap/src/backend.rs
+++ b/crates/wrap/src/backend.rs
@@ -191,6 +191,25 @@ pub trait ExecutionBackend: Send + Sync {
         Ok(None)
     }
 
+    /// Resize the PTY terminal dimensions for a session.
+    ///
+    /// Only PTY-backed sessions support resize; all other backends no-op by
+    /// default. Callers should handle the no-op gracefully.
+    ///
+    /// # Arguments
+    ///
+    /// * `session_name` — Name of the session to resize
+    /// * `cols` — New terminal width in columns
+    /// * `rows` — New terminal height in rows
+    async fn resize_session(
+        &self,
+        _session_name: &str,
+        _cols: u16,
+        _rows: u16,
+    ) -> anyhow::Result<()> {
+        Ok(()) // no-op for non-PTY backends
+    }
+
     /// Returns the output stream for a PTY-backed session, if available.
     ///
     /// Only [`PtyBackend`](crate::pty::PtyBackend) implements this; all other

--- a/crates/wrap/src/pty.rs
+++ b/crates/wrap/src/pty.rs
@@ -189,6 +189,20 @@ impl ExecutionBackend for PtyBackend {
         &self.prefix
     }
 
+    async fn resize_session(&self, session_name: &str, cols: u16, rows: u16) -> Result<()> {
+        let sessions = self.sessions.read().await;
+        if let Some(session) = sessions.get(session_name) {
+            let master = session
+                .master
+                .lock()
+                .map_err(|_| anyhow!("PTY master lock poisoned for '{}'", session_name))?;
+            master
+                .resize(PtySize { rows, cols, pixel_width: 0, pixel_height: 0 })
+                .with_context(|| format!("Failed to resize PTY session '{}'", session_name))?;
+        }
+        Ok(())
+    }
+
     async fn session_output_stream(&self, session_name: &str) -> Result<Option<PtyOutputStream>> {
         let sessions = self.sessions.read().await;
         Ok(sessions.get(session_name).map(|s| s.stream.clone()))
@@ -362,5 +376,42 @@ mod tests {
         backend.shutdown_all_sessions().await.unwrap();
         let sessions = backend.list_sessions().await.unwrap();
         assert!(sessions.is_empty());
+    }
+
+    #[tokio::test]
+    async fn resize_session_noop_for_missing() {
+        // Resizing a session that doesn't exist should return Ok(()) silently.
+        let backend = PtyBackend::new("test");
+        let result = backend.resize_session("nonexistent", 120, 40).await;
+        assert!(result.is_ok());
+    }
+
+    #[tokio::test]
+    async fn session_output_stream_none_for_missing() {
+        let backend = PtyBackend::new("test");
+        let stream = backend.session_output_stream("nonexistent").await.unwrap();
+        assert!(stream.is_none());
+    }
+
+    #[tokio::test]
+    #[ignore = "requires PTY support (not available in sandbox/CI)"]
+    async fn resize_session_ok_for_live_session() {
+        let backend = PtyBackend::new("test");
+        let config = test_config("resize-session");
+        backend.create_session(&config).await.unwrap();
+        let result = backend.resize_session("resize-session", 120, 40).await;
+        assert!(result.is_ok(), "resize should succeed: {result:?}");
+        backend.kill_session("resize-session").await.unwrap();
+    }
+
+    #[tokio::test]
+    #[ignore = "requires PTY support (not available in sandbox/CI)"]
+    async fn session_output_stream_some_for_live_session() {
+        let backend = PtyBackend::new("test");
+        let config = test_config("stream-session");
+        backend.create_session(&config).await.unwrap();
+        let stream = backend.session_output_stream("stream-session").await.unwrap();
+        assert!(stream.is_some(), "should return PtyOutputStream for live PTY session");
+        backend.kill_session("stream-session").await.unwrap();
     }
 }


### PR DESCRIPTION
feat: add PTY stream relay WebSocket endpoint to orchestrator

feat(orchestrator): add PTY terminal relay WebSocket endpoint (closes #675)

Adds GET /terminal/{agent_id} — a binary WebSocket that bridges the
PtyOutputStream (from the wrap layer) to web terminal clients.

## Changes

### crates/wrap/src/backend.rs
- Add `resize_session(session_name, cols, rows)` default no-op method to
  `ExecutionBackend` trait

### crates/wrap/src/pty.rs
- Implement `resize_session` for `PtyBackend` via `MasterPty::resize()`
- Add unit tests: `resize_session_noop_for_missing`,
  `session_output_stream_none_for_missing`, and two ignored PTY tests

### crates/orchestrator/src/manager.rs
- Add `get_agent_pty_stream(agent_id)` — resolves agent → session →
  `PtyOutputStream` (returns `None` for non-PTY backends)
- Add `resize_agent_pty(agent_id, cols, rows)` — delegates to backend

### crates/orchestrator/src/websocket.rs
- Add `TerminalControlMessage` enum (`resize` variant) with serde
- Add `TerminalRelayState` state wrapper for the terminal route
- Add `ws_terminal_handler` and `handle_terminal_socket`:
  - Resolves PTY stream; sends error text frame + closes on no stream
  - Replays ring-buffer history as binary frames on connect
  - Spawns send task: PTY broadcast → binary WS frames
  - Main loop: binary frames → PTY stdin; text frames parsed as resize
  - Handles `RecvError::Lagged` by skipping and continuing
- Add 5 unit tests for control message parsing and state cloneability

### crates/orchestrator/src/api.rs
- Register `GET /terminal/{agent_id}` route with `TerminalRelayState`

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>