### PR TITLE
feat: add webhook-triggered pull request review workflow

### DIFF
--- a/.agentd/workflows/webhook-pull-request-reviewer.yml
+++ b/.agentd/workflows/webhook-pull-request-reviewer.yml
@@ -1,0 +1,203 @@
+# Webhook-triggered PR reviewer workflow — fires immediately on GitHub webhook events.
+#
+# Unlike the polling-based pull-request-reviewer, this workflow is triggered in
+# real time when GitHub delivers a webhook event. The recommended setup is to
+# configure a GitHub repository webhook that sends `pull_request` events to this
+# workflow's endpoint. Whenever the `review-agent` label is applied to a PR,
+# GitHub delivers a `pull_request` / `labeled` event and the reviewer agent
+# begins immediately — no polling delay.
+#
+# GitHub webhook setup (one-time, per repository):
+#
+#   1. Deploy this workflow and note its UUID:
+#        agent apply .agentd/workflows/webhook-pull-request-reviewer.yml
+#        agent orchestrator list-workflows | grep webhook-pull-request-reviewer
+#
+#   2. In your GitHub repo → Settings → Webhooks → Add webhook:
+#        Payload URL:   https://<your-agentd-host>/webhooks/<WORKFLOW_UUID>
+#        Content type:  application/json
+#        Secret:        <same value as `secret` below>
+#        Events:        Select "Pull requests"
+#
+#   3. To test immediately without GitHub:
+#        curl -s -X POST http://127.0.0.1:17006/webhooks/<WORKFLOW_UUID> \
+#          -H "Content-Type: application/json" \
+#          -H "X-GitHub-Event: pull_request" \
+#          -H "X-GitHub-Delivery: test-$(date +%s)" \
+#          -d '{"action":"labeled","number":123,"pull_request":{"title":"Test PR","body":"Test body","html_url":"https://github.com/geoffjay/agentd/pull/123","labels":[{"name":"review-agent"}]}}'
+#
+# Worktree considerations:
+#   The reviewer agent checks out the PR branch in an isolated git worktree so
+#   the review does not disturb the main working tree. The worktree is created
+#   at /tmp/agentd-review-<pr_number> and cleaned up after the review completes.
+#
+# Memory integration:
+#   The reviewer stores review findings in shared memory so patterns can be
+#   detected across multiple PRs over time. Each run also queries memory to
+#   incorporate past decisions and known recurring issues.
+#
+# IMPORTANT: This workflow ships as `enabled: false`. Set `enabled: true` only
+# after configuring the GitHub webhook and (optionally) setting a shared secret
+# to protect the endpoint from unauthenticated deliveries.
+#
+# Usage:
+#   agent apply .agentd/workflows/webhook-pull-request-reviewer.yml
+#   agent apply .agentd/  # creates all agents + workflows together
+
+name: webhook-pull-request-reviewer
+agent: reviewer
+
+source:
+  type: webhook
+  # secret: ""  # Set to a random string and configure the same value in GitHub
+                 # webhook settings to enable HMAC-SHA256 signature verification.
+                 # If omitted, all incoming requests are accepted without
+                 # verification (not recommended for production).
+
+enabled: false
+
+prompt_template: |
+  A GitHub pull_request webhook event was received. Review the pull request
+  if it has the `review-agent` label; otherwise skip it.
+
+  Webhook delivery context:
+  - Event:       {{github_event}}
+  - Action:      {{action}}
+  - Delivery ID: {{delivery_id}}
+  - Received at: {{timestamp}}
+  - PR number:   {{pr_number}}
+  - PR title:    {{title}}
+  - PR URL:      {{url}}
+  - Labels:      {{labels}}
+
+  Step 0 — Guard: only review when labeled `review-agent`
+
+  If `{{action}}` is not `labeled` or `{{labels}}` does not contain
+  `review-agent`, stop here — output "Skipping: event action is {{action}},
+  labels are {{labels}}" and do nothing else.
+
+  Step 1 — Gather context from memory
+
+  Before reviewing, query shared memory for relevant context:
+
+  ```bash
+  agent memory search "{{title}}" --as-actor reviewer --limit 5 --json
+  agent memory search "review findings" --as-actor reviewer --tags reviewer --limit 5 --json
+  ```
+
+  Review the results and factor known recurring issues or past decisions into
+  your evaluation.
+
+  Step 2 — Check the stack position of this PR
+
+  ```bash
+  git-spice log short
+  ```
+
+  This shows where the branch sits in the stack and whether it has a parent PR
+  that should be reviewed first. If the parent PR has not yet been reviewed and
+  merged, note the dependency in your review comment.
+
+  Step 3 — Create an isolated worktree for the review
+
+  Check out the PR branch in a temporary worktree so the review does not
+  disturb the main working tree:
+
+  ```bash
+  REVIEW_DIR="/tmp/agentd-review-{{pr_number}}"
+  gh pr checkout {{pr_number}} --repo geoffjay/agentd --worktree "$REVIEW_DIR" || \
+    git worktree add "$REVIEW_DIR" "origin/$(gh pr view {{pr_number}} --repo geoffjay/agentd --json headRefName --jq '.headRefName')"
+  ```
+
+  All file reads and test runs during the review should be performed from
+  `$REVIEW_DIR` to ensure isolation.
+
+  Step 4 — Fetch the full diff
+
+  ```bash
+  gh pr diff {{pr_number}} --repo geoffjay/agentd
+  ```
+
+  Read the diff carefully, noting each changed file and the nature of the changes.
+
+  Step 5 — Review the changes
+
+  Evaluate the diff against the following criteria:
+
+  a. **Correctness** — Does the code do what the PR description claims?
+  b. **Safety** — Are there security issues, data races, or panic paths?
+  c. **Consistency** — Does the code follow existing patterns in the crate?
+  d. **Tests** — Are new code paths covered by tests? Do existing tests pass?
+  e. **Scope** — Is the change focused on the stated issue without unrelated edits?
+
+  For any files where you need more context, read them from the worktree:
+
+  ```bash
+  cat "$REVIEW_DIR/<path/to/file>"
+  ```
+
+  To run the test suite in the isolated worktree:
+
+  ```bash
+  cd "$REVIEW_DIR" && cargo test 2>&1 | tail -30
+  ```
+
+  Step 6 — Note any stack impact
+
+  If this is a stacked PR, mention in your review whether approval of the parent
+  branch would affect this branch (e.g., merge conflicts, dependent changes).
+
+  Step 7 — Submit the review
+
+  Apply the appropriate label transition:
+
+  - **Approved** — approve and add `merge-queue` label:
+      ```bash
+      gh pr review {{pr_number}} --repo geoffjay/agentd --approve --body "..."
+      gh pr edit {{pr_number}} --repo geoffjay/agentd --add-label "merge-queue"
+      ```
+
+  - **Non-blocking suggestions** — comment only (no label change):
+      ```bash
+      gh pr review {{pr_number}} --repo geoffjay/agentd --comment --body "..."
+      ```
+
+  - **Changes required** — request changes and add `needs-rework` label:
+      ```bash
+      gh pr review {{pr_number}} --repo geoffjay/agentd --request-changes --body "..."
+      gh pr edit {{pr_number}} --repo geoffjay/agentd --add-label "needs-rework"
+      ```
+
+  - **Branch needs rebasing on its parent** — add `needs-restack` label:
+      ```bash
+      gh pr edit {{pr_number}} --repo geoffjay/agentd --add-label "needs-restack"
+      ```
+
+  Step 8 — Remove the `review-agent` label
+
+  ```bash
+  gh pr edit {{pr_number}} --repo geoffjay/agentd --remove-label review-agent
+  ```
+
+  Step 9 — Store findings in memory
+
+  If you found a recurring pattern or notable issue worth tracking across PRs:
+
+  ```bash
+  agent memory remember "<finding>" \
+    --created-by reviewer \
+    --type information \
+    --tags reviewer,pr-{{pr_number}} \
+    --visibility public
+  ```
+
+  Step 10 — Clean up the worktree
+
+  ```bash
+  git worktree remove "$REVIEW_DIR" --force 2>/dev/null || rm -rf "$REVIEW_DIR"
+  ```
+
+  Label reference:
+  - merge-queue   — PR approved; triggers conductor to merge
+  - needs-rework  — changes requested; worker must address feedback and resubmit
+  - needs-restack — branch is behind its parent; worker must run git-spice upstack restack

