### PR TITLE
feat: use HighlightedCode for launch command display

### DIFF
--- a/ui/src/components/agents/AgentConfigPanel.tsx
+++ b/ui/src/components/agents/AgentConfigPanel.tsx
@@ -82,6 +82,29 @@ function EnvVarsRow({ env }: { env: Record<string, string> }) {
   )
 }
 
+// ---------------------------------------------------------------------------
+// Launch command helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Replace the system prompt value in a launch command string with a
+ * `<system prompt>` placeholder so the full (potentially long) prompt text
+ * is not duplicated in the debug view.
+ *
+ * The command builder shell-escapes the system prompt using single-quote
+ * POSIX escaping (`'value'` with embedded `'` replaced by `'\''`), so we
+ * reconstruct the same escaped form and replace it with the placeholder.
+ */
+function redactSystemPromptInCommand(command: string, systemPrompt: string | undefined | null): string {
+  if (!systemPrompt) return command
+  const escaped = systemPrompt.replace(/'/g, "'\\''")
+  return command.replace(`--system-prompt '${escaped}'`, "--system-prompt '<system prompt>'")
+}
+
+// ---------------------------------------------------------------------------
+// System prompt row
+// ---------------------------------------------------------------------------
+
 function SystemPromptRow({ prompt }: { prompt: string }) {
   const [expanded, setExpanded] = useState(false)
   const isLong = prompt.length > 200
@@ -438,13 +461,18 @@ export function AgentConfigPanel({ agent, onAddDir, onRemoveDir }: AgentConfigPa
           />
 
           {agent.launch_command && (
-            <div className="flex flex-col gap-0.5 sm:flex-row sm:gap-4">
-              <span className="w-36 flex-shrink-0 text-xs font-medium text-gray-400 dark:text-gray-500">
+            <div className="flex flex-col gap-1">
+              <span className="text-xs font-medium text-gray-400 dark:text-gray-500">
                 Launch Command
               </span>
-              <code className="min-w-0 flex-1 break-all rounded bg-gray-100 px-2 py-1 font-mono text-xs text-gray-800 dark:bg-gray-800 dark:text-gray-200">
-                {agent.launch_command}
-              </code>
+              <div data-testid="launch-command-code">
+                <HighlightedCode
+                  code={redactSystemPromptInCommand(agent.launch_command, config.system_prompt)}
+                  language="bash"
+                  maxHeight="12rem"
+                  className="border border-gray-200 dark:border-gray-700"
+                />
+              </div>
             </div>
           )}
         </div>

--- a/ui/src/test/components/agents/AgentConfigPanel.test.tsx
+++ b/ui/src/test/components/agents/AgentConfigPanel.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi } from 'vitest'
 import { render, screen, fireEvent } from '@testing-library/react'
 import { AgentConfigPanel } from '@/components/agents/AgentConfigPanel'
 import { makeAgent } from '@/test/mocks/factories'
+import type { AgentConfig } from '@/types/orchestrator'
 
 describe('AgentConfigPanel', () => {
   it('renders configuration section', () => {
@@ -133,7 +134,32 @@ describe('AgentConfigPanel', () => {
     const agent = makeAgent({ launch_command: cmd })
     render(<AgentConfigPanel agent={agent} />)
     expect(screen.getByText('Launch Command')).toBeInTheDocument()
-    expect(screen.getByText(cmd)).toBeInTheDocument()
+    // HighlightedCode renders the command via react-shiki which splits text
+    // into syntax-highlighted spans. Verify the highlighted code block is
+    // rendered rather than searching for the raw command string.
+    expect(screen.getByTestId('launch-command-code')).toBeInTheDocument()
+  })
+
+  it('redacts system prompt in launch command display', () => {
+    const systemPrompt = 'You are a helpful assistant'
+    const cmd = `claude --sdk-url ws://localhost:7006/ws/abc --system-prompt '${systemPrompt}' --model sonnet`
+    const agent = makeAgent({
+      launch_command: cmd,
+      config: {
+        working_dir: '/tmp',
+        shell: '/bin/bash',
+        interactive: false,
+        tool_policy: { mode: 'allow_all' },
+        system_prompt: systemPrompt,
+      } as AgentConfig,
+    })
+    render(<AgentConfigPanel agent={agent} />)
+    // The highlighted code block should be present
+    const codeBlock = screen.getByTestId('launch-command-code')
+    expect(codeBlock).toBeInTheDocument()
+    // The raw system prompt text should not appear inside the launch command block
+    // (it may still appear in the SystemPromptRow above, but not here)
+    expect(codeBlock.textContent).not.toContain(systemPrompt)
   })
 
   it('does not show launch command row when absent', () => {


### PR DESCRIPTION
feat: use HighlightedCode for launch command display

feat(ui): use HighlightedCode for launch command and redact system prompt (closes #790)

- Replace plain <code> element with HighlightedCode component using bash syntax highlighting
- Add redactSystemPromptInCommand helper that replaces the shell-escaped system prompt value with '<system prompt>' placeholder to avoid duplicating it in the debug view
- Add data-testid="launch-command-code" wrapper for reliable test selection
- Update and extend AgentConfigPanel tests to cover launch command display and system prompt redaction