### PR TITLE
feat(infra): Add setup script, teardown script, and unified observability docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,26 @@ agent teardown .agentd/               # delete in reverse order
 - **Cooldown logic** — Prevents notification spam
 - **REST API** for triggering checks and answering questions
 
+## Local Observability Stack
+
+All agentd services expose Prometheus `/metrics` endpoints. A ready-to-use
+local observability stack (Prometheus + Grafana with pre-built dashboards) is
+included in `infra/`:
+
+```bash
+# One-command install — configures and starts Prometheus + Grafana
+./infra/setup.sh
+
+# Open dashboards (default credentials: admin / admin)
+open http://localhost:3000
+```
+
+Pre-built dashboards: **Service Overview**, **Agent Activity**,
+**Workflow Execution**, and **Experiment Tracking**.
+
+See **[docs/observability/README.md](docs/observability/README.md)** for the
+full guide including manual setup, dashboard descriptions, and troubleshooting.
+
 ## Installation
 
 ### Prerequisites

--- a/docs/observability/README.md
+++ b/docs/observability/README.md
@@ -1,0 +1,196 @@
+# agentd Observability Guide
+
+The agentd local observability stack provides real-time visibility into all
+running services using Prometheus for metrics collection and Grafana for
+visualization.
+
+## Architecture
+
+```
+┌─────────────────────────────────────────────────┐
+│                  agentd services                │
+│                                                 │
+│  orchestrator :17006   communicate :17010       │
+│  notify       :17004   ask         :17001       │
+│  wrap         :17005   memory      :17008       │
+│                   │ /metrics                    │
+└───────────────────┼─────────────────────────────┘
+                    │ scrape (15s)
+                    ▼
+           ┌─────────────────┐
+           │   Prometheus    │  :9090
+           │  (time-series   │
+           │   database)     │
+           └────────┬────────┘
+                    │ PromQL
+                    ▼
+           ┌─────────────────┐
+           │     Grafana     │  :3000
+           │  (dashboards +  │
+           │  provisioning)  │
+           └─────────────────┘
+```
+
+All agentd services expose a Prometheus-compatible `/metrics` endpoint.
+Prometheus scrapes these every 15 seconds and stores the time-series data
+locally. Grafana connects to Prometheus as a data source and renders
+pre-built dashboards that are auto-provisioned from this repository.
+
+## Quick Start
+
+```bash
+# Install and configure everything in one command
+./infra/setup.sh
+
+# Open the dashboards
+open http://localhost:3000
+```
+
+The setup script:
+1. Installs Prometheus and Grafana via Homebrew (if not already installed)
+2. Configures Prometheus to scrape all agentd service `/metrics` endpoints
+3. Configures Grafana provisioning to auto-load data sources and dashboards
+4. Registers both services as macOS launchd agents (start at login, stay alive)
+5. Waits for services to start and prints status
+
+Default credentials: `admin` / `admin` — change after first login.
+
+## Manual Setup
+
+If you prefer to configure services manually or need to understand the
+individual components:
+
+- **[Prometheus setup](prometheus-setup.md)** — installation, configuration, launchd plist
+- **[Grafana setup](grafana-setup.md)** — installation, provisioning, launchd plist, troubleshooting
+
+## Pre-Built Dashboards
+
+All dashboards are provisioned automatically and appear in the **agentd**
+folder in Grafana.
+
+### Service Overview
+
+**UID:** `agentd-service-overview` | **Tags:** `agentd`, `overview`
+
+Shows the health and activity of all agentd services at a glance:
+
+- Per-service up/down status (green/red stat panel per service)
+- HTTP request rate over time by service
+
+Use this dashboard to confirm all services are running and to spot
+unusual request rate spikes.
+
+### Agent Activity
+
+**UID:** `agentd-agent-activity` | **Tags:** `agentd`, `agents`
+
+Focused on agent and messaging metrics:
+
+- Active WebSocket connections (communicate service)
+- Active agent count and total agents created (orchestrator)
+- Total usage session cost in USD
+- Messages delivered, dropped, and queued over time
+- Workflow dispatches by status (completed, failed, pending)
+- Usage session cost accumulation over time
+
+Use this dashboard to monitor agent health, detect connection loss,
+and track token spending.
+
+### Workflow Execution
+
+**UID:** `agentd-workflow-execution` | **Tags:** `agentd`, `workflows`
+
+Focused on workflow and notification pipeline:
+
+- Total dispatches, failed dispatches, pending notifications, pending approvals
+- Dispatch rate by status (timeseries)
+- Dispatch status breakdown (pie chart)
+- Notifications by priority over time
+
+Use this dashboard to diagnose workflow failures and notification backlogs.
+
+### Experiment Tracking
+
+**UID:** `agentd-experiment-tracking` | **Tags:** `agentd`, `experiments`
+
+Filterable by the `experiment` Prometheus label:
+
+- Variable dropdown populates dynamically from active experiment labels
+- Dispatch count and failure count for selected experiment(s)
+- Cost accumulated during the experiment
+- Median dispatch duration
+- Cost accumulation over time (one series per experiment)
+- Side-by-side comparison table across all experiments
+
+> **Note:** This dashboard requires experiment label injection (issue #833).
+> Until that is implemented, panels will show "No data".
+
+## Using Projects and Experiments with Observability
+
+When an experiment is active, Prometheus metrics are tagged with an
+`experiment` label (e.g., `experiment="exp-q1-cost-reduction"`). This enables:
+
+- **Filtering**: Use the Experiment dropdown in the Experiment Tracking dashboard
+  to see metrics for a specific experiment only.
+- **Comparing**: Select multiple experiments in the dropdown to overlay their
+  metrics side-by-side.
+- **Cost tracking**: The `experiment_cost_usd_total` counter accumulates spend
+  attributed to each experiment.
+
+## Removing the Stack
+
+```bash
+# Stop services and remove plists (preserves data)
+./infra/teardown.sh
+
+# Also delete all logs, Prometheus history, and Grafana state
+./infra/teardown.sh --purge
+```
+
+## Configuration Files
+
+| File | Purpose |
+|------|---------|
+| `infra/prometheus/prometheus.yml` | Prometheus scrape config (service targets) |
+| `infra/grafana/grafana.ini` | Grafana settings (ports, provisioning path, data dir) |
+| `infra/grafana/provisioning/datasources/agentd-prometheus.yml` | Auto-configure Prometheus datasource |
+| `infra/grafana/provisioning/dashboards/agentd.yml` | Auto-load dashboards from `infra/grafana/dashboards/` |
+| `infra/grafana/dashboards/*.json` | Pre-built dashboard definitions |
+| `infra/launchd/com.agentd.prometheus.plist` | macOS launchd plist for Prometheus |
+| `infra/launchd/com.agentd.grafana.plist` | macOS launchd plist for Grafana |
+
+## Extending the Stack
+
+### Adding a custom dashboard
+
+1. Build your dashboard in Grafana UI (connected to `agentd-prometheus` datasource)
+2. Export as JSON: **Dashboard settings → JSON Model → Copy to clipboard**
+3. Save to `infra/grafana/dashboards/my-dashboard.json`
+4. Grafana reloads provisioned dashboards every 30s automatically
+
+### Adding alerting rules
+
+1. Create `infra/prometheus/alert_rules.yml` with your rules
+2. Uncomment the `rule_files:` section in `infra/prometheus/prometheus.yml`
+3. Reload Prometheus: `curl -X POST http://localhost:9090/-/reload`
+
+### Changing scrape intervals
+
+Edit `infra/prometheus/prometheus.yml`:
+- `global.scrape_interval` — default for all jobs
+- Per-job override: add `scrape_interval: 5s` inside a `scrape_configs` entry
+
+## Troubleshooting
+
+| Symptom | Likely cause | Fix |
+|---------|-------------|-----|
+| Grafana shows "No data" | Prometheus not running | `curl http://localhost:9090/-/healthy` |
+| Prometheus target is DOWN | agentd service not running | `cargo run -p agentd-orchestrator` |
+| Grafana dashboards not loading | Wrong provisioning path | Check `provisioning` in `grafana.ini` |
+| Port 9090 / 3000 in use | Another process | `lsof -i :9090` or `lsof -i :3000` |
+| Service not starting at login | Plist not loaded | `launchctl list \| grep agentd` |
+
+For detailed troubleshooting, see the individual setup guides:
+
+- [prometheus-setup.md](prometheus-setup.md#troubleshooting)
+- [grafana-setup.md](grafana-setup.md#troubleshooting)

--- a/infra/setup.sh
+++ b/infra/setup.sh
@@ -1,0 +1,337 @@
+#!/usr/bin/env bash
+# infra/setup.sh — One-command local observability stack setup for agentd.
+#
+# Installs and configures Prometheus + Grafana on macOS, sets up the agentd
+# scrape config and dashboards, and registers both services as launchd agents
+# so they start automatically at login.
+#
+# Usage:
+#   ./infra/setup.sh              # full install
+#   ./infra/setup.sh --dry-run    # show what would be done without doing it
+#   ./infra/setup.sh --uninstall  # remove services (see infra/teardown.sh)
+#
+# Requirements:
+#   - macOS (tested on macOS 13+)
+#   - Homebrew (https://brew.sh)
+#
+# Idempotent: safe to run multiple times. Already-installed components are
+# detected and skipped.
+
+set -euo pipefail
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+INFRA_DIR="$REPO_ROOT/infra"
+
+# Shared state directory (writable by all users — avoids home-dir path issues
+# in launchd plists which run before user home is mounted on some macOS versions)
+STATE_DIR="/Users/Shared/agentd"
+LOG_DIR="$STATE_DIR/logs"
+GRAFANA_DATA_DIR="$STATE_DIR/grafana-data"
+PROMETHEUS_DATA_DIR="$STATE_DIR/prometheus-data"
+
+LAUNCH_AGENTS_DIR="$HOME/Library/LaunchAgents"
+PROMETHEUS_PLIST="com.agentd.prometheus.plist"
+GRAFANA_PLIST="com.agentd.grafana.plist"
+
+PROMETHEUS_PORT=9090
+GRAFANA_PORT=3000
+
+DRY_RUN=false
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+info()    { echo "  [INFO]  $*"; }
+ok()      { echo "  [OK]    $*"; }
+warn()    { echo "  [WARN]  $*" >&2; }
+error()   { echo "  [ERROR] $*" >&2; exit 1; }
+step()    { echo; echo "==> $*"; }
+
+run() {
+    if [[ "$DRY_RUN" == true ]]; then
+        echo "  [DRY]   $*"
+    else
+        "$@"
+    fi
+}
+
+require_brew() {
+    if ! command -v brew &>/dev/null; then
+        error "Homebrew is required but not installed. Install it from https://brew.sh then re-run this script."
+    fi
+}
+
+brew_prefix() {
+    brew --prefix 2>/dev/null
+}
+
+is_loaded() {
+    launchctl list | grep -q "$1" 2>/dev/null
+}
+
+wait_for_port() {
+    local port="$1"
+    local name="$2"
+    local max=30
+    local count=0
+    printf "  [WAIT]  Waiting for %s on port %d" "$name" "$port"
+    while ! curl -sf "http://127.0.0.1:$port" &>/dev/null && [[ $count -lt $max ]]; do
+        printf "."
+        sleep 1
+        ((count++)) || true
+    done
+    echo
+    if [[ $count -ge $max ]]; then
+        warn "$name did not start within ${max}s — check logs at $LOG_DIR"
+        return 1
+    fi
+    return 0
+}
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run)   DRY_RUN=true ;;
+        --uninstall) exec "$SCRIPT_DIR/teardown.sh" "$@" ;;
+        --help|-h)
+            grep '^#' "$0" | sed 's/^# \?//'
+            exit 0
+            ;;
+        *) warn "Unknown argument: $arg" ;;
+    esac
+done
+
+[[ "$DRY_RUN" == true ]] && info "Dry-run mode — no changes will be made."
+
+# ---------------------------------------------------------------------------
+# Step 1: Homebrew check
+# ---------------------------------------------------------------------------
+
+step "Checking dependencies"
+require_brew
+
+BREW_PREFIX="$(brew_prefix)"
+info "Homebrew prefix: $BREW_PREFIX"
+
+# ---------------------------------------------------------------------------
+# Step 2: Install Prometheus and Grafana
+# ---------------------------------------------------------------------------
+
+step "Installing Prometheus and Grafana via Homebrew"
+
+if command -v prometheus &>/dev/null; then
+    ok "Prometheus already installed: $(prometheus --version 2>&1 | head -1)"
+else
+    info "Installing Prometheus..."
+    run brew install prometheus
+fi
+
+if command -v grafana &>/dev/null; then
+    ok "Grafana already installed: $(grafana --version 2>&1 | head -1)"
+else
+    info "Installing Grafana..."
+    run brew install grafana
+fi
+
+# ---------------------------------------------------------------------------
+# Step 3: Create state directories
+# ---------------------------------------------------------------------------
+
+step "Creating state and log directories"
+
+for dir in "$LOG_DIR" "$GRAFANA_DATA_DIR" "$PROMETHEUS_DATA_DIR"; do
+    if [[ -d "$dir" ]]; then
+        ok "Already exists: $dir"
+    else
+        info "Creating: $dir"
+        run mkdir -p "$dir"
+        run chmod 755 "$dir"
+    fi
+done
+
+# ---------------------------------------------------------------------------
+# Step 4: Configure Prometheus
+# ---------------------------------------------------------------------------
+
+step "Configuring Prometheus"
+
+PROM_CONFIG_SRC="$INFRA_DIR/prometheus/prometheus.yml"
+
+if [[ ! -f "$PROM_CONFIG_SRC" ]]; then
+    error "Prometheus config not found: $PROM_CONFIG_SRC"
+fi
+
+ok "Using config: $PROM_CONFIG_SRC"
+info "Scrape targets are read from the file above — edit it to change ports."
+
+# ---------------------------------------------------------------------------
+# Step 5: Configure Grafana
+# ---------------------------------------------------------------------------
+
+step "Configuring Grafana"
+
+GRAFANA_INI_SRC="$INFRA_DIR/grafana/grafana.ini"
+GRAFANA_INI_TMP="$INFRA_DIR/grafana/grafana.ini.configured"
+
+if [[ ! -f "$GRAFANA_INI_SRC" ]]; then
+    error "Grafana config not found: $GRAFANA_INI_SRC"
+fi
+
+# Substitute placeholder paths with actual repo root
+if [[ "$DRY_RUN" == false ]]; then
+    sed \
+        -e "s|/Users/Shared/agentd/infra/grafana/provisioning|$INFRA_DIR/grafana/provisioning|g" \
+        -e "s|/Users/Shared/agentd/logs|$LOG_DIR|g" \
+        -e "s|/Users/Shared/agentd/grafana-data|$GRAFANA_DATA_DIR|g" \
+        "$GRAFANA_INI_SRC" > "$GRAFANA_INI_TMP"
+    ok "Generated: $GRAFANA_INI_TMP"
+else
+    info "[DRY] Would generate $GRAFANA_INI_TMP with repo-specific paths"
+fi
+
+# Update dashboard provisioning path
+DASH_PROV_SRC="$INFRA_DIR/grafana/provisioning/dashboards/agentd.yml"
+DASH_PROV_TMP="$INFRA_DIR/grafana/provisioning/dashboards/agentd.yml.configured"
+
+if [[ "$DRY_RUN" == false ]]; then
+    sed \
+        -e "s|/Users/Shared/agentd/infra/grafana/dashboards|$INFRA_DIR/grafana/dashboards|g" \
+        "$DASH_PROV_SRC" > "$DASH_PROV_TMP"
+    ok "Generated: $DASH_PROV_TMP"
+else
+    info "[DRY] Would generate $DASH_PROV_TMP with repo-specific paths"
+fi
+
+# ---------------------------------------------------------------------------
+# Step 6: Install launchd plists
+# ---------------------------------------------------------------------------
+
+step "Installing launchd plists"
+
+run mkdir -p "$LAUNCH_AGENTS_DIR"
+
+# --- Prometheus plist ---
+
+PROM_PLIST_SRC="$INFRA_DIR/launchd/$PROMETHEUS_PLIST"
+PROM_PLIST_DST="$LAUNCH_AGENTS_DIR/$PROMETHEUS_PLIST"
+
+if [[ "$DRY_RUN" == false ]]; then
+    sed \
+        -e "s|/opt/homebrew|$BREW_PREFIX|g" \
+        -e "s|/Users/Shared/agentd/infra/prometheus/prometheus.yml|$INFRA_DIR/prometheus/prometheus.yml|g" \
+        -e "s|/opt/homebrew/var/prometheus|$PROMETHEUS_DATA_DIR|g" \
+        -e "s|/Users/Shared/agentd/logs/prometheus.log|$LOG_DIR/prometheus.log|g" \
+        "$PROM_PLIST_SRC" > "$PROM_PLIST_DST"
+    ok "Installed: $PROM_PLIST_DST"
+else
+    info "[DRY] Would install $PROM_PLIST_DST"
+fi
+
+# --- Grafana plist ---
+
+GRAFANA_PLIST_SRC="$INFRA_DIR/launchd/$GRAFANA_PLIST"
+GRAFANA_PLIST_DST="$LAUNCH_AGENTS_DIR/$GRAFANA_PLIST"
+
+GRAFANA_HOME="$BREW_PREFIX/share/grafana"
+GRAFANA_INI_CONFIGURED="${GRAFANA_INI_TMP:-$GRAFANA_INI_SRC}"
+
+if [[ "$DRY_RUN" == false ]]; then
+    sed \
+        -e "s|/opt/homebrew|$BREW_PREFIX|g" \
+        -e "s|/Users/Shared/agentd/infra/grafana/grafana.ini|$GRAFANA_INI_TMP|g" \
+        -e "s|/Users/Shared/agentd/logs/grafana.log|$LOG_DIR/grafana.log|g" \
+        "$GRAFANA_PLIST_SRC" > "$GRAFANA_PLIST_DST"
+    ok "Installed: $GRAFANA_PLIST_DST"
+else
+    info "[DRY] Would install $GRAFANA_PLIST_DST"
+fi
+
+# ---------------------------------------------------------------------------
+# Step 7: Load (or reload) services
+# ---------------------------------------------------------------------------
+
+step "Loading services via launchctl"
+
+if [[ "$DRY_RUN" == false ]]; then
+    # Prometheus
+    if is_loaded "com.agentd.prometheus"; then
+        info "Reloading Prometheus..."
+        launchctl unload "$PROM_PLIST_DST" 2>/dev/null || true
+    fi
+    launchctl load "$PROM_PLIST_DST"
+    ok "Prometheus loaded"
+
+    # Grafana
+    if is_loaded "com.agentd.grafana"; then
+        info "Reloading Grafana..."
+        launchctl unload "$GRAFANA_PLIST_DST" 2>/dev/null || true
+    fi
+    launchctl load "$GRAFANA_PLIST_DST"
+    ok "Grafana loaded"
+else
+    info "[DRY] Would load com.agentd.prometheus via launchctl"
+    info "[DRY] Would load com.agentd.grafana via launchctl"
+fi
+
+# ---------------------------------------------------------------------------
+# Step 8: Wait for services and print status
+# ---------------------------------------------------------------------------
+
+step "Verifying services"
+
+if [[ "$DRY_RUN" == false ]]; then
+    sleep 2
+
+    PROM_OK=false
+    GRAFANA_OK=false
+
+    if wait_for_port "$PROMETHEUS_PORT" "Prometheus" 2>/dev/null; then
+        PROM_STATUS=$(curl -sf "http://127.0.0.1:$PROMETHEUS_PORT/-/ready" 2>/dev/null && echo "ready" || echo "starting")
+        ok "Prometheus: http://localhost:$PROMETHEUS_PORT ($PROM_STATUS)"
+        PROM_OK=true
+    else
+        warn "Prometheus not responding on port $PROMETHEUS_PORT"
+    fi
+
+    if wait_for_port "$GRAFANA_PORT" "Grafana" 2>/dev/null; then
+        ok "Grafana: http://localhost:$GRAFANA_PORT (admin/admin)"
+        GRAFANA_OK=true
+    else
+        warn "Grafana not responding on port $GRAFANA_PORT"
+    fi
+fi
+
+# ---------------------------------------------------------------------------
+# Done
+# ---------------------------------------------------------------------------
+
+echo
+echo "============================================================"
+echo " agentd observability stack setup complete"
+echo "============================================================"
+echo
+echo "  Prometheus UI:  http://localhost:$PROMETHEUS_PORT"
+echo "  Grafana UI:     http://localhost:$GRAFANA_PORT  (admin / admin)"
+echo
+echo "  Logs:           $LOG_DIR"
+echo "  Config:         $INFRA_DIR"
+echo
+echo "  To stop services:"
+echo "    launchctl unload $LAUNCH_AGENTS_DIR/$PROMETHEUS_PLIST"
+echo "    launchctl unload $LAUNCH_AGENTS_DIR/$GRAFANA_PLIST"
+echo
+echo "  To remove completely: ./infra/teardown.sh"
+echo
+if [[ "$DRY_RUN" == true ]]; then
+    echo "  (Dry-run — no changes were made)"
+    echo
+fi