--- a/.agentd/workflows/webhook-pull-request-reviewer.yml
+++ b/.agentd/workflows/webhook-pull-request-reviewer.yml
@@ -49,10 +49,11 @@ agent: reviewer
 
 source:
   type: webhook
-  # secret: ""  # Set to a random string and configure the same value in GitHub
-                 # webhook settings to enable HMAC-SHA256 signature verification.
-                 # If omitted, all incoming requests are accepted without
-                 # verification (not recommended for production).
+  # secret: "replace-with-a-random-string"  # Configure the same value in GitHub
+                                             # webhook settings to enable HMAC-SHA256
+                                             # signature verification. If omitted, all
+                                             # incoming requests are accepted without
+                                             # verification (not recommended for production).
 
 enabled: false
 
@@ -105,8 +106,9 @@ prompt_template: |
 
   ```bash
   REVIEW_DIR="/tmp/agentd-review-{{pr_number}}"
-  gh pr checkout {{pr_number}} --repo geoffjay/agentd --worktree "$REVIEW_DIR" || \
-    git worktree add "$REVIEW_DIR" "origin/$(gh pr view {{pr_number}} --repo geoffjay/agentd --json headRefName --jq '.headRefName')"
+  BRANCH=$(gh pr view {{pr_number}} --repo geoffjay/agentd --json headRefName --jq '.headRefName')
+  git fetch origin "$BRANCH"
+  git worktree add "$REVIEW_DIR" "origin/$BRANCH"
   ```
 
   All file reads and test runs during the review should be performed from

