### PR TITLE
spike: investigate and fix ANSI color support in AgentTerminal

### DIFF
--- a/crates/wrap/src/pty.rs
+++ b/crates/wrap/src/pty.rs
@@ -84,6 +84,18 @@ impl ExecutionBackend for PtyBackend {
             // Build a simple shell command — agent is launched in launch_agent()
             let mut cmd = CommandBuilder::new_default_prog();
             cmd.cwd(&working_dir);
+            // Ensure color output works inside the PTY. Without these, Claude Code
+            // and shell tools detect a non-color terminal and emit plain text:
+            //   - TERM=xterm-256color   tells the shell and CLI tools the terminal
+            //     supports 256-color ANSI sequences.
+            //   - COLORTERM=truecolor   enables 24-bit color for tools that check it
+            //     (e.g. bat, delta, some editors).
+            //   - FORCE_COLOR=1         overrides Claude Code's isatty heuristic so
+            //     it always emits ANSI escape sequences even if the detection path
+            //     inside the spawned process is uncertain.
+            cmd.env("TERM", "xterm-256color");
+            cmd.env("COLORTERM", "truecolor");
+            cmd.env("FORCE_COLOR", "1");
 
             let child = pair.slave.spawn_command(cmd).context("Failed to spawn shell in PTY")?;
             let writer = pair.master.take_writer().context("Failed to get PTY writer")?;


### PR DESCRIPTION
spike: investigate and fix ANSI color support in AgentTerminal

spike(ui): investigate and fix ANSI color support in AgentTerminal (closes #783)

Investigation findings:

1. PTY TERM env (FIXED): The PTY backend (crates/wrap/src/pty.rs) spawned the
   shell via CommandBuilder without setting TERM, COLORTERM, or FORCE_COLOR.
   Without TERM=xterm-256color the shell and CLI tools (including Claude Code)
   default to monochrome output. Fixed by adding all three env vars.

2. xterm.js theme (OK - no change needed): AgentTerminal.tsx already has a
   full 16-color ANSI palette in TERMINAL_THEME (lines 69-93), foreground,
   background, cursor, selection, and all bright variants. No fix required.

3. Binary frame pipeline (OK - no change needed): orchestrator/src/websocket.rs
   relays raw PTY bytes as binary WebSocket frames directly into
   term.write(new Uint8Array(event.data)) with no transformation. ANSI escape
   sequences pass through intact.

4. Claude Code color detection (FIXED via FORCE_COLOR=1): Claude Code may
   bypass color output if its isatty heuristic is uncertain. FORCE_COLOR=1
   overrides that check. COLORTERM=truecolor enables 24-bit color for tools
   that inspect it (bat, delta, etc.).

Remaining effort: None — all root causes are trivially addressed by this commit.

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>