### PR TITLE
feat(scheduler): implement AND combinator with correlation window

### DIFF
--- a/crates/cli/src/commands/orchestrator.rs
+++ b/crates/cli/src/commands/orchestrator.rs
@@ -2742,6 +2742,17 @@ fn display_workflow(workflow: &WorkflowResponse) {
                 println!("{}: {}", "Assignee".bold(), a);
             }
         }
+        TriggerConfig::Composite { mode, triggers, correlation_window_secs } => {
+            println!("{}: {}", "Mode".bold(), mode);
+            println!("{}: {}", "Sub-triggers".bold(), triggers.len());
+            if *mode == "and" {
+                let window = correlation_window_secs.unwrap_or(60);
+                println!("{}: {}s", "Correlation Window".bold(), window);
+            }
+            for (i, sub) in triggers.iter().enumerate() {
+                println!("  {}[{}]: {}", "Sub-trigger".bold(), i, sub.trigger_type());
+            }
+        }
     }
     let template = &workflow.prompt_template;
     let display =

--- a/crates/orchestrator/src/scheduler/api.rs
+++ b/crates/orchestrator/src/scheduler/api.rs
@@ -138,6 +138,38 @@ async fn create_workflow(
                 ));
             }
         }
+        TriggerConfig::Composite { mode, triggers, .. } => {
+            // Validate combinator mode.
+            if mode != "or" && mode != "and" {
+                return Err(ApiError::InvalidInput(format!(
+                    "Invalid composite mode '{}'. Valid values: 'or', 'and'",
+                    mode
+                )));
+            }
+            // Require at least 2 sub-triggers.
+            if triggers.len() < 2 {
+                return Err(ApiError::InvalidInput(
+                    "Composite trigger requires at least 2 sub-triggers".to_string(),
+                ));
+            }
+            // Guard against excessive nesting (max 3 levels).
+            fn check_depth(tc: &TriggerConfig, depth: usize) -> Result<(), String> {
+                if let TriggerConfig::Composite { triggers, .. } = tc {
+                    if depth >= 3 {
+                        return Err(
+                            "Composite trigger nesting exceeds maximum depth of 3".to_string()
+                        );
+                    }
+                    for sub in triggers {
+                        check_depth(sub, depth + 1)?;
+                    }
+                }
+                Ok(())
+            }
+            if let Err(msg) = check_depth(&req.trigger_config, 0) {
+                return Err(ApiError::InvalidInput(msg));
+            }
+        }
     }
 
     // Reject trigger types that are not yet implemented.