--- a/crates/orchestrator/src/scheduler/template.rs
+++ b/crates/orchestrator/src/scheduler/template.rs
@@ -19,6 +19,10 @@ use crate::scheduler::types::Task;
 /// | `status`             | dispatch_result        | Completion status (`completed` or `failed`)    |
 /// | `timestamp`          | dispatch_result        | RFC 3339 timestamp of the completion event     |
 /// | `original_source_id` | dispatch_result        | Source ID from the parent dispatch (if any)    |
+/// | `github_event`       | webhook                | GitHub event name (e.g. `pull_request`)        |
+/// | `action`             | webhook                | Event action (e.g. `labeled`, `opened`)        |
+/// | `delivery_id`        | webhook                | GitHub delivery UUID from `X-GitHub-Delivery` |
+/// | `pr_number`          | webhook                | Pull request number (PR/issue webhook events)  |
 pub const KNOWN_VARIABLES: &[&str] = &[
     // Top-level task fields
     "title",
@@ -40,6 +44,11 @@ pub const KNOWN_VARIABLES: &[&str] = &[
     "status",
     "timestamp",
     "original_source_id",
+    // Metadata-backed (webhook triggers)
+    "github_event",
+    "action",
+    "delivery_id",
+    "pr_number",
 ];
 
 /// Validate a prompt template, returning any warnings or errors.
@@ -409,5 +418,65 @@ mod tests {
             result,
             "Cron job fired at 2025-06-01T09:00:00Z (schedule: 0 9 * * MON-FRI).\nRun the daily report generation."
         );
+    }
+
+    // ── Webhook trigger variable tests ───────────────────────────────
+
+    #[test]
+    fn test_validate_webhook_variables_accepted() {
+        let template = "{{github_event}} {{action}} {{delivery_id}} {{pr_number}}";
+        let warnings = validate_template(template);
+        assert!(warnings.is_empty(), "Expected no warnings, got: {:?}", warnings);
+    }
+
+    #[test]
+    fn test_render_webhook_variables() {
+        let mut task = sample_task();
+        task.metadata.insert("github_event".to_string(), "pull_request".to_string());
+        task.metadata.insert("action".to_string(), "labeled".to_string());
+        task.metadata.insert("delivery_id".to_string(), "abc-delivery-123".to_string());
+        task.metadata.insert("pr_number".to_string(), "42".to_string());
+
+        let result = render_template(
+            "Event: {{github_event}}, Action: {{action}}, Delivery: {{delivery_id}}, PR: {{pr_number}}",
+            &task,
+        );
+        assert_eq!(
+            result,
+            "Event: pull_request, Action: labeled, Delivery: abc-delivery-123, PR: 42"
+        );
+    }
+
+    #[test]
+    fn test_validate_all_variables_including_webhook() {
+        let template = "{{title}} {{body}} {{url}} {{labels}} {{assignee}} {{source_id}} {{metadata}} \
+                        {{fire_time}} {{cron_expression}} {{trigger_type}} {{run_at}} {{workflow_id}} \
+                        {{source_workflow_id}} {{dispatch_id}} {{status}} {{timestamp}} {{original_source_id}} \
+                        {{github_event}} {{action}} {{delivery_id}} {{pr_number}}";
+        let warnings = validate_template(template);
+        assert!(warnings.is_empty(), "Expected no warnings, got: {:?}", warnings);
+    }
+
+    #[test]
+    fn test_render_webhook_pr_review_guard_template() {
+        // Simulate a realistic webhook trigger task for a labeled PR event.
+        let mut task = Task {
+            source_id: "webhook:abc-delivery-123".to_string(),
+            title: "fix: address review feedback".to_string(),
+            body: String::new(),
+            url: "https://github.com/geoffjay/agentd/pull/42".to_string(),
+            labels: vec!["review-agent".to_string()],
+            assignee: None,
+            metadata: HashMap::new(),
+        };
+        task.metadata.insert("github_event".to_string(), "pull_request".to_string());
+        task.metadata.insert("action".to_string(), "labeled".to_string());
+        task.metadata.insert("delivery_id".to_string(), "abc-delivery-123".to_string());
+        task.metadata.insert("pr_number".to_string(), "42".to_string());
+
+        let template =
+            "Event: {{github_event}}, Action: {{action}}, PR: {{pr_number}}, Labels: {{labels}}";
+        let result = render_template(template, &task);
+        assert_eq!(result, "Event: pull_request, Action: labeled, PR: 42, Labels: review-agent");
     }
 }

