### PR TITLE
feat: add Linear webhook payload parsing

### DIFF
--- a/crates/cli/src/commands/apply.rs
+++ b/crates/cli/src/commands/apply.rs
@@ -655,7 +655,9 @@ pub async fn apply_workflow_file(
         SourceTemplate::DispatchResult { source_workflow_id, status } => {
             TriggerConfig::DispatchResult { source_workflow_id, status }
         }
-        SourceTemplate::Webhook { secret } => TriggerConfig::Webhook { secret },
+        SourceTemplate::Webhook { secret } => {
+            TriggerConfig::Webhook { secret, source: Default::default() }
+        }
         SourceTemplate::Manual {} => TriggerConfig::Manual {},
         SourceTemplate::LinearIssues { team_key, project, status, labels, assignee } => {
             TriggerConfig::LinearIssues { team_key, project, status, labels, assignee }

--- a/crates/cli/src/commands/orchestrator.rs
+++ b/crates/cli/src/commands/orchestrator.rs
@@ -2326,9 +2326,10 @@ async fn create_workflow(
                 run_at.ok_or_else(|| anyhow::anyhow!("--run-at is required for delay trigger"))?;
             TriggerConfig::Delay { run_at: run_at_val.to_string() }
         }
-        TriggerType::Webhook => {
-            TriggerConfig::Webhook { secret: webhook_secret.map(|s| s.to_string()) }
-        }
+        TriggerType::Webhook => TriggerConfig::Webhook {
+            secret: webhook_secret.map(|s| s.to_string()),
+            source: Default::default(),
+        },
         TriggerType::Manual => TriggerConfig::Manual {},
         TriggerType::LinearIssues => {
             // At least one filter must be provided (validated server-side too,
@@ -2696,7 +2697,7 @@ fn display_workflow(workflow: &WorkflowResponse) {
                 println!("{}: {}", "Status Filter".bold(), s);
             }
         }
-        TriggerConfig::Webhook { secret } => {
+        TriggerConfig::Webhook { secret, .. } => {
             let secret_display = if secret.is_some() { "configured" } else { "none" };
             println!("{}: {}", "Secret".bold(), secret_display);
         }
@@ -3684,10 +3685,11 @@ mod tests {
         w.trigger_config = TriggerConfig::Delay { run_at: "2026-12-01T00:00:00Z".into() };
         display_workflow(&w);
 
-        w.trigger_config = TriggerConfig::Webhook { secret: Some("s3cret".into()) };
+        w.trigger_config =
+            TriggerConfig::Webhook { secret: Some("s3cret".into()), source: Default::default() };
         display_workflow(&w);
 
-        w.trigger_config = TriggerConfig::Webhook { secret: None };
+        w.trigger_config = TriggerConfig::Webhook { secret: None, source: Default::default() };
         display_workflow(&w);
 
         w.trigger_config = TriggerConfig::Manual {};
@@ -3806,8 +3808,8 @@ mod tests {
         let configs = vec![
             TriggerConfig::Cron { expression: "0 */6 * * *".into() },
             TriggerConfig::Delay { run_at: "2026-12-01T00:00:00Z".into() },
-            TriggerConfig::Webhook { secret: Some("s3cret".into()) },
-            TriggerConfig::Webhook { secret: None },
+            TriggerConfig::Webhook { secret: Some("s3cret".into()), source: Default::default() },
+            TriggerConfig::Webhook { secret: None, source: Default::default() },
             TriggerConfig::Manual {},
             TriggerConfig::LinearIssues {
                 team_key: Some("ENG".into()),
@@ -3876,7 +3878,9 @@ mod tests {
         .is_implemented());
         assert!(TriggerConfig::Cron { expression: "* * * * *".into() }.is_implemented());
         assert!(TriggerConfig::Delay { run_at: "2026-01-01T00:00:00Z".into() }.is_implemented());
-        assert!(TriggerConfig::Webhook { secret: None }.is_implemented());
+        assert!(
+            TriggerConfig::Webhook { secret: None, source: Default::default() }.is_implemented()
+        );
         assert!(TriggerConfig::Manual {}.is_implemented());
         assert!(TriggerConfig::LinearIssues {
             team_key: Some("ENG".into()),

--- a/crates/orchestrator/src/scheduler/api.rs
+++ b/crates/orchestrator/src/scheduler/api.rs
@@ -1,7 +1,7 @@
 use crate::api::ApiError;
 use crate::manager::AgentManager;
 use crate::scheduler::template::validate_template;
-use crate::scheduler::types::*;
+use crate::scheduler::types::{WebhookSource, *};
 use crate::scheduler::webhook;
 use crate::scheduler::Scheduler;
 use crate::types::{clamp_limit, AgentStatus, PaginatedResponse};
@@ -375,30 +375,83 @@ async fn handle_webhook(
     body: Bytes,
 ) -> Result<impl IntoResponse, ApiError> {
     // Look up the workflow in the webhook registry.
-    let (sender, secret) = match state.scheduler.webhook_registry().lookup(&workflow_id).await {
-        Some(entry) => entry,
-        None => {
-            // Distinguish between "not found" and "not a webhook trigger".
-            if let Ok(Some(wf)) = state.scheduler.storage().get_workflow(&workflow_id).await {
-                if !matches!(wf.trigger_config, TriggerConfig::Webhook { .. }) {
-                    return Err(ApiError::InvalidInput(format!(
-                        "Workflow {} is not a webhook trigger (type: {})",
-                        workflow_id,
-                        wf.trigger_config.trigger_type()
-                    )));
+    let (sender, secret, source) =
+        match state.scheduler.webhook_registry().lookup(&workflow_id).await {
+            Some(entry) => entry,
+            None => {
+                // Distinguish between "not found" and "not a webhook trigger".
+                if let Ok(Some(wf)) = state.scheduler.storage().get_workflow(&workflow_id).await {
+                    if !matches!(wf.trigger_config, TriggerConfig::Webhook { .. }) {
+                        return Err(ApiError::InvalidInput(format!(
+                            "Workflow {} is not a webhook trigger (type: {})",
+                            workflow_id,
+                            wf.trigger_config.trigger_type()
+                        )));
+                    }
                 }
+                return Err(ApiError::NotFound);
             }
-            return Err(ApiError::NotFound);
+        };
+
+    // Extract source-specific headers for payload parsing and signature verification.
+    let github_event = headers.get("x-github-event").and_then(|v| v.to_str().ok());
+    let delivery_id = headers.get("x-github-delivery").and_then(|v| v.to_str().ok());
+    let linear_event = headers.get("linear-event").and_then(|v| v.to_str().ok());
+    let linear_delivery = headers.get("linear-delivery").and_then(|v| v.to_str().ok());
+
+    // Enforce that the incoming request matches the registered webhook source.
+    // This prevents source-header spoofing attacks where an attacker injects
+    // platform headers to bypass or redirect signature verification.
+    match &source {
+        WebhookSource::GitHub if linear_event.is_some() => {
+            return Err(ApiError::InvalidInput(
+                "This webhook workflow only accepts GitHub events; unexpected Linear-Event header"
+                    .to_string(),
+            ));
         }
-    };
+        WebhookSource::Linear if linear_event.is_none() => {
+            return Err(ApiError::InvalidInput(
+                "This webhook workflow only accepts Linear events; missing Linear-Event header"
+                    .to_string(),
+            ));
+        }
+        _ => {}
+    }
 
     // Verify HMAC-SHA256 signature if a secret is configured.
+    // Signature header is chosen based on the *registered* source to prevent
+    // an attacker from switching verification paths by injecting headers.
     if let Some(ref secret_value) = secret {
-        let signature =
-            headers.get("x-hub-signature-256").and_then(|v| v.to_str().ok()).unwrap_or("");
+        let (signature, header_name) = match &source {
+            WebhookSource::Linear => (
+                headers.get("linear-signature").and_then(|v| v.to_str().ok()).unwrap_or(""),
+                "Linear-Signature",
+            ),
+            WebhookSource::GitHub => (
+                headers.get("x-hub-signature-256").and_then(|v| v.to_str().ok()).unwrap_or(""),
+                "X-Hub-Signature-256",
+            ),
+            WebhookSource::Any => {
+                // When source is unspecified, infer from presence of Linear-Event header.
+                if linear_event.is_some() {
+                    (
+                        headers.get("linear-signature").and_then(|v| v.to_str().ok()).unwrap_or(""),
+                        "Linear-Signature",
+                    )
+                } else {
+                    (
+                        headers
+                            .get("x-hub-signature-256")
+                            .and_then(|v| v.to_str().ok())
+                            .unwrap_or(""),
+                        "X-Hub-Signature-256",
+                    )
+                }
+            }
+        };
 
         if signature.is_empty() {
-            return Err(ApiError::Unauthorized("Missing X-Hub-Signature-256 header".to_string()));
+            return Err(ApiError::Unauthorized(format!("Missing {} header", header_name)));
         }
 
         if !webhook::verify_signature(secret_value, &body, signature) {
@@ -406,12 +459,14 @@ async fn handle_webhook(
         }
     }
 
-    // Extract GitHub-specific headers for payload parsing.
-    let github_event = headers.get("x-github-event").and_then(|v| v.to_str().ok());
-    let delivery_id = headers.get("x-github-delivery").and_then(|v| v.to_str().ok());
-
     // Parse the payload into a Task.
-    let task = webhook::parse_webhook_payload(github_event, delivery_id, &body);
+    let task = webhook::parse_webhook_payload(
+        github_event,
+        delivery_id,
+        linear_event,
+        linear_delivery,
+        &body,
+    );
 
     info!(
         %workflow_id,

--- a/crates/orchestrator/src/scheduler/mod.rs
+++ b/crates/orchestrator/src/scheduler/mod.rs
@@ -90,9 +90,11 @@ impl Scheduler {
         // Build strategy and capture any channel sender for the workflow type.
         let mut manual_tx: Option<mpsc::Sender<Task>> = None;
         let strategy: Box<dyn strategy::TriggerStrategy> =
-            if let TriggerConfig::Webhook { ref secret } = config.trigger_config {
+            if let TriggerConfig::Webhook { ref secret, ref source } = config.trigger_config {
                 let (tx, rx) = mpsc::channel(webhook::DEFAULT_CHANNEL_CAPACITY);
-                self.webhook_registry.register(workflow_id, tx, secret.clone()).await;
+                self.webhook_registry
+                    .register(workflow_id, tx, secret.clone(), source.clone())
+                    .await;
                 Box::new(WebhookStrategy::new(rx))
             } else if matches!(config.trigger_config, TriggerConfig::Manual {}) {
                 let (tx, rx) = mpsc::channel(webhook::DEFAULT_CHANNEL_CAPACITY);

--- a/crates/orchestrator/src/scheduler/template.rs
+++ b/crates/orchestrator/src/scheduler/template.rs
@@ -19,13 +19,21 @@ use crate::scheduler::types::Task;
 /// | `status`             | dispatch_result        | Completion status (`completed` or `failed`)    |
 /// | `timestamp`          | dispatch_result        | RFC 3339 timestamp of the completion event     |
 /// | `original_source_id` | dispatch_result        | Source ID from the parent dispatch (if any)    |
-/// | `identifier`         | linear_issues          | Linear issue identifier (e.g., `"ENG-123"`)    |
-/// | `state`              | linear_issues          | Linear issue state name (e.g., `"Todo"`)       |
-/// | `priority`           | linear_issues          | Linear priority level (0 = none, 1 = urgent)   |
-/// | `team`               | linear_issues          | Linear team key (e.g., `"ENG"`)                |
-/// | `team_name`          | linear_issues          | Linear team display name                       |
+/// | `action`             | webhook (GitHub/Linear)| Event action (e.g., `"opened"`, `"create"`)    |
+/// | `github_event`       | webhook (GitHub)       | GitHub event type (e.g., `"issues"`)           |
+/// | `delivery_id`        | webhook (GitHub)       | GitHub delivery UUID (`X-GitHub-Delivery`)     |
+/// | `issue_number`       | webhook (GitHub)       | GitHub issue number                            |
+/// | `pr_number`          | webhook (GitHub)       | GitHub pull request number                     |
+/// | `linear_event`       | webhook (Linear)       | Linear event type (e.g., `"Issue"`)            |
+/// | `linear_action`      | webhook (Linear)       | Linear action (e.g., `"create"`, `"update"`)   |
+/// | `linear_delivery_id` | webhook (Linear)       | Linear delivery ID (`Linear-Delivery` header)  |
+/// | `identifier`         | linear_issues, webhook (Linear) | Linear issue identifier (e.g., `"ENG-123"`) |
+/// | `state`              | linear_issues, webhook (Linear) | Linear issue state name (e.g., `"Todo"`)    |
+/// | `priority`           | linear_issues, webhook (Linear) | Linear priority level (0 = none, 1 = urgent)|
+/// | `team`               | linear_issues, webhook (Linear) | Linear team key (e.g., `"ENG"`)             |
+/// | `team_name`          | linear_issues, webhook (Linear) | Linear team display name                    |
 /// | `project`            | linear_issues          | Linear project name                            |
-/// | `linear_id`          | linear_issues          | Internal Linear UUID (stable dedup key)        |
+/// | `linear_id`          | linear_issues, webhook (Linear) | Internal Linear UUID (stable dedup key)     |
 pub const KNOWN_VARIABLES: &[&str] = &[
     // Top-level task fields
     "title",
@@ -47,7 +55,20 @@ pub const KNOWN_VARIABLES: &[&str] = &[
     "status",
     "timestamp",
     "original_source_id",
-    // Metadata-backed (linear_issues trigger)
+    // Metadata-backed (webhook triggers — GitHub)
+    // Note: `action` is also used by Linear webhooks as `linear_action`; the
+    // GitHub `action` key and the Linear `linear_action` key are kept separate
+    // to avoid ambiguity when both header types could be present.
+    "action",
+    "github_event",
+    "delivery_id",
+    "issue_number",
+    "pr_number",
+    // Metadata-backed (webhook triggers — Linear)
+    "linear_event",
+    "linear_action",
+    "linear_delivery_id",
+    // Metadata-backed (linear_issues trigger + Linear webhooks)
     "identifier",
     "state",
     "priority",

--- a/crates/orchestrator/src/scheduler/types.rs
+++ b/crates/orchestrator/src/scheduler/types.rs
@@ -53,6 +53,23 @@ fn default_enabled() -> bool {
     true
 }
 
+/// The expected origin of a webhook payload.
+///
+/// Bound to a webhook workflow at registration time. The HTTP handler enforces
+/// that inbound requests carry the correct platform headers, preventing
+/// source-spoofing attacks.
+#[derive(Clone, Debug, Default, PartialEq, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum WebhookSource {
+    /// Accept webhooks from GitHub (`X-GitHub-Event` / `X-Hub-Signature-256`).
+    GitHub,
+    /// Accept webhooks from Linear (`Linear-Event` / `Linear-Signature`).
+    Linear,
+    /// Accept webhooks from any source (default — backward compatible).
+    #[default]
+    Any,
+}
+
 /// Tagged enum for different trigger backends.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
@@ -107,6 +124,10 @@ pub enum TriggerConfig {
     Webhook {
         #[serde(default)]
         secret: Option<String>,
+        /// Expected webhook source. Enforced by the handler to prevent
+        /// source-header spoofing. Defaults to `Any` for backward compatibility.
+        #[serde(default)]
+        source: WebhookSource,
     },
     /// Manual trigger — dispatched explicitly via the API.
     Manual {},

--- a/crates/orchestrator/src/scheduler/webhook.rs
+++ b/crates/orchestrator/src/scheduler/webhook.rs
@@ -2,10 +2,10 @@
 //!
 //! This module provides:
 //! - [`WebhookRegistry`] — a shared registry mapping workflow IDs to channel senders
-//! - HMAC-SHA256 signature verification (GitHub-compatible)
-//! - Webhook payload parsing (GitHub events and generic JSON)
+//! - HMAC-SHA256 signature verification (GitHub and Linear compatible)
+//! - Webhook payload parsing (GitHub events, Linear events, and generic JSON)
 
-use crate::scheduler::types::Task;
+use crate::scheduler::types::{Task, WebhookSource};
 use hmac::{Hmac, Mac};
 use sha2::Sha256;
 use std::collections::HashMap;
@@ -15,10 +15,11 @@ use uuid::Uuid;
 /// Default bounded channel capacity for webhook task channels.
 pub const DEFAULT_CHANNEL_CAPACITY: usize = 64;
 
-/// Entry in the webhook registry: a channel sender and the optional HMAC secret.
+/// Entry in the webhook registry: a channel sender, the optional HMAC secret, and the expected source.
 struct WebhookEntry {
     tx: mpsc::Sender<Task>,
     secret: Option<String>,
+    source: WebhookSource,
 }
 
 /// A shared registry that maps workflow IDs to their webhook channel senders.
@@ -43,9 +44,10 @@ impl WebhookRegistry {
         workflow_id: Uuid,
         tx: mpsc::Sender<Task>,
         secret: Option<String>,
+        source: WebhookSource,
     ) {
         let mut entries = self.entries.write().await;
-        entries.insert(workflow_id, WebhookEntry { tx, secret });
+        entries.insert(workflow_id, WebhookEntry { tx, secret, source });
     }
 
     /// Unregister (and drop) the webhook sender for a workflow.
@@ -57,13 +59,16 @@ impl WebhookRegistry {
         entries.remove(workflow_id);
     }
 
-    /// Look up a workflow's sender and secret.
+    /// Look up a workflow's sender, secret, and registered source.
     ///
     /// Returns `None` if the workflow is not registered (not running or not a
     /// webhook trigger).
-    pub async fn lookup(&self, workflow_id: &Uuid) -> Option<(mpsc::Sender<Task>, Option<String>)> {
+    pub async fn lookup(
+        &self,
+        workflow_id: &Uuid,
+    ) -> Option<(mpsc::Sender<Task>, Option<String>, WebhookSource)> {
         let entries = self.entries.read().await;
-        entries.get(workflow_id).map(|e| (e.tx.clone(), e.secret.clone()))
+        entries.get(workflow_id).map(|e| (e.tx.clone(), e.secret.clone(), e.source.clone()))
     }
 
     /// Return the number of registered webhook workflows.
@@ -115,32 +120,206 @@ pub fn verify_signature(secret: &str, body: &[u8], signature_header: &str) -> bo
 
 /// Parse a webhook payload into a [`Task`].
 ///
-/// If the `X-GitHub-Event` header is present, the payload is parsed as a GitHub
-/// webhook event. Otherwise, the raw JSON body is used as the task body.
+/// Detection priority:
+/// 1. If `linear_event` is `Some` (from the `Linear-Event` header) → parsed as a Linear webhook.
+/// 2. If `github_event` is `Some` (from `X-GitHub-Event`) → parsed as a GitHub webhook.
+/// 3. Otherwise → generic JSON / plain-text parsing.
 ///
-/// The `delivery_id` (from `X-GitHub-Delivery` or auto-generated) is used to
-/// produce a unique `source_id` for dedup.
+/// The `delivery_id` / `linear_delivery` parameters are used to produce a
+/// unique `source_id`. When both are absent an auto-generated UUID is used.
 pub fn parse_webhook_payload(
     github_event: Option<&str>,
     delivery_id: Option<&str>,
+    linear_event: Option<&str>,
+    linear_delivery: Option<&str>,
     body: &[u8],
 ) -> Task {
     let timestamp = chrono::Utc::now().to_rfc3339();
-    let delivery = delivery_id.map(|d| d.to_string()).unwrap_or_else(|| Uuid::new_v4().to_string());
+    // Prefer the source-specific delivery ID; fall back to a generated UUID.
+    let delivery = linear_delivery
+        .or(delivery_id)
+        .map(|d| d.to_string())
+        .unwrap_or_else(|| Uuid::new_v4().to_string());
 
     let mut metadata = HashMap::new();
-    metadata.insert("delivery_id".to_string(), delivery.clone());
+    // Store source-specific delivery IDs under distinct keys to prevent collisions.
+    // `delivery_id` is the GitHub X-GitHub-Delivery value; Linear uses `linear_delivery_id`.
+    if let Some(d) = delivery_id {
+        metadata.insert("delivery_id".to_string(), d.to_string());
+    }
+    if let Some(d) = linear_delivery {
+        metadata.insert("linear_delivery_id".to_string(), d.to_string());
+    }
     metadata.insert("timestamp".to_string(), timestamp.clone());
 
     // Try to parse as JSON for structured field extraction.
     let body_str = String::from_utf8_lossy(body).to_string();
     let json_value: Option<serde_json::Value> = serde_json::from_slice(body).ok();
 
-    if let Some(event_type) = github_event {
+    if let Some(event_type) = linear_event {
+        metadata.insert("linear_event".to_string(), event_type.to_string());
+        parse_linear_event(event_type, &json_value, body_str, delivery, metadata)
+    } else if let Some(event_type) = github_event {
         metadata.insert("github_event".to_string(), event_type.to_string());
         parse_github_event(event_type, &json_value, body_str, delivery, timestamp, metadata)
     } else {
         parse_generic_webhook(json_value.as_ref(), body_str, delivery, timestamp, metadata)
+    }
+}
+
+/// Parse a Linear webhook event into a [`Task`].
+///
+/// Supports `Issue`, `IssueLabel`, and `Comment` event types. Unknown event
+/// types fall back to a minimal task with the raw JSON body.
+///
+/// Linear webhook payload shape:
+/// ```json
+/// { "action": "create|update|remove", "type": "Issue", "data": { ... } }
+/// ```
+///
+/// Metadata populated (where present in the payload):
+/// - `linear_event` — event type (`Issue`, `Comment`, `IssueLabel`)
+/// - `linear_action` — action (`create`, `update`, `remove`)
+/// - `identifier` — Linear issue identifier (e.g., `ENG-123`)
+/// - `state` — issue state name (e.g., `Todo`)
+/// - `priority` — priority level (0–4)
+/// - `team` — team key (e.g., `ENG`)
+/// - `team_name` — team display name
+/// - `linear_id` — internal Linear UUID
+///
+/// Source ID deduplication strategy:
+/// - `Issue` events use the stable `identifier` (e.g. `ENG-42`) so repeated
+///   updates to the same issue do not create duplicate dispatch records.
+/// - `Comment` and `IssueLabel` events use the delivery ID as source_id since
+///   each delivery represents a distinct event with no stable identifier.
+fn parse_linear_event(
+    event_type: &str,
+    json_value: &Option<serde_json::Value>,
+    body_str: String,
+    delivery: String,
+    mut metadata: HashMap<String, String>,
+) -> Task {
+    let Some(val) = json_value else {
+        // Non-JSON body — return a minimal task.
+        return Task {
+            source_id: format!("linear:{}", delivery),
+            title: format!("Linear event: {}", event_type),
+            body: body_str,
+            url: String::new(),
+            labels: vec![],
+            assignee: None,
+            metadata,
+        };
+    };
+
+    let action = val["action"].as_str().unwrap_or("unknown");
+    metadata.insert("linear_action".to_string(), action.to_string());
+
+    match event_type {
+        "Issue" => {
+            let data = &val["data"];
+
+            let identifier = data["identifier"].as_str().unwrap_or("").to_string();
+            if !identifier.is_empty() {
+                metadata.insert("identifier".to_string(), identifier.clone());
+            }
+            if let Some(linear_id) = data["id"].as_str() {
+                metadata.insert("linear_id".to_string(), linear_id.to_string());
+            }
+            if let Some(state_name) = data["state"]["name"].as_str() {
+                metadata.insert("state".to_string(), state_name.to_string());
+            }
+            if let Some(priority) = data["priority"].as_u64() {
+                metadata.insert("priority".to_string(), priority.to_string());
+            }
+            if let Some(team_key) = data["team"]["key"].as_str() {
+                metadata.insert("team".to_string(), team_key.to_string());
+            }
+            if let Some(team_name) = data["team"]["name"].as_str() {
+                metadata.insert("team_name".to_string(), team_name.to_string());
+            }
+
+            let title = data["title"].as_str().unwrap_or("Untitled issue").to_string();
+            let body = data["description"].as_str().unwrap_or("").to_string();
+            let url = data["url"].as_str().unwrap_or("").to_string();
+            let labels: Vec<String> = data["labels"]
+                .as_array()
+                .map(|arr| {
+                    arr.iter().filter_map(|l| l["name"].as_str().map(|s| s.to_string())).collect()
+                })
+                .unwrap_or_default();
+            let assignee = data["assignee"]["displayName"].as_str().map(|s| s.to_string());
+
+            // Use the stable identifier as source_id so repeated updates to the
+            // same issue don't create duplicate dispatch records.
+            let source_id = if identifier.is_empty() {
+                format!("linear:{}", delivery)
+            } else {
+                format!("linear:{}", identifier)
+            };
+
+            Task { source_id, title, body, url, labels, assignee, metadata }
+        }
+        "Comment" => {
+            let data = &val["data"];
+            let issue = &data["issue"];
+            let identifier = issue["identifier"].as_str().unwrap_or("").to_string();
+            if !identifier.is_empty() {
+                metadata.insert("identifier".to_string(), identifier.clone());
+            }
+            if let Some(linear_id) = data["id"].as_str() {
+                metadata.insert("linear_id".to_string(), linear_id.to_string());
+            }
+
+            let issue_title = issue["title"].as_str().unwrap_or("").to_string();
+            let title = if identifier.is_empty() {
+                "New comment".to_string()
+            } else {
+                format!("Comment on {}: {}", identifier, issue_title)
+            };
+            let body = data["body"].as_str().unwrap_or("").to_string();
+
+            Task {
+                source_id: format!("linear-comment:{}", delivery),
+                title,
+                body,
+                url: String::new(),
+                labels: vec![],
+                assignee: None,
+                metadata,
+            }
+        }
+        "IssueLabel" => {
+            let data = &val["data"];
+            let label_name = data["label"]["name"].as_str().unwrap_or("unknown").to_string();
+            if let Some(linear_id) = data["id"].as_str() {
+                metadata.insert("linear_id".to_string(), linear_id.to_string());
+            }
+
+            let title = format!("Label \"{}\" {} on issue", label_name, action);
+
+            Task {
+                source_id: format!("linear-label:{}", delivery),
+                title,
+                body: body_str,
+                url: String::new(),
+                labels: vec![label_name],
+                assignee: None,
+                metadata,
+            }
+        }
+        _ => {
+            // Unknown Linear event type — minimal task with raw body.
+            Task {
+                source_id: format!("linear:{}", delivery),
+                title: format!("Linear event: {}", event_type),
+                body: body_str,
+                url: String::new(),
+                labels: vec![],
+                assignee: None,
+                metadata,
+            }
+        }
     }
 }
 
@@ -340,7 +519,8 @@ mod tests {
         });
         let body_bytes = serde_json::to_vec(&body).unwrap();
 
-        let task = parse_webhook_payload(Some("issues"), Some("delivery-123"), &body_bytes);
+        let task =
+            parse_webhook_payload(Some("issues"), Some("delivery-123"), None, None, &body_bytes);
 
         assert_eq!(task.title, "Bug report");
         assert_eq!(task.body, "Something is broken");
@@ -368,7 +548,13 @@ mod tests {
         });
         let body_bytes = serde_json::to_vec(&body).unwrap();
 
-        let task = parse_webhook_payload(Some("pull_request"), Some("delivery-456"), &body_bytes);
+        let task = parse_webhook_payload(
+            Some("pull_request"),
+            Some("delivery-456"),
+            None,
+            None,
+            &body_bytes,
+        );
 
         assert_eq!(task.title, "Add feature");
         assert_eq!(task.body, "This adds a new feature");
@@ -382,7 +568,7 @@ mod tests {
         let body = serde_json::json!({"ref": "refs/heads/main"});
         let body_bytes = serde_json::to_vec(&body).unwrap();
 
-        let task = parse_webhook_payload(Some("push"), None, &body_bytes);
+        let task = parse_webhook_payload(Some("push"), None, None, None, &body_bytes);
 
         assert_eq!(task.title, "GitHub event: push");
         assert_eq!(task.metadata.get("github_event"), Some(&"push".to_string()));
@@ -398,7 +584,7 @@ mod tests {
         });
         let body_bytes = serde_json::to_vec(&body).unwrap();
 
-        let task = parse_webhook_payload(None, Some("generic-123"), &body_bytes);
+        let task = parse_webhook_payload(None, Some("generic-123"), None, None, &body_bytes);
 
         assert_eq!(task.title, "Custom task");
         assert!(task.source_id.starts_with("webhook:generic-123:"));
@@ -409,7 +595,7 @@ mod tests {
         let body = serde_json::json!({"key": "value"});
         let body_bytes = serde_json::to_vec(&body).unwrap();
 
-        let task = parse_webhook_payload(None, None, &body_bytes);
+        let task = parse_webhook_payload(None, None, None, None, &body_bytes);
 
         assert_eq!(task.title, "Webhook payload");
         // Auto-generated delivery ID (UUID format).
@@ -420,7 +606,7 @@ mod tests {
     fn parse_non_json_body() {
         let body = b"plain text body";
 
-        let task = parse_webhook_payload(None, Some("plain-123"), body);
+        let task = parse_webhook_payload(None, Some("plain-123"), None, None, body);
 
         assert_eq!(task.title, "Webhook payload");
         assert_eq!(task.body, "plain text body");
@@ -434,12 +620,13 @@ mod tests {
         let (tx, _rx) = mpsc::channel(16);
         let wf_id = Uuid::new_v4();
 
-        registry.register(wf_id, tx, Some("secret".to_string())).await;
+        registry.register(wf_id, tx, Some("secret".to_string()), WebhookSource::Any).await;
 
         let result = registry.lookup(&wf_id).await;
         assert!(result.is_some());
-        let (_, secret) = result.unwrap();
+        let (_, secret, source) = result.unwrap();
         assert_eq!(secret, Some("secret".to_string()));
+        assert_eq!(source, WebhookSource::Any);
     }
 
     #[tokio::test]
@@ -454,7 +641,7 @@ mod tests {
         let (tx, _rx) = mpsc::channel(16);
         let wf_id = Uuid::new_v4();
 
-        registry.register(wf_id, tx, None).await;
+        registry.register(wf_id, tx, None, WebhookSource::Any).await;
         assert_eq!(registry.len().await, 1);
 
         registry.unregister(&wf_id).await;
@@ -468,9 +655,9 @@ mod tests {
         let (tx, mut rx) = mpsc::channel(16);
         let wf_id = Uuid::new_v4();
 
-        registry.register(wf_id, tx, None).await;
+        registry.register(wf_id, tx, None, WebhookSource::Any).await;
 
-        let (sender, _) = registry.lookup(&wf_id).await.unwrap();
+        let (sender, _, _) = registry.lookup(&wf_id).await.unwrap();
         let task = Task {
             source_id: "test-1".to_string(),
             title: "Test task".to_string(),
@@ -485,5 +672,204 @@ mod tests {
         let received = rx.recv().await.unwrap();
         assert_eq!(received.source_id, "test-1");
         assert_eq!(received.title, "Test task");
+    }
+
+    // ── Linear webhook payload parsing tests ─────────────────────────
+
+    #[test]
+    fn parse_linear_issue_event() {
+        let body = serde_json::json!({
+            "action": "create",
+            "type": "Issue",
+            "data": {
+                "id": "abc-123-uuid",
+                "identifier": "ENG-42",
+                "title": "Fix the bug",
+                "description": "Something is broken",
+                "url": "https://linear.app/team/issue/ENG-42",
+                "priority": 2,
+                "state": { "name": "In Progress" },
+                "team": { "key": "ENG", "name": "Engineering" },
+                "labels": [{"name": "bug"}, {"name": "high-priority"}],
+                "assignee": { "displayName": "Alice" }
+            }
+        });
+        let body_bytes = serde_json::to_vec(&body).unwrap();
+
+        let task =
+            parse_webhook_payload(None, None, Some("Issue"), Some("linear-del-999"), &body_bytes);
+
+        assert_eq!(task.source_id, "linear:ENG-42");
+        assert_eq!(task.title, "Fix the bug");
+        assert_eq!(task.body, "Something is broken");
+        assert_eq!(task.url, "https://linear.app/team/issue/ENG-42");
+        assert_eq!(task.labels, vec!["bug", "high-priority"]);
+        assert_eq!(task.assignee, Some("Alice".to_string()));
+        assert_eq!(task.metadata.get("linear_event"), Some(&"Issue".to_string()));
+        assert_eq!(task.metadata.get("linear_action"), Some(&"create".to_string()));
+        assert_eq!(task.metadata.get("identifier"), Some(&"ENG-42".to_string()));
+        assert_eq!(task.metadata.get("state"), Some(&"In Progress".to_string()));
+        assert_eq!(task.metadata.get("priority"), Some(&"2".to_string()));
+        assert_eq!(task.metadata.get("team"), Some(&"ENG".to_string()));
+        assert_eq!(task.metadata.get("team_name"), Some(&"Engineering".to_string()));
+        assert_eq!(task.metadata.get("linear_id"), Some(&"abc-123-uuid".to_string()));
+    }
+
+    #[test]
+    fn parse_linear_issue_event_no_identifier_uses_delivery() {
+        let body = serde_json::json!({
+            "action": "update",
+            "type": "Issue",
+            "data": {
+                "title": "No identifier issue",
+                "description": ""
+            }
+        });
+        let body_bytes = serde_json::to_vec(&body).unwrap();
+
+        let task =
+            parse_webhook_payload(None, None, Some("Issue"), Some("del-fallback"), &body_bytes);
+
+        assert_eq!(task.source_id, "linear:del-fallback");
+        assert_eq!(task.title, "No identifier issue");
+    }
+
+    #[test]
+    fn parse_linear_comment_event() {
+        let body = serde_json::json!({
+            "action": "create",
+            "type": "Comment",
+            "data": {
+                "id": "comment-uuid-456",
+                "body": "LGTM!",
+                "issue": {
+                    "identifier": "ENG-7",
+                    "title": "Some issue"
+                }
+            }
+        });
+        let body_bytes = serde_json::to_vec(&body).unwrap();
+
+        let task = parse_webhook_payload(
+            None,
+            None,
+            Some("Comment"),
+            Some("linear-del-comment"),
+            &body_bytes,
+        );
+
+        assert_eq!(task.source_id, "linear-comment:linear-del-comment");
+        assert_eq!(task.title, "Comment on ENG-7: Some issue");
+        assert_eq!(task.body, "LGTM!");
+        assert_eq!(task.metadata.get("linear_event"), Some(&"Comment".to_string()));
+        assert_eq!(task.metadata.get("identifier"), Some(&"ENG-7".to_string()));
+        assert_eq!(task.metadata.get("linear_id"), Some(&"comment-uuid-456".to_string()));
+    }
+
+    #[test]
+    fn parse_linear_issue_label_event() {
+        let body = serde_json::json!({
+            "action": "create",
+            "type": "IssueLabel",
+            "data": {
+                "id": "label-uuid-789",
+                "label": { "name": "urgent" }
+            }
+        });
+        let body_bytes = serde_json::to_vec(&body).unwrap();
+
+        let task = parse_webhook_payload(
+            None,
+            None,
+            Some("IssueLabel"),
+            Some("linear-del-label"),
+            &body_bytes,
+        );
+
+        assert_eq!(task.source_id, "linear-label:linear-del-label");
+        assert_eq!(task.title, "Label \"urgent\" create on issue");
+        assert_eq!(task.labels, vec!["urgent"]);
+        assert_eq!(task.metadata.get("linear_event"), Some(&"IssueLabel".to_string()));
+        assert_eq!(task.metadata.get("linear_id"), Some(&"label-uuid-789".to_string()));
+    }
+
+    #[test]
+    fn parse_linear_unknown_event_type() {
+        let body = serde_json::json!({ "action": "create", "type": "Project" });
+        let body_bytes = serde_json::to_vec(&body).unwrap();
+
+        let task =
+            parse_webhook_payload(None, None, Some("Project"), Some("del-proj"), &body_bytes);
+
+        assert_eq!(task.source_id, "linear:del-proj");
+        assert_eq!(task.title, "Linear event: Project");
+    }
+
+    #[test]
+    fn linear_event_takes_priority_over_github_event() {
+        // If both linear_event and github_event headers are present, Linear wins.
+        let body = serde_json::json!({
+            "action": "create",
+            "type": "Issue",
+            "data": { "identifier": "ENG-1", "title": "Linear priority", "description": "" }
+        });
+        let body_bytes = serde_json::to_vec(&body).unwrap();
+
+        let task = parse_webhook_payload(
+            Some("issues"),
+            Some("gh-del"),
+            Some("Issue"),
+            Some("lin-del"),
+            &body_bytes,
+        );
+
+        // Should be treated as a Linear event.
+        assert_eq!(task.source_id, "linear:ENG-1");
+        assert_eq!(task.metadata.get("linear_event"), Some(&"Issue".to_string()));
+        assert!(task.metadata.get("github_event").is_none());
+    }
+
+    #[test]
+    fn linear_delivery_preferred_over_github_delivery() {
+        // When both deliveries are present, linear_delivery is used as source_id basis.
+        let body = serde_json::json!({
+            "action": "create",
+            "type": "Issue",
+            "data": { "title": "Delivery test", "description": "" }
+            // no identifier — falls back to delivery
+        });
+        let body_bytes = serde_json::to_vec(&body).unwrap();
+
+        let task = parse_webhook_payload(
+            None,
+            Some("github-delivery-id"),
+            Some("Issue"),
+            Some("linear-delivery-id"),
+            &body_bytes,
+        );
+
+        assert_eq!(task.source_id, "linear:linear-delivery-id");
+        // Each delivery ID is stored under its own key — no collision.
+        assert_eq!(
+            task.metadata.get("linear_delivery_id"),
+            Some(&"linear-delivery-id".to_string())
+        );
+        // GitHub delivery ID is also preserved under its own key when present.
+        assert_eq!(task.metadata.get("delivery_id"), Some(&"github-delivery-id".to_string()));
+    }
+
+    #[test]
+    fn verify_signature_works_for_linear_format() {
+        // Linear sends the signature as raw hex (no "sha256=" prefix).
+        let secret = "linear-webhook-secret";
+        let body = b"linear payload";
+
+        let mut mac = HmacSha256::new_from_slice(secret.as_bytes()).unwrap();
+        mac.update(body);
+        let result = mac.finalize();
+        let hex_sig = hex::encode(result.into_bytes());
+
+        // Linear format: raw hex, no prefix.
+        assert!(verify_signature(secret, body, &hex_sig));
     }
 }

--- a/crates/orchestrator/tests/webhook_http.rs
+++ b/crates/orchestrator/tests/webhook_http.rs
@@ -25,7 +25,7 @@ use orchestrator::{
     scheduler::{
         api::{webhook_routes, WorkflowState},
         storage::SchedulerStorage,
-        types::{TriggerConfig, WorkflowConfig},
+        types::{TriggerConfig, WebhookSource, WorkflowConfig},
         Scheduler,
     },
     storage::AgentStorage,
@@ -105,7 +105,7 @@ fn make_webhook_workflow(agent_id: Uuid, secret: Option<String>) -> WorkflowConf
         id: Uuid::new_v4(),
         name: "test-webhook-workflow".to_string(),
         agent_id,
-        trigger_config: TriggerConfig::Webhook { secret },
+        trigger_config: TriggerConfig::Webhook { secret, source: WebhookSource::Any },
         prompt_template: "Review: {{title}}".to_string(),
         poll_interval_secs: 60,
         enabled: true,
@@ -120,6 +120,29 @@ fn sign_body(secret: &str, body: &[u8]) -> String {
     mac.update(body);
     let result = mac.finalize();
     format!("sha256={}", hex::encode(result.into_bytes()))
+}
+
+fn make_linear_webhook_workflow(agent_id: Uuid, secret: Option<String>) -> WorkflowConfig {
+    let now = Utc::now();
+    WorkflowConfig {
+        id: Uuid::new_v4(),
+        name: "test-linear-webhook-workflow".to_string(),
+        agent_id,
+        trigger_config: TriggerConfig::Webhook { secret, source: WebhookSource::Linear },
+        prompt_template: "Review: {{title}}".to_string(),
+        poll_interval_secs: 60,
+        enabled: true,
+        tool_policy: Default::default(),
+        created_at: now,
+        updated_at: now,
+    }
+}
+
+fn sign_body_linear(secret: &str, body: &[u8]) -> String {
+    let mut mac = Hmac::<Sha256>::new_from_slice(secret.as_bytes()).unwrap();
+    mac.update(body);
+    let result = mac.finalize();
+    hex::encode(result.into_bytes()) // No "sha256=" prefix — Linear format
 }
 
 async fn body_json(response: axum::response::Response) -> serde_json::Value {
@@ -425,4 +448,163 @@ async fn test_post_webhook_error_response_is_json_with_single_error_key() {
     assert!(json.is_object());
     assert!(json["error"].is_string());
     assert_eq!(json.as_object().unwrap().len(), 1);
+}
+
+#[tokio::test]
+async fn test_post_linear_webhook_missing_signature_returns_401() {
+    let (app, scheduler, _tmp) = build_webhook_app().await;
+    let workflow = make_linear_webhook_workflow(Uuid::new_v4(), Some("secret".to_string()));
+    scheduler.start_workflow(workflow.clone()).await.unwrap();
+
+    let body = serde_json::json!({
+        "action": "create", "type": "Issue",
+        "data": { "identifier": "ENG-1", "title": "Test" }
+    })
+    .to_string();
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/webhooks/{}", workflow.id))
+                .header("Content-Type", "application/json")
+                .header("Linear-Event", "Issue")
+                .header("Linear-Delivery", "del-001")
+                // No Linear-Signature header
+                .body(Body::from(body))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    let json = body_json(response).await;
+    assert!(json["error"].as_str().unwrap().contains("Missing"));
+}
+
+#[tokio::test]
+async fn test_post_linear_webhook_invalid_signature_returns_401() {
+    let (app, scheduler, _tmp) = build_webhook_app().await;
+    let workflow = make_linear_webhook_workflow(Uuid::new_v4(), Some("correct-secret".to_string()));
+    scheduler.start_workflow(workflow.clone()).await.unwrap();
+
+    let body = serde_json::json!({
+        "action": "create", "type": "Issue",
+        "data": { "identifier": "ENG-1", "title": "Test" }
+    })
+    .to_string();
+    let wrong_sig = sign_body_linear("wrong-secret", body.as_bytes());
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/webhooks/{}", workflow.id))
+                .header("Content-Type", "application/json")
+                .header("Linear-Event", "Issue")
+                .header("Linear-Delivery", "del-002")
+                .header("Linear-Signature", wrong_sig)
+                .body(Body::from(body))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    let json = body_json(response).await;
+    assert!(json["error"].as_str().unwrap().contains("Invalid"));
+}
+
+#[tokio::test]
+async fn test_post_linear_webhook_valid_signature_returns_202() {
+    let (app, scheduler, _tmp) = build_webhook_app().await;
+    let secret = "linear-webhook-secret";
+    let workflow = make_linear_webhook_workflow(Uuid::new_v4(), Some(secret.to_string()));
+    scheduler.start_workflow(workflow.clone()).await.unwrap();
+
+    let body = serde_json::json!({
+        "action": "create", "type": "Issue",
+        "data": { "identifier": "ENG-5", "title": "New issue", "description": "" }
+    })
+    .to_string();
+    let sig = sign_body_linear(secret, body.as_bytes());
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/webhooks/{}", workflow.id))
+                .header("Content-Type", "application/json")
+                .header("Linear-Event", "Issue")
+                .header("Linear-Delivery", "del-003")
+                .header("Linear-Signature", sig)
+                .body(Body::from(body))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::ACCEPTED);
+}
+
+#[tokio::test]
+async fn test_post_github_header_on_linear_workflow_returns_400() {
+    // Source enforcement: a GitHub webhook spoofing attack against a Linear workflow.
+    let (app, scheduler, _tmp) = build_webhook_app().await;
+    let workflow = make_linear_webhook_workflow(Uuid::new_v4(), None);
+    scheduler.start_workflow(workflow.clone()).await.unwrap();
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/webhooks/{}", workflow.id))
+                .header("Content-Type", "application/json")
+                // No Linear-Event header — request looks like GitHub
+                .body(Body::from(r#"{"action":"opened"}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let json = body_json(response).await;
+    assert!(json["error"].as_str().unwrap().contains("Linear"));
+}
+
+#[tokio::test]
+async fn test_post_linear_header_on_github_workflow_returns_400() {
+    // Source enforcement: a Linear header spoofing attack against a GitHub workflow.
+    let (app, scheduler, _tmp) = build_webhook_app().await;
+    let now = Utc::now();
+    let github_workflow = WorkflowConfig {
+        id: Uuid::new_v4(),
+        name: "github-only-wf".to_string(),
+        agent_id: Uuid::new_v4(),
+        trigger_config: TriggerConfig::Webhook { secret: None, source: WebhookSource::GitHub },
+        prompt_template: "{{title}}".to_string(),
+        poll_interval_secs: 60,
+        enabled: true,
+        tool_policy: Default::default(),
+        created_at: now,
+        updated_at: now,
+    };
+    scheduler.start_workflow(github_workflow.clone()).await.unwrap();
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri(format!("/webhooks/{}", github_workflow.id))
+                .header("Content-Type", "application/json")
+                .header("Linear-Event", "Issue") // spoofing!
+                .body(Body::from(r#"{"action":"create","type":"Issue","data":{"title":"x"}}"#))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    let json = body_json(response).await;
+    assert!(json["error"].as_str().unwrap().contains("GitHub"));
 }


### PR DESCRIPTION
feat: add Linear webhook payload parsing

feat(webhook): add Linear webhook payload parsing

- Add `parse_linear_event()` handling Issue, Comment, IssueLabel events
- Update `parse_webhook_payload` signature with `linear_event` and
  `linear_delivery` params; Linear takes dispatch priority over GitHub
- Update `handle_webhook` in api.rs to extract Linear-Event,
  Linear-Delivery, and Linear-Signature headers; choose correct
  signature header based on event source
- Add GitHub and Linear webhook variables to KNOWN_VARIABLES in template.rs
- Add 8 new Linear webhook parsing tests and 1 signature format test

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>