### PR TITLE
fix(workflows): use dedicated Closes #N line in PR bodies for GitHub issue linking

### DIFF
--- a/.agentd/agents/worker.yml
+++ b/.agentd/agents/worker.yml
@@ -110,10 +110,17 @@ system_prompt: |
 
   ### Submitting a Pull Request
 
+  Always use explicit `--title` and `--body` so that `Closes #N` appears on
+  its own line — GitHub only auto-links issues when the closing keyword is on
+  a dedicated line, not embedded inline (e.g. `(closes #N)` does NOT work):
+
   ```bash
-  # Submit the current branch as a PR (creates or updates — idempotent)
-  # Add --label review-agent when the PR is ready for automated review
-  git-spice branch submit --fill --no-prompt --label review-agent
+  # Replace <N> with the issue number, <title> and <body> with real content
+  git-spice branch submit --no-prompt --label review-agent \
+    --title "feat: <title>" \
+    --body "<one-sentence summary of what was implemented>
+
+  Closes #<N>"
   ```
 
   ### Handling Reviewer Change Requests
@@ -124,8 +131,12 @@ system_prompt: |
   # Make the required code changes, then amend the commit
   git-spice commit amend -m "feat(scope): description (address review feedback)"
 
-  # Resubmit — this updates the existing PR
-  git-spice branch submit --fill --no-prompt --label review-agent
+  # Resubmit — this updates the existing PR (keep Closes #N in the body)
+  git-spice branch submit --no-prompt --label review-agent \
+    --title "feat: <title>" \
+    --body "<summary of changes addressing review feedback>
+
+  Closes #<N>"
   ```
 
   ### Session Start

--- a/.agentd/workflows/epic-issue-worker.yml
+++ b/.agentd/workflows/epic-issue-worker.yml
@@ -136,16 +136,20 @@ prompt_template: |
   6. Commit:
      ```bash
      git add <changed-files>
-     git-spice commit create -m "feat(<scope>): <description> (closes #<N>)"
+     git-spice commit create -m "feat(<scope>): <description>"
      ```
 
   ### 3c — Submit the sub-issue PR
 
-  Submit a PR for this sub-issue branch. git-spice will automatically
-  target the correct base branch (the one it was stacked on):
+  Submit a PR for this sub-issue branch with an explicit body so GitHub
+  links the issue. git-spice automatically targets the correct base branch:
 
   ```bash
-  git-spice branch submit --fill --no-prompt --label review-agent
+  git-spice branch submit --no-prompt --label review-agent \
+    --title "feat: <brief description from sub-issue title>" \
+    --body "<one-sentence summary of what was implemented>
+
+  Closes #<N>"
   ```
 
   ### 3d — Move to the next sub-issue
@@ -173,10 +177,16 @@ prompt_template: |
   ```
 
   If any PRs were not submitted during the per-issue step (e.g. due to
-  an error), submit the remaining stack:
+  an error), submit each remaining branch individually with an explicit body:
 
   ```bash
-  git-spice stack submit --fill --no-prompt --label review-agent
+  # For each unsubmitted branch (replace <N> with the sub-issue number):
+  git checkout issue-<N>
+  git-spice branch submit --no-prompt --label review-agent \
+    --title "feat: <brief description>" \
+    --body "<one-sentence summary>
+
+  Closes #<N>"
   ```
 
   ## Step 5 — Store findings and close the epic
@@ -218,7 +228,11 @@ prompt_template: |
   4. Amend and resubmit:
      ```bash
      git-spice commit amend -m "feat(<scope>): <description> (address review feedback)"
-     git-spice branch submit --fill --no-prompt --label review-agent
+     git-spice branch submit --no-prompt --label review-agent \
+       --title "feat: <description>" \
+       --body "<summary of changes addressing review feedback>
+
+     Closes #<N>"
      ```
   5. Restack any branches above:
      ```bash

--- a/.agentd/workflows/issue-worker.yml
+++ b/.agentd/workflows/issue-worker.yml
@@ -51,10 +51,15 @@ prompt_template: |
   4. Implement the changes described in the issue
   5. Run tests to verify: cargo test
   6. Ensure cargo fmt and cargo clippy pass for Rust changes
-  7. Commit with a descriptive message referencing the issue:
-     git-spice commit create -m "feat: <description> (closes #{{source_id}})"
-  8. Submit the branch as a PR (creates or updates — idempotent):
-     git-spice branch submit --fill --no-prompt --label review-agent
+  7. Commit with a descriptive message:
+     git-spice commit create -m "feat: <description>"
+  8. Submit the branch as a PR with an explicit body so GitHub links the issue.
+     Replace <title> and <body> with the actual title and a one-sentence summary:
+     git-spice branch submit --no-prompt --label review-agent \
+       --title "feat: <title>" \
+       --body "<one-sentence summary of what was implemented>
+
+Closes #{{source_id}}"
   9. Store any significant findings or decisions made during implementation:
      agent memory remember "<what you learned>" --created-by worker --type information --tags worker,issue-{{source_id}} --visibility public
   10. Close the issue: gh issue close {{source_id}} --repo geoffjay/agentd
@@ -63,4 +68,8 @@ prompt_template: |
   If this issue's PR has the "needs-rework" label, the reviewer found issues.
   Fetch the review comments, address the feedback, then:
      git-spice commit amend -m "feat: <description> (address review feedback)"
-     git-spice branch submit --fill --no-prompt --label review-agent
+     git-spice branch submit --no-prompt --label review-agent \
+       --title "feat: <title>" \
+       --body "<summary of changes made>
+
+Closes #{{source_id}}"


### PR DESCRIPTION
GitHub only auto-links issues to PRs when the closing keyword appears on its own dedicated line. The previous pattern of embedding `(closes #N)` inline in commit messages and using `--fill` to auto-generate PR bodies was not triggering GitHub's issue-link parser.

Changes:
- Replace `--fill` with explicit `--title`/`--body` in all `git-spice branch submit` calls
- Remove `(closes #N)` from commit message format (commit messages stay clean)
- Add `Closes #N` as a standalone last line in PR body templates
- Updated in `.agentd/workflows/issue-worker.yml`, `epic-issue-worker.yml`, and `.agentd/agents/worker.yml`