--- a/docs/public/agents/onboarding.md
+++ b/docs/public/agents/onboarding.md
@@ -56,9 +56,10 @@ agent teardown .agentd/
 │   ├── security.yml        # Security auditing
 │   └── architect.yml       # Architecture review
 └── workflows/
-    ├── issue-worker.yml    # Dispatches on work-agent label
-    ├── plan-worker.yml     # Dispatches on plan-agent label
-    ├── pull-request-reviewer.yml
+    ├── issue-worker.yml                   # Dispatches on work-agent label
+    ├── plan-worker.yml                    # Dispatches on plan-agent label
+    ├── pull-request-reviewer.yml          # Polls PRs with review-agent label
+    ├── webhook-pull-request-reviewer.yml  # Webhook-triggered PR review
     ├── docs-worker.yml
     ├── research-worker.yml
     ├── enrichment-worker.yml
@@ -372,7 +373,8 @@ dispatch it to the corresponding agent. **The agent removes the label when it fi
 | `refactor-agent` | `refactor-worker` | refactor agent | Issue |
 | `research-agent` | `research-worker` | research agent | Issue |
 | `security-agent` | `security-worker` | security agent | Issue |
-| `review-agent` | `pull-request-reviewer` | reviewer | Pull request |
+| `review-agent` | `pull-request-reviewer` | reviewer | Pull request (polling) |
+| `review-agent` | `webhook-pull-request-reviewer` | reviewer | Pull request (webhook) |
 | `conductor-sync` | conductor sync | conductor | Manual trigger |
 
 !!! tip "Re-triggering an agent"

--- a/docs/public/pipeline-state-machine.md
+++ b/docs/public/pipeline-state-machine.md
@@ -78,7 +78,8 @@ dispatch the matching agent. The agent removes the label when done.
 | Label | Workflow | Agent | Trigger target |
 |-------|----------|-------|---------------|
 | `work-agent` | issue-worker | worker | Issue |
-| `review-agent` | pull-request-reviewer | reviewer | Pull request |
+| `review-agent` | pull-request-reviewer | reviewer | Pull request (polling) |
+| `review-agent` | webhook-pull-request-reviewer | reviewer | Pull request (webhook) |
 | `plan-agent` | plan-worker | planner | Issue |
 | `docs-agent` | docs-worker | documenter | Issue / PR |
 | `enrich-agent` | enrichment-worker | enricher | Issue |


### PR DESCRIPTION
feat: add webhook-triggered pull request review workflow

feat(workflows): add webhook-triggered pull request review workflow (closes #459)

Add webhook-pull-request-reviewer.yml — a new workflow that triggers
immediately when GitHub delivers a pull_request webhook event rather than
polling on a 60-second interval. Key features:

- webhook trigger type with optional HMAC-SHA256 secret verification
- guard clause: only processes labeled events with the review-agent label
- memory integration: queries shared reviewer memory before each review
- isolated git worktree: checks out the PR branch under /tmp/agentd-review-<pr_number>
  so the review does not disturb the main working tree, then cleans up afterward
- same label transition logic as the polling reviewer (merge-queue, needs-rework,
  needs-restack) with review-agent label removal on completion
- ships as enabled: false; requires GitHub webhook configuration before enabling

Update onboarding.md and pipeline-state-machine.md to document both the
polling and webhook reviewer variants.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>