### PR TITLE
feat: CLI backend selection and PTY session management commands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -985,11 +985,13 @@ version = "0.2.0"
 dependencies = [
  "anyhow",
  "ask",
+ "bytes",
  "chrono",
  "clap",
  "clap_complete",
  "colored",
  "communicate",
+ "crossterm",
  "futures-util",
  "hook",
  "memory",
@@ -1245,6 +1247,32 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "crossterm"
+version = "0.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+dependencies = [
+ "bitflags 2.10.0",
+ "crossterm_winapi",
+ "futures-core",
+ "mio",
+ "parking_lot",
+ "rustix 0.38.44",
+ "signal-hook",
+ "signal-hook-mio",
+ "winapi",
+]
+
+[[package]]
+name = "crossterm_winapi"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "acdd7c62a3665c7f6830a51635d9ac9b23ed385797f70a83bb8bafe9c572ab2b"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "crunchy"
@@ -4141,6 +4169,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69d83b0086dc8ecf3ce9ae2874b2d1290252e2a30720bea58a5c6639b0092873"
 dependencies = [
  "libc",
+ "log",
  "wasi",
  "windows-sys 0.61.2",
 ]
@@ -6018,6 +6047,27 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-mio"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b75a19a7a740b25bc7944bdee6172368f988763b744e3d4dfe753f6b4ece40cc"
+dependencies = [
+ "libc",
+ "mio",
+ "signal-hook",
+]
 
 [[package]]
 name = "signal-hook-registry"
