### PR TITLE
feat: add PTY mode badge and SDK-mode info banner to AgentTerminal

### DIFF
--- a/ui/src/components/agents/AgentTerminal.tsx
+++ b/ui/src/components/agents/AgentTerminal.tsx
@@ -27,6 +27,7 @@ import '@xterm/xterm/css/xterm.css'
 import {
   ChevronDown,
   ChevronUp,
+  Info,
   Keyboard,
   KeyboardOff,
   Loader2,
@@ -141,6 +142,49 @@ function TerminalStatusBadge({ status }: { status: TerminalStatus }) {
 }
 
 // ---------------------------------------------------------------------------
+// PTY mode badge
+// ---------------------------------------------------------------------------
+
+function TerminalModeBadge({ interactive }: { interactive: boolean }) {
+  return (
+    <span
+      aria-label={interactive ? 'PTY interactive mode' : 'PTY SDK mode'}
+      className="flex items-center gap-1 rounded bg-gray-800 px-1.5 py-0.5 font-mono text-xs text-gray-400"
+    >
+      PTY · {interactive ? 'Interactive' : 'SDK'}
+    </span>
+  )
+}
+
+// ---------------------------------------------------------------------------
+// SDK-mode info banner
+// ---------------------------------------------------------------------------
+
+function SdkModeBanner({ onDismiss }: { onDismiss: () => void }) {
+  return (
+    <div
+      role="note"
+      aria-label="SDK mode info"
+      className="flex items-center gap-2 border-b border-blue-800 bg-blue-950/50 px-3 py-1.5 text-xs text-blue-300"
+    >
+      <Info size={12} aria-hidden="true" className="shrink-0" />
+      <span className="flex-1">
+        SDK mode — This terminal shows raw protocol output. Use the{' '}
+        <strong className="text-blue-200">Logs</strong> tab for structured output.
+      </span>
+      <button
+        type="button"
+        aria-label="Dismiss SDK mode info"
+        onClick={onDismiss}
+        className="rounded p-0.5 text-blue-400 hover:bg-blue-800 hover:text-white"
+      >
+        <X size={12} aria-hidden="true" />
+      </button>
+    </div>
+  )
+}
+
+// ---------------------------------------------------------------------------
 // Unavailable fallback
 // ---------------------------------------------------------------------------
 
@@ -236,6 +280,7 @@ export function AgentTerminal({
   const [sdkMessage, setSdkMessage] = useState('')
   const [sdkSending, setSdkSending] = useState(false)
   const [sdkError, setSdkError] = useState<string | undefined>()
+  const [showSdkBanner, setShowSdkBanner] = useState(true)
 
   // Keep a ref in sync with interactive state so the onData closure can read it
   const interactiveRef = useRef(!readOnly)
@@ -549,7 +594,10 @@ export function AgentTerminal({
     >
       {/* Toolbar */}
       <div className="flex items-center justify-between border-b border-gray-700 bg-gray-900 px-3 py-2">
-        <TerminalStatusBadge status={status} />
+        <div className="flex items-center gap-2">
+          <TerminalStatusBadge status={status} />
+          <TerminalModeBadge interactive={agentInteractive} />
+        </div>
 
         <div className="flex items-center gap-2">
           {/* Search toggle */}
@@ -614,6 +662,11 @@ export function AgentTerminal({
           )}
         </div>
       </div>
+
+      {/* SDK-mode info banner — dismissible, shown by default for SDK agents */}
+      {!agentInteractive && showSdkBanner && (
+        <SdkModeBanner onDismiss={() => setShowSdkBanner(false)} />
+      )}
 
       {/* SDK-mode error banner */}
       {!agentInteractive && sdkError && (

--- a/ui/src/test/components/agents/AgentTerminal.test.tsx
+++ b/ui/src/test/components/agents/AgentTerminal.test.tsx
@@ -144,6 +144,56 @@ describe('AgentTerminal', () => {
   })
 
   // ---------------------------------------------------------------------------
+  // PTY mode badge
+  // ---------------------------------------------------------------------------
+
+  describe('PTY mode badge', () => {
+    it('shows "PTY · Interactive" badge when agentInteractive=true', () => {
+      renderTerminal({ agentInteractive: true })
+      expect(screen.getByLabelText(/pty interactive mode/i)).toBeInTheDocument()
+      expect(screen.getByLabelText(/pty interactive mode/i)).toHaveTextContent('PTY · Interactive')
+    })
+
+    it('shows "PTY · SDK" badge when agentInteractive=false', () => {
+      renderTerminal({ agentInteractive: false })
+      expect(screen.getByLabelText(/pty sdk mode/i)).toBeInTheDocument()
+      expect(screen.getByLabelText(/pty sdk mode/i)).toHaveTextContent('PTY · SDK')
+    })
+
+    it('shows "PTY · SDK" badge by default (agentInteractive omitted)', () => {
+      renderTerminal()
+      expect(screen.getByLabelText(/pty sdk mode/i)).toBeInTheDocument()
+    })
+  })
+
+  // ---------------------------------------------------------------------------
+  // SDK-mode info banner
+  // ---------------------------------------------------------------------------
+
+  describe('SDK-mode info banner', () => {
+    it('shows the info banner by default for SDK-mode agents', () => {
+      renderTerminal({ agentInteractive: false })
+      expect(screen.getByRole('note', { name: /sdk mode info/i })).toBeInTheDocument()
+    })
+
+    it('shows the info banner by default when agentInteractive is omitted', () => {
+      renderTerminal()
+      expect(screen.getByRole('note', { name: /sdk mode info/i })).toBeInTheDocument()
+    })
+
+    it('dismisses the info banner when the × button is clicked', () => {
+      renderTerminal({ agentInteractive: false })
+      fireEvent.click(screen.getByRole('button', { name: /dismiss sdk mode info/i }))
+      expect(screen.queryByRole('note', { name: /sdk mode info/i })).toBeNull()
+    })
+
+    it('does not show the info banner for interactive-mode agents', () => {
+      renderTerminal({ agentInteractive: true })
+      expect(screen.queryByRole('note', { name: /sdk mode info/i })).toBeNull()
+    })
+  })
+
+  // ---------------------------------------------------------------------------
   // Toolbar — interactive toggle (agentInteractive=true only)
   // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
feat: add PTY mode badge and SDK-mode info banner to AgentTerminal

feat(ui): add PTY mode badge and dismissible SDK-mode info banner to AgentTerminal

- Add TerminalModeBadge sub-component showing 'PTY · Interactive' or 'PTY · SDK'
  in the toolbar alongside the connection status badge
- Add SdkModeBanner sub-component: dismissible info note shown by default for
  SDK-mode agents explaining the raw protocol output and directing users to Logs tab
- Add showSdkBanner state (default true); dismissed per-mount via × button
- Import Info icon from lucide-react for the banner
- Add 7 tests: mode badge for both modes, banner visibility/dismiss/absent for interactive

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>