### PR TITLE
feat(ci): add frontend test job with codecov coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,6 +86,32 @@ jobs:
         if: matrix.os == 'macos-latest'
         run: cargo test --workspace
 
+  frontend-test:
+    name: Frontend Tests
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ui
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Run tests with coverage
+        run: bun run test:coverage
+
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: ui/coverage/lcov.info
+          flags: frontend
+          fail_ci_if_error: true
+          token: ${{ secrets.CODECOV_TOKEN }}
+
   clippy:
     name: Clippy (${{ matrix.os }})
     runs-on: ${{ matrix.os }}

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -60,7 +60,7 @@ export default defineConfig(({ mode }) => {
 			setupFiles: ["./src/test/setup.ts"],
 			coverage: {
 				provider: "v8",
-				reporter: ["text", "json", "html"],
+				reporter: ["text", "json", "html", "lcov"],
 				// Exclude test infrastructure, config, and generated files
 				exclude: [
 					"src/test/**",


### PR DESCRIPTION
## Summary

- Add a `frontend-test` CI job that runs vitest with coverage using bun on ubuntu-latest
- Upload lcov coverage results to Codecov with a `frontend` flag to separate from Rust coverage
- Add `lcov` to vite coverage reporters in `ui/vite.config.ts`

## Test plan

- [ ] Verify the `frontend-test` job runs successfully in CI
- [ ] Confirm coverage report appears in Codecov with the `frontend` flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)