--- a/infra/teardown.sh
+++ b/infra/teardown.sh
@@ -1,0 +1,177 @@
+#!/usr/bin/env bash
+# infra/teardown.sh — Remove agentd observability stack from macOS.
+#
+# Unloads launchd services, removes plists from ~/Library/LaunchAgents,
+# and optionally removes state data (logs, Grafana DB, Prometheus TSDB).
+#
+# Usage:
+#   ./infra/teardown.sh              # unload services, remove plists
+#   ./infra/teardown.sh --purge      # also delete all state/data directories
+#   ./infra/teardown.sh --dry-run    # show what would be done
+#
+# This script is idempotent — safe to run multiple times.
+
+set -euo pipefail
+
+LAUNCH_AGENTS_DIR="$HOME/Library/LaunchAgents"
+PROMETHEUS_PLIST="com.agentd.prometheus.plist"
+GRAFANA_PLIST="com.agentd.grafana.plist"
+
+STATE_DIR="/Users/Shared/agentd"
+LOG_DIR="$STATE_DIR/logs"
+GRAFANA_DATA_DIR="$STATE_DIR/grafana-data"
+PROMETHEUS_DATA_DIR="$STATE_DIR/prometheus-data"
+
+DRY_RUN=false
+PURGE=false
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+info()  { echo "  [INFO]  $*"; }
+ok()    { echo "  [OK]    $*"; }
+warn()  { echo "  [WARN]  $*" >&2; }
+step()  { echo; echo "==> $*"; }
+
+run() {
+    if [[ "$DRY_RUN" == true ]]; then
+        echo "  [DRY]   $*"
+    else
+        "$@"
+    fi
+}
+
+unload_service() {
+    local label="$1"
+    local plist="$LAUNCH_AGENTS_DIR/$2"
+
+    if launchctl list | grep -q "$label" 2>/dev/null; then
+        info "Unloading $label..."
+        run launchctl unload "$plist" 2>/dev/null || true
+        ok "Unloaded: $label"
+    else
+        ok "Not running: $label"
+    fi
+}
+
+remove_plist() {
+    local plist="$LAUNCH_AGENTS_DIR/$1"
+    if [[ -f "$plist" ]]; then
+        info "Removing plist: $plist"
+        run rm -f "$plist"
+        ok "Removed: $plist"
+    else
+        ok "Not found: $plist"
+    fi
+}
+
+remove_dir() {
+    local dir="$1"
+    if [[ -d "$dir" ]]; then
+        info "Removing directory: $dir"
+        run rm -rf "$dir"
+        ok "Removed: $dir"
+    else
+        ok "Not found: $dir"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Argument parsing
+# ---------------------------------------------------------------------------
+
+for arg in "$@"; do
+    case "$arg" in
+        --dry-run) DRY_RUN=true ;;
+        --purge)   PURGE=true ;;
+        --help|-h)
+            grep '^#' "$0" | sed 's/^# \?//'
+            exit 0
+            ;;
+        *) warn "Unknown argument: $arg" ;;
+    esac
+done
+
+[[ "$DRY_RUN" == true ]] && info "Dry-run mode — no changes will be made."
+
+# ---------------------------------------------------------------------------
+# Step 1: Unload services
+# ---------------------------------------------------------------------------
+
+step "Unloading launchd services"
+
+unload_service "com.agentd.prometheus" "$PROMETHEUS_PLIST"
+unload_service "com.agentd.grafana"    "$GRAFANA_PLIST"
+
+# ---------------------------------------------------------------------------
+# Step 2: Remove plists
+# ---------------------------------------------------------------------------
+
+step "Removing launchd plists from ~/Library/LaunchAgents"
+
+remove_plist "$PROMETHEUS_PLIST"
+remove_plist "$GRAFANA_PLIST"
+
+# ---------------------------------------------------------------------------
+# Step 3: Remove generated config files from infra/
+# ---------------------------------------------------------------------------
+
+step "Removing generated config files"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+INFRA_DIR="$SCRIPT_DIR"
+
+for f in \
+    "$INFRA_DIR/grafana/grafana.ini.configured" \
+    "$INFRA_DIR/grafana/provisioning/dashboards/agentd.yml.configured"
+do
+    if [[ -f "$f" ]]; then
+        info "Removing: $f"
+        run rm -f "$f"
+        ok "Removed: $f"
+    fi
+done
+
+# ---------------------------------------------------------------------------
+# Step 4: Optionally purge state data
+# ---------------------------------------------------------------------------
+
+if [[ "$PURGE" == true ]]; then
+    step "Purging state data (--purge flag set)"
+    warn "This will delete all Prometheus metrics history and Grafana configuration."
+    echo
+    if [[ "$DRY_RUN" == false ]]; then
+        read -r -p "  Are you sure? [y/N] " confirm
+        if [[ "${confirm,,}" != "y" ]]; then
+            info "Purge cancelled."
+            PURGE=false
+        fi
+    fi
+
+    if [[ "$PURGE" == true ]]; then
+        remove_dir "$LOG_DIR"
+        remove_dir "$GRAFANA_DATA_DIR"
+        remove_dir "$PROMETHEUS_DATA_DIR"
+    fi
+else
+    info "State data preserved at: $STATE_DIR"
+    info "Run with --purge to also remove logs and data."
+fi
+
+# ---------------------------------------------------------------------------
+# Done
+# ---------------------------------------------------------------------------
+
+echo
+echo "============================================================"
+echo " agentd observability stack removed"
+echo "============================================================"
+echo
+echo "  Prometheus and Grafana binaries are still installed."
+echo "  To uninstall them: brew uninstall prometheus grafana"
+echo
+if [[ "$DRY_RUN" == true ]]; then
+    echo "  (Dry-run — no changes were made)"
+    echo
+fi


### PR DESCRIPTION
## Summary

- `infra/setup.sh` — idempotent one-command install: Homebrew deps, config generation, launchd plist install, service load, health check. Supports `--dry-run` and `--uninstall`
- `infra/teardown.sh` — cleanly removes services, plists, and generated configs. Supports `--purge` to also delete state data
- `docs/observability/README.md` — unified guide: architecture diagram, quick start, all four dashboard descriptions, experiment tracking, extension guide, troubleshooting table
- `README.md` — added Local Observability Stack section with quick-start snippet

## Stacked on

- #858 (Grafana config — PR for #838)
- #857 (Prometheus config — PR for #837)

Closes #839

🤖 Generated with [Claude Code](https://claude.com/claude-code)