### PR TITLE
feat: add interactive-mode toggle to agent creation form

### DIFF
--- a/ui/src/pages/agents/CreateAgentDialog.tsx
+++ b/ui/src/pages/agents/CreateAgentDialog.tsx
@@ -7,7 +7,7 @@
  */
 
 import { useState } from 'react'
-import { Plus, Trash2, X } from 'lucide-react'
+import { AlertTriangle, ChevronDown, ChevronRight, Plus, Trash2, X } from 'lucide-react'
 import type { CreateAgentRequest, ToolPolicy } from '@/types/orchestrator'
 import { HighlightedCode } from '@/components/common'
 
@@ -178,6 +178,7 @@ export function CreateAgentDialog({ open, onClose, onCreate }: CreateAgentDialog
   const [form, setForm] = useState<FormState>(DEFAULT_FORM)
   const [errors, setErrors] = useState<FormErrors>({})
   const [submitting, setSubmitting] = useState(false)
+  const [advancedOpen, setAdvancedOpen] = useState(false)
 
   function update<K extends keyof FormState>(key: K, value: FormState[K]) {
     setForm((prev) => ({ ...prev, [key]: value }))
@@ -348,36 +349,6 @@ export function CreateAgentDialog({ open, onClose, onCreate }: CreateAgentDialog
               </select>
             </div>
 
-            {/* Interactive toggle */}
-            <div className="flex items-center justify-between">
-              <div>
-                <span className="block text-sm font-medium text-gray-700 dark:text-gray-300">
-                  Interactive
-                </span>
-                <span className="text-xs text-gray-400 dark:text-gray-500">
-                  Run agent in interactive (TTY) mode
-                </span>
-              </div>
-              <button
-                type="button"
-                role="switch"
-                aria-checked={form.interactive}
-                aria-label="Interactive mode"
-                onClick={() => update('interactive', !form.interactive)}
-                className={[
-                  'relative inline-flex h-6 w-11 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 dark:focus:ring-offset-gray-900',
-                  form.interactive ? 'bg-primary-600' : 'bg-gray-200 dark:bg-gray-700',
-                ].join(' ')}
-              >
-                <span
-                  className={[
-                    'inline-block h-4 w-4 rounded-full bg-white shadow transition-transform',
-                    form.interactive ? 'translate-x-6' : 'translate-x-1',
-                  ].join(' ')}
-                />
-              </button>
-            </div>
-
             {/* Prompt — only shown when non-interactive */}
             {!form.interactive && (
               <div>
@@ -452,89 +423,158 @@ export function CreateAgentDialog({ open, onClose, onCreate }: CreateAgentDialog
               )}
             </div>
 
-            {/* Auto-clear Threshold */}
-            <div>
-              <SectionLabel htmlFor="agent-auto-clear" label="Auto-clear Threshold" optional />
-              <input
-                id="agent-auto-clear"
-                type="number"
-                min="1"
-                step="1"
-                value={form.auto_clear_threshold}
-                onChange={(e) => update('auto_clear_threshold', e.target.value)}
-                placeholder="e.g. 100000"
-                className={[
-                  inputCls,
-                  errors.auto_clear_threshold ? 'border-red-500 focus:ring-red-500' : '',
-                ].join(' ')}
-              />
-              <p className="mt-1 text-xs text-gray-400 dark:text-gray-500">
-                Automatically clear context when cumulative input tokens exceed this threshold. Leave empty to disable.
-              </p>
-              <FieldError msg={errors.auto_clear_threshold} />
-            </div>
+            {/* ── Advanced section ─────────────────────────────────────── */}
+            <div className="rounded-md border border-gray-200 dark:border-gray-700">
+              <button
+                type="button"
+                aria-expanded={advancedOpen}
+                aria-controls="create-agent-advanced"
+                onClick={() => setAdvancedOpen((v) => !v)}
+                className="flex w-full items-center justify-between px-4 py-3 text-sm font-medium text-gray-700 hover:bg-gray-50 dark:text-gray-300 dark:hover:bg-gray-800/50"
+              >
+                <span>Advanced</span>
+                {advancedOpen ? <ChevronDown size={15} /> : <ChevronRight size={15} />}
+              </button>
 
-            {/* Shell */}
-            <div>
-              <SectionLabel htmlFor="agent-shell" label="Shell" optional />
-              <input
-                id="agent-shell"
-                type="text"
-                value={form.shell}
-                onChange={(e) => update('shell', e.target.value)}
-                placeholder="/bin/bash"
-                className={inputCls}
-              />
-            </div>
-
-            {/* Environment Variables */}
-            <div>
-              <span className="block text-sm font-medium text-gray-700 dark:text-gray-300">
-                Environment Variables{' '}
-                <span className="text-xs font-normal text-gray-400 dark:text-gray-500">
-                  (optional)
-                </span>
-              </span>
-              <div className="mt-2 space-y-2">
-                {form.env_keys.map((key, i) => (
-                  <div key={i} className="flex items-center gap-2">
-                    <input
-                      type="text"
-                      aria-label={`Environment variable key ${i + 1}`}
-                      value={key}
-                      onChange={(e) => updateEnvKey(i, e.target.value)}
-                      placeholder="KEY"
-                      className={[inputCls, 'flex-1 font-mono text-xs'].join(' ')}
-                    />
-                    <span className="text-gray-400">=</span>
-                    <input
-                      type="text"
-                      aria-label={`Environment variable value ${i + 1}`}
-                      value={form.env_values[i] ?? ''}
-                      onChange={(e) => updateEnvValue(i, e.target.value)}
-                      placeholder="value"
-                      className={[inputCls, 'flex-1 font-mono text-xs'].join(' ')}
-                    />
-                    <button
-                      type="button"
-                      aria-label={`Remove environment variable ${i + 1}`}
-                      onClick={() => removeEnvRow(i)}
-                      disabled={form.env_keys.length === 1}
-                      className="rounded p-1 text-gray-400 hover:text-red-500 disabled:opacity-30"
-                    >
-                      <Trash2 size={13} />
-                    </button>
-                  </div>
-                ))}
-                <button
-                  type="button"
-                  onClick={addEnvRow}
-                  className="flex items-center gap-1 text-xs text-primary-600 hover:text-primary-700 dark:text-primary-400 dark:hover:text-primary-300"
+              {advancedOpen && (
+                <div
+                  id="create-agent-advanced"
+                  className="space-y-5 border-t border-gray-200 px-4 py-4 dark:border-gray-700"
                 >
-                  <Plus size={12} />
-                  Add variable
-                </button>
-              </div>
+                  {/* Interactive mode toggle */}
+                  <div>
+                    <div className="flex items-center justify-between">
+                      <div className="flex-1 pr-4">
+                        <span className="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                          Interactive mode
+                        </span>
+                        <span className="mt-0.5 block text-xs text-gray-400 dark:text-gray-500">
+                          Runs Claude without the SDK protocol. The Terminal tab becomes the
+                          primary interface; you can type directly and the application can inject
+                          prompts via PTY stdin. Cost tracking and tool policies are unavailable
+                          in this mode.
+                        </span>
+                      </div>
+                      <button
+                        type="button"
+                        role="switch"
+                        aria-checked={form.interactive}
+                        aria-label="Interactive mode"
+                        onClick={() => update('interactive', !form.interactive)}
+                        className={[
+                          'relative inline-flex h-6 w-11 flex-shrink-0 items-center rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-primary-500 focus:ring-offset-2 dark:focus:ring-offset-gray-900',
+                          form.interactive ? 'bg-primary-600' : 'bg-gray-200 dark:bg-gray-700',
+                        ].join(' ')}
+                      >
+                        <span
+                          className={[
+                            'inline-block h-4 w-4 rounded-full bg-white shadow transition-transform',
+                            form.interactive ? 'translate-x-6' : 'translate-x-1',
+                          ].join(' ')}
+                        />
+                      </button>
+                    </div>
+                    {form.interactive && (
+                      <div
+                        role="note"
+                        className="mt-2 flex items-start gap-2 rounded-md border border-amber-200 bg-amber-50 px-3 py-2 text-xs text-amber-700 dark:border-amber-800 dark:bg-amber-950/40 dark:text-amber-400"
+                      >
+                        <AlertTriangle size={13} className="mt-0.5 shrink-0" aria-hidden="true" />
+                        <span>
+                          Interactive mode enabled. Cost tracking and tool policies will not be
+                          available for this agent. The initial prompt field is also disabled.
+                        </span>
+                      </div>
+                    )}
+                  </div>
+
+                  {/* Auto-clear Threshold */}
+                  <div>
+                    <SectionLabel htmlFor="agent-auto-clear" label="Auto-clear Threshold" optional />
+                    <input
+                      id="agent-auto-clear"
+                      type="number"
+                      min="1"
+                      step="1"
+                      value={form.auto_clear_threshold}
+                      onChange={(e) => update('auto_clear_threshold', e.target.value)}
+                      placeholder="e.g. 100000"
+                      className={[
+                        inputCls,
+                        errors.auto_clear_threshold ? 'border-red-500 focus:ring-red-500' : '',
+                      ].join(' ')}
+                    />
+                    <p className="mt-1 text-xs text-gray-400 dark:text-gray-500">
+                      Automatically clear context when cumulative input tokens exceed this
+                      threshold. Leave empty to disable.
+                    </p>
+                    <FieldError msg={errors.auto_clear_threshold} />
+                  </div>
+
+                  {/* Shell */}
+                  <div>
+                    <SectionLabel htmlFor="agent-shell" label="Shell" optional />
+                    <input
+                      id="agent-shell"
+                      type="text"
+                      value={form.shell}
+                      onChange={(e) => update('shell', e.target.value)}
+                      placeholder="/bin/bash"
+                      className={inputCls}
+                    />
+                  </div>
+
+                  {/* Environment Variables */}
+                  <div>
+                    <span className="block text-sm font-medium text-gray-700 dark:text-gray-300">
+                      Environment Variables{' '}
+                      <span className="text-xs font-normal text-gray-400 dark:text-gray-500">
+                        (optional)
+                      </span>
+                    </span>
+                    <div className="mt-2 space-y-2">
+                      {form.env_keys.map((key, i) => (
+                        <div key={i} className="flex items-center gap-2">
+                          <input
+                            type="text"
+                            aria-label={`Environment variable key ${i + 1}`}
+                            value={key}
+                            onChange={(e) => updateEnvKey(i, e.target.value)}
+                            placeholder="KEY"
+                            className={[inputCls, 'flex-1 font-mono text-xs'].join(' ')}
+                          />
+                          <span className="text-gray-400">=</span>
+                          <input
+                            type="text"
+                            aria-label={`Environment variable value ${i + 1}`}
+                            value={form.env_values[i] ?? ''}
+                            onChange={(e) => updateEnvValue(i, e.target.value)}
+                            placeholder="value"
+                            className={[inputCls, 'flex-1 font-mono text-xs'].join(' ')}
+                          />
+                          <button
+                            type="button"
+                            aria-label={`Remove environment variable ${i + 1}`}
+                            onClick={() => removeEnvRow(i)}
+                            disabled={form.env_keys.length === 1}
+                            className="rounded p-1 text-gray-400 hover:text-red-500 disabled:opacity-30"
+                          >
+                            <Trash2 size={13} />
+                          </button>
+                        </div>
+                      ))}
+                      <button
+                        type="button"
+                        onClick={addEnvRow}
+                        className="flex items-center gap-1 text-xs text-primary-600 hover:text-primary-700 dark:text-primary-400 dark:hover:text-primary-300"
+                      >
+                        <Plus size={12} />
+                        Add variable
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              )}
             </div>
           </div>
         </form>

--- a/ui/src/test/pages/agents/CreateAgentDialog.test.tsx
+++ b/ui/src/test/pages/agents/CreateAgentDialog.test.tsx
@@ -1,0 +1,201 @@
+/**
+ * CreateAgentDialog tests.
+ *
+ * Covers rendering, interactive-mode toggle behaviour, the Advanced
+ * collapsible section, form submission, and validation.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { CreateAgentDialog } from '@/pages/agents/CreateAgentDialog'
+import type { CreateAgentRequest } from '@/types/orchestrator'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function renderDialog(
+  props: Partial<Parameters<typeof CreateAgentDialog>[0]> = {},
+) {
+  const onClose = vi.fn()
+  const onCreate = vi.fn().mockResolvedValue(undefined)
+
+  render(
+    <CreateAgentDialog
+      open={true}
+      onClose={onClose}
+      onCreate={onCreate}
+      {...props}
+    />,
+  )
+
+  return { onClose, onCreate }
+}
+
+/** Open the Advanced collapsible section. */
+function openAdvanced() {
+  fireEvent.click(screen.getByRole('button', { name: /advanced/i }))
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('CreateAgentDialog', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  // ── Rendering ────────────────────────────────────────────────────────────
+
+  it('renders the dialog with the correct title', () => {
+    renderDialog()
+    expect(screen.getByRole('dialog', { name: /create agent/i })).toBeInTheDocument()
+  })
+
+  it('does not render when open=false', () => {
+    renderDialog({ open: false })
+    expect(screen.queryByRole('dialog')).toBeNull()
+  })
+
+  it('renders required fields: name and working directory', () => {
+    renderDialog()
+    expect(screen.getByLabelText(/name/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/working directory/i)).toBeInTheDocument()
+  })
+
+  // ── Advanced section ─────────────────────────────────────────────────────
+
+  it('Advanced section is collapsed by default', () => {
+    renderDialog()
+    expect(screen.queryByLabelText(/interactive mode/i)).toBeNull()
+  })
+
+  it('Advanced section expands when the header is clicked', () => {
+    renderDialog()
+    openAdvanced()
+    expect(screen.getByRole('switch', { name: /interactive mode/i })).toBeInTheDocument()
+  })
+
+  it('Advanced section collapses when the header is clicked again', () => {
+    renderDialog()
+    openAdvanced()
+    fireEvent.click(screen.getByRole('button', { name: /advanced/i }))
+    expect(screen.queryByRole('switch', { name: /interactive mode/i })).toBeNull()
+  })
+
+  it('shell and environment variable fields are inside the Advanced section', () => {
+    renderDialog()
+    // Fields not visible before opening
+    expect(screen.queryByLabelText(/shell/i)).toBeNull()
+    openAdvanced()
+    expect(screen.getByLabelText(/shell/i)).toBeInTheDocument()
+    expect(screen.getByLabelText(/environment variable key 1/i)).toBeInTheDocument()
+  })
+
+  // ── Interactive mode toggle ───────────────────────────────────────────────
+
+  it('interactive toggle defaults to off (aria-checked=false)', () => {
+    renderDialog()
+    openAdvanced()
+    expect(screen.getByRole('switch', { name: /interactive mode/i })).toHaveAttribute(
+      'aria-checked',
+      'false',
+    )
+  })
+
+  it('toggling interactive on changes aria-checked to true', () => {
+    renderDialog()
+    openAdvanced()
+    fireEvent.click(screen.getByRole('switch', { name: /interactive mode/i }))
+    expect(screen.getByRole('switch', { name: /interactive mode/i })).toHaveAttribute(
+      'aria-checked',
+      'true',
+    )
+  })
+
+  it('shows the interactive mode description text', () => {
+    renderDialog()
+    openAdvanced()
+    expect(screen.getByText(/runs claude without the sdk protocol/i)).toBeInTheDocument()
+  })
+
+  it('shows a warning note when interactive mode is enabled', () => {
+    renderDialog()
+    openAdvanced()
+    // No warning before toggling
+    expect(screen.queryByRole('note')).toBeNull()
+    fireEvent.click(screen.getByRole('switch', { name: /interactive mode/i }))
+    expect(screen.getByRole('note')).toBeInTheDocument()
+    expect(screen.getByRole('note')).toHaveTextContent(/cost tracking and tool policies/i)
+  })
+
+  it('hides the warning note when interactive mode is toggled back off', () => {
+    renderDialog()
+    openAdvanced()
+    fireEvent.click(screen.getByRole('switch', { name: /interactive mode/i }))
+    fireEvent.click(screen.getByRole('switch', { name: /interactive mode/i }))
+    expect(screen.queryByRole('note')).toBeNull()
+  })
+
+  it('hides the initial Prompt field when interactive mode is enabled', () => {
+    renderDialog()
+    // Use placeholder text to unambiguously identify the initial prompt textarea
+    // (avoids matching "System Prompt" label which also contains "prompt").
+    expect(
+      screen.getByPlaceholderText(/initial prompt for the agent/i),
+    ).toBeInTheDocument()
+    openAdvanced()
+    fireEvent.click(screen.getByRole('switch', { name: /interactive mode/i }))
+    expect(
+      screen.queryByPlaceholderText(/initial prompt for the agent/i),
+    ).toBeNull()
+  })
+
+  // ── Form submission ───────────────────────────────────────────────────────
+
+  it('calls onCreate with interactive=false by default', async () => {
+    const { onCreate } = renderDialog()
+
+    fireEvent.change(screen.getByLabelText(/name/i), { target: { value: 'my-agent' } })
+    fireEvent.change(screen.getByLabelText(/working directory/i), {
+      target: { value: '/tmp/work' },
+    })
+    fireEvent.click(screen.getByRole('button', { name: /create agent/i }))
+
+    await waitFor(() => expect(onCreate).toHaveBeenCalledOnce())
+    const request = onCreate.mock.calls[0][0] as CreateAgentRequest
+    expect(request.interactive).toBe(false)
+  })
+
+  it('calls onCreate with interactive=true when toggled on', async () => {
+    const { onCreate } = renderDialog()
+
+    fireEvent.change(screen.getByLabelText(/name/i), { target: { value: 'pty-agent' } })
+    fireEvent.change(screen.getByLabelText(/working directory/i), {
+      target: { value: '/tmp/work' },
+    })
+    openAdvanced()
+    fireEvent.click(screen.getByRole('switch', { name: /interactive mode/i }))
+    fireEvent.click(screen.getByRole('button', { name: /create agent/i }))
+
+    await waitFor(() => expect(onCreate).toHaveBeenCalledOnce())
+    const request = onCreate.mock.calls[0][0] as CreateAgentRequest
+    expect(request.interactive).toBe(true)
+  })
+
+  // ── Validation ────────────────────────────────────────────────────────────
+
+  it('shows validation errors when required fields are empty', async () => {
+    renderDialog()
+    fireEvent.click(screen.getByRole('button', { name: /create agent/i }))
+    await waitFor(() => expect(screen.getByText(/name is required/i)).toBeInTheDocument())
+    expect(screen.getByText(/working directory is required/i)).toBeInTheDocument()
+  })
+
+  it('calls onClose when Cancel is clicked', () => {
+    const { onClose } = renderDialog()
+    fireEvent.click(screen.getByRole('button', { name: /cancel/i }))
+    expect(onClose).toHaveBeenCalledOnce()
+  })
+})


### PR DESCRIPTION
feat: add interactive-mode toggle to agent creation form

feat(ui): add interactive-mode toggle to Advanced section of agent creation form (closes #775)

- Move interactive mode toggle into a collapsible Advanced section
  (collapsed by default) alongside Shell, Auto-clear, and Environment
  Variables — keeps the primary form uncluttered
- Update toggle description to the full text from the issue spec:
  'Runs Claude without the SDK protocol. The Terminal tab becomes the
  primary interface; you can type directly and the application can inject
  prompts via PTY stdin. Cost tracking and tool policies are unavailable
  in this mode.'
- Add amber warning note that appears when interactive=true, reminding
  users that cost tracking, tool policies, and the initial prompt are
  unavailable
- CreateAgentRequest.interactive is already included in buildRequest()
  and defaults to false — no payload changes needed
- AgentConfigPanel already shows config.interactive as 'Yes (TTY)' / 'No'
  — no changes needed there either
- Add 17-test suite for CreateAgentDialog covering: rendering, Advanced
  section expand/collapse, toggle behaviour, warning note visibility,
  Prompt field hiding, form submission payload, and validation

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>