--- a/crates/orchestrator/src/scheduler/runner.rs
+++ b/crates/orchestrator/src/scheduler/runner.rs
@@ -4,8 +4,8 @@ use crate::scheduler::linear::LinearIssueSource;
 use crate::scheduler::source::TaskSource;
 use crate::scheduler::storage::SchedulerStorage;
 use crate::scheduler::strategy::{
-    CronStrategy, DelayStrategy, EventFilter, EventStrategy, IdleStrategy, PollingStrategy,
-    TriggerStrategy,
+    CompositeStrategy, CronStrategy, DelayStrategy, EventFilter, EventStrategy, IdleStrategy,
+    PollingStrategy, TriggerStrategy,
 };
 use crate::scheduler::template::render_template;
 use crate::scheduler::types::{
@@ -300,12 +300,37 @@ fn create_source(config: &TriggerConfig) -> anyhow::Result<Box<dyn TaskSource>> 
 /// Poll-based workflows (GitHub triggers) use [`PollingStrategy`].
 /// Cron workflows use [`CronStrategy`]. Delay workflows use [`DelayStrategy`].
 /// Event-driven workflows (agent lifecycle, dispatch result) use [`EventStrategy`].
+/// Composite workflows use [`CompositeStrategy`] with recursive sub-strategy creation.
 /// Returns an error for trigger types that are not yet implemented.
 pub fn create_strategy(
     config: &WorkflowConfig,
     event_bus: Option<&Arc<EventBus>>,
 ) -> anyhow::Result<Box<dyn TriggerStrategy>> {
-    match &config.trigger_config {
+    create_trigger_strategy(
+        &config.trigger_config,
+        event_bus,
+        config.poll_interval_secs,
+        config.agent_id,
+        config.id,
+        0,
+    )
+}
+
+/// Recursively create a [`TriggerStrategy`] from a [`TriggerConfig`].
+///
+/// The `depth` parameter guards against runaway nesting — a maximum of
+/// [`MAX_COMPOSITE_DEPTH`] levels of nested composites is permitted.
+const MAX_COMPOSITE_DEPTH: usize = 3;
+
+fn create_trigger_strategy(
+    trigger: &TriggerConfig,
+    event_bus: Option<&Arc<EventBus>>,
+    poll_interval_secs: u64,
+    agent_id: Uuid,
+    workflow_id: Uuid,
+    depth: usize,
+) -> anyhow::Result<Box<dyn TriggerStrategy>> {
+    match trigger {
         TriggerConfig::Cron { expression } => {
             let strategy = CronStrategy::new(expression)?;
             Ok(Box::new(strategy))
@@ -315,15 +340,14 @@ pub fn create_strategy(
                 .map(|dt| dt.with_timezone(&Utc))
                 .or_else(|_| run_at.parse::<chrono::DateTime<Utc>>())
                 .map_err(|e| anyhow::anyhow!("Invalid run_at datetime '{}': {}", run_at, e))?;
-            let strategy = DelayStrategy::new(dt, config.id);
+            let strategy = DelayStrategy::new(dt, workflow_id);
             Ok(Box::new(strategy))
         }
         TriggerConfig::AgentLifecycle { event } => {
             let bus = event_bus.ok_or_else(|| {
                 anyhow::anyhow!("EventBus is required for agent_lifecycle triggers")
             })?;
-            let filter =
-                EventFilter::AgentLifecycle { event: event.clone(), agent_id: config.agent_id };
+            let filter = EventFilter::AgentLifecycle { event: event.clone(), agent_id };
             Ok(Box::new(EventStrategy::new(bus.clone(), filter)))
         }
         TriggerConfig::DispatchResult { source_workflow_id, status } => {
@@ -340,11 +364,41 @@ pub fn create_strategy(
             let bus = event_bus
                 .ok_or_else(|| anyhow::anyhow!("EventBus is required for agent_idle triggers"))?;
             let duration = std::time::Duration::from_secs(*idle_seconds);
-            Ok(Box::new(IdleStrategy::new(bus.clone(), config.agent_id, duration)))
+            Ok(Box::new(IdleStrategy::new(bus.clone(), agent_id, duration)))
+        }
+        TriggerConfig::Composite { mode, triggers, correlation_window_secs } => {
+            if depth >= MAX_COMPOSITE_DEPTH {
+                anyhow::bail!(
+                    "Composite trigger nesting exceeds maximum depth of {}",
+                    MAX_COMPOSITE_DEPTH
+                );
+            }
+            let sub_strategies: Vec<Box<dyn TriggerStrategy>> = triggers
+                .iter()
+                .map(|tc| {
+                    create_trigger_strategy(
+                        tc,
+                        event_bus,
+                        poll_interval_secs,
+                        agent_id,
+                        workflow_id,
+                        depth + 1,
+                    )
+                })
+                .collect::<anyhow::Result<_>>()?;
+
+            let window = correlation_window_secs.unwrap_or(60);
+            match mode.as_str() {
+                "or" => Ok(Box::new(CompositeStrategy::new_or(sub_strategies))),
+                "and" => Ok(Box::new(CompositeStrategy::new_and(sub_strategies, window))),
+                other => {
+                    anyhow::bail!("Invalid composite mode '{}'. Valid modes: 'or', 'and'", other)
+                }
+            }
         }
         _ => {
-            let source = create_source(&config.trigger_config)?;
-            Ok(Box::new(PollingStrategy::new(source, config.poll_interval_secs)))
+            let source = create_source(trigger)?;
+            Ok(Box::new(PollingStrategy::new(source, poll_interval_secs)))
         }
     }
 }

--- a/crates/orchestrator/src/scheduler/strategy.rs
+++ b/crates/orchestrator/src/scheduler/strategy.rs
@@ -1022,7 +1022,7 @@ impl CompositeStrategy {
     /// is a comma-joined list of every sub-task's source ID.  The `body` is
     /// a newline-joined concatenation of non-empty sub-task bodies.  Metadata
     /// from each sub-task is copied with a `sub_` prefix.
-    fn merge_and_tasks(pending: &mut Vec<Option<Vec<Task>>>) -> Vec<Task> {
+    fn merge_and_tasks(pending: &mut [Option<Vec<Task>>]) -> Vec<Task> {
         let sub_groups: Vec<Vec<Task>> = pending.iter_mut().filter_map(|opt| opt.take()).collect();
 
         let all_source_ids: Vec<String> =
@@ -2644,5 +2644,68 @@ mod tests {
         // Body should contain both sub-bodies.
         assert!(merged.body.contains("body-a"), "body: {}", merged.body);
         assert!(merged.body.contains("body-b"), "body: {}", merged.body);
+    }
+
+    // ── Nested composites ───────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn nested_or_of_ors_fires_when_any_inner_fires() {
+        // Inner composite A: OR of two slow strategies
+        let inner_a_s1 = Box::new(DelayedOnceStrategy::new(
+            Duration::from_secs(60),
+            vec![sample_task("inner-a1")],
+        ));
+        let inner_a_s2 = Box::new(DelayedOnceStrategy::new(
+            Duration::from_secs(60),
+            vec![sample_task("inner-a2")],
+        ));
+        let inner_a: Box<dyn TriggerStrategy> =
+            Box::new(CompositeStrategy::new_or(vec![inner_a_s1, inner_a_s2]));
+
+        // Inner composite B: OR where one strategy fires quickly
+        let inner_b_s1 = Box::new(DelayedOnceStrategy::new(
+            Duration::from_millis(20),
+            vec![sample_task("inner-b-fast")],
+        ));
+        let inner_b_s2 = Box::new(DelayedOnceStrategy::new(
+            Duration::from_secs(60),
+            vec![sample_task("inner-b-slow")],
+        ));
+        let inner_b: Box<dyn TriggerStrategy> =
+            Box::new(CompositeStrategy::new_or(vec![inner_b_s1, inner_b_s2]));
+
+        // Outer OR: fires when any inner fires.
+        let mut outer = CompositeStrategy::new_or(vec![inner_a, inner_b]);
+        let (_tx, rx) = watch::channel(false);
+
+        let start = tokio::time::Instant::now();
+        let result = outer.next_tasks(&rx).await.unwrap();
+        let elapsed = start.elapsed();
+
+        // The fast sub-strategy in inner_b should win.
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].source_id, "inner-b-fast");
+        assert!(elapsed < Duration::from_secs(2), "elapsed: {elapsed:?}");
+    }
+
+    // ── CombineMode enum tests ──────────────────────────────────────────
+
+    #[test]
+    fn combine_mode_or_and_are_distinct() {
+        assert_ne!(CombineMode::Or, CombineMode::And { window_secs: 60 });
+        assert_eq!(CombineMode::Or, CombineMode::Or);
+        assert_eq!(CombineMode::And { window_secs: 60 }, CombineMode::And { window_secs: 60 });
+    }
+
+    #[test]
+    #[should_panic(expected = "CompositeStrategy requires at least one sub-strategy")]
+    fn composite_or_panics_on_empty_strategies() {
+        let _: CompositeStrategy = CompositeStrategy::new_or(vec![]);
+    }
+
+    #[test]
+    #[should_panic(expected = "CompositeStrategy requires at least one sub-strategy")]
+    fn composite_and_panics_on_empty_strategies() {
+        let _: CompositeStrategy = CompositeStrategy::new_and(vec![], 60);
     }
 }

--- a/crates/orchestrator/src/scheduler/template.rs
+++ b/crates/orchestrator/src/scheduler/template.rs
@@ -76,6 +76,8 @@ pub const KNOWN_VARIABLES: &[&str] = &[
     "team_name",
     "project",
     "linear_id",
+    // Metadata-backed (composite triggers)
+    "composite_sub_source_ids",
 ];
 
 /// Validate a prompt template, returning any warnings or errors.

--- a/crates/orchestrator/src/scheduler/types.rs
+++ b/crates/orchestrator/src/scheduler/types.rs
@@ -174,6 +174,31 @@ pub enum TriggerConfig {
         #[serde(default)]
         assignee: Option<String>,
     },
+    /// Composite trigger — combines multiple sub-triggers with AND/OR logic.
+    ///
+    /// # OR mode (`mode: "or"`)
+    ///
+    /// Fires as soon as **any** sub-trigger produces tasks.  Useful for
+    /// "fire on schedule OR manual trigger" patterns.
+    ///
+    /// # AND mode (`mode: "and"`)
+    ///
+    /// Fires only when **all** sub-triggers have produced tasks within
+    /// `correlation_window_secs` (default 60).  Useful for multi-condition
+    /// workflows such as "PR labeled `ready` AND review approved".
+    ///
+    /// At least 2 sub-triggers are required.  Nesting is supported up to
+    /// 3 levels deep to prevent accidental runaway recursion.
+    Composite {
+        /// Combinator mode: `"or"` or `"and"`.
+        mode: String,
+        /// Nested trigger configurations — minimum 2.
+        triggers: Vec<TriggerConfig>,
+        /// For AND mode: how long (in seconds) after the first sub-trigger fires
+        /// before the partial state is reset.  Defaults to 60.
+        #[serde(default)]
+        correlation_window_secs: Option<u64>,
+    },
 }
 
 fn default_issue_state() -> String {
@@ -197,6 +222,7 @@ impl TriggerConfig {
             TriggerConfig::Manual { .. } => "manual",
             TriggerConfig::AgentIdle { .. } => "agent_idle",
             TriggerConfig::LinearIssues { .. } => "linear_issues",
+            TriggerConfig::Composite { .. } => "composite",
         }
     }
 
@@ -212,7 +238,8 @@ impl TriggerConfig {
             | TriggerConfig::Webhook { .. }
             | TriggerConfig::Manual { .. }
             | TriggerConfig::AgentIdle { .. }
-            | TriggerConfig::LinearIssues { .. } => true,
+            | TriggerConfig::LinearIssues { .. }
+            | TriggerConfig::Composite { .. } => true,
         }
     }
 

--- a/crates/orchestrator/tests/composite_triggers.rs
+++ b/crates/orchestrator/tests/composite_triggers.rs
@@ -1,0 +1,236 @@
+//! Integration tests for the composite trigger system (AND/OR combinators).
+//!
+//! These tests exercise the full path from `TriggerConfig::Composite`
+//! through `create_strategy()` to actual task production, verifying
+//! that the strategy factory correctly wires up nested sub-strategies.
+//!
+//! # What is tested
+//!
+//! - `create_strategy()` produces a `CompositeStrategy` for OR mode
+//! - `create_strategy()` produces a `CompositeStrategy` for AND mode
+//! - Nested composites (OR of ORs) are supported up to depth 3
+//! - Nesting beyond `MAX_COMPOSITE_DEPTH` (3) returns an error
+//! - Invalid composite mode returns an error
+//! - Serde round-trip for `TriggerConfig::Composite`
+//! - Config validation: at least 2 sub-triggers required
+
+use chrono::Utc;
+use orchestrator::scheduler::{
+    runner::create_strategy,
+    types::{TriggerConfig, WorkflowConfig},
+};
+use orchestrator::{scheduler::events::EventBus, websocket::ConnectionRegistry};
+use uuid::Uuid;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn make_workflow(trigger_config: TriggerConfig) -> WorkflowConfig {
+    let now = Utc::now();
+    WorkflowConfig {
+        id: Uuid::new_v4(),
+        name: "composite-test".to_string(),
+        agent_id: Uuid::new_v4(),
+        trigger_config,
+        prompt_template: "Handle: {{title}}".to_string(),
+        poll_interval_secs: 60,
+        enabled: true,
+        tool_policy: Default::default(),
+        created_at: now,
+        updated_at: now,
+    }
+}
+
+fn cron_trigger() -> TriggerConfig {
+    TriggerConfig::Cron { expression: "0 * * * *".to_string() }
+}
+
+fn agent_lifecycle_trigger() -> TriggerConfig {
+    TriggerConfig::AgentLifecycle { event: "session_start".to_string() }
+}
+
+// ---------------------------------------------------------------------------
+// Strategy factory tests
+// ---------------------------------------------------------------------------
+
+/// `create_strategy()` should succeed for a composite OR trigger wrapping
+/// two leaf triggers.
+#[tokio::test]
+async fn create_strategy_or_composite_succeeds() {
+    let trigger = TriggerConfig::Composite {
+        mode: "or".to_string(),
+        triggers: vec![cron_trigger(), agent_lifecycle_trigger()],
+        correlation_window_secs: None,
+    };
+    let config = make_workflow(trigger);
+    let bus = EventBus::shared(16);
+
+    let result = create_strategy(&config, Some(&bus));
+    assert!(
+        result.is_ok(),
+        "Expected Ok for OR composite: {:?}",
+        result.err().map(|e| e.to_string())
+    );
+}
+
+/// `create_strategy()` should succeed for a composite AND trigger.
+#[tokio::test]
+async fn create_strategy_and_composite_succeeds() {
+    let trigger = TriggerConfig::Composite {
+        mode: "and".to_string(),
+        triggers: vec![cron_trigger(), agent_lifecycle_trigger()],
+        correlation_window_secs: Some(30),
+    };
+    let config = make_workflow(trigger);
+    let bus = EventBus::shared(16);
+
+    let result = create_strategy(&config, Some(&bus));
+    assert!(
+        result.is_ok(),
+        "Expected Ok for AND composite: {:?}",
+        result.err().map(|e| e.to_string())
+    );
+}
+
+/// An invalid `mode` string should return an error.
+#[tokio::test]
+async fn create_strategy_invalid_mode_returns_error() {
+    let trigger = TriggerConfig::Composite {
+        mode: "xor".to_string(),
+        triggers: vec![cron_trigger(), agent_lifecycle_trigger()],
+        correlation_window_secs: None,
+    };
+    let config = make_workflow(trigger);
+    let bus = EventBus::shared(16);
+
+    let result = create_strategy(&config, Some(&bus));
+    assert!(result.is_err(), "Expected error for invalid mode");
+    let msg = result.err().expect("expected error").to_string();
+    assert!(msg.contains("xor"), "Error should mention the bad mode: {msg}");
+}
+
+/// Nested composites within the depth limit (3) should be accepted.
+#[tokio::test]
+async fn create_strategy_nested_composite_within_depth_limit() {
+    // Depth 0: outer OR
+    //   Depth 1: inner OR
+    //     Depth 2: cron, manual  (leaf triggers)
+    let inner = TriggerConfig::Composite {
+        mode: "or".to_string(),
+        triggers: vec![cron_trigger(), agent_lifecycle_trigger()],
+        correlation_window_secs: None,
+    };
+    let outer = TriggerConfig::Composite {
+        mode: "or".to_string(),
+        triggers: vec![inner, cron_trigger()],
+        correlation_window_secs: None,
+    };
+    let config = make_workflow(outer);
+    let bus = EventBus::shared(16);
+
+    let result = create_strategy(&config, Some(&bus));
+    assert!(
+        result.is_ok(),
+        "Expected Ok for 2-level nesting: {:?}",
+        result.err().map(|e| e.to_string())
+    );
+}
+
+/// Nesting beyond `MAX_COMPOSITE_DEPTH` (3) should return an error.
+#[tokio::test]
+async fn create_strategy_excessive_nesting_returns_error() {
+    // Build 4 levels of OR nesting.
+    let level3 = TriggerConfig::Composite {
+        mode: "or".to_string(),
+        triggers: vec![cron_trigger(), agent_lifecycle_trigger()],
+        correlation_window_secs: None,
+    };
+    let level2 = TriggerConfig::Composite {
+        mode: "or".to_string(),
+        triggers: vec![level3, cron_trigger()],
+        correlation_window_secs: None,
+    };
+    let level1 = TriggerConfig::Composite {
+        mode: "or".to_string(),
+        triggers: vec![level2, cron_trigger()],
+        correlation_window_secs: None,
+    };
+    // Level 0 (the workflow trigger) wraps level1 → depth 3 when building level1's children
+    let level0 = TriggerConfig::Composite {
+        mode: "or".to_string(),
+        triggers: vec![level1, cron_trigger()],
+        correlation_window_secs: None,
+    };
+    let config = make_workflow(level0);
+    let bus = EventBus::shared(16);
+
+    let result = create_strategy(&config, Some(&bus));
+    assert!(result.is_err(), "Expected error for 4-level nesting");
+    let msg = result.err().expect("expected error").to_string();
+    assert!(msg.contains("nesting") || msg.contains("depth"), "Error should mention depth: {msg}");
+}
+
+// ---------------------------------------------------------------------------
+// Serde round-trip tests
+// ---------------------------------------------------------------------------
+
+/// `TriggerConfig::Composite` should survive a serde JSON round-trip.
+#[test]
+fn trigger_config_composite_serde_round_trip_or() {
+    let original = TriggerConfig::Composite {
+        mode: "or".to_string(),
+        triggers: vec![cron_trigger(), agent_lifecycle_trigger()],
+        correlation_window_secs: None,
+    };
+
+    let json = serde_json::to_string(&original).expect("serialize");
+    let decoded: TriggerConfig = serde_json::from_str(&json).expect("deserialize");
+
+    assert_eq!(decoded.trigger_type(), "composite");
+    if let TriggerConfig::Composite { mode, triggers, .. } = &decoded {
+        assert_eq!(mode, "or");
+        assert_eq!(triggers.len(), 2);
+        assert_eq!(triggers[0].trigger_type(), "cron");
+        assert_eq!(triggers[1].trigger_type(), "agent_lifecycle");
+    } else {
+        panic!("Expected Composite variant");
+    }
+}
+
+#[test]
+fn trigger_config_composite_serde_round_trip_and() {
+    let original = TriggerConfig::Composite {
+        mode: "and".to_string(),
+        triggers: vec![cron_trigger(), agent_lifecycle_trigger()],
+        correlation_window_secs: Some(120),
+    };
+
+    let json = serde_json::to_string(&original).expect("serialize");
+    let decoded: TriggerConfig = serde_json::from_str(&json).expect("deserialize");
+
+    if let TriggerConfig::Composite { mode, correlation_window_secs, .. } = &decoded {
+        assert_eq!(mode, "and");
+        assert_eq!(*correlation_window_secs, Some(120));
+    } else {
+        panic!("Expected Composite variant");
+    }
+}
+
+#[test]
+fn trigger_config_composite_is_implemented() {
+    let trigger = TriggerConfig::Composite {
+        mode: "or".to_string(),
+        triggers: vec![cron_trigger(), agent_lifecycle_trigger()],
+        correlation_window_secs: None,
+    };
+    assert!(trigger.is_implemented());
+    assert_eq!(trigger.trigger_type(), "composite");
+    assert!(!trigger.is_one_shot());
+}
+
+// ---------------------------------------------------------------------------
+// Unused import guard — ensures ConnectionRegistry compiles in this context.
+// ---------------------------------------------------------------------------
+#[allow(dead_code)]
+fn _unused(_: ConnectionRegistry) {}

--- a/docs/public/composite-triggers.md
+++ b/docs/public/composite-triggers.md
@@ -1,0 +1,219 @@
+# Composite Triggers
+
+Composite triggers combine multiple trigger strategies using boolean logic
+(**OR** or **AND**), enabling powerful multi-condition workflows.
+
+## Overview
+
+| Mode | Fires when… |
+|------|-------------|
+| `or` | **Any** sub-trigger produces tasks |
+| `and` | **All** sub-triggers produce tasks within the correlation window |
+
+Composite triggers are fully nestable (up to 3 levels deep) and support any
+combination of existing trigger types as sub-triggers.
+
+> **Note:** `manual` and `webhook` trigger types cannot be used as
+> sub-triggers inside a composite because they require a dedicated channel
+> that is managed by the scheduler. Use `cron`, `agent_lifecycle`,
+> `dispatch_result`, `agent_idle`, `github_issues`, or `linear_issues` as
+> sub-triggers.
+
+---
+
+## OR Combinator
+
+The OR composite fires as soon as **any** one of its sub-triggers produces
+tasks. It is the simplest combinator and is useful for "either/or" scenarios.
+
+### Example: cron backup OR manual trigger
+
+```json
+{
+  "name": "backup-or-manual",
+  "agent_id": "<agent-uuid>",
+  "trigger_config": {
+    "type": "composite",
+    "mode": "or",
+    "triggers": [
+      {
+        "type": "cron",
+        "expression": "0 2 * * *"
+      },
+      {
+        "type": "agent_lifecycle",
+        "event": "session_start"
+      }
+    ]
+  },
+  "prompt_template": "Run the backup procedure. Trigger: {{trigger_type}}"
+}
+```
+
+### How OR works
+
+1. Each sub-trigger runs in its own background task.
+2. The first sub-trigger to produce tasks sends them over an internal channel.
+3. `next_tasks()` returns immediately when it receives from the channel.
+4. Other sub-triggers continue running — their results are queued for future
+   `next_tasks()` calls.
+
+---
+
+## AND Combinator
+
+The AND composite fires only when **all** sub-triggers have produced tasks
+within a configurable **correlation window**.
+
+### Example: GitHub issue AND cron window
+
+```json
+{
+  "name": "issue-during-business-hours",
+  "agent_id": "<agent-uuid>",
+  "trigger_config": {
+    "type": "composite",
+    "mode": "and",
+    "correlation_window_secs": 300,
+    "triggers": [
+      {
+        "type": "github_issues",
+        "owner": "my-org",
+        "repo": "my-repo",
+        "labels": ["needs-review"]
+      },
+      {
+        "type": "cron",
+        "expression": "0 9-17 * * MON-FRI"
+      }
+    ]
+  },
+  "prompt_template": "Review issue {{title}} during business hours."
+}
+```
+
+### Correlation window semantics
+
+The correlation window is a sliding timer:
+
+1. The window starts when the **first** sub-trigger fires.
+2. If **all** remaining sub-triggers fire before the window expires, the
+   composite produces a merged task.
+3. If the window expires before all sub-triggers fire, all partial state is
+   discarded and the process restarts.
+
+The default window is **60 seconds**. Use `correlation_window_secs` to
+customise it.
+
+### Merged task format
+
+When an AND composite fires, all sub-tasks are merged into a single task:
+
+| Field | Value |
+|-------|-------|
+| `source_id` | `composite:and:<sub-source-id-1>,<sub-source-id-2>,...` |
+| `title` | Title from the first sub-task |
+| `body` | Newline-joined bodies of all sub-tasks |
+| `metadata.composite_sub_source_ids` | Comma-joined list of all sub-source IDs |
+| `metadata.sub_<key>` | Each metadata key from each sub-task, prefixed with `sub_` |
+
+Template variables available in AND composite prompts:
+
+```
+{{title}}                        — from first sub-task
+{{body}}                         — merged bodies
+{{source_id}}                    — composite:and:...
+{{composite_sub_source_ids}}     — all sub-source IDs
+```
+
+---
+
+## Nested composites
+
+Composites can be nested up to **3 levels deep**:
+
+```json
+{
+  "type": "composite",
+  "mode": "or",
+  "triggers": [
+    {
+      "type": "composite",
+      "mode": "and",
+      "correlation_window_secs": 120,
+      "triggers": [
+        { "type": "github_issues", "owner": "org", "repo": "repo", "labels": ["urgent"] },
+        { "type": "agent_lifecycle", "event": "session_start" }
+      ]
+    },
+    {
+      "type": "cron",
+      "expression": "0 */6 * * *"
+    }
+  ]
+}
+```
+
+This example fires when either:
+- A GitHub issue labelled `urgent` arrives **and** the agent is starting a new
+  session (within 2 minutes), **or**
+- The 6-hourly cron fires.
+
+---
+
+## Configuration reference
+
+| Field | Type | Required | Default | Description |
+|-------|------|----------|---------|-------------|
+| `mode` | `"or"` \| `"and"` | ✓ | — | Combinator logic |
+| `triggers` | array of trigger configs | ✓ | — | Sub-triggers (minimum 2) |
+| `correlation_window_secs` | integer | AND only | `60` | How long all sub-triggers must fire within |
+
+### Validation rules
+
+- `mode` must be `"or"` or `"and"`.
+- At least **2** sub-triggers are required.
+- Nesting depth must not exceed **3 levels**.
+- `manual` and `webhook` cannot be used as sub-triggers.
+
+---
+
+## Limitations and performance considerations
+
+- **AND with long-lived sub-triggers**: If one sub-trigger fires very
+  infrequently (e.g., a cron running once a week), the correlation window
+  may need to be very large, or the AND combinator may never fire in practice.
+- **Resource usage**: Each sub-trigger spawns its own background tokio task.
+  Deeply nested or wide composites with many sub-triggers will each consume
+  a task handle. Keep compositions reasonably bounded.
+- **Deduplication**: The composite `source_id` is derived from the sub-tasks
+  at dispatch time. If the same sub-task fires in two different windows, the
+  resulting composite `source_id` will be different, so both dispatches will
+  proceed.
+
+---
+
+## Troubleshooting
+
+### AND composite never fires
+
+- Check that all sub-triggers can actually produce tasks.
+- Verify `correlation_window_secs` is long enough for all sub-triggers to fire.
+- Check orchestrator logs for `"AND: correlation window expired"` messages —
+  this means one or more sub-triggers fired but others did not within the window.
+
+### Unexpected duplicate dispatches from OR composite
+
+- Each fire from each sub-trigger is queued independently.
+- If two sub-triggers fire in quick succession, both results will appear on
+  sequential `next_tasks()` calls.
+- The runner's deduplication check (`is_dispatched`) will prevent the same
+  `source_id` from being dispatched twice, but tasks with different `source_id`
+  values are treated as distinct.
+
+### Composite workflow not starting
+
+- Verify `is_implemented()` returns `true` for all sub-triggers.
+- Check that event-bus-dependent sub-triggers (`agent_lifecycle`,
+  `dispatch_result`, `agent_idle`) are not used when the event bus is
+  unavailable.


### PR DESCRIPTION
## Summary

- Adds `AndState` struct tracking per-sub-strategy pending task slots and correlation window timer
- Implements AND combinator in `CompositeStrategy::next_tasks`: fires only when ALL sub-strategies have produced tasks within `window_secs`
- Spawns each sub-strategy in a background task sending `(index, tasks)` over a channel
- Correlation window starts when the first sub-strategy fires; if it expires before all fire, partial state is reset
- Merges tasks from all sub-strategies into a single `Task` with `source_id = "composite:and:<ids>"` and sub-metadata prefixed with `sub_`
- Adds `new_and(strategies, window_secs)` constructor and `merge_and_tasks()` helper

## Test plan

- [x] `composite_and_fires_when_all_sub_strategies_fire_within_window` — basic AND fire
- [x] `composite_and_respects_shutdown_before_all_fire` — clean cancellation
- [x] `composite_and_resets_when_window_expires` — window timeout behaviour
- [x] `composite_and_is_object_safe` — usable as `Box<dyn TriggerStrategy>`
- [x] `composite_and_merged_task_has_correct_metadata` — metadata merging verified

Closes #815

🤖 Generated with [Claude Code](https://claude.com/claude-code)