@@ -8018,6 +8068,7 @@ dependencies = [
  "bollard",
  "bytes",
  "chrono",
+ "futures-util",
  "metrics",
  "metrics-exporter-prometheus",
  "portable-pty",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -22,6 +22,8 @@ uuid = { version = "1.11", features = ["serde", "v4"] }
 prettytable-rs = "0.10"
 tokio-tungstenite = { version = "0.26", features = ["connect", "handshake"] }
 futures-util = "0.3"
+crossterm = { version = "0.28", features = ["event-stream"] }
+bytes = "1"
 serde_yaml = "0.9"
 urlencoding = "2.1"
 

--- a/crates/cli/src/commands/wrap.rs
+++ b/crates/cli/src/commands/wrap.rs
@@ -1,43 +1,47 @@
 //! Wrap service command implementations.
 //!
-//! This module implements all subcommands for managing agent launches via the wrap service.
-//! The wrap service is responsible for launching agent CLIs in tmux sessions and monitoring
-//! their lifecycle.
+//! This module implements all subcommands for managing agent launches via the
+//! wrap service. The wrap service supports three execution backends selected
+//! with the `AGENTD_BACKEND` environment variable on the service side:
+//!
+//! | Backend | Description |
+//! |---------|-------------|
+//! | `tmux`  | Detached tmux sessions (default) |
+//! | `docker`| Docker containers |
+//! | `pty`   | In-process PTY sessions — supports interactive attach |
 //!
 //! # Available Commands
 //!
-//! - **launch**: Launch an agent in a tmux session with specified configuration
+//! - **health**  — Check service health
+//! - **info**    — Show active backend type and capabilities
+//! - **list**    — List sessions with backend/capability columns
+//! - **kill**    — Kill a session by name
+//! - **launch**  — Launch an agent session
+//! - **attach**  — Interactively attach to a PTY session (PTY backend only)
 //!
 //! # Examples
 //!
-//! ## Launch a Claude Code agent
+//! ## Show backend info
 //!
 //! ```bash
-//! agentd wrap launch \
-//!   --session-name my-session \
+//! agent wrap info
+//! ```
+//!
+//! ## Launch a PTY session
+//!
+//! ```bash
+//! agent wrap launch my-project \
 //!   --path /path/to/project \
 //!   --agent claude-code \
-//!   --provider anthropic \
-//!   --model claude-sonnet-4.5
+//!   --backend pty
 //! ```
 //!
-//! ## Launch with custom layout
+//! ## Attach to a PTY session
 //!
 //! ```bash
-//! agentd wrap launch \
-//!   --session-name my-session \
-//!   --path /path/to/project \
-//!   --agent opencode \
-//!   --provider openai \
-//!   --model gpt-4 \
-//!   --layout '{"type":"vertical"}'
+//! agent wrap attach my-project
+//! # Press Ctrl-D to detach
 //! ```
-//!
-//! # Output Formatting
-//!
-//! - **launch**: Displays session information and launch status
-//!
-//! All output uses colored terminal formatting for better readability.
 
 use anyhow::{Context, Result};
 use clap::Subcommand;
@@ -46,49 +50,50 @@ use wrap::client::WrapClient;
 use wrap::types::*;
 
 /// Wrap service management subcommands.
-///
-/// Each variant corresponds to a specific operation on the wrap service.
-/// All commands communicate with the wrap service REST API on port 7002.
 #[derive(Subcommand)]
 pub enum WrapCommand {
     /// Check the health of the wrap service.
     Health,
 
-    /// List all active tmux sessions.
+    /// Show the active execution backend type and capabilities.
     ///
-    /// Shows all tmux sessions managed by the wrap service.
+    /// Queries the wrap service for its current backend configuration.
+    Info,
+
+    /// List all active sessions.
+    ///
+    /// Shows sessions managed by the wrap service with their backend type
+    /// and supported capabilities.
     List,
 
-    /// Kill a tmux session by name.
+    /// Kill a session by name.
     ///
-    /// Terminates the specified tmux session and any processes running in it.
+    /// Terminates the specified session and any processes running in it.
     Kill {
         /// Session name to kill
         name: String,
     },
 
-    /// Launch an agent in a tmux session.
+    /// Launch an agent session.
     ///
-    /// Creates a new tmux session and starts the specified agent with the
-    /// given configuration. The agent will run in the background in the
-    /// tmux session.
+    /// Creates a new session and starts the specified agent with the given
+    /// configuration. The session runs in the background.
     ///
     /// # Examples
     ///
     /// ```bash
-    /// # Launch Claude Code
-    /// agentd wrap launch my-project \
-    ///   --path /home/user/projects/my-project \
-    ///   --agent claude-code \
-    ///   --provider anthropic \
-    ///   --model claude-sonnet-4.5
+    /// # Launch with default settings
+    /// agent wrap launch my-project --path /home/user/projects/my-project
     ///
-    /// # Launch with custom tmux layout
-    /// agentd wrap launch my-project \
+    /// # Launch with specific backend hint
+    /// agent wrap launch my-project --path /home/user/project --backend pty
+    ///
+    /// # Launch with custom model
+    /// agent wrap launch my-project \
+    ///   --path /home/user/project \
     ///   --agent opencode \
     ///   --provider openai \
-    ///   --model gpt-4 \
-    ///   --layout-json '{"type":"vertical","panes":2}'
+    ///   --model gpt-4
     /// ```
     Launch {
         /// Session name (required)
@@ -113,26 +118,52 @@ pub enum WrapCommand {
         /// Optional tmux layout configuration as JSON string
         #[arg(long)]
         layout_json: Option<String>,
+
+        /// Requested backend type (tmux, docker, pty).
+        ///
+        /// This is forwarded to the service as a hint. The service uses
+        /// whatever backend is configured via `AGENTD_BACKEND` at startup;
+        /// this flag does not override the service configuration.
+        #[arg(long)]
+        backend: Option<String>,
+    },
+
+    /// Interactively attach to a PTY session.
+    ///
+    /// Opens a raw terminal connected to the named session via the wrap
+    /// service's WebSocket PTY relay. Only available when the wrap service
+    /// is running with the PTY backend (`AGENTD_BACKEND=pty`).
+    ///
+    /// Press **Ctrl-D** to detach cleanly.
+    ///
+    /// # Examples
+    ///
+    /// ```bash
+    /// agent wrap attach my-project
+    /// ```
+    Attach {
+        /// Session name to attach to
+        session: String,
     },
 }
 
 impl WrapCommand {
-    /// Execute the wrap command by dispatching to the appropriate handler.
-    ///
-    /// # Arguments
-    ///
-    /// * `client` - The wrap service client
-    /// * `json` - If true, output raw JSON instead of formatted text
-    ///
-    /// # Returns
-    ///
-    /// Returns `Ok(())` on success, or an error if the command fails.
+    /// Execute the wrap command.
     pub async fn execute(&self, client: &WrapClient, json: bool) -> Result<()> {
         match self {
             WrapCommand::Health => wrap_health(client, json).await,
+            WrapCommand::Info => wrap_info(client, json).await,
             WrapCommand::List => list_sessions(client, json).await,
             WrapCommand::Kill { name } => kill_session(client, name, json).await,
-            WrapCommand::Launch { session_name, path, agent, provider, model, layout_json } => {
+            WrapCommand::Launch {
+                session_name,
+                path,
+                agent,
+                provider,
+                model,
+                layout_json,
+                backend,
+            } => {
                 launch_agent(
                     client,
                     session_name,
@@ -141,27 +172,63 @@ impl WrapCommand {
                     provider.as_deref(),
                     model.as_deref(),
                     layout_json.as_deref(),
+                    backend.as_deref(),
                     json,
                 )
                 .await
             }
+            WrapCommand::Attach { session } => attach_session(client, session).await,
         }
     }
 }
 
+// ---------------------------------------------------------------------------
+// Health
+// ---------------------------------------------------------------------------
+
 async fn wrap_health(client: &WrapClient, json: bool) -> Result<()> {
     client.health().await.context("Failed to reach wrap service. Is it running?")?;
-
     if json {
         println!("{}", serde_json::to_string_pretty(&serde_json::json!({"status": "ok"}))?);
     } else {
         println!("{} {}", "wrap:".bold(), "ok".green().bold());
     }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Info
+// ---------------------------------------------------------------------------
+
+async fn wrap_info(client: &WrapClient, json: bool) -> Result<()> {
+    let info = client.info().await.context("Failed to reach wrap service. Is it running?")?;
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&info)?);
+    } else {
+        println!("{}", "Wrap Service Backend".blue().bold());
+        println!("{}", "=".repeat(40).cyan());
+        println!("{:<16} {}", "Backend:".bold(), info.backend_type.to_string().bright_white());
+        println!("{:<16} {}", "Version:".bold(), info.version.bright_white());
+        if info.capabilities.is_empty() {
+            println!("{:<16} {}", "Capabilities:".bold(), "none".yellow());
+        } else {
+            println!(
+                "{:<16} {}",
+                "Capabilities:".bold(),
+                info.capabilities.join(", ").bright_white()
+            );
+        }
+        println!("{}", "=".repeat(40).cyan());
+    }
 
     Ok(())
 }
 
-/// List all active tmux sessions.
+// ---------------------------------------------------------------------------
+// List
+// ---------------------------------------------------------------------------
+
 async fn list_sessions(client: &WrapClient, json: bool) -> Result<()> {
     let response = client.list_sessions().await.context("Failed to list sessions")?;
 
@@ -170,23 +237,47 @@ async fn list_sessions(client: &WrapClient, json: bool) -> Result<()> {
     } else if response.sessions.is_empty() {
         println!("{}", "No active sessions.".yellow());
     } else {
-        println!("{}", "Active Sessions:".blue().bold());
-        println!("{}", "=".repeat(60).cyan());
+        // Column widths
+        let name_w = response.sessions.iter().map(|s| s.name.len()).max().unwrap_or(4).max(4);
+        let backend_w = 7usize;
+        let status_w = 7usize;
+
+        println!(
+            "{:<name_w$}  {:<backend_w$}  {:<status_w$}  {}",
+            "NAME".bold(),
+            "BACKEND".bold(),
+            "STATUS".bold(),
+            "CAPABILITIES".bold(),
+        );
+        println!("{}", "-".repeat(name_w + backend_w + status_w + 20).cyan());
+
         for session in &response.sessions {
+            let status = if session.active { "running".green() } else { "stopped".red() };
+            let caps = if session.capabilities.is_empty() {
+                "-".to_string()
+            } else {
+                session.capabilities.join(",")
+            };
             println!(
-                "  {}: {}",
+                "{:<name_w$}  {:<backend_w$}  {:<status_w$}  {}",
                 session.name.bright_white(),
-                if session.active { "active".green() } else { "inactive".red() }
+                session.backend.to_string(),
+                status,
+                caps.bright_black(),
             );
         }
-        println!("{}", "=".repeat(60).cyan());
+
+        println!();
         println!("Total: {} session(s)", response.count);
     }
 
     Ok(())
 }
 
-/// Kill a tmux session by name.
+// ---------------------------------------------------------------------------
+// Kill
+// ---------------------------------------------------------------------------
+
 async fn kill_session(client: &WrapClient, name: &str, json: bool) -> Result<()> {
     let response =
         client.kill_session(name).await.context(format!("Failed to kill session '{}'", name))?;
@@ -202,33 +293,10 @@ async fn kill_session(client: &WrapClient, name: &str, json: bool) -> Result<()>
     Ok(())
 }
 
-/// Launch an agent in a tmux session via POST request to the API.
-///
-/// Creates a `LaunchRequest` with the provided configuration and sends it
-/// to the wrap service. The service will create a tmux session and start
-/// the agent with the specified parameters.
-///
-/// # Arguments
-///
-/// * `client` - Wrap service client
-/// * `session_name` - Session name for tmux
-/// * `path` - Working directory path for the agent (can be relative)
-/// * `agent` - Optional agent type (claude-code, opencode, gemini, etc.)
-/// * `provider` - Optional model provider (anthropic, openai, ollama, etc.)
-/// * `model` - Optional model name (claude-sonnet-4.5, gpt-4, etc.)
-/// * `layout_json` - Optional tmux layout configuration as JSON string
-/// * `json` - Whether to output raw JSON
-///
-/// # Returns
-///
-/// Returns `Ok(())` on success after displaying the launch response.
-///
-/// # Errors
-///
-/// Returns an error if:
-/// - The network request fails
-/// - The API returns an error
-/// - The agent fails to launch
+// ---------------------------------------------------------------------------
+// Launch
+// ---------------------------------------------------------------------------
+
 #[allow(clippy::too_many_arguments)]
 async fn launch_agent(
     client: &WrapClient,
@@ -238,47 +306,41 @@ async fn launch_agent(
     provider: Option<&str>,
     model: Option<&str>,
     layout_json: Option<&str>,
+    backend: Option<&str>,
     json: bool,
 ) -> Result<()> {
-    // Expand tilde and resolve the path to an absolute path
-    let expanded_path = if path.starts_with("~/") {
-        // Expand ~ to home directory
+    // Expand ~ and resolve to absolute path
+    let expanded = if path.starts_with("~/") {
         if let Ok(home) = std::env::var("HOME") {
-            path.replacen("~", &home, 1)
+            path.replacen('~', &home, 1)
         } else {
             path.to_string()
         }
     } else if path == "~" {
-        // Handle bare ~ (though unlikely for project paths)
         std::env::var("HOME").unwrap_or_else(|_| path.to_string())
     } else {
         path.to_string()
     };
 
-    let absolute_path = std::path::PathBuf::from(&expanded_path)
+    let absolute_path = std::path::PathBuf::from(&expanded)
         .canonicalize()
-        .context(format!("Failed to resolve project path: {}", expanded_path))?;
+        .context(format!("Failed to resolve project path: {expanded}"))?;
     let project_path = absolute_path.to_str().context("Invalid UTF-8 in project path")?.to_string();
 
-    // Parse layout JSON if provided
     let layout_obj = if let Some(layout_str) = layout_json {
         Some(serde_json::from_str::<TmuxLayout>(layout_str).context("Invalid layout JSON")?)
     } else {
         None
     };
 
-    // Use defaults for optional fields
-    let agent_type = agent.unwrap_or("claude-code").to_string();
-    let model_provider = provider.unwrap_or("anthropic").to_string();
-    let model_name = model.unwrap_or("claude-sonnet-4.5").to_string();
-
     let request = LaunchRequest {
         project_name: session_name.to_string(),
         project_path,
-        agent_type,
-        model_provider,
-        model_name,
+        agent_type: agent.unwrap_or("claude-code").to_string(),
+        model_provider: provider.unwrap_or("anthropic").to_string(),
+        model_name: model.unwrap_or("claude-sonnet-4.5").to_string(),
         layout: layout_obj,
+        backend: backend.map(str::to_string),
     };
 
     let response = client.launch(&request).await.context("Failed to launch agent")?;
@@ -298,14 +360,6 @@ async fn launch_agent(
     Ok(())
 }
 
-/// Display a launch response with formatted, colored output.
-///
-/// Shows all response fields with visual separators and color-coded
-/// success/failure indicators.
-///
-/// # Arguments
-///
-/// * `response` - The launch response to display
 fn display_launch_response(response: &LaunchResponse) {
     println!("{}", "=".repeat(80).cyan());
     println!(
@@ -313,19 +367,141 @@ fn display_launch_response(response: &LaunchResponse) {
         "Status".bold(),
         if response.success { "Success".green() } else { "Failed".red() }
     );
-
-    if let Some(ref session_name) = response.session_name {
-        println!("{}: {}", "Session Name".bold(), session_name.bright_white());
+    if let Some(ref name) = response.session_name {
+        println!("{}: {}", "Session Name".bold(), name.bright_white());
     }
-
     println!("{}: {}", "Message".bold(), response.message);
-
     if let Some(ref error) = response.error {
         println!("{}: {}", "Error".bold().red(), error.bright_red());
     }
-
     println!("{}", "=".repeat(80).cyan());
 }
+
+// ---------------------------------------------------------------------------
+// Attach
+// ---------------------------------------------------------------------------
+
+/// Attach to a PTY session using a raw terminal + WebSocket relay.
+///
+/// Verifies that:
+/// 1. The wrap service is using the PTY backend.
+/// 2. The named session exists.
+///
+/// Then opens the WebSocket terminal endpoint, enables crossterm raw mode,
+/// and bridges stdin/stdout with the remote PTY until Ctrl-D is pressed or
+/// the connection closes.
+async fn attach_session(client: &WrapClient, session: &str) -> Result<()> {
+    // 1. Verify PTY backend is active
+    let info = client.info().await.context("Failed to reach wrap service. Is it running?")?;
+
+    if info.backend_type != BackendType::Pty {
+        anyhow::bail!(
+            "Session attach requires the PTY backend.\n\
+             Active backend: {}\n\
+             Set AGENTD_BACKEND=pty on the wrap service to enable interactive attach.",
+            info.backend_type
+        );
+    }
+
+    // 2. Verify session exists
+    client
+        .get_session(session)
+        .await
+        .with_context(|| format!("Session '{}' not found", session))?;
+
+    // 3. Build WebSocket URL
+    let ws_url = client.terminal_ws_url(session);
+
+    // 4. Connect to the PTY terminal relay
+    let (ws_stream, _) = tokio_tungstenite::connect_async(&ws_url)
+        .await
+        .with_context(|| format!("Failed to connect to terminal at {ws_url}"))?;
+
+    let (mut ws_tx, mut ws_rx) = futures_util::StreamExt::split(ws_stream);
+
+    // 5. Enable raw terminal mode — disable_raw_mode on all exit paths via guard
+    crossterm::terminal::enable_raw_mode().context("Failed to enable raw terminal mode")?;
+
+    struct RawModeGuard;
+    impl Drop for RawModeGuard {
+        fn drop(&mut self) {
+            let _ = crossterm::terminal::disable_raw_mode();
+        }
+    }
+    let _guard = RawModeGuard;
+
+    // Print detach hint before raw mode output begins
+    eprintln!("Attached to '{}'. Press Ctrl-D to detach.\r", session);
+
+    // Send initial terminal size so the server can size the PTY
+    if let Ok((cols, rows)) = crossterm::terminal::size() {
+        let resize = serde_json::json!({"type": "resize", "cols": cols, "rows": rows});
+        let _ = ws_tx
+            .send(tokio_tungstenite::tungstenite::Message::Text(resize.to_string().into()))
+            .await;
+    }
+
+    // 6. I/O relay: stdin → WS (binary), WS → stdout (binary)
+    use futures_util::SinkExt;
+    use std::io::Write as _;
+    use tokio::io::AsyncReadExt as _;
+
+    let mut stdin = tokio::io::stdin();
+    let mut stdout = std::io::stdout();
+    let mut buf = [0u8; 1024];
+
+    let result: Result<()> = loop {
+        tokio::select! {
+            // Terminal stdin → WebSocket
+            n = stdin.read(&mut buf) => {
+                match n {
+                    Ok(0) => break Ok(()), // EOF
+                    Ok(n) => {
+                        let data = &buf[..n];
+                        // Ctrl-D (\x04) detaches
+                        if data.contains(&0x04) {
+                            break Ok(());
+                        }
+                        if ws_tx
+                            .send(tokio_tungstenite::tungstenite::Message::Binary(
+                                bytes::Bytes::copy_from_slice(data),
+                            ))
+                            .await
+                            .is_err()
+                        {
+                            break Ok(()); // WS closed
+                        }
+                    }
+                    Err(e) => break Err(e.into()),
+                }
+            }
+            // WebSocket → terminal stdout
+            msg = futures_util::StreamExt::next(&mut ws_rx) => {
+                match msg {
+                    Some(Ok(tokio_tungstenite::tungstenite::Message::Binary(data))) => {
+                        stdout.write_all(&data)?;
+                        stdout.flush()?;
+                    }
+                    Some(Ok(tokio_tungstenite::tungstenite::Message::Close(_))) | None => {
+                        break Ok(());
+                    }
+                    Some(Err(_)) => break Ok(()),
+                    _ => {}
+                }
+            }
+        }
+    };
+
+    // Drop _guard here → disable_raw_mode runs, then print a clean newline
+    drop(_guard);
+    eprintln!("\r\nDetached from '{}'.", session);
+
+    result
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
 
 #[cfg(test)]
 mod tests {
@@ -339,8 +515,6 @@ mod tests {
             message: "Agent launched successfully".to_string(),
             error: None,
         };
-
-        // This should not panic
         display_launch_response(&response);
     }
 
@@ -349,11 +523,51 @@ mod tests {
         let response = LaunchResponse {
             success: false,
             session_name: None,
-            message: "Failed to start tmux session".to_string(),
-            error: Some("Failed to start tmux session".to_string()),
+            message: "Failed to start session".to_string(),
+            error: Some("Failed to start session".to_string()),
         };
-
-        // This should not panic
         display_launch_response(&response);
+    }
+
+    #[test]
+    fn backend_type_display() {
+        assert_eq!(BackendType::Tmux.to_string(), "tmux");
+        assert_eq!(BackendType::Docker.to_string(), "docker");
+        assert_eq!(BackendType::Pty.to_string(), "pty");
+    }
+
+    #[test]
+    fn backend_type_capabilities() {
+        assert!(BackendType::Pty.capabilities().contains(&"terminal".to_string()));
+        assert!(BackendType::Pty.capabilities().contains(&"interactive".to_string()));
+        assert!(BackendType::Tmux.capabilities().contains(&"attach-tmux".to_string()));
+        assert!(BackendType::Docker.capabilities().contains(&"health-check".to_string()));
+    }
+
+    #[test]
+    fn backend_type_serde_roundtrip() {
+        for bt in [BackendType::Tmux, BackendType::Docker, BackendType::Pty] {
+            let json = serde_json::to_string(&bt).unwrap();
+            let decoded: BackendType = serde_json::from_str(&json).unwrap();
+            assert_eq!(decoded, bt);
+        }
+    }
+
+    #[test]
+    fn terminal_ws_url_converts_scheme() {
+        let client = WrapClient::new("http://localhost:17005");
+        assert_eq!(
+            client.terminal_ws_url("my-session"),
+            "ws://localhost:17005/sessions/my-session/terminal"
+        );
+    }
+
+    #[test]
+    fn terminal_ws_url_https_converts_to_wss() {
+        let client = WrapClient::new("https://example.com:17005");
+        assert_eq!(
+            client.terminal_ws_url("my-session"),
+            "wss://example.com:17005/sessions/my-session/terminal"
+        );
     }
 }

--- a/crates/wrap/Cargo.toml
+++ b/crates/wrap/Cargo.toml
@@ -18,7 +18,8 @@ thiserror = { workspace = true }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 
-axum = { workspace = true }
+axum = { workspace = true, features = ["ws"] }
+futures-util = "0.3"
 tower-http = { workspace = true }
 chrono = { workspace = true }
 uuid = { version = "1.11", features = ["v4", "serde"] }

--- a/crates/wrap/src/api.rs
+++ b/crates/wrap/src/api.rs
@@ -1,164 +1,88 @@
 //! REST API handlers for the wrap service.
 //!
-//! This module provides HTTP endpoints for launching and managing agent sessions
-//! in tmux environments. It uses the Axum web framework to expose a REST API
-//! for the agentd-wrap service.
+//! This module provides HTTP endpoints for launching and managing agent sessions.
+//! It uses the Axum web framework and the [`ExecutionBackend`] abstraction so the
+//! same API works with tmux, Docker, and PTY backends.
 //!
 //! # API Endpoints
 //!
-//! - `GET /health` - Health check endpoint
-//! - `POST /launch` - Launch an agent session in tmux
-//!
-//! # Examples
-//!
-//! ## Creating a Router
-//!
-//! ```no_run
-//! use wrap::api::create_router;
-//!
-//! #[tokio::main]
-//! async fn main() -> anyhow::Result<()> {
-//!     let router = create_router();
-//!
-//!     // Bind and serve
-//!     let listener = tokio::net::TcpListener::bind("127.0.0.1:17005").await?;
-//!     axum::serve(listener, router).await?;
-//!     Ok(())
-//! }
-//! ```
-//!
-//! ## Making Requests
-//!
-//! ```bash
-//! # Health check
-//! curl http://localhost:17005/health
-//!
-//! # Launch an agent session
-//! curl -X POST http://localhost:17005/launch \
-//!   -H "Content-Type: application/json" \
-//!   -d '{
-//!     "session_name": "my-project",
-//!     "path": "/home/user/projects/my-project",
-//!     "agent": "claude-code",
-//!     "provider": "anthropic",
-//!     "model": "claude-sonnet-4.5"
-//!   }'
-//! ```
+//! - `GET /health`                       — Health check
+//! - `GET /info`                         — Active backend type and capabilities
+//! - `POST /launch`                      — Launch an agent session
+//! - `GET /sessions`                     — List active sessions
+//! - `GET /sessions/{name}`              — Get a specific session
+//! - `DELETE /sessions/{name}`           — Kill a session
+//! - `GET /sessions/{name}/terminal`     — WebSocket PTY terminal relay (PTY only)
 
-use crate::{tmux::TmuxManager, types::*};
-use axum::{extract::Path, http::StatusCode, response::IntoResponse, Json, Router};
-use tracing::{error, info};
+use crate::{
+    backend::{ExecutionBackend, SessionConfig},
+    types::*,
+};
+use axum::{
+    extract::{ws::WebSocketUpgrade, Path, State},
+    http::StatusCode,
+    response::IntoResponse,
+    Json, Router,
+};
+use std::sync::Arc;
+use tracing::{error, info, warn};
+
+// ---------------------------------------------------------------------------
+// Shared state
+// ---------------------------------------------------------------------------
+
+/// Shared application state injected into all API handlers.
+#[derive(Clone)]
+pub struct AppState {
+    /// The active execution backend (tmux / docker / pty).
+    pub backend: Arc<dyn ExecutionBackend>,
+    /// The type of the active backend — used for capability reporting.
+    pub backend_type: BackendType,
+}
+
+// ---------------------------------------------------------------------------
+// Router
+// ---------------------------------------------------------------------------
 
 /// Creates and configures the Axum router with all API endpoints.
-///
-/// Sets up all HTTP routes for the wrap service. The router is
-/// ready to be served by Axum's `serve` function.
-///
-/// # Returns
-///
-/// Returns a configured [`Router`] ready to serve HTTP requests.
-///
-/// # Examples
-///
-/// ```no_run
-/// use wrap::api::create_router;
-///
-/// #[tokio::main]
-/// async fn main() -> anyhow::Result<()> {
-///     let router = create_router();
-///
-///     let listener = tokio::net::TcpListener::bind("127.0.0.1:17005").await?;
-///     axum::serve(listener, router).await?;
-///     Ok(())
-/// }
-/// ```
-pub fn create_router() -> Router {
+pub fn create_router(state: AppState) -> Router {
     Router::new()
         .route("/health", axum::routing::get(health_check))
+        .route("/info", axum::routing::get(backend_info))
         .route("/launch", axum::routing::post(launch_session))
         .route("/sessions", axum::routing::get(list_sessions))
         .route("/sessions/{name}", axum::routing::get(get_session).delete(kill_session))
+        .route("/sessions/{name}/terminal", axum::routing::get(terminal_ws))
+        .with_state(state)
 }
 
-/// Health check endpoint handler.
-///
-/// Returns basic service information including status and version.
-/// This endpoint is useful for monitoring and load balancer health checks.
-///
-/// # Endpoint
-///
-/// `GET /health`
-///
-/// # Response
-///
-/// Returns HTTP 200 with JSON body:
-/// ```json
-/// {
-///   "status": "ok",
-///   "version": "0.1.0"
-/// }
-/// ```
-///
-/// # Examples
-///
-/// ```bash
-/// curl http://localhost:17005/health
-/// ```
+// ---------------------------------------------------------------------------
+// Handlers
+// ---------------------------------------------------------------------------
+
+/// `GET /health` — service liveness.
 async fn health_check() -> impl IntoResponse {
     Json(HealthResponse::ok("agentd-wrap", env!("CARGO_PKG_VERSION")))
 }
 
-/// Launch an agent session in a tmux environment.
-///
-/// Creates a new tmux session for the specified project and agent configuration.
-/// The session is created in detached mode and can be attached to by the user.
-///
-/// # Endpoint
-///
-/// `POST /launch`
-///
-/// # Request Body
-///
-/// JSON object with the following fields:
-/// - `session_name` - Unique name for the tmux session
-/// - `path` - Absolute path to the project directory
-/// - `agent` - Type of agent to launch (claude-code, crush, opencode, gemini, general)
-/// - `provider` - Model provider (anthropic, openai, ollama, etc.)
-/// - `model` - Name of the model to use
-/// - `layout` (optional) - Tmux layout configuration as JSON string
-/// - `env` (optional) - Additional environment variables
-///
-/// # Response
-///
-/// Returns HTTP 200 with JSON body containing:
-/// - `session_id` - Unique identifier for the session
-/// - `session_name` - Name of the created tmux session
-/// - `success` - Whether the launch was successful
-/// - `error` (optional) - Error message if launch failed
-/// - `pid` (optional) - Process ID if available
-///
-/// # Errors
-///
-/// - HTTP 400 - Invalid request body
-/// - HTTP 500 - Failed to create tmux session or launch agent
-///
-/// # Examples
-///
-/// ```bash
-/// curl -X POST http://localhost:17005/launch \
-///   -H "Content-Type: application/json" \
-///   -d '{
-///     "session_name": "my-project",
-///     "path": "/home/user/projects/my-project",
-///     "agent": "claude-code",
-///     "provider": "anthropic",
-///     "model": "claude-sonnet-4.5"
-///   }'
-/// ```
-async fn launch_session(Json(req): Json<LaunchRequest>) -> Result<Json<LaunchResponse>, ApiError> {
+/// `GET /info` — active backend type and capabilities.
+async fn backend_info(State(state): State<AppState>) -> impl IntoResponse {
+    let caps = state.backend_type.capabilities();
+    Json(BackendInfo {
+        backend_type: state.backend_type,
+        version: env!("CARGO_PKG_VERSION").to_string(),
+        capabilities: caps,
+    })
+}
+
+/// `POST /launch` — create and start an agent session.
+async fn launch_session(
+    State(state): State<AppState>,
+    Json(req): Json<LaunchRequest>,
+) -> Result<Json<LaunchResponse>, ApiError> {
     info!(
-        "Launching agent session: session={}, agent={}, model={}/{}",
-        req.project_name, req.agent_type, req.model_provider, req.model_name
+        "Launching agent session: session={}, agent={}, model={}/{}, backend={}",
+        req.project_name, req.agent_type, req.model_provider, req.model_name, state.backend_type,
     );
 
     // Validate project path exists
@@ -172,174 +96,110 @@ async fn launch_session(Json(req): Json<LaunchRequest>) -> Result<Json<LaunchRes
         }));
     }
 
-    // Create tmux manager
-    let tmux = TmuxManager::new("agentd");
-
-    // Use the provided session name or generate one
+    // Derive session name (timestamp suffix if project name is empty)
     let session_name = if req.project_name.is_empty() {
-        let timestamp = chrono::Local::now().format("%Y%m%d-%H%M%S");
-        format!("{}-{}", tmux.prefix(), timestamp)
+        let ts = chrono::Local::now().format("%Y%m%d-%H%M%S");
+        format!("{}-{}", state.backend.prefix(), ts)
     } else {
         req.project_name.clone()
     };
 
-    // Create tmux session with layout if provided
-    match tmux.create_session(&session_name, &req.project_path, req.layout.as_ref()) {
-        Ok(_) => {
-            info!("Created tmux session: {}", session_name);
-
-            // Launch agent in the session
-            match launch_agent(&tmux, &session_name, &req) {
-                Ok(_) => {
-                    info!("Successfully launched agent in session: {}", session_name);
-                    Ok(Json(LaunchResponse {
-                        success: true,
-                        session_name: Some(session_name.clone()),
-                        message: format!(
-                            "Agent launched successfully in session: {}",
-                            session_name
-                        ),
-                        error: None,
-                    }))
-                }
-                Err(e) => {
-                    error!("Failed to launch agent: {}", e);
-                    // Kill the session since agent launch failed
-                    let _ = tmux.kill_session(&session_name);
-                    Ok(Json(LaunchResponse {
-                        success: false,
-                        session_name: Some(session_name.clone()),
-                        message: format!("Failed to launch agent: {}", e),
-                        error: Some(e.to_string()),
-                    }))
-                }
-            }
-        }
-        Err(e) => {
-            error!("Failed to create tmux session: {}", e);
-            Ok(Json(LaunchResponse {
-                success: false,
-                session_name: Some(session_name.clone()),
-                message: format!("Failed to create tmux session: {}", e),
-                error: Some(e.to_string()),
-            }))
-        }
-    }
-}
-
-/// Launch the specified agent in a tmux session.
-///
-/// This function sends the appropriate commands to start the agent CLI
-/// based on the agent type and configuration provided in the request.
-///
-/// # Arguments
-///
-/// * `tmux` - The tmux manager instance
-/// * `session_name` - Name of the tmux session to launch the agent in
-/// * `req` - The launch request containing agent configuration
-///
-/// # Returns
-///
-/// Returns `Ok(())` if the agent was launched successfully, or an error
-/// if the agent type is unsupported or the launch command fails.
-fn launch_agent(tmux: &TmuxManager, session_name: &str, req: &LaunchRequest) -> anyhow::Result<()> {
-    // Build the agent launch command based on agent type
-    let command = match req.agent_type.as_str() {
-        "claude-code" => {
-            // Launch Claude Code CLI
-            "claude".to_string()
-        }
-        "crush" => {
-            // Launch Crush CLI
-            "crush".to_string()
-        }
-        "opencode" => {
-            // Launch opencode CLI
-            format!("opencode --model-provider {} --model {}", req.model_provider, req.model_name)
-        }
-        "gemini" => {
-            // Launch Gemini CLI
-            format!("gemini --model {}", req.model_name)
-        }
-        "general" => {
-            // General purpose agent - just start a shell
-            std::env::var("SHELL").unwrap_or_else(|_| "/bin/bash".to_string())
-        }
-        _ => {
-            return Err(anyhow::anyhow!("Unsupported agent type: {}", req.agent_type));
-        }
+    let config = SessionConfig {
+        session_name: session_name.clone(),
+        working_dir: req.project_path.clone(),
+        agent_type: req.agent_type.clone(),
+        model_provider: req.model_provider.clone(),
+        model_name: req.model_name.clone(),
+        layout: req.layout.clone(),
+        network_policy: None,
     };
 
-    // Send the command to the tmux session
-    tmux.send_command(session_name, &command)?;
+    // Create session, then launch agent inside it
+    if let Err(e) = state.backend.create_session(&config).await {
+        error!("Failed to create session '{}': {}", session_name, e);
+        return Ok(Json(LaunchResponse {
+            success: false,
+            session_name: Some(session_name.clone()),
+            message: format!("Failed to create session: {e}"),
+            error: Some(e.to_string()),
+        }));
+    }
+    info!("Created session: {}", session_name);
 
-    Ok(())
+    if let Err(e) = state.backend.launch_agent(&config).await {
+        error!("Failed to launch agent in '{}': {}", session_name, e);
+        let _ = state.backend.kill_session(&session_name).await;
+        return Ok(Json(LaunchResponse {
+            success: false,
+            session_name: Some(session_name.clone()),
+            message: format!("Failed to launch agent: {e}"),
+            error: Some(e.to_string()),
+        }));
+    }
+    info!("Successfully launched agent in session: {}", session_name);
+
+    Ok(Json(LaunchResponse {
+        success: true,
+        session_name: Some(session_name.clone()),
+        message: format!("Agent launched successfully in session: {session_name}"),
+        error: None,
+    }))
 }
 
-/// List all active tmux sessions.
-///
-/// # Endpoint
-///
-/// `GET /sessions`
-///
-/// # Response
-///
-/// Returns HTTP 200 with a list of active sessions.
-async fn list_sessions() -> Result<Json<SessionListResponse>, ApiError> {
-    let tmux = TmuxManager::new("agentd");
-
-    let session_names = tmux.list_sessions().map_err(|e| {
+/// `GET /sessions` — list all active sessions with backend metadata.
+async fn list_sessions(
+    State(state): State<AppState>,
+) -> Result<Json<SessionListResponse>, ApiError> {
+    let names = state.backend.list_sessions().await.map_err(|e| {
         error!("Failed to list sessions: {}", e);
         ApiError::Internal(e)
     })?;
 
-    let sessions: Vec<SessionInfo> =
-        session_names.into_iter().map(|name| SessionInfo { name, active: true }).collect();
+    let caps = state.backend_type.capabilities();
+    let sessions: Vec<SessionInfo> = names
+        .into_iter()
+        .map(|name| SessionInfo {
+            name,
+            active: true,
+            backend: state.backend_type.clone(),
+            capabilities: caps.clone(),
+        })
+        .collect();
 
     let count = sessions.len();
-
     Ok(Json(SessionListResponse { sessions, count }))
 }
 
-/// Get the status of a specific tmux session.
-///
-/// # Endpoint
-///
-/// `GET /sessions/{name}`
-///
-/// # Response
-///
-/// Returns HTTP 200 with session info if found, or HTTP 404 if not found.
-async fn get_session(Path(name): Path<String>) -> Result<Json<SessionInfo>, ApiError> {
-    let tmux = TmuxManager::new("agentd");
-
-    let exists = tmux.session_exists(&name).map_err(|e| {
-        error!("Failed to check session: {}", e);
+/// `GET /sessions/{name}` — get info for a single session.
+async fn get_session(
+    Path(name): Path<String>,
+    State(state): State<AppState>,
+) -> Result<Json<SessionInfo>, ApiError> {
+    let exists = state.backend.session_exists(&name).await.map_err(|e| {
+        error!("Failed to check session '{}': {}", name, e);
         ApiError::Internal(e)
     })?;
 
     if exists {
-        Ok(Json(SessionInfo { name, active: true }))
+        let caps = state.backend_type.capabilities();
+        Ok(Json(SessionInfo {
+            name,
+            active: true,
+            backend: state.backend_type.clone(),
+            capabilities: caps,
+        }))
     } else {
         Err(ApiError::NotFound(format!("Session '{}' not found", name)))
     }
 }
 
-/// Kill/terminate a specific tmux session.
-///
-/// # Endpoint
-///
-/// `DELETE /sessions/{name}`
-///
-/// # Response
-///
-/// Returns HTTP 200 with success status, or HTTP 404 if session not found.
-async fn kill_session(Path(name): Path<String>) -> Result<Json<KillSessionResponse>, ApiError> {
-    let tmux = TmuxManager::new("agentd");
-
-    // Check if session exists first
-    let exists = tmux.session_exists(&name).map_err(|e| {
-        error!("Failed to check session: {}", e);
+/// `DELETE /sessions/{name}` — kill a session.
+async fn kill_session(
+    Path(name): Path<String>,
+    State(state): State<AppState>,
+) -> Result<Json<KillSessionResponse>, ApiError> {
+    let exists = state.backend.session_exists(&name).await.map_err(|e| {
+        error!("Failed to check session '{}': {}", name, e);
         ApiError::Internal(e)
     })?;
 
@@ -347,28 +207,140 @@ async fn kill_session(Path(name): Path<String>) -> Result<Json<KillSessionRespon
         return Err(ApiError::NotFound(format!("Session '{}' not found", name)));
     }
 
-    tmux.kill_session(&name).map_err(|e| {
-        error!("Failed to kill session: {}", e);
+    state.backend.kill_session(&name).await.map_err(|e| {
+        error!("Failed to kill session '{}': {}", name, e);
         ApiError::Internal(e)
     })?;
 
-    info!("Killed tmux session: {}", name);
-
+    info!("Killed session: {}", name);
     Ok(Json(KillSessionResponse {
         success: true,
         message: format!("Session '{}' terminated", name),
     }))
 }
 
-// === Error Handling ===
+// ---------------------------------------------------------------------------
+// PTY WebSocket terminal relay
+// ---------------------------------------------------------------------------
+
+/// `GET /sessions/{name}/terminal` — WebSocket PTY terminal relay.
+///
+/// Streams raw PTY output to the WebSocket client as binary frames and
+/// forwards binary frames from the client as PTY stdin. Text frames are
+/// interpreted as JSON control messages (currently `{"type":"resize","cols":N,"rows":N}`).
+///
+/// Returns `400 Bad Request` for non-PTY backends, or `404` if the session
+/// does not exist or has no PTY stream.
+async fn terminal_ws(
+    ws: WebSocketUpgrade,
+    Path(name): Path<String>,
+    State(state): State<AppState>,
+) -> impl IntoResponse {
+    // Only PTY backend supports terminal streaming
+    if state.backend_type != BackendType::Pty {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({
+                "error": format!(
+                    "Terminal attach requires PTY backend; active backend is '{}'",
+                    state.backend_type
+                )
+            })),
+        )
+            .into_response();
+    }
+
+    // Look up the PTY output stream
+    match state.backend.session_output_stream(&name).await {
+        Err(e) => {
+            error!("Failed to get PTY stream for session '{}': {}", name, e);
+            ApiError::Internal(e).into_response()
+        }
+        Ok(None) => {
+            ApiError::NotFound(format!("Session '{}' not found or has no PTY stream", name))
+                .into_response()
+        }
+        Ok(Some(stream)) => {
+            let backend = Arc::clone(&state.backend);
+            let session_name = name.clone();
+            ws.on_upgrade(move |socket| handle_terminal_ws(socket, stream, backend, session_name))
+        }
+    }
+}
+
+/// Drive the bidirectional PTY ↔ WebSocket relay.
+async fn handle_terminal_ws(
+    mut socket: axum::extract::ws::WebSocket,
+    stream: crate::pty_stream::PtyOutputStream,
+    backend: Arc<dyn ExecutionBackend>,
+    session_name: String,
+) {
+    use axum::extract::ws::Message;
+
+    let (history, mut rx) = stream.subscribe();
+
+    // Replay buffered history so the client sees prior output immediately
+    for chunk in history {
+        if socket.send(Message::Binary(chunk)).await.is_err() {
+            return;
+        }
+    }
+
+    loop {
+        tokio::select! {
+            // PTY output → WebSocket (binary frames)
+            result = rx.recv() => {
+                match result {
+                    Ok(chunk) => {
+                        if socket.send(Message::Binary(chunk)).await.is_err() {
+                            break;
+                        }
+                    }
+                    Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
+                    Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
+                        warn!("WS terminal client lagged {} messages for session '{}'", n, session_name);
+                        // Continue — the client just missed some output
+                    }
+                }
+            }
+            // WebSocket → PTY stdin
+            result = socket.recv() => {
+                match result {
+                    Some(Ok(Message::Binary(data))) => {
+                        if let Err(e) = stream.write_input(&data) {
+                            warn!("Failed to write to PTY '{}': {}", session_name, e);
+                            break;
+                        }
+                    }
+                    Some(Ok(Message::Text(text))) => {
+                        // JSON control frame: {"type":"resize","cols":N,"rows":N}
+                        if let Ok(msg) = serde_json::from_str::<serde_json::Value>(&text) {
+                            if msg.get("type").and_then(|t| t.as_str()) == Some("resize") {
+                                if let (Some(cols), Some(rows)) = (
+                                    msg.get("cols").and_then(|v| v.as_u64()),
+                                    msg.get("rows").and_then(|v| v.as_u64()),
+                                ) {
+                                    let _ = backend
+                                        .resize_session(&session_name, cols as u16, rows as u16)
+                                        .await;
+                                }
+                            }
+                        }
+                    }
+                    Some(Ok(Message::Close(_))) | None => break,
+                    Some(Err(_)) => break,
+                    Some(Ok(_)) => {} // Ping/Pong handled automatically by axum
+                }
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Error type
+// ---------------------------------------------------------------------------
 
 /// API error types for the wrap service.
-///
-/// # HTTP Status Mapping
-///
-/// - `Internal` -> 500 Internal Server Error
-/// - `NotFound` -> 404 Not Found
-/// - `InvalidInput` -> 400 Bad Request
 #[derive(Debug, thiserror::Error)]
 pub enum ApiError {
     /// Internal server error (HTTP 500)
@@ -390,7 +362,6 @@ impl IntoResponse for ApiError {
             ApiError::NotFound(_) => (StatusCode::NOT_FOUND, self.to_string()),
             ApiError::InvalidInput(_) => (StatusCode::BAD_REQUEST, self.to_string()),
         };
-
         (status, Json(serde_json::json!({ "error": message }))).into_response()
     }
 }

--- a/crates/wrap/src/client.rs
+++ b/crates/wrap/src/client.rs
@@ -35,6 +35,7 @@
 //!     model_provider: "anthropic".to_string(),
 //!     model_name: "claude-sonnet-4.5".to_string(),
 //!     layout: None,
+//!     backend: None,
 //! };
 //!
 //! let response = client.launch(&request).await?;
@@ -49,6 +50,9 @@ use crate::types::*;
 use anyhow::{Context, Result};
 use serde::de::DeserializeOwned;
 use serde::Serialize;
+
+// Re-export so callers can build WS URLs without constructing them manually.
+pub use crate::types::BackendInfo;
 
 /// Client for the wrap service REST API.
 ///
@@ -116,6 +120,7 @@ impl WrapClient {
     ///     model_provider: "anthropic".to_string(),
     ///     model_name: "claude-sonnet-4.5".to_string(),
     ///     layout: None,
+    ///     backend: None,
     /// };
     ///
     /// let response = client.launch(&request).await?;
@@ -142,6 +147,25 @@ impl WrapClient {
     /// Kill/terminate a specific session by name.
     pub async fn kill_session(&self, name: &str) -> Result<KillSessionResponse> {
         self.delete(&format!("/sessions/{}", name)).await
+    }
+
+    /// Fetch information about the active execution backend.
+    ///
+    /// Returns [`BackendInfo`] containing the backend type, version, and
+    /// supported capabilities.
+    pub async fn info(&self) -> Result<BackendInfo> {
+        self.get("/info").await
+    }
+
+    /// Build the WebSocket URL for the PTY terminal relay of a session.
+    ///
+    /// The returned URL uses the `ws://` scheme and can be passed directly
+    /// to `tokio-tungstenite::connect_async`.
+    pub fn terminal_ws_url(&self, session_name: &str) -> String {
+        // Convert http:// → ws:// (or https:// → wss://)
+        let ws_base =
+            self.base_url.replacen("https://", "wss://", 1).replacen("http://", "ws://", 1);
+        format!("{}/sessions/{}/terminal", ws_base, session_name)
     }
 
     /// Check the health of the wrap service.

--- a/crates/wrap/src/lib.rs
+++ b/crates/wrap/src/lib.rs
@@ -23,6 +23,7 @@
 //!     model_provider: "anthropic".to_string(),
 //!     model_name: "claude-sonnet-4.5".to_string(),
 //!     layout: None,
+//!     backend: None,
 //! };
 //! # Ok(())
 //! # }
@@ -43,8 +44,8 @@ pub use docker::{DockerBackend, NetworkPolicy};
 pub use pty::PtyBackend;
 pub use pty_stream::PtyOutputStream;
 pub use types::{
-    HealthResponse, KillSessionResponse, LaunchRequest, LaunchResponse, SessionInfo,
-    SessionListResponse, TmuxLayout,
+    BackendInfo, BackendType, HealthResponse, KillSessionResponse, LaunchRequest, LaunchResponse,
+    SessionInfo, SessionListResponse, TmuxLayout,
 };
 
 #[cfg(test)]

--- a/crates/wrap/src/main.rs
+++ b/crates/wrap/src/main.rs
@@ -1,134 +1,106 @@
 //! agentd-wrap service entry point.
 //!
-//! This is the main executable for the wrap service. It provides a REST API
-//! for launching and managing agent sessions in tmux environments.
+//! Provides a REST API for launching and managing agent sessions. The active
+//! execution backend is selected via the `AGENTD_BACKEND` environment variable:
 //!
-//! # Features
-//!
-//! - REST API on `http://127.0.0.1:17005` (dev) or port from AGENTD_PORT env var
-//! - Tmux session management for agent workflows
-//! - Support for multiple agent types (claude-code, opencode, gemini)
-//! - Structured logging with tracing
-//! - Graceful shutdown support
+//! | Value    | Backend                 |
+//! |----------|-------------------------|
+//! | `tmux`   | tmux sessions (default) |
+//! | `docker` | Docker containers       |
+//! | `pty`    | In-process PTY          |
 //!
 //! # Running the Service
 //!
 //! ```bash
-//! # Run with default INFO logging
-//! cargo run -p agentd-wrap
+//! # PTY backend on default port
+//! AGENTD_BACKEND=pty cargo run -p agentd-wrap
 //!
-//! # Run with DEBUG logging
-//! RUST_LOG=debug cargo run -p agentd-wrap
-//!
-//! # Run on a different port
+//! # tmux backend on a custom port
 //! AGENTD_PORT=8080 cargo run -p agentd-wrap
 //! ```
 //!
 //! # Environment Variables
 //!
-//! - `RUST_LOG` - Controls logging level (e.g., `debug`, `info`, `warn`, `error`)
-//!   Defaults to `info` if not set.
-//! - `AGENTD_PORT` - Port to listen on. Defaults to `17005` for development.
-//!
-//! # API Endpoints
-//!
-//! Once running, the service exposes the following endpoints:
-//!
-//! - `GET /health` - Health check
-//! - `POST /launch` - Launch an agent session in tmux
-//!
-//! # Examples
-//!
-//! ```bash
-//! # Start the service
-//! cargo run -p agentd-wrap
-//!
-//! # In another terminal, test the API
-//! curl http://localhost:17005/health
-//!
-//! # Launch a session
-//! curl -X POST http://localhost:17005/launch \
-//!   -H "Content-Type: application/json" \
-//!   -d '{
-//!     "project_name": "my-project",
-//!     "project_path": "/path/to/project",
-//!     "agent_type": "claude-code",
-//!     "model_provider": "anthropic",
-//!     "model_name": "claude-sonnet-4.5"
-//!   }'
-//! ```
+//! - `RUST_LOG`        — Logging level (default: `info`)
+//! - `AGENTD_PORT`     — Listen port (default: `17005`)
+//! - `AGENTD_BACKEND`  — Execution backend: `tmux` | `docker` | `pty` (default: `tmux`)
 
-mod api;
-mod tmux;
-mod types;
+// Import from the library target — avoids re-declaring modules in the binary and
+// triggering dead-code warnings on items that are only used by the library.
+use wrap::{
+    api::{create_router, AppState},
+    backend::{ExecutionBackend, TmuxBackend},
+    docker::{DockerBackend, DEFAULT_IMAGE},
+    pty::PtyBackend,
+    types::BackendType,
+};
 
-use api::create_router;
 use axum::{extract::State, response::IntoResponse, routing::get};
 use metrics_exporter_prometheus::PrometheusHandle;
-use std::env;
+use std::{env, sync::Arc};
 use tracing::info;
 
-/// Initialize Prometheus metrics recorder and return a handle for rendering.
 fn init_metrics() -> PrometheusHandle {
     let builder = metrics_exporter_prometheus::PrometheusBuilder::new();
     let handle = builder.install_recorder().expect("failed to install metrics recorder");
-
-    // Register service metadata gauge
     metrics::gauge!("service_info", "version" => env!("CARGO_PKG_VERSION"), "service" => "wrap")
         .set(1.0);
-
     handle
 }
 
-/// GET /metrics — render Prometheus text format.
 async fn metrics_handler(State(handle): State<PrometheusHandle>) -> impl IntoResponse {
     handle.render()
 }
 
-/// Main entry point for the agentd-wrap service.
-///
-/// This function performs the following initialization steps:
-/// 1. Sets up structured logging with tracing
-/// 2. Creates and configures the Axum HTTP router
-/// 3. Starts the HTTP server on the configured port
-///
-/// # Returns
-///
-/// Returns `Ok(())` on successful shutdown, or an error if initialization
-/// or server startup fails.
-///
-/// # Errors
-///
-/// Returns an error if:
-/// - Unable to bind to the network address
-/// - The HTTP server encounters a fatal error
-///
-/// # Panics
-///
-/// Does not panic under normal operation.
 #[tokio::main]
 async fn main() -> anyhow::Result<()> {
     agentd_common::server::init_tracing();
-
     info!("Starting agentd-wrap service...");
 
-    // Initialize Prometheus metrics
-    let metrics_handle = init_metrics();
+    // --- Select execution backend ---
+    let backend_type = BackendType::from_env();
+    info!("Using execution backend: {}", backend_type);
 
-    // Create API router with metrics endpoint and tracing middleware
+    let exec_backend: Arc<dyn ExecutionBackend> = match &backend_type {
+        BackendType::Pty => {
+            info!("Initialising PTY backend");
+            Arc::new(PtyBackend::new("agentd"))
+        }
+        BackendType::Docker => {
+            info!("Initialising Docker backend");
+            // Fail loudly — an explicit AGENTD_BACKEND=docker request must not
+            // silently degrade to a tmux backend (no container isolation, no
+            // network policies). Fix the Docker configuration and restart.
+            let b = DockerBackend::new("agentd", DEFAULT_IMAGE).map_err(|e| {
+                anyhow::anyhow!(
+                    "AGENTD_BACKEND=docker requested but Docker initialisation failed: {e}\n\
+                     Fix the Docker configuration and restart the service."
+                )
+            })?;
+            Arc::new(b)
+        }
+        BackendType::Tmux => {
+            info!("Initialising tmux backend");
+            Arc::new(TmuxBackend::new("agentd"))
+        }
+    };
+
+    let state = AppState { backend: exec_backend, backend_type };
+
+    // --- Build router ---
+    let metrics_handle = init_metrics();
     let metrics_router =
         axum::Router::new().route("/metrics", get(metrics_handler)).with_state(metrics_handle);
 
-    let app = create_router().merge(metrics_router).layer(agentd_common::server::trace_layer());
+    let app =
+        create_router(state).merge(metrics_router).layer(agentd_common::server::trace_layer());
 
-    // Bind to address (use AGENTD_PORT env var, default 17005 for dev)
+    // --- Bind and serve ---
     let port = env::var("AGENTD_PORT").unwrap_or_else(|_| "17005".to_string());
     let addr = format!("127.0.0.1:{port}");
     let listener = tokio::net::TcpListener::bind(&addr).await?;
     info!("Wrap API server listening on http://{}", addr);
 
-    // Start the HTTP server
     axum::serve(listener, app).await?;
-
     Ok(())
 }

--- a/crates/wrap/src/pty_stream.rs
+++ b/crates/wrap/src/pty_stream.rs
@@ -27,7 +27,7 @@
 //!
 //! # fn make_writer() -> Box<dyn Write + Send> { unimplemented!() }
 //! # fn make_reader() -> Box<dyn std::io::Read + Send + 'static> { unimplemented!() }
-//! # tokio_test::block_on(async {
+//! # async fn example() {
 //! let stream = PtyOutputStream::new(
 //!     DEFAULT_CHANNEL_CAPACITY,
 //!     DEFAULT_HISTORY_BYTES,
@@ -42,7 +42,7 @@
 //!
 //! // Send terminal input
 //! stream.write_input(b"echo hello\n").unwrap();
-//! # });
+//! # }
 //! ```
 
 use bytes::Bytes;

--- a/crates/wrap/src/types.rs
+++ b/crates/wrap/src/types.rs
@@ -4,8 +4,69 @@
 //! with the wrap service REST API.
 
 use serde::{Deserialize, Serialize};
+use std::fmt;
 
-/// Request to launch an agent in a tmux session.
+// ---------------------------------------------------------------------------
+// Backend selection
+// ---------------------------------------------------------------------------
+
+/// The execution backend used to run agent sessions.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum BackendType {
+    /// tmux-based sessions (default)
+    #[default]
+    Tmux,
+    /// Docker container sessions
+    Docker,
+    /// In-process PTY sessions
+    Pty,
+}
+
+impl fmt::Display for BackendType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            BackendType::Tmux => write!(f, "tmux"),
+            BackendType::Docker => write!(f, "docker"),
+            BackendType::Pty => write!(f, "pty"),
+        }
+    }
+}
+
+impl BackendType {
+    /// Read the backend type from the `AGENTD_BACKEND` environment variable.
+    ///
+    /// Returns [`BackendType::Tmux`] if the variable is unset or unrecognised.
+    pub fn from_env() -> Self {
+        match std::env::var("AGENTD_BACKEND").as_deref() {
+            Ok("docker") => BackendType::Docker,
+            Ok("pty") => BackendType::Pty,
+            _ => BackendType::Tmux,
+        }
+    }
+
+    /// Returns the capabilities exposed by this backend.
+    pub fn capabilities(&self) -> Vec<String> {
+        match self {
+            BackendType::Tmux => vec!["attach-tmux".to_string()],
+            BackendType::Docker => vec!["health-check".to_string(), "logs".to_string()],
+            BackendType::Pty => vec!["terminal".to_string(), "interactive".to_string()],
+        }
+    }
+}
+
+/// Information about the active execution backend returned by `GET /info`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct BackendInfo {
+    /// The active backend type
+    pub backend_type: BackendType,
+    /// Service version
+    pub version: String,
+    /// Capabilities supported by this backend
+    pub capabilities: Vec<String>,
+}
+
+/// Request to launch an agent in a session.
 ///
 /// Contains all configuration needed to start an agent CLI with proper
 /// environment and parameters.
@@ -29,6 +90,11 @@ pub struct LaunchRequest {
     /// Optional tmux layout configuration
     #[serde(skip_serializing_if = "Option::is_none")]
     pub layout: Option<TmuxLayout>,
+
+    /// Requested backend override (informational; the service uses whatever
+    /// backend is configured at startup via `AGENTD_BACKEND`).
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub backend: Option<String>,
 }
 
 /// Response from launching an agent.
@@ -54,7 +120,7 @@ pub struct LaunchResponse {
 // Re-export shared HealthResponse from agentd-common.
 pub use agentd_common::types::HealthResponse;
 
-/// Information about a single tmux session.
+/// Information about a single agent session.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SessionInfo {
     /// Session name
@@ -62,6 +128,14 @@ pub struct SessionInfo {
 
     /// Whether the session is currently active
     pub active: bool,
+
+    /// Execution backend for this session
+    #[serde(default)]
+    pub backend: BackendType,
+
+    /// Capabilities of this session's backend
+    #[serde(default)]
+    pub capabilities: Vec<String>,
 }
 
 /// Response listing all active sessions.
@@ -113,6 +187,7 @@ mod tests {
             model_provider: "anthropic".to_string(),
             model_name: "claude-sonnet-4.5".to_string(),
             layout: None,
+            backend: None,
         };
 
         let json = serde_json::to_string(&request).unwrap();
@@ -129,6 +204,7 @@ mod tests {
             model_provider: "openai".to_string(),
             model_name: "gpt-4".to_string(),
             layout: Some(TmuxLayout { layout_type: "vertical".to_string(), panes: Some(2) }),
+            backend: None,
         };
 
         let json = serde_json::to_string(&request).unwrap();
@@ -182,9 +258,18 @@ mod tests {
         assert!(json.contains("3"));
     }
 
+    fn make_session(name: &str) -> SessionInfo {
+        SessionInfo {
+            name: name.to_string(),
+            active: true,
+            backend: BackendType::default(),
+            capabilities: vec![],
+        }
+    }
+
     #[test]
     fn test_session_info_serialization() {
-        let session = SessionInfo { name: "my-session".to_string(), active: true };
+        let session = make_session("my-session");
 
         let json = serde_json::to_string(&session).unwrap();
         assert!(json.contains("my-session"));
@@ -198,10 +283,7 @@ mod tests {
     #[test]
     fn test_session_list_response_serialization() {
         let response = SessionListResponse {
-            sessions: vec![
-                SessionInfo { name: "session-1".to_string(), active: true },
-                SessionInfo { name: "session-2".to_string(), active: true },
-            ],
+            sessions: vec![make_session("session-1"), make_session("session-2")],
             count: 2,
         };
 


### PR DESCRIPTION
feat: CLI backend selection and PTY session management commands

feat(cli,wrap): backend selection and PTY session management commands (closes #677)

- Add BackendType enum and BackendInfo struct to wrap types
- Refactor wrap API to use AppState with shared ExecutionBackend
- Add GET /info endpoint returning active backend + capabilities
- Add WS /sessions/{name}/terminal PTY relay endpoint (PTY backend only)
- Select backend at wrap service startup via AGENTD_BACKEND env var
- Add info() and terminal_ws_url() methods to WrapClient
- Add 'agent wrap info' subcommand to show backend type and capabilities
- Add 'agent wrap attach <session>' for interactive PTY terminal sessions
  - Uses crossterm raw mode, forwards stdin/stdout over WebSocket
  - Detaches cleanly on Ctrl-D; sends initial terminal size on connect
  - Returns clear error for non-PTY backends
- Add --backend flag to 'agent wrap launch' for backend hint
- Update 'agent wrap list' to show BACKEND and CAPABILITIES columns
- Add crossterm and bytes dependencies to CLI crate
- Update all existing SessionInfo/LaunchRequest constructors for new fields