### PR TITLE
fix(ui): auto-focus terminal on interactive mode toggle

### DIFF
--- a/ui/src/components/agents/AgentTerminal.tsx
+++ b/ui/src/components/agents/AgentTerminal.tsx
@@ -207,6 +207,13 @@ export function AgentTerminal({ agentId, readOnly = true }: AgentTerminalProps) 
     // Sync xterm stdin option — disableStdin hides the cursor in read-only mode
     if (termRef.current) {
       termRef.current.options.disableStdin = !interactive
+      // Auto-focus the terminal when switching to interactive mode so the user
+      // can type immediately without having to click inside the terminal canvas.
+      // Without this, focus stays on the toolbar button after the toggle click
+      // and keystrokes never reach xterm's onData handler.
+      if (interactive) {
+        termRef.current.focus()
+      }
     }
   }, [interactive])
 

--- a/ui/src/test/components/agents/AgentTerminal.test.tsx
+++ b/ui/src/test/components/agents/AgentTerminal.test.tsx
@@ -18,6 +18,7 @@ const mockTermOpen = vi.fn()
 const mockTermWrite = vi.fn()
 const mockTermWriteln = vi.fn()
 const mockTermDispose = vi.fn()
+const mockTermFocus = vi.fn()
 const mockOnDataDispose = vi.fn()
 const mockTermOnData = vi.fn(() => ({ dispose: mockOnDataDispose }))
 const mockFitAddonFit = vi.fn()
@@ -39,6 +40,7 @@ vi.mock('@xterm/xterm', () => {
     writeln = mockTermWriteln
     onData = mockTermOnData
     dispose = mockTermDispose
+    focus = mockTermFocus
   }
   return { Terminal }
 })
@@ -159,6 +161,18 @@ describe('AgentTerminal', () => {
       renderTerminal({ readOnly: false })
       fireEvent.click(screen.getByRole('button', { name: /switch to read-only mode/i }))
       expect(screen.getByText('Read-only')).toBeInTheDocument()
+    })
+
+    it('focuses the terminal when switching to interactive mode', () => {
+      renderTerminal({ readOnly: true })
+      fireEvent.click(screen.getByRole('button', { name: /switch to interactive mode/i }))
+      expect(mockTermFocus).toHaveBeenCalledOnce()
+    })
+
+    it('does not focus the terminal when switching to read-only mode', () => {
+      renderTerminal({ readOnly: false })
+      fireEvent.click(screen.getByRole('button', { name: /switch to read-only mode/i }))
+      expect(mockTermFocus).not.toHaveBeenCalled()
     })
   })
 


### PR DESCRIPTION
fix(ui): auto-focus terminal on interactive mode toggle

fix(ui): auto-focus terminal when switching to interactive mode

When the user clicked the Interactive toggle in AgentTerminal, focus
stayed on the toolbar button so keystrokes never reached xterm's onData
handler. Call terminal.focus() when interactive becomes true so the user
can type immediately after toggling.

Add mock focus() to the Terminal mock and two new tests: one confirming
focus is called on toggle-to-interactive, one confirming it is NOT called
on toggle-to-read-only.

Closes #770