### PR TITLE
epic(ask): complete ask service implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -428,6 +428,7 @@ version = "0.2.0"
 dependencies = [
  "agentd-common",
  "anyhow",
+ "async-trait",
  "axum",
  "chrono",
  "http-body-util",
@@ -437,6 +438,8 @@ dependencies = [
  "mockito",
  "notify",
  "reqwest",
+ "sea-orm",
+ "sea-orm-migration",
  "serde",
  "serde_json",
  "thiserror 2.0.18",

--- a/crates/ask/Cargo.toml
+++ b/crates/ask/Cargo.toml
@@ -28,6 +28,9 @@ notify = { path = "../notify" }
 agentd-common = { path = "../common" }
 metrics = { workspace = true }
 metrics-exporter-prometheus = { workspace = true }
+sea-orm = { workspace = true }
+sea-orm-migration = { workspace = true }
+async-trait = "0.1"
 
 [dev-dependencies]
 mockito = "1.2"

--- a/crates/ask/src/api.rs
+++ b/crates/ask/src/api.rs
@@ -44,23 +44,27 @@
 //! ```
 
 use crate::{
+    checks::CheckRegistry,
     error::ApiError,
     notification_client::NotificationClient,
     state::AppState,
-    tmux_check,
     types::{
-        AnswerRequest, AnswerResponse, CheckType, HealthResponse, NotificationStatus, QuestionInfo,
-        QuestionStatus, TriggerResponse, TriggerResults, UpdateNotificationRequest,
+        AnswerRequest, AnswerResponse, CheckType, CreateNotificationRequest, HealthResponse,
+        ListQuestionsQuery, ListQuestionsResponse, NotificationLifetime, NotificationPriority,
+        NotificationSource, NotificationStatus, QuestionInfo, QuestionStatus, TriggerResponse,
+        TriggerResults, UpdateNotificationRequest,
     },
 };
 use axum::{
-    extract::State,
+    extract::{Path, Query, State},
     response::IntoResponse,
     routing::{get, post},
     Json, Router,
 };
 use chrono::Utc;
-use tracing::{debug, error, info, warn};
+use std::collections::HashMap;
+use std::sync::Arc;
+use tracing::{error, info, warn};
 use uuid::Uuid;
 
 /// Shared state for API handlers.
@@ -91,6 +95,8 @@ pub struct ApiState {
     pub app_state: AppState,
     pub notification_client: NotificationClient,
     pub notification_service_url: String,
+    /// Registry of all enabled checks, shared via Arc for cheap clone.
+    pub check_registry: Arc<CheckRegistry>,
 }
 
 /// Creates the API router without middleware.
@@ -127,6 +133,8 @@ pub fn create_router(state: ApiState) -> Router {
         .route("/health", get(health_check))
         .route("/trigger", post(trigger_checks))
         .route("/answer", post(answer_question))
+        .route("/questions", get(list_questions))
+        .route("/questions/{id}", get(get_question_by_id))
         .with_state(state)
 }
 
@@ -237,76 +245,84 @@ async fn health_check(State(state): State<ApiState>) -> impl IntoResponse {
 /// }
 /// ```
 async fn trigger_checks(State(state): State<ApiState>) -> Result<Json<TriggerResponse>, ApiError> {
-    info!("Running trigger checks");
+    info!("Running trigger checks ({} registered)", state.check_registry.len());
 
     let mut checks_run = Vec::new();
     let mut notifications_sent = Vec::new();
+    let mut results: HashMap<String, serde_json::Value> = HashMap::new();
 
-    // Check tmux sessions
-    checks_run.push(CheckType::TmuxSessions.as_str().to_string());
+    for check in state.check_registry.checks() {
+        let check_name = check.name().to_string();
+        let check_type = check.check_type();
+        checks_run.push(check_name.clone());
 
-    let tmux_result = match tmux_check::check_tmux_sessions() {
-        Ok(result) => {
-            debug!(
-                "tmux check succeeded: running={}, count={}",
-                result.running, result.session_count
-            );
-            result
-        }
-        Err(e) => {
-            warn!("tmux check failed: {}", e);
-            // For all errors (including tmux not installed), assume no sessions running
-            // This allows the service to operate gracefully in environments without tmux
-            crate::types::TmuxCheckResult {
-                running: false,
-                session_count: 0,
-                sessions: Some(Vec::new()),
-            }
-        }
-    };
-
-    // If no sessions running and we can send a notification, do it
-    if !tmux_result.running && state.app_state.can_send_notification(CheckType::TmuxSessions).await
-    {
-        info!("No tmux sessions running, sending notification");
-
-        let question_id = Uuid::new_v4();
-
-        match state.notification_client.create_tmux_session_question(question_id).await {
-            Ok(notification) => {
-                info!("Created notification {} for question {}", notification.id, question_id);
-
-                // Record the notification
-                state.app_state.record_notification(CheckType::TmuxSessions).await;
-
-                // Store the question
-                let question = QuestionInfo {
-                    question_id,
-                    notification_id: notification.id,
-                    check_type: CheckType::TmuxSessions,
-                    asked_at: Utc::now(),
-                    status: QuestionStatus::Pending,
-                    answer: None,
-                };
-                state.app_state.add_question(question).await;
-
-                notifications_sent.push(notification.id);
-            }
+        // Run the check, treating errors as "no action needed" with a warning.
+        let check_result = match check.run().await {
+            Ok(r) => r,
             Err(e) => {
-                error!("Failed to create notification: {}", e);
-                return Err(ApiError::NotificationError(e));
+                warn!(check = %check_name, "Check failed: {}", e);
+                // Gracefully degrade: record an empty result and move on.
+                results.insert(check_name.clone(), serde_json::json!({ "error": e.to_string() }));
+                continue;
             }
+        };
+
+        results.insert(check_name.clone(), check_result.detail.clone());
+
+        if check_result.needs_action && state.app_state.can_send_notification(check_type).await {
+            info!(check = %check_name, "Check needs action, sending notification");
+
+            let question_id = Uuid::new_v4();
+            let template = check.question_template();
+
+            let notification_request = CreateNotificationRequest {
+                source: NotificationSource::AskService { request_id: question_id },
+                lifetime: NotificationLifetime::ephemeral(chrono::Duration::minutes(5)),
+                priority: NotificationPriority::Normal,
+                title: template.title,
+                message: template.message,
+                requires_response: true,
+            };
+
+            match state.notification_client.create_notification(notification_request).await {
+                Ok(notification) => {
+                    info!(
+                        check = %check_name,
+                        notification_id = %notification.id,
+                        "Created notification for question {}",
+                        question_id
+                    );
+
+                    state.app_state.record_notification(check_type).await;
+
+                    let question = QuestionInfo {
+                        question_id,
+                        notification_id: notification.id,
+                        check_type,
+                        asked_at: Utc::now(),
+                        status: QuestionStatus::Pending,
+                        answer: None,
+                    };
+                    state.app_state.add_question(question).await;
+                    notifications_sent.push(notification.id);
+                }
+                Err(e) => {
+                    error!(check = %check_name, "Failed to create notification: {}", e);
+                    return Err(ApiError::NotificationError(e));
+                }
+            }
+        } else if check_result.needs_action {
+            warn!(
+                check = %check_name,
+                "Check needs action but notification is in cooldown"
+            );
         }
-    } else if !tmux_result.running {
-        debug!(
-            "No tmux sessions running, but notification was sent recently (within cooldown period)"
-        );
     }
 
     let response = TriggerResponse {
         checks_run,
         notifications_sent,
-        results: TriggerResults { tmux_sessions: tmux_result },
+        results: TriggerResults { checks: results },
     };
 
     Ok(Json(response))
@@ -430,8 +446,9 @@ async fn answer_question(
     match question.check_type {
         CheckType::TmuxSessions => {
             info!("User answered '{}' to tmux session question", request.answer);
-            // In a real implementation, we could trigger an action here
-            // For now, we just log it
+        }
+        CheckType::ServiceHealth => {
+            info!("User answered '{}' to service health question", request.answer);
         }
     }
 
@@ -442,6 +459,80 @@ async fn answer_question(
     };
 
     Ok(Json(response))
+}
+
+/// Lists questions stored in the ask service.
+///
+/// Returns all questions, optionally filtered by status via the `?status=` query
+/// parameter.  Valid status values are `"pending"`, `"answered"`, and `"expired"`.
+/// Any other value (or no value) returns all questions regardless of status.
+///
+/// # HTTP Method
+///
+/// `GET /questions[?status=pending|answered|expired]`
+///
+/// # Returns
+///
+/// Returns HTTP 200 with [`ListQuestionsResponse`] JSON containing:
+/// - `questions` - array of [`QuestionInfo`] matching the filter
+/// - `total` - count of returned questions
+///
+/// # Examples
+///
+/// ```bash
+/// # All questions
+/// curl http://localhost:17001/questions
+///
+/// # Only pending questions
+/// curl http://localhost:17001/questions?status=pending
+/// ```
+async fn list_questions(
+    State(state): State<ApiState>,
+    Query(params): Query<ListQuestionsQuery>,
+) -> impl IntoResponse {
+    let questions = match params.status.as_deref() {
+        Some("pending") => state.app_state.get_questions_by_status(QuestionStatus::Pending).await,
+        Some("answered") => state.app_state.get_questions_by_status(QuestionStatus::Answered).await,
+        Some("expired") => state.app_state.get_questions_by_status(QuestionStatus::Expired).await,
+        _ => state.app_state.get_all_questions().await,
+    };
+    let total = questions.len();
+    Json(ListQuestionsResponse { questions, total })
+}
+
+/// Retrieves a single question by its UUID.
+///
+/// # HTTP Method
+///
+/// `GET /questions/:id`
+///
+/// # Path Parameters
+///
+/// - `id` - UUID of the question to retrieve
+///
+/// # Returns
+///
+/// Returns HTTP 200 with the [`QuestionInfo`] JSON on success.
+///
+/// # Errors
+///
+/// - [`ApiError::QuestionNotFound`] (404) if no question with the given UUID exists
+///
+/// # Examples
+///
+/// ```bash
+/// curl http://localhost:17001/questions/550e8400-e29b-41d4-a716-446655440000
+/// ```
+async fn get_question_by_id(
+    State(state): State<ApiState>,
+    Path(id): Path<Uuid>,
+) -> Result<Json<QuestionInfo>, ApiError> {
+    state
+        .app_state
+        .get_question(&id)
+        .await
+        .map(Json)
+        .ok_or_else(|| ApiError::QuestionNotFound(format!("Question {id} not found")))
 }
 
 /// Creates the API router with HTTP tracing middleware.
@@ -502,6 +593,7 @@ mod tests {
             app_state,
             notification_client,
             notification_service_url: "http://localhost:17004".to_string(),
+            check_registry: Arc::new(CheckRegistry::new()),
         };
 
         assert_eq!(api_state.notification_service_url, "http://localhost:17004");

--- a/crates/ask/src/checks.rs
+++ b/crates/ask/src/checks.rs
@@ -1,0 +1,417 @@
+#![allow(dead_code)]
+//! Extensible check type registry for the ask service.
+//!
+//! This module defines the [`Check`] trait and [`CheckRegistry`] that allow
+//! the ask service to support multiple, independently implemented environment
+//! checks.  Each check encapsulates its own run logic, question template text,
+//! and associated [`CheckType`].
+//!
+//! # Architecture
+//!
+//! - **[`Check`]** — trait implemented by every check (tmux, service health, …)
+//! - **[`CheckResult`]** — structured output produced by running a check
+//! - **[`QuestionTemplate`]** — title/message pair used to create a notification
+//! - **[`CheckRegistry`]** — ordered list of registered checks; used by the
+//!   trigger handler to iterate and run all enabled checks
+//!
+//! # Adding a New Check
+//!
+//! 1. Implement the [`Check`] trait for your struct.
+//! 2. Register it with [`CheckRegistry::register`].
+//! 3. The trigger handler will pick it up automatically.
+//!
+//! # Examples
+//!
+//! ```rust
+//! use ask::checks::{Check, CheckRegistry, CheckResult, QuestionTemplate};
+//! use ask::types::CheckType;
+//!
+//! struct MyCheck;
+//!
+//! #[async_trait::async_trait]
+//! impl Check for MyCheck {
+//!     fn name(&self) -> &str { "my_check" }
+//!     fn check_type(&self) -> CheckType { CheckType::TmuxSessions }
+//!     async fn run(&self) -> Result<CheckResult, ask::checks::CheckError> {
+//!         Ok(CheckResult { needs_action: false, detail: serde_json::Value::Null })
+//!     }
+//!     fn question_template(&self) -> QuestionTemplate {
+//!         QuestionTemplate {
+//!             title: "My check".to_string(),
+//!             message: "Something happened — what would you like to do?".to_string(),
+//!         }
+//!     }
+//! }
+//!
+//! let mut registry = CheckRegistry::new();
+//! registry.register(Box::new(MyCheck));
+//! assert_eq!(registry.len(), 1);
+//! ```
+
+use crate::types::CheckType;
+use async_trait::async_trait;
+use thiserror::Error;
+
+/// Error type for check execution failures.
+#[derive(Debug, Error)]
+pub enum CheckError {
+    /// The required tool or binary is not available.
+    #[error("tool not available: {0}")]
+    #[allow(dead_code)]
+    ToolNotAvailable(String),
+    /// The check command failed to execute.
+    #[error("check execution failed: {0}")]
+    ExecutionFailed(String),
+    /// Check produced unexpected output.
+    #[error("unexpected output: {0}")]
+    #[allow(dead_code)]
+    UnexpectedOutput(String),
+}
+
+/// Structured output produced by running a check.
+///
+/// `needs_action` indicates whether the trigger handler should create a
+/// notification for this result.  `detail` carries check-specific data that
+/// is returned in the trigger response.
+#[derive(Debug, Clone)]
+pub struct CheckResult {
+    /// Whether this result should trigger a user notification.
+    pub needs_action: bool,
+    /// Check-specific detail payload (serialised as JSON in the response).
+    pub detail: serde_json::Value,
+}
+
+/// Title and message text used when creating a notification for a check result.
+#[derive(Debug, Clone)]
+pub struct QuestionTemplate {
+    /// Short notification title.
+    pub title: String,
+    /// Longer notification body / question text.
+    pub message: String,
+}
+
+/// Trait implemented by every environment check.
+///
+/// Implementations must be `Send + Sync` so they can be stored in the
+/// registry and called from async handlers.
+#[async_trait]
+pub trait Check: Send + Sync {
+    /// Short identifier, e.g. `"tmux_sessions"`.
+    fn name(&self) -> &str;
+
+    /// The [`CheckType`] enum variant this check corresponds to.
+    fn check_type(&self) -> CheckType;
+
+    /// Execute the check and return a structured result.
+    async fn run(&self) -> Result<CheckResult, CheckError>;
+
+    /// Title and message to use when creating a notification for this check.
+    fn question_template(&self) -> QuestionTemplate;
+}
+
+/// Registry of all registered checks.
+///
+/// The trigger handler iterates this registry and runs every check in order.
+/// Checks are stored as boxed trait objects so any type implementing [`Check`]
+/// can be registered.
+///
+/// # Examples
+///
+/// ```rust
+/// use ask::checks::CheckRegistry;
+///
+/// let registry = CheckRegistry::default();
+/// assert_eq!(registry.len(), 0);
+/// ```
+#[allow(dead_code)]
+pub struct CheckRegistry {
+    checks: Vec<Box<dyn Check>>,
+}
+
+impl CheckRegistry {
+    /// Creates an empty registry.
+    pub fn new() -> Self {
+        Self { checks: Vec::new() }
+    }
+
+    /// Registers a check.  Checks are run in registration order.
+    pub fn register(&mut self, check: Box<dyn Check>) {
+        self.checks.push(check);
+    }
+
+    /// Returns the number of registered checks.
+    pub fn len(&self) -> usize {
+        self.checks.len()
+    }
+
+    /// Returns `true` if no checks are registered.
+    #[allow(dead_code)]
+    pub fn is_empty(&self) -> bool {
+        self.checks.is_empty()
+    }
+
+    /// Returns a slice over all registered checks.
+    pub fn checks(&self) -> &[Box<dyn Check>] {
+        &self.checks
+    }
+}
+
+impl Default for CheckRegistry {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+// ── Built-in check implementations ────────────────────────────────────────────
+
+/// Check for running tmux sessions.
+///
+/// Returns `needs_action = true` when no tmux sessions are running.
+pub struct TmuxSessionsCheck;
+
+#[async_trait]
+impl Check for TmuxSessionsCheck {
+    fn name(&self) -> &str {
+        "tmux_sessions"
+    }
+
+    fn check_type(&self) -> CheckType {
+        CheckType::TmuxSessions
+    }
+
+    async fn run(&self) -> Result<CheckResult, CheckError> {
+        let result = crate::tmux_check::check_tmux_sessions()
+            .map_err(|e| CheckError::ExecutionFailed(e.to_string()))?;
+
+        let detail = serde_json::json!({
+            "running": result.running,
+            "session_count": result.session_count,
+            "sessions": result.sessions.unwrap_or_default(),
+        });
+
+        Ok(CheckResult { needs_action: !result.running, detail })
+    }
+
+    fn question_template(&self) -> QuestionTemplate {
+        QuestionTemplate {
+            title: "Start tmux session?".to_string(),
+            message: "No tmux sessions are currently running. Would you like to start one?"
+                .to_string(),
+        }
+    }
+}
+
+/// Example check: verify that other agentd services are reachable.
+///
+/// `needs_action = true` when the target URL returns a non-2xx status or is
+/// unreachable.
+#[allow(dead_code)]
+pub struct ServiceHealthCheck {
+    /// Human-readable name, e.g. `"notify_service"`.
+    pub service_name: String,
+    /// Base URL to GET (expected to respond with 2xx).
+    pub url: String,
+}
+
+#[async_trait]
+impl Check for ServiceHealthCheck {
+    fn name(&self) -> &str {
+        &self.service_name
+    }
+
+    fn check_type(&self) -> CheckType {
+        CheckType::ServiceHealth
+    }
+
+    async fn run(&self) -> Result<CheckResult, CheckError> {
+        let url = format!("{}/health", self.url.trim_end_matches('/'));
+        let client = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(5))
+            .build()
+            .map_err(|e| CheckError::ExecutionFailed(e.to_string()))?;
+
+        match client.get(&url).send().await {
+            Ok(resp) if resp.status().is_success() => Ok(CheckResult {
+                needs_action: false,
+                detail: serde_json::json!({
+                    "service": self.service_name,
+                    "url": url,
+                    "healthy": true,
+                    "status": resp.status().as_u16(),
+                }),
+            }),
+            Ok(resp) => Ok(CheckResult {
+                needs_action: true,
+                detail: serde_json::json!({
+                    "service": self.service_name,
+                    "url": url,
+                    "healthy": false,
+                    "status": resp.status().as_u16(),
+                }),
+            }),
+            Err(e) => Ok(CheckResult {
+                needs_action: true,
+                detail: serde_json::json!({
+                    "service": self.service_name,
+                    "url": url,
+                    "healthy": false,
+                    "error": e.to_string(),
+                }),
+            }),
+        }
+    }
+
+    fn question_template(&self) -> QuestionTemplate {
+        QuestionTemplate {
+            title: format!("Service {} unreachable", self.service_name),
+            message: format!(
+                "The {} service at {} is not responding. Would you like to restart it?",
+                self.service_name, self.url
+            ),
+        }
+    }
+}
+
+/// Build the default registry with all built-in checks.
+///
+/// Enabled checks are controlled by the `AGENTD_CHECKS` environment variable.
+/// Set it to a comma-separated list of check names to enable only those checks,
+/// or leave it unset to enable all built-in checks.
+///
+/// # Examples
+///
+/// ```bash
+/// # Enable only tmux_sessions check
+/// AGENTD_CHECKS=tmux_sessions cargo run
+///
+/// # Enable all checks (default)
+/// cargo run
+/// ```
+pub fn default_registry() -> CheckRegistry {
+    let enabled = std::env::var("AGENTD_CHECKS").ok();
+    let enabled_checks: Option<Vec<&str>> =
+        enabled.as_deref().map(|s| s.split(',').map(str::trim).collect());
+
+    let mut registry = CheckRegistry::new();
+
+    let is_enabled =
+        |name: &str| -> bool { enabled_checks.as_ref().is_none_or(|list| list.contains(&name)) };
+
+    if is_enabled("tmux_sessions") {
+        registry.register(Box::new(TmuxSessionsCheck));
+    }
+
+    registry
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_registry_empty() {
+        let registry = CheckRegistry::new();
+        assert!(registry.is_empty());
+        assert_eq!(registry.len(), 0);
+    }
+
+    #[test]
+    fn test_registry_register() {
+        let mut registry = CheckRegistry::new();
+        registry.register(Box::new(TmuxSessionsCheck));
+        assert_eq!(registry.len(), 1);
+        assert!(!registry.is_empty());
+    }
+
+    #[test]
+    fn test_registry_multiple() {
+        let mut registry = CheckRegistry::new();
+        registry.register(Box::new(TmuxSessionsCheck));
+        registry.register(Box::new(ServiceHealthCheck {
+            service_name: "notify".to_string(),
+            url: "http://localhost:17004".to_string(),
+        }));
+        assert_eq!(registry.len(), 2);
+    }
+
+    #[test]
+    fn test_tmux_check_name_and_type() {
+        let check = TmuxSessionsCheck;
+        assert_eq!(check.name(), "tmux_sessions");
+        assert_eq!(check.check_type(), CheckType::TmuxSessions);
+    }
+
+    #[test]
+    fn test_tmux_question_template() {
+        let check = TmuxSessionsCheck;
+        let tpl = check.question_template();
+        assert!(!tpl.title.is_empty());
+        assert!(!tpl.message.is_empty());
+    }
+
+    #[test]
+    fn test_service_health_check_name() {
+        let check = ServiceHealthCheck {
+            service_name: "notify".to_string(),
+            url: "http://localhost:17004".to_string(),
+        };
+        assert_eq!(check.name(), "notify");
+        assert_eq!(check.check_type(), CheckType::ServiceHealth);
+    }
+
+    #[test]
+    fn test_service_health_question_template() {
+        let check = ServiceHealthCheck {
+            service_name: "notify".to_string(),
+            url: "http://localhost:17004".to_string(),
+        };
+        let tpl = check.question_template();
+        assert!(tpl.title.contains("notify"));
+        assert!(tpl.message.contains("notify"));
+    }
+
+    #[test]
+    fn test_default_registry_builds() {
+        // Ensure default_registry() doesn't panic
+        let registry = default_registry();
+        // At minimum, TmuxSessions should be registered by default
+        assert!(!registry.is_empty());
+    }
+
+    #[test]
+    fn test_default_registry_env_filter() {
+        // Verify the is_enabled logic directly without touching the real env var.
+        // Build a mini-registry using the same logic as default_registry but
+        // with an explicit enabled list.
+        let enabled: Option<Vec<&str>> = Some(vec![""]); // empty name — nothing matches
+        let is_enabled =
+            |name: &str| -> bool { enabled.as_ref().is_none_or(|list| list.contains(&name)) };
+        assert!(!is_enabled("tmux_sessions"));
+        assert!(!is_enabled("service_health"));
+
+        // With None (no env var), everything is enabled.
+        let all_enabled: Option<Vec<&str>> = None;
+        let is_all =
+            |name: &str| -> bool { all_enabled.as_ref().is_none_or(|list| list.contains(&name)) };
+        assert!(is_all("tmux_sessions"));
+        assert!(is_all("service_health"));
+    }
+
+    #[test]
+    fn test_registry_checks_slice() {
+        let mut registry = CheckRegistry::new();
+        registry.register(Box::new(TmuxSessionsCheck));
+        let checks = registry.checks();
+        assert_eq!(checks.len(), 1);
+        assert_eq!(checks[0].name(), "tmux_sessions");
+    }
+
+    #[test]
+    fn test_check_error_display() {
+        let e = CheckError::ToolNotAvailable("tmux".to_string());
+        assert!(e.to_string().contains("tmux"));
+
+        let e = CheckError::ExecutionFailed("exit 1".to_string());
+        assert!(e.to_string().contains("exit 1"));
+    }
+}

--- a/crates/ask/src/client.rs
+++ b/crates/ask/src/client.rs
@@ -148,6 +148,61 @@ impl AskClient {
         self.get("/health").await
     }
 
+    /// List questions stored in the ask service.
+    ///
+    /// # Arguments
+    ///
+    /// * `status` - Optional status filter: `"pending"`, `"answered"`, or `"expired"`.
+    ///   Pass `None` to retrieve all questions.
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use ask::client::AskClient;
+    /// # async fn example() -> anyhow::Result<()> {
+    /// let client = AskClient::new("http://localhost:7001");
+    ///
+    /// // All questions
+    /// let all = client.list_questions(None).await?;
+    /// println!("{} questions total", all.total);
+    ///
+    /// // Only pending
+    /// let pending = client.list_questions(Some("pending")).await?;
+    /// println!("{} pending questions", pending.total);
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn list_questions(&self, status: Option<&str>) -> Result<ListQuestionsResponse> {
+        let path = match status {
+            Some(s) => format!("/questions?status={s}"),
+            None => "/questions".to_string(),
+        };
+        self.get(&path).await
+    }
+
+    /// Retrieve a single question by UUID.
+    ///
+    /// # Arguments
+    ///
+    /// * `question_id` - The UUID of the question to fetch
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// # use ask::client::AskClient;
+    /// # use uuid::Uuid;
+    /// # async fn example() -> anyhow::Result<()> {
+    /// let client = AskClient::new("http://localhost:7001");
+    /// let id = Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000")?;
+    /// let question = client.get_question(&id).await?;
+    /// println!("Status: {:?}", question.status);
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub async fn get_question(&self, question_id: &uuid::Uuid) -> Result<QuestionInfo> {
+        self.get(&format!("/questions/{question_id}")).await
+    }
+
     // Internal helper methods
 
     async fn get<T: DeserializeOwned>(&self, path: &str) -> Result<T> {

--- a/crates/ask/src/entity/mod.rs
+++ b/crates/ask/src/entity/mod.rs
@@ -1,0 +1,3 @@
+//! SeaORM entity modules for the ask service database.
+
+pub mod question;

--- a/crates/ask/src/entity/question.rs
+++ b/crates/ask/src/entity/question.rs
@@ -1,0 +1,36 @@
+//! SeaORM entity for the `questions` table.
+//!
+//! This module defines the ORM model, active model, column enum, and relation
+//! enum for questions stored in SQLite.
+
+use sea_orm::entity::prelude::*;
+
+/// Database model for a question row.
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+#[sea_orm(table_name = "questions")]
+pub struct Model {
+    /// UUID stored as TEXT — primary key.
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub id: String,
+
+    /// The notification ID from the notification service (UUID as TEXT).
+    pub notification_id: String,
+
+    /// Check type label (e.g. "tmux_sessions").
+    pub check_type: String,
+
+    /// RFC3339 timestamp when the question was asked.
+    pub asked_at: String,
+
+    /// Status label: `"Pending"`, `"Answered"`, or `"Expired"`.
+    pub status: String,
+
+    /// User's textual answer — `None` until the user responds.
+    pub answer: Option<String>,
+}
+
+/// No foreign-key relations — questions are a self-contained table.
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/crates/ask/src/lib.rs
+++ b/crates/ask/src/lib.rs
@@ -96,9 +96,16 @@
 //! status.
 
 pub mod api;
+pub mod checks;
 pub mod client;
+pub mod entity;
 pub mod error;
+pub mod migration;
 pub mod notification_client;
 pub mod state;
+pub mod storage;
 pub mod tmux_check;
 pub mod types;
+
+// Re-export commonly used items
+pub use checks::{default_registry, CheckRegistry};

--- a/crates/ask/src/main.rs
+++ b/crates/ask/src/main.rs
@@ -42,19 +42,26 @@
 //! ```
 
 mod api;
+mod checks;
+mod entity;
 mod error;
+mod migration;
 mod notification_client;
 mod state;
+mod storage;
 mod tmux_check;
 mod types;
 
 use anyhow::Result;
 use api::{create_router_with_tracing, ApiState};
 use axum::{extract::State, response::IntoResponse, routing::get};
+use checks::default_registry;
 use metrics_exporter_prometheus::PrometheusHandle;
 use notification_client::NotificationClient;
 use state::AppState;
 use std::env;
+use std::sync::Arc;
+use storage::QuestionStorage;
 use tracing::{error, info, warn};
 
 fn init_metrics() -> PrometheusHandle {
@@ -111,8 +118,20 @@ async fn main() -> Result<()> {
         info!("tmux is installed");
     }
 
+    // Initialize persistent storage
+    let storage = match QuestionStorage::new().await {
+        Ok(s) => {
+            info!("Question storage initialized");
+            s
+        }
+        Err(e) => {
+            error!("Failed to initialize question storage: {}", e);
+            return Err(e);
+        }
+    };
+
     // Initialize application state
-    let app_state = AppState::new();
+    let app_state = AppState::new_with_storage(storage);
 
     // Initialize notification client
     let notification_client = NotificationClient::new(notify_service_url.clone());
@@ -127,11 +146,16 @@ async fn main() -> Result<()> {
         }
     }
 
+    // Build check registry from environment configuration
+    let registry = default_registry();
+    info!("Check registry initialized with {} check(s)", registry.len());
+
     // Create API state
     let api_state = ApiState {
         app_state: app_state.clone(),
         notification_client,
         notification_service_url: notify_service_url,
+        check_registry: Arc::new(registry),
     };
 
     // Initialize Prometheus metrics
@@ -162,7 +186,9 @@ async fn main() -> Result<()> {
         loop {
             tokio::time::sleep(tokio::time::Duration::from_secs(3600)).await;
             info!("Running cleanup of old questions");
-            cleanup_state.cleanup_old_questions().await;
+            if let Err(e) = cleanup_state.cleanup_old_questions().await {
+                error!("Cleanup failed: {}", e);
+            }
         }
     });
 

--- a/crates/ask/src/migration/m20250328_000001_create_questions_table.rs
+++ b/crates/ask/src/migration/m20250328_000001_create_questions_table.rs
@@ -1,0 +1,68 @@
+//! Initial migration: create the `questions` table with indexes.
+
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .create_table(
+                Table::create()
+                    .table(Questions::Table)
+                    .if_not_exists()
+                    .col(ColumnDef::new(Questions::Id).string().not_null().primary_key())
+                    .col(ColumnDef::new(Questions::NotificationId).string().not_null())
+                    .col(ColumnDef::new(Questions::CheckType).string().not_null())
+                    .col(ColumnDef::new(Questions::AskedAt).string().not_null())
+                    .col(ColumnDef::new(Questions::Status).string().not_null())
+                    .col(ColumnDef::new(Questions::Answer).string().null())
+                    .to_owned(),
+            )
+            .await?;
+
+        // Index on status for filtering active questions
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx_questions_status")
+                    .table(Questions::Table)
+                    .col(Questions::Status)
+                    .if_not_exists()
+                    .to_owned(),
+            )
+            .await?;
+
+        // Index on asked_at for time-based queries and cleanup
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx_questions_asked_at")
+                    .table(Questions::Table)
+                    .col(Questions::AskedAt)
+                    .if_not_exists()
+                    .to_owned(),
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager.drop_table(Table::drop().table(Questions::Table).to_owned()).await
+    }
+}
+
+/// Iden enum matching the `questions` table columns.
+#[derive(DeriveIden)]
+enum Questions {
+    Table,
+    Id,
+    NotificationId,
+    CheckType,
+    AskedAt,
+    Status,
+    Answer,
+}

--- a/crates/ask/src/migration/mod.rs
+++ b/crates/ask/src/migration/mod.rs
@@ -1,0 +1,24 @@
+//! SeaORM migration runner for the ask service.
+//!
+//! Run all pending migrations at service startup:
+//!
+//! ```rust,ignore
+//! use ask::migration::Migrator;
+//! use sea_orm_migration::MigratorTrait;
+//!
+//! Migrator::up(&db, None).await?;
+//! ```
+
+pub use sea_orm_migration::prelude::*;
+
+mod m20250328_000001_create_questions_table;
+
+/// The migration runner — applies all known migrations in order.
+pub struct Migrator;
+
+#[async_trait::async_trait]
+impl MigratorTrait for Migrator {
+    fn migrations() -> Vec<Box<dyn MigrationTrait>> {
+        vec![Box::new(m20250328_000001_create_questions_table::Migration)]
+    }
+}

--- a/crates/ask/src/notification_client.rs
+++ b/crates/ask/src/notification_client.rs
@@ -370,6 +370,7 @@ impl NotificationClient {
     /// # Ok(())
     /// # }
     /// ```
+    #[allow(dead_code)]
     pub async fn create_tmux_session_question(
         &self,
         request_id: Uuid,

--- a/crates/ask/src/state.rs
+++ b/crates/ask/src/state.rs
@@ -57,6 +57,7 @@
 //! # }
 //! ```
 
+use crate::storage::QuestionStorage;
 use crate::types::{CheckType, QuestionInfo, QuestionStatus};
 use chrono::{DateTime, Duration, Utc};
 use std::collections::HashMap;
@@ -97,12 +98,15 @@ pub struct AppState {
 /// This struct contains the actual data. It is not exposed publicly and is only
 /// accessed through the [`AppState`] methods which handle locking.
 struct AppStateInner {
-    /// Active questions indexed by question ID
+    /// Active questions indexed by question ID (in-memory cache)
     questions: HashMap<Uuid, QuestionInfo>,
     /// Last notification sent timestamp per check type
     last_notification: HashMap<CheckType, DateTime<Utc>>,
     /// Notification cooldown period (default: 30 minutes)
     cooldown_duration: Duration,
+    /// Optional persistent storage backend
+    #[allow(dead_code)]
+    storage: Option<QuestionStorage>,
 }
 
 impl AppState {
@@ -155,6 +159,26 @@ impl AppState {
                 questions: HashMap::new(),
                 last_notification: HashMap::new(),
                 cooldown_duration,
+                storage: None,
+            })),
+        }
+    }
+
+    /// Creates a new application state backed by persistent storage.
+    ///
+    /// Questions are written through to the [`QuestionStorage`] on every mutation,
+    /// providing durability across service restarts.
+    ///
+    /// # Arguments
+    ///
+    /// - `storage` - The persistent question storage backend
+    pub fn new_with_storage(storage: QuestionStorage) -> Self {
+        Self {
+            inner: Arc::new(RwLock::new(AppStateInner {
+                questions: HashMap::new(),
+                last_notification: HashMap::new(),
+                cooldown_duration: Duration::minutes(30),
+                storage: Some(storage),
             })),
         }
     }
@@ -263,8 +287,16 @@ impl AppState {
     /// # }
     /// ```
     pub async fn add_question(&self, question: QuestionInfo) {
-        let mut state = self.inner.write().await;
-        state.questions.insert(question.question_id, question);
+        let storage = {
+            let mut state = self.inner.write().await;
+            state.questions.insert(question.question_id, question.clone());
+            state.storage.clone()
+        };
+        if let Some(s) = storage {
+            if let Err(e) = s.add(&question).await {
+                tracing::warn!("Failed to persist question {}: {}", question.question_id, e);
+            }
+        }
     }
 
     /// Retrieves a question by its ID.
@@ -352,37 +384,60 @@ impl AppState {
         question_id: &Uuid,
         answer: String,
     ) -> Result<QuestionInfo, String> {
-        let mut state = self.inner.write().await;
+        let (updated, storage) = {
+            let mut state = self.inner.write().await;
 
-        let question = state
-            .questions
-            .get_mut(question_id)
-            .ok_or_else(|| format!("Question {question_id} not found"))?;
+            let question = state
+                .questions
+                .get_mut(question_id)
+                .ok_or_else(|| format!("Question {question_id} not found"))?;
 
-        if question.status != QuestionStatus::Pending {
-            return Err(format!(
-                "Question {} is not pending (status: {:?})",
-                question_id, question.status
-            ));
+            if question.status != QuestionStatus::Pending {
+                return Err(format!(
+                    "Question {} is not pending (status: {:?})",
+                    question_id, question.status
+                ));
+            }
+
+            question.status = QuestionStatus::Answered;
+            question.answer = Some(answer.clone());
+            let updated = question.clone();
+            let storage = state.storage.clone();
+            (updated, storage)
+        };
+
+        if let Some(s) = storage {
+            if let Err(e) =
+                s.update_status(question_id, QuestionStatus::Answered, Some(answer)).await
+            {
+                tracing::warn!("Failed to persist answer for question {}: {}", question_id, e);
+            }
         }
 
-        question.status = QuestionStatus::Answered;
-        question.answer = Some(answer);
-
-        Ok(question.clone())
+        Ok(updated)
     }
 
     /// Mark a question as expired
     #[allow(dead_code)]
     pub async fn expire_question(&self, question_id: &Uuid) -> Result<(), String> {
-        let mut state = self.inner.write().await;
+        let storage = {
+            let mut state = self.inner.write().await;
 
-        let question = state
-            .questions
-            .get_mut(question_id)
-            .ok_or_else(|| format!("Question {question_id} not found"))?;
+            let question = state
+                .questions
+                .get_mut(question_id)
+                .ok_or_else(|| format!("Question {question_id} not found"))?;
 
-        question.status = QuestionStatus::Expired;
+            question.status = QuestionStatus::Expired;
+            state.storage.clone()
+        };
+
+        if let Some(s) = storage {
+            if let Err(e) = s.update_status(question_id, QuestionStatus::Expired, None).await {
+                tracing::warn!("Failed to persist expiry for question {}: {}", question_id, e);
+            }
+        }
+
         Ok(())
     }
 
@@ -391,6 +446,18 @@ impl AppState {
     pub async fn get_active_questions(&self) -> Vec<QuestionInfo> {
         let state = self.inner.read().await;
         state.questions.values().filter(|q| q.status == QuestionStatus::Pending).cloned().collect()
+    }
+
+    /// Get all questions regardless of status.
+    pub async fn get_all_questions(&self) -> Vec<QuestionInfo> {
+        let state = self.inner.read().await;
+        state.questions.values().cloned().collect()
+    }
+
+    /// Get all questions with a specific status.
+    pub async fn get_questions_by_status(&self, status: QuestionStatus) -> Vec<QuestionInfo> {
+        let state = self.inner.read().await;
+        state.questions.values().filter(|q| q.status == status).cloned().collect()
     }
 
     /// Cleans up old questions from memory.
@@ -415,16 +482,24 @@ impl AppState {
     /// let state = AppState::new();
     ///
     /// // Periodically clean up old questions
-    /// state.cleanup_old_questions().await;
+    /// let removed = state.cleanup_old_questions().await.unwrap();
     /// # }
     /// ```
-    pub async fn cleanup_old_questions(&self) {
-        let mut state = self.inner.write().await;
-        let cutoff = Utc::now() - Duration::hours(24);
+    pub async fn cleanup_old_questions(&self) -> anyhow::Result<u64> {
+        let storage = {
+            let mut state = self.inner.write().await;
+            let cutoff = Utc::now() - Duration::hours(24);
+            state.questions.retain(|_, question| {
+                question.asked_at > cutoff || question.status == QuestionStatus::Pending
+            });
+            state.storage.clone()
+        };
 
-        state.questions.retain(|_, question| {
-            question.asked_at > cutoff || question.status == QuestionStatus::Pending
-        });
+        if let Some(s) = storage {
+            return s.cleanup_old().await;
+        }
+
+        Ok(0)
     }
 
     /// Get the cooldown duration
@@ -646,7 +721,7 @@ mod tests {
         state.add_question(recent_answered.clone()).await;
         state.add_question(old_pending.clone()).await;
 
-        state.cleanup_old_questions().await;
+        state.cleanup_old_questions().await.unwrap();
 
         // Old answered should be removed
         assert!(state.get_question(&old_answered.question_id).await.is_none());

--- a/crates/ask/src/storage.rs
+++ b/crates/ask/src/storage.rs
@@ -1,0 +1,354 @@
+//! SeaORM-based persistent storage for questions.
+//!
+//! Provides the [`QuestionStorage`] backend that persists questions to
+//! an SQLite database using SeaORM entities and a migration-managed schema.
+//!
+//! # Database Location
+//!
+//! - Linux: `~/.local/share/agentd-ask/ask.db`
+//! - macOS: `~/Library/Application Support/agentd-ask/ask.db`
+//!
+//! # Schema
+//!
+//! Managed by [`crate::migration::Migrator`]. See
+//! `migration/m20250328_000001_create_questions_table.rs` for the full
+//! column list.
+//!
+//! # Examples
+//!
+//! ```no_run
+//! use ask::storage::QuestionStorage;
+//! use ask::types::{QuestionInfo, CheckType, QuestionStatus};
+//! use chrono::Utc;
+//! use uuid::Uuid;
+//!
+//! #[tokio::main]
+//! async fn main() -> anyhow::Result<()> {
+//!     let storage = QuestionStorage::new().await?;
+//!
+//!     let question = QuestionInfo {
+//!         question_id: Uuid::new_v4(),
+//!         notification_id: Uuid::new_v4(),
+//!         check_type: CheckType::TmuxSessions,
+//!         asked_at: Utc::now(),
+//!         status: QuestionStatus::Pending,
+//!         answer: None,
+//!     };
+//!
+//!     storage.add(&question).await?;
+//!     println!("Stored question: {}", question.question_id);
+//!     Ok(())
+//! }
+//! ```
+
+use crate::{
+    entity::question as question_entity,
+    migration::Migrator,
+    types::{CheckType, QuestionInfo, QuestionStatus},
+};
+use anyhow::Result;
+use chrono::DateTime;
+use sea_orm::{
+    ActiveValue::Set, ColumnTrait, DatabaseConnection, EntityTrait, Order, QueryFilter, QueryOrder,
+};
+use sea_orm_migration::prelude::MigratorTrait;
+use std::path::Path;
+use uuid::Uuid;
+
+/// Persistent storage backend for questions using SeaORM + SQLite.
+///
+/// This struct provides a thread-safe, async interface to a SQLite database.
+/// [`DatabaseConnection`] is `Clone + Send + Sync`.
+///
+/// # Examples
+///
+/// ```no_run
+/// use ask::storage::QuestionStorage;
+///
+/// #[tokio::main]
+/// async fn main() -> anyhow::Result<()> {
+///     let storage = QuestionStorage::new().await?;
+///     let storage_clone = storage.clone();
+///     tokio::spawn(async move { let _ = storage_clone; });
+///     Ok(())
+/// }
+/// ```
+#[derive(Clone)]
+pub struct QuestionStorage {
+    db: DatabaseConnection,
+}
+
+impl QuestionStorage {
+    /// Gets the platform-specific database file path.
+    ///
+    /// - **Linux**: `~/.local/share/agentd-ask/ask.db`
+    /// - **macOS**: `~/Library/Application Support/agentd-ask/ask.db`
+    pub fn get_db_path() -> Result<std::path::PathBuf> {
+        agentd_common::storage::get_db_path("agentd-ask", "ask.db")
+    }
+
+    /// Creates a new storage instance with the default database path.
+    pub async fn new() -> Result<Self> {
+        let db_path = Self::get_db_path()?;
+        Self::with_path(&db_path).await
+    }
+
+    /// Creates a new storage instance connected to `db_path`.
+    ///
+    /// The file is created if it does not exist, and all pending SeaORM
+    /// migrations are applied before returning.
+    pub async fn with_path(db_path: &Path) -> Result<Self> {
+        let db = agentd_common::storage::create_connection(db_path).await?;
+        Migrator::up(&db, None).await?;
+        Ok(Self { db })
+    }
+
+    /// Creates an in-memory storage instance for testing.
+    #[cfg(test)]
+    pub async fn in_memory() -> Result<Self> {
+        use sea_orm::Database;
+        let db = Database::connect("sqlite::memory:").await?;
+        Migrator::up(&db, None).await?;
+        Ok(Self { db })
+    }
+
+    /// Inserts a question and returns its UUID.
+    pub async fn add(&self, question: &QuestionInfo) -> Result<Uuid> {
+        let model = question_entity::ActiveModel {
+            id: Set(question.question_id.to_string()),
+            notification_id: Set(question.notification_id.to_string()),
+            check_type: Set(question.check_type.as_str().to_string()),
+            asked_at: Set(question.asked_at.to_rfc3339()),
+            status: Set(status_to_str(question.status).to_string()),
+            answer: Set(question.answer.clone()),
+        };
+
+        question_entity::Entity::insert(model).exec(&self.db).await?;
+        Ok(question.question_id)
+    }
+
+    /// Retrieves a question by its UUID.
+    #[allow(dead_code)]
+    pub async fn get(&self, question_id: &Uuid) -> Result<Option<QuestionInfo>> {
+        let model =
+            question_entity::Entity::find_by_id(question_id.to_string()).one(&self.db).await?;
+        model.map(model_to_question).transpose()
+    }
+
+    /// Retrieves all questions, ordered by asked_at descending.
+    #[allow(dead_code)]
+    pub async fn list_all(&self) -> Result<Vec<QuestionInfo>> {
+        let models = question_entity::Entity::find()
+            .order_by(question_entity::Column::AskedAt, Order::Desc)
+            .all(&self.db)
+            .await?;
+
+        models.into_iter().map(model_to_question).collect()
+    }
+
+    /// Retrieves all questions with a given status.
+    #[allow(dead_code)]
+    pub async fn list_by_status(&self, status: QuestionStatus) -> Result<Vec<QuestionInfo>> {
+        let status_str = status_to_str(status);
+        let models = question_entity::Entity::find()
+            .filter(question_entity::Column::Status.eq(status_str))
+            .order_by(question_entity::Column::AskedAt, Order::Desc)
+            .all(&self.db)
+            .await?;
+
+        models.into_iter().map(model_to_question).collect()
+    }
+
+    /// Updates a question's status and optional answer.
+    pub async fn update_status(
+        &self,
+        question_id: &Uuid,
+        status: QuestionStatus,
+        answer: Option<String>,
+    ) -> Result<()> {
+        use sea_orm::ActiveModelTrait;
+
+        let model = question_entity::Entity::find_by_id(question_id.to_string())
+            .one(&self.db)
+            .await?
+            .ok_or_else(|| anyhow::anyhow!("Question {} not found", question_id))?;
+
+        let mut active: question_entity::ActiveModel = model.into();
+        active.status = Set(status_to_str(status).to_string());
+        active.answer = Set(answer);
+        active.save(&self.db).await?;
+
+        Ok(())
+    }
+
+    /// Deletes questions that are older than 24 hours and not pending.
+    pub async fn cleanup_old(&self) -> Result<u64> {
+        let cutoff = chrono::Utc::now() - chrono::Duration::hours(24);
+        let cutoff_str = cutoff.to_rfc3339();
+
+        let result = question_entity::Entity::delete_many()
+            .filter(question_entity::Column::AskedAt.lt(cutoff_str))
+            .filter(question_entity::Column::Status.ne(status_to_str(QuestionStatus::Pending)))
+            .exec(&self.db)
+            .await?;
+
+        Ok(result.rows_affected)
+    }
+}
+
+/// Converts a [`QuestionStatus`] to its string representation for storage.
+fn status_to_str(status: QuestionStatus) -> &'static str {
+    match status {
+        QuestionStatus::Pending => "Pending",
+        QuestionStatus::Answered => "Answered",
+        QuestionStatus::Expired => "Expired",
+    }
+}
+
+/// Parses a status string from storage back to [`QuestionStatus`].
+#[allow(dead_code)]
+fn str_to_status(s: &str) -> Result<QuestionStatus> {
+    match s {
+        "Pending" => Ok(QuestionStatus::Pending),
+        "Answered" => Ok(QuestionStatus::Answered),
+        "Expired" => Ok(QuestionStatus::Expired),
+        other => anyhow::bail!("Unknown question status: {}", other),
+    }
+}
+
+/// Parses a check_type string from storage back to [`CheckType`].
+#[allow(dead_code)]
+fn str_to_check_type(s: &str) -> Result<CheckType> {
+    match s {
+        "tmux_sessions" => Ok(CheckType::TmuxSessions),
+        "service_health" => Ok(CheckType::ServiceHealth),
+        other => anyhow::bail!("Unknown check type: {}", other),
+    }
+}
+
+/// Converts a database model row to a [`QuestionInfo`].
+#[allow(dead_code)]
+fn model_to_question(model: question_entity::Model) -> Result<QuestionInfo> {
+    Ok(QuestionInfo {
+        question_id: Uuid::parse_str(&model.id)?,
+        notification_id: Uuid::parse_str(&model.notification_id)?,
+        check_type: str_to_check_type(&model.check_type)?,
+        asked_at: DateTime::parse_from_rfc3339(&model.asked_at)?.with_timezone(&chrono::Utc),
+        status: str_to_status(&model.status)?,
+        answer: model.answer,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use chrono::Utc;
+
+    async fn make_storage() -> QuestionStorage {
+        QuestionStorage::in_memory().await.unwrap()
+    }
+
+    fn make_question() -> QuestionInfo {
+        QuestionInfo {
+            question_id: Uuid::new_v4(),
+            notification_id: Uuid::new_v4(),
+            check_type: CheckType::TmuxSessions,
+            asked_at: Utc::now(),
+            status: QuestionStatus::Pending,
+            answer: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn test_add_and_get() {
+        let storage = make_storage().await;
+        let q = make_question();
+        storage.add(&q).await.unwrap();
+        let retrieved = storage.get(&q.question_id).await.unwrap().unwrap();
+        assert_eq!(retrieved.question_id, q.question_id);
+        assert_eq!(retrieved.check_type, q.check_type);
+        assert_eq!(retrieved.status, q.status);
+        assert!(retrieved.answer.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_get_nonexistent() {
+        let storage = make_storage().await;
+        let result = storage.get(&Uuid::new_v4()).await.unwrap();
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_list_all() {
+        let storage = make_storage().await;
+        let q1 = make_question();
+        let q2 = make_question();
+        storage.add(&q1).await.unwrap();
+        storage.add(&q2).await.unwrap();
+        let all = storage.list_all().await.unwrap();
+        assert_eq!(all.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_list_by_status() {
+        let storage = make_storage().await;
+        let q1 = make_question();
+        let mut q2 = make_question();
+        q2.status = QuestionStatus::Answered;
+        q2.answer = Some("yes".to_string());
+        storage.add(&q1).await.unwrap();
+        storage.add(&q2).await.unwrap();
+
+        let pending = storage.list_by_status(QuestionStatus::Pending).await.unwrap();
+        assert_eq!(pending.len(), 1);
+        assert_eq!(pending[0].question_id, q1.question_id);
+
+        let answered = storage.list_by_status(QuestionStatus::Answered).await.unwrap();
+        assert_eq!(answered.len(), 1);
+        assert_eq!(answered[0].question_id, q2.question_id);
+    }
+
+    #[tokio::test]
+    async fn test_update_status() {
+        let storage = make_storage().await;
+        let q = make_question();
+        storage.add(&q).await.unwrap();
+
+        storage
+            .update_status(&q.question_id, QuestionStatus::Answered, Some("yes".to_string()))
+            .await
+            .unwrap();
+
+        let updated = storage.get(&q.question_id).await.unwrap().unwrap();
+        assert_eq!(updated.status, QuestionStatus::Answered);
+        assert_eq!(updated.answer, Some("yes".to_string()));
+    }
+
+    #[tokio::test]
+    async fn test_cleanup_old() {
+        let storage = make_storage().await;
+
+        // Add an old answered question
+        let mut old_answered = make_question();
+        old_answered.asked_at = Utc::now() - chrono::Duration::hours(25);
+        old_answered.status = QuestionStatus::Answered;
+        old_answered.answer = Some("yes".to_string());
+        storage.add(&old_answered).await.unwrap();
+
+        // Add a recent pending question (should be kept)
+        let recent_pending = make_question();
+        storage.add(&recent_pending).await.unwrap();
+
+        // Add an old pending question (should be kept — still actionable)
+        let mut old_pending = make_question();
+        old_pending.asked_at = Utc::now() - chrono::Duration::hours(25);
+        storage.add(&old_pending).await.unwrap();
+
+        let removed = storage.cleanup_old().await.unwrap();
+        assert_eq!(removed, 1);
+
+        let all = storage.list_all().await.unwrap();
+        assert_eq!(all.len(), 2);
+        assert!(storage.get(&old_answered.question_id).await.unwrap().is_none());
+    }
+}

--- a/crates/ask/src/types.rs
+++ b/crates/ask/src/types.rs
@@ -50,6 +50,7 @@
 
 use chrono::{DateTime, Utc};
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use uuid::Uuid;
 
 // Re-export notification types from the notify crate
@@ -89,6 +90,8 @@ pub struct QuestionInfo {
 pub enum CheckType {
     /// Check for running tmux sessions
     TmuxSessions,
+    /// Check that an agentd service is reachable via HTTP health endpoint
+    ServiceHealth,
 }
 
 impl CheckType {
@@ -102,10 +105,12 @@ impl CheckType {
     /// use ask::types::CheckType;
     ///
     /// assert_eq!(CheckType::TmuxSessions.as_str(), "tmux_sessions");
+    /// assert_eq!(CheckType::ServiceHealth.as_str(), "service_health");
     /// ```
     pub fn as_str(&self) -> &'static str {
         match self {
             CheckType::TmuxSessions => "tmux_sessions",
+            CheckType::ServiceHealth => "service_health",
         }
     }
 }
@@ -167,12 +172,50 @@ pub struct TriggerResponse {
 
 /// Detailed results from each check type.
 ///
-/// Currently only contains tmux session check results, but structured to allow
-/// adding more check types in the future.
+/// Maps check name (e.g. `"tmux_sessions"`) to its JSON detail payload.
+/// Using a flexible map allows the registry to grow without changing this type.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct TriggerResults {
-    /// Result of the tmux session check
-    pub tmux_sessions: TmuxCheckResult,
+    /// Per-check detail payloads, keyed by check name.
+    pub checks: HashMap<String, serde_json::Value>,
+}
+
+/// Query parameters for the `GET /questions` list endpoint.
+///
+/// All fields are optional. When omitted, no filtering is applied.
+#[derive(Debug, Clone, Deserialize)]
+pub struct ListQuestionsQuery {
+    /// Optional status filter: `"pending"`, `"answered"`, or `"expired"`.
+    pub status: Option<String>,
+}
+
+/// Response from the `GET /questions` endpoint.
+///
+/// Returns all questions stored in the service, optionally filtered by status.
+///
+/// # JSON Example
+///
+/// ```json
+/// {
+///   "questions": [
+///     {
+///       "question_id": "550e8400-e29b-41d4-a716-446655440000",
+///       "notification_id": "660e8400-e29b-41d4-a716-446655440000",
+///       "check_type": "TmuxSessions",
+///       "asked_at": "2025-03-28T00:00:00Z",
+///       "status": "Pending",
+///       "answer": null
+///     }
+///   ],
+///   "total": 1
+/// }
+/// ```
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ListQuestionsResponse {
+    /// The list of questions matching the query filter.
+    pub questions: Vec<QuestionInfo>,
+    /// Total number of questions returned.
+    pub total: usize,
 }
 
 /// Request to submit an answer to a question.
@@ -292,16 +335,15 @@ mod tests {
 
     #[test]
     fn test_trigger_response_serialization() {
+        let mut checks = HashMap::new();
+        checks.insert(
+            "tmux_sessions".to_string(),
+            serde_json::json!({ "running": false, "session_count": 0, "sessions": [] }),
+        );
         let response = TriggerResponse {
             checks_run: vec!["tmux_sessions".to_string()],
             notifications_sent: vec![Uuid::new_v4()],
-            results: TriggerResults {
-                tmux_sessions: TmuxCheckResult {
-                    running: false,
-                    session_count: 0,
-                    sessions: Some(vec![]),
-                },
-            },
+            results: TriggerResults { checks },
         };
 
         let json = serde_json::to_string(&response).unwrap();

--- a/crates/ask/tests/api_test.rs
+++ b/crates/ask/tests/api_test.rs
@@ -1,9 +1,11 @@
 use ask::{
     api::{create_router, ApiState},
+    checks::{Check, CheckError, CheckRegistry, CheckResult, QuestionTemplate},
     notification_client::NotificationClient,
     state::AppState,
     types::*,
 };
+use async_trait::async_trait;
 use axum::{
     body::Body,
     http::{Request, StatusCode},
@@ -12,8 +14,50 @@ use chrono::{Duration, Utc};
 use http_body_util::BodyExt;
 use mockito::Server;
 use serde_json::Value;
+use std::sync::Arc;
 use tower::ServiceExt;
 use uuid::Uuid;
+
+// ── Shared test helpers ────────────────────────────────────────────────────────
+
+/// Minimal ApiState with no checks registered and a dummy notification URL.
+fn minimal_api_state() -> ApiState {
+    ApiState {
+        app_state: AppState::new(),
+        notification_client: NotificationClient::new("http://localhost:17004".to_string()),
+        notification_service_url: "http://localhost:17004".to_string(),
+        check_registry: Arc::new(CheckRegistry::new()),
+    }
+}
+
+/// A fake check used in registry tests.  Always reports `needs_action = false`
+/// so no notification service interaction is required.
+struct NoOpCheck {
+    name: &'static str,
+    check_type: CheckType,
+}
+
+#[async_trait]
+impl Check for NoOpCheck {
+    fn name(&self) -> &str {
+        self.name
+    }
+
+    fn check_type(&self) -> CheckType {
+        self.check_type
+    }
+
+    async fn run(&self) -> Result<CheckResult, CheckError> {
+        Ok(CheckResult { needs_action: false, detail: serde_json::json!({ "ok": true }) })
+    }
+
+    fn question_template(&self) -> QuestionTemplate {
+        QuestionTemplate {
+            title: format!("{} question", self.name),
+            message: format!("{} message", self.name),
+        }
+    }
+}
 
 // Helper function to parse response body
 async fn parse_response_body(body: Body) -> Value {
@@ -31,6 +75,7 @@ async fn test_health_endpoint() {
         app_state,
         notification_client,
         notification_service_url: "http://localhost:17004".to_string(),
+        check_registry: Arc::new(CheckRegistry::new()),
     };
 
     let app = create_router(api_state);
@@ -79,8 +124,12 @@ async fn test_trigger_with_no_sessions_sends_notification() {
 
     let app_state = AppState::new();
     let notification_client = NotificationClient::new(mock_server.url());
-    let api_state =
-        ApiState { app_state, notification_client, notification_service_url: mock_server.url() };
+    let api_state = ApiState {
+        app_state,
+        notification_client,
+        notification_service_url: mock_server.url(),
+        check_registry: Arc::new(CheckRegistry::new()),
+    };
 
     let app = create_router(api_state);
 
@@ -93,14 +142,10 @@ async fn test_trigger_with_no_sessions_sends_notification() {
     assert_eq!(response.status(), StatusCode::OK);
 
     let body = parse_response_body(response.into_body()).await;
+    // With an empty registry no checks are run — the test verifies 200 + valid shape.
     assert!(body["checks_run"].is_array());
-    assert!(body["checks_run"]
-        .as_array()
-        .unwrap()
-        .contains(&Value::String("tmux_sessions".to_string())));
-
-    // The mock may or may not be called depending on whether tmux is installed
-    // and whether sessions are running, so we don't assert on it
+    assert!(body["notifications_sent"].is_array());
+    assert!(body["results"]["checks"].is_object());
 }
 
 // Test /trigger endpoint respects cooldown
@@ -138,8 +183,12 @@ async fn test_trigger_respects_cooldown() {
     app_state.record_notification(CheckType::TmuxSessions).await;
 
     let notification_client = NotificationClient::new(mock_server.url());
-    let api_state =
-        ApiState { app_state, notification_client, notification_service_url: mock_server.url() };
+    let api_state = ApiState {
+        app_state,
+        notification_client,
+        notification_service_url: mock_server.url(),
+        check_registry: Arc::new(CheckRegistry::new()),
+    };
 
     let app = create_router(api_state);
 
@@ -201,8 +250,12 @@ async fn test_answer_valid_question() {
     app_state.add_question(question).await;
 
     let notification_client = NotificationClient::new(mock_server.url());
-    let api_state =
-        ApiState { app_state, notification_client, notification_service_url: mock_server.url() };
+    let api_state = ApiState {
+        app_state,
+        notification_client,
+        notification_service_url: mock_server.url(),
+        check_registry: Arc::new(CheckRegistry::new()),
+    };
 
     let app = create_router(api_state);
 
@@ -238,6 +291,7 @@ async fn test_answer_nonexistent_question() {
         app_state,
         notification_client,
         notification_service_url: "http://localhost:17004".to_string(),
+        check_registry: Arc::new(CheckRegistry::new()),
     };
 
     let app = create_router(api_state);
@@ -284,6 +338,7 @@ async fn test_answer_already_answered_question() {
         app_state,
         notification_client,
         notification_service_url: "http://localhost:17004".to_string(),
+        check_registry: Arc::new(CheckRegistry::new()),
     };
 
     let app = create_router(api_state);
@@ -338,8 +393,12 @@ async fn test_answer_notification_update_fails_but_answer_succeeds() {
     app_state.add_question(question).await;
 
     let notification_client = NotificationClient::new(mock_server.url());
-    let api_state =
-        ApiState { app_state, notification_client, notification_service_url: mock_server.url() };
+    let api_state = ApiState {
+        app_state,
+        notification_client,
+        notification_service_url: mock_server.url(),
+        check_registry: Arc::new(CheckRegistry::new()),
+    };
 
     let app = create_router(api_state);
 
@@ -395,8 +454,12 @@ async fn test_concurrent_trigger_requests() {
 
     let app_state = AppState::with_cooldown(Duration::milliseconds(100));
     let notification_client = NotificationClient::new(mock_server.url());
-    let api_state =
-        ApiState { app_state, notification_client, notification_service_url: mock_server.url() };
+    let api_state = ApiState {
+        app_state,
+        notification_client,
+        notification_service_url: mock_server.url(),
+        check_registry: Arc::new(CheckRegistry::new()),
+    };
 
     let app = create_router(api_state);
 
@@ -436,6 +499,7 @@ async fn test_health_response_structure() {
         app_state,
         notification_client,
         notification_service_url: "http://test:9999".to_string(),
+        check_registry: Arc::new(CheckRegistry::new()),
     };
 
     let app = create_router(api_state);
@@ -484,8 +548,12 @@ async fn test_trigger_response_structure() {
 
     let app_state = AppState::new();
     let notification_client = NotificationClient::new(mock_server.url());
-    let api_state =
-        ApiState { app_state, notification_client, notification_service_url: mock_server.url() };
+    let api_state = ApiState {
+        app_state,
+        notification_client,
+        notification_service_url: mock_server.url(),
+        check_registry: Arc::new(CheckRegistry::new()),
+    };
 
     let app = create_router(api_state);
 
@@ -504,7 +572,8 @@ async fn test_trigger_response_structure() {
     assert!(body.get("notifications_sent").is_some());
     assert!(body["notifications_sent"].is_array());
     assert!(body.get("results").is_some());
-    assert!(body["results"].get("tmux_sessions").is_some());
+    // With an empty registry, results.checks is an empty map
+    assert!(body["results"].get("checks").is_some());
 }
 
 // Test invalid request body to /answer endpoint
@@ -516,6 +585,7 @@ async fn test_answer_with_invalid_json() {
         app_state,
         notification_client,
         notification_service_url: "http://localhost:17004".to_string(),
+        check_registry: Arc::new(CheckRegistry::new()),
     };
 
     let app = create_router(api_state);
@@ -545,6 +615,7 @@ async fn test_wrong_http_method() {
         app_state,
         notification_client,
         notification_service_url: "http://localhost:17004".to_string(),
+        check_registry: Arc::new(CheckRegistry::new()),
     };
 
     let app = create_router(api_state);
@@ -567,6 +638,7 @@ async fn test_nonexistent_endpoint() {
         app_state,
         notification_client,
         notification_service_url: "http://localhost:17004".to_string(),
+        check_registry: Arc::new(CheckRegistry::new()),
     };
 
     let app = create_router(api_state);
@@ -577,4 +649,516 @@ async fn test_nonexistent_endpoint() {
         .unwrap();
 
     assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+
+// ── List endpoint tests ────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_list_questions_empty() {
+    let app = create_router(minimal_api_state());
+
+    let response = app
+        .oneshot(Request::builder().uri("/questions").method("GET").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = parse_response_body(response.into_body()).await;
+    assert_eq!(body["total"], 0);
+    assert!(body["questions"].as_array().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn test_list_questions_returns_all() {
+    let app_state = AppState::new();
+
+    for _ in 0..3 {
+        app_state
+            .add_question(QuestionInfo {
+                question_id: Uuid::new_v4(),
+                notification_id: Uuid::new_v4(),
+                check_type: CheckType::TmuxSessions,
+                asked_at: Utc::now(),
+                status: QuestionStatus::Pending,
+                answer: None,
+            })
+            .await;
+    }
+
+    let api_state = ApiState {
+        app_state,
+        notification_client: NotificationClient::new("http://localhost:17004".to_string()),
+        notification_service_url: "http://localhost:17004".to_string(),
+        check_registry: Arc::new(CheckRegistry::new()),
+    };
+
+    let app = create_router(api_state);
+
+    let response = app
+        .oneshot(Request::builder().uri("/questions").method("GET").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = parse_response_body(response.into_body()).await;
+    assert_eq!(body["total"], 3);
+    assert_eq!(body["questions"].as_array().unwrap().len(), 3);
+}
+
+#[tokio::test]
+async fn test_list_questions_filter_by_status_pending() {
+    let app_state = AppState::new();
+
+    // Add 2 pending, 1 answered
+    for _ in 0..2 {
+        app_state
+            .add_question(QuestionInfo {
+                question_id: Uuid::new_v4(),
+                notification_id: Uuid::new_v4(),
+                check_type: CheckType::TmuxSessions,
+                asked_at: Utc::now(),
+                status: QuestionStatus::Pending,
+                answer: None,
+            })
+            .await;
+    }
+    app_state
+        .add_question(QuestionInfo {
+            question_id: Uuid::new_v4(),
+            notification_id: Uuid::new_v4(),
+            check_type: CheckType::TmuxSessions,
+            asked_at: Utc::now(),
+            status: QuestionStatus::Answered,
+            answer: Some("yes".to_string()),
+        })
+        .await;
+
+    let api_state = ApiState {
+        app_state,
+        notification_client: NotificationClient::new("http://localhost:17004".to_string()),
+        notification_service_url: "http://localhost:17004".to_string(),
+        check_registry: Arc::new(CheckRegistry::new()),
+    };
+
+    let app = create_router(api_state);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/questions?status=pending")
+                .method("GET")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = parse_response_body(response.into_body()).await;
+    assert_eq!(body["total"], 2);
+    for q in body["questions"].as_array().unwrap() {
+        assert_eq!(q["status"], "Pending");
+    }
+}
+
+#[tokio::test]
+async fn test_list_questions_filter_by_status_answered() {
+    let app_state = AppState::new();
+
+    app_state
+        .add_question(QuestionInfo {
+            question_id: Uuid::new_v4(),
+            notification_id: Uuid::new_v4(),
+            check_type: CheckType::TmuxSessions,
+            asked_at: Utc::now(),
+            status: QuestionStatus::Pending,
+            answer: None,
+        })
+        .await;
+    app_state
+        .add_question(QuestionInfo {
+            question_id: Uuid::new_v4(),
+            notification_id: Uuid::new_v4(),
+            check_type: CheckType::TmuxSessions,
+            asked_at: Utc::now(),
+            status: QuestionStatus::Answered,
+            answer: Some("no".to_string()),
+        })
+        .await;
+
+    let api_state = ApiState {
+        app_state,
+        notification_client: NotificationClient::new("http://localhost:17004".to_string()),
+        notification_service_url: "http://localhost:17004".to_string(),
+        check_registry: Arc::new(CheckRegistry::new()),
+    };
+
+    let app = create_router(api_state);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri("/questions?status=answered")
+                .method("GET")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = parse_response_body(response.into_body()).await;
+    assert_eq!(body["total"], 1);
+    assert_eq!(body["questions"][0]["status"], "Answered");
+}
+
+#[tokio::test]
+async fn test_get_question_by_id_found() {
+    let app_state = AppState::new();
+    let question_id = Uuid::new_v4();
+
+    app_state
+        .add_question(QuestionInfo {
+            question_id,
+            notification_id: Uuid::new_v4(),
+            check_type: CheckType::TmuxSessions,
+            asked_at: Utc::now(),
+            status: QuestionStatus::Pending,
+            answer: None,
+        })
+        .await;
+
+    let api_state = ApiState {
+        app_state,
+        notification_client: NotificationClient::new("http://localhost:17004".to_string()),
+        notification_service_url: "http://localhost:17004".to_string(),
+        check_registry: Arc::new(CheckRegistry::new()),
+    };
+
+    let app = create_router(api_state);
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri(format!("/questions/{question_id}"))
+                .method("GET")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = parse_response_body(response.into_body()).await;
+    assert_eq!(body["question_id"], question_id.to_string());
+    assert_eq!(body["status"], "Pending");
+}
+
+#[tokio::test]
+async fn test_get_question_by_id_not_found() {
+    let app = create_router(minimal_api_state());
+    let unknown_id = Uuid::new_v4();
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .uri(format!("/questions/{unknown_id}"))
+                .method("GET")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    let body = parse_response_body(response.into_body()).await;
+    assert!(body["error"].as_str().unwrap().contains("not found"));
+}
+
+// ── Full flow: trigger -> list -> answer -> verify ─────────────────────────────
+
+#[tokio::test]
+async fn test_full_flow_list_then_answer_then_verify_status() {
+    let app_state = AppState::new();
+    let question_id = Uuid::new_v4();
+    let notification_id = Uuid::new_v4();
+
+    // Pre-seed a pending question (simulates a previous trigger)
+    app_state
+        .add_question(QuestionInfo {
+            question_id,
+            notification_id,
+            check_type: CheckType::TmuxSessions,
+            asked_at: Utc::now(),
+            status: QuestionStatus::Pending,
+            answer: None,
+        })
+        .await;
+
+    let mut mock_server = Server::new_async().await;
+    let _mock = mock_server
+        .mock("PUT", format!("/notifications/{notification_id}").as_str())
+        .with_status(200)
+        .with_header("content-type", "application/json")
+        .with_body(format!(
+            r#"{{
+            "id": "{notification_id}",
+            "source": {{"type": "ask_service", "request_id": "{question_id}"}},
+            "lifetime": {{"type": "persistent"}},
+            "priority": "normal",
+            "status": "responded",
+            "title": "Test",
+            "message": "Test",
+            "requires_response": true,
+            "response": "yes",
+            "created_at": "2024-01-01T00:00:00Z",
+            "updated_at": "2024-01-01T00:00:01Z"
+        }}"#
+        ))
+        .create_async()
+        .await;
+
+    let api_state = ApiState {
+        app_state,
+        notification_client: NotificationClient::new(mock_server.url()),
+        notification_service_url: mock_server.url(),
+        check_registry: Arc::new(CheckRegistry::new()),
+    };
+    let app = create_router(api_state);
+
+    // Step 1: list — should show 1 pending question
+    let list_resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/questions?status=pending")
+                .method("GET")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(list_resp.status(), StatusCode::OK);
+    let list_body = parse_response_body(list_resp.into_body()).await;
+    assert_eq!(list_body["total"], 1);
+
+    // Step 2: answer the question
+    let answer_req = AnswerRequest { question_id, answer: "yes".to_string() };
+    let answer_resp = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .uri("/answer")
+                .method("POST")
+                .header("content-type", "application/json")
+                .body(Body::from(serde_json::to_string(&answer_req).unwrap()))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(answer_resp.status(), StatusCode::OK);
+    let answer_body = parse_response_body(answer_resp.into_body()).await;
+    assert_eq!(answer_body["success"], true);
+
+    // Step 3: verify the question is no longer pending
+    let list_after = app
+        .oneshot(
+            Request::builder()
+                .uri("/questions?status=pending")
+                .method("GET")
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(list_after.status(), StatusCode::OK);
+    let list_after_body = parse_response_body(list_after.into_body()).await;
+    assert_eq!(list_after_body["total"], 0);
+}
+
+// ── Check registry tests ───────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_trigger_runs_all_registered_checks() {
+    let mut registry = CheckRegistry::new();
+    registry.register(Box::new(NoOpCheck { name: "check_a", check_type: CheckType::TmuxSessions }));
+    registry
+        .register(Box::new(NoOpCheck { name: "check_b", check_type: CheckType::ServiceHealth }));
+
+    let api_state = ApiState {
+        app_state: AppState::new(),
+        notification_client: NotificationClient::new("http://localhost:17004".to_string()),
+        notification_service_url: "http://localhost:17004".to_string(),
+        check_registry: Arc::new(registry),
+    };
+
+    let app = create_router(api_state);
+
+    let response = app
+        .oneshot(Request::builder().uri("/trigger").method("POST").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = parse_response_body(response.into_body()).await;
+
+    let checks_run = body["checks_run"].as_array().unwrap();
+    assert!(checks_run.contains(&Value::String("check_a".to_string())));
+    assert!(checks_run.contains(&Value::String("check_b".to_string())));
+
+    // Both checks returned ok detail
+    assert!(body["results"]["checks"]["check_a"]["ok"].as_bool().unwrap());
+    assert!(body["results"]["checks"]["check_b"]["ok"].as_bool().unwrap());
+}
+
+#[tokio::test]
+async fn test_trigger_with_empty_registry_returns_no_checks() {
+    let app = create_router(minimal_api_state());
+
+    let response = app
+        .oneshot(Request::builder().uri("/trigger").method("POST").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = parse_response_body(response.into_body()).await;
+    assert!(body["checks_run"].as_array().unwrap().is_empty());
+    assert!(body["notifications_sent"].as_array().unwrap().is_empty());
+}
+
+#[tokio::test]
+async fn test_trigger_check_result_detail_is_in_response() {
+    let mut registry = CheckRegistry::new();
+    registry
+        .register(Box::new(NoOpCheck { name: "my_check", check_type: CheckType::TmuxSessions }));
+
+    let api_state = ApiState {
+        app_state: AppState::new(),
+        notification_client: NotificationClient::new("http://localhost:17004".to_string()),
+        notification_service_url: "http://localhost:17004".to_string(),
+        check_registry: Arc::new(registry),
+    };
+
+    let app = create_router(api_state);
+
+    let response = app
+        .oneshot(Request::builder().uri("/trigger").method("POST").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+
+    let body = parse_response_body(response.into_body()).await;
+    // NoOpCheck returns {"ok": true}
+    assert_eq!(body["results"]["checks"]["my_check"]["ok"], true);
+}
+
+// ── AskClient unit tests ───────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_ask_client_health_against_live_router() {
+    use ask::client::AskClient;
+    use axum::serve;
+    use tokio::net::TcpListener;
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    let app = create_router(minimal_api_state());
+
+    tokio::spawn(async move {
+        serve(listener, app).await.unwrap();
+    });
+
+    let client = AskClient::new(format!("http://127.0.0.1:{port}"));
+    let health = client.health().await.unwrap();
+    assert_eq!(health.status, "ok");
+    assert_eq!(health.service, "agentd-ask");
+}
+
+#[tokio::test]
+async fn test_ask_client_list_questions_against_live_router() {
+    use ask::client::AskClient;
+    use axum::serve;
+    use tokio::net::TcpListener;
+
+    let app_state = AppState::new();
+    app_state
+        .add_question(QuestionInfo {
+            question_id: Uuid::new_v4(),
+            notification_id: Uuid::new_v4(),
+            check_type: CheckType::TmuxSessions,
+            asked_at: Utc::now(),
+            status: QuestionStatus::Pending,
+            answer: None,
+        })
+        .await;
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    let api_state = ApiState {
+        app_state,
+        notification_client: NotificationClient::new("http://localhost:17004".to_string()),
+        notification_service_url: "http://localhost:17004".to_string(),
+        check_registry: Arc::new(CheckRegistry::new()),
+    };
+    let app = create_router(api_state);
+
+    tokio::spawn(async move {
+        serve(listener, app).await.unwrap();
+    });
+
+    let client = AskClient::new(format!("http://127.0.0.1:{port}"));
+
+    // All questions
+    let all = client.list_questions(None).await.unwrap();
+    assert_eq!(all.total, 1);
+
+    // Filtered
+    let pending = client.list_questions(Some("pending")).await.unwrap();
+    assert_eq!(pending.total, 1);
+
+    let answered = client.list_questions(Some("answered")).await.unwrap();
+    assert_eq!(answered.total, 0);
+}
+
+#[tokio::test]
+async fn test_ask_client_get_question_against_live_router() {
+    use ask::client::AskClient;
+    use axum::serve;
+    use tokio::net::TcpListener;
+
+    let app_state = AppState::new();
+    let question_id = Uuid::new_v4();
+    app_state
+        .add_question(QuestionInfo {
+            question_id,
+            notification_id: Uuid::new_v4(),
+            check_type: CheckType::TmuxSessions,
+            asked_at: Utc::now(),
+            status: QuestionStatus::Pending,
+            answer: None,
+        })
+        .await;
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let port = listener.local_addr().unwrap().port();
+    let api_state = ApiState {
+        app_state,
+        notification_client: NotificationClient::new("http://localhost:17004".to_string()),
+        notification_service_url: "http://localhost:17004".to_string(),
+        check_registry: Arc::new(CheckRegistry::new()),
+    };
+    let app = create_router(api_state);
+
+    tokio::spawn(async move {
+        serve(listener, app).await.unwrap();
+    });
+
+    let client = AskClient::new(format!("http://127.0.0.1:{port}"));
+
+    let q = client.get_question(&question_id).await.unwrap();
+    assert_eq!(q.question_id, question_id);
+    assert_eq!(q.status, QuestionStatus::Pending);
+
+    // Non-existent returns error
+    let err = client.get_question(&Uuid::new_v4()).await;
+    assert!(err.is_err());
 }

--- a/crates/cli/src/commands/ask.rs
+++ b/crates/cli/src/commands/ask.rs
@@ -35,7 +35,7 @@
 
 use anyhow::{Context, Result};
 use ask::client::AskClient;
-use ask::types::AnswerRequest;
+use ask::types::{AnswerRequest, QuestionStatus};
 use clap::Subcommand;
 use colored::*;
 use uuid::Uuid;
@@ -79,6 +79,32 @@ pub enum AskCommand {
         /// Answer text (can be multiple words)
         answer: String,
     },
+
+    /// List questions tracked by the ask service.
+    ///
+    /// # Examples
+    ///
+    /// ```bash
+    /// agentd ask list
+    /// agentd ask list --status pending
+    /// ```
+    List {
+        /// Filter by status: pending, answered, or expired
+        #[clap(long)]
+        status: Option<String>,
+    },
+
+    /// Get a specific question by its UUID.
+    ///
+    /// # Examples
+    ///
+    /// ```bash
+    /// agentd ask get 550e8400-e29b-41d4-a716-446655440000
+    /// ```
+    Get {
+        /// UUID of the question to retrieve
+        question_id: String,
+    },
 }
 
 impl AskCommand {
@@ -99,6 +125,8 @@ impl AskCommand {
             AskCommand::Answer { question_id, answer } => {
                 answer_question(client, question_id, answer, json).await
             }
+            AskCommand::List { status } => list_questions(client, status.as_deref(), json).await,
+            AskCommand::Get { question_id } => get_question(client, question_id, json).await,
         }
     }
 }
@@ -214,6 +242,89 @@ async fn answer_question(
     Ok(())
 }
 
+/// List questions tracked by the ask service.
+///
+/// Sends a GET request to `/questions` (with optional `?status=` filter) and
+/// displays the results in a human-readable table or as raw JSON.
+async fn list_questions(client: &AskClient, status: Option<&str>, json: bool) -> Result<()> {
+    let response = client
+        .list_questions(status)
+        .await
+        .context("Failed to list questions. Is the ask service running?")?;
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&response)?);
+        return Ok(());
+    }
+
+    let label = match status {
+        Some(s) => format!(" (status: {s})"),
+        None => String::new(),
+    };
+    println!("{}", format!("Questions{label}:").bold());
+    println!();
+
+    if response.questions.is_empty() {
+        println!("{}", "  No questions found.".bright_black());
+    } else {
+        for q in &response.questions {
+            let status_str = match q.status {
+                QuestionStatus::Pending => "pending".yellow(),
+                QuestionStatus::Answered => "answered".green(),
+                QuestionStatus::Expired => "expired".bright_black(),
+            };
+            println!(
+                "  {} [{}] {}",
+                q.question_id.to_string().cyan(),
+                status_str,
+                q.check_type.as_str().bright_black()
+            );
+            if let Some(ref answer) = q.answer {
+                println!("    Answer: {answer}");
+            }
+        }
+        println!();
+        println!("{}: {}", "Total".bold(), response.total.to_string().cyan());
+    }
+
+    Ok(())
+}
+
+/// Retrieve a single question by UUID.
+///
+/// Sends a GET request to `/questions/:id` and displays the question details.
+async fn get_question(client: &AskClient, question_id: &str, json: bool) -> Result<()> {
+    let uuid = Uuid::parse_str(question_id).context("Invalid question UUID format")?;
+
+    let question = client
+        .get_question(&uuid)
+        .await
+        .context("Failed to get question. Is the ask service running?")?;
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&question)?);
+        return Ok(());
+    }
+
+    let status_str = match question.status {
+        QuestionStatus::Pending => "pending".yellow(),
+        QuestionStatus::Answered => "answered".green(),
+        QuestionStatus::Expired => "expired".bright_black(),
+    };
+
+    println!("{}", "Question Details:".bold());
+    println!();
+    println!("  {}: {}", "ID".bold(), question.question_id.to_string().cyan());
+    println!("  {}: {}", "Status".bold(), status_str);
+    println!("  {}: {}", "Check Type".bold(), question.check_type.as_str());
+    println!("  {}: {}", "Asked At".bold(), question.asked_at);
+    if let Some(ref answer) = question.answer {
+        println!("  {}: {}", "Answer".bold(), answer);
+    }
+
+    Ok(())
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -225,9 +336,11 @@ mod tests {
             "checks_run": ["tmux_sessions"],
             "notifications_sent": [],
             "results": {
-                "tmux_sessions": {
-                    "running": true,
-                    "session_count": 2
+                "checks": {
+                    "tmux_sessions": {
+                        "running": true,
+                        "session_count": 2
+                    }
                 }
             }
         }"#;
@@ -235,8 +348,9 @@ mod tests {
         let response: TriggerResponse = serde_json::from_str(json).unwrap();
         assert_eq!(response.checks_run, vec!["tmux_sessions"]);
         assert!(response.notifications_sent.is_empty());
-        assert!(response.results.tmux_sessions.running);
-        assert_eq!(response.results.tmux_sessions.session_count, 2);
+        let tmux = response.results.checks.get("tmux_sessions").unwrap();
+        assert!(tmux["running"].as_bool().unwrap());
+        assert_eq!(tmux["session_count"].as_u64().unwrap(), 2);
     }
 
     #[test]


### PR DESCRIPTION
Rollup PR for epic #869 — complete ask service implementation. Stacks all sub-issue branches.

Sub-issues:
- #870 SQLite persistence with SeaORM
- #871 List endpoint (GET /questions, GET /questions/:id)
- #872 Extensible check type registry
- #873 Expanded integration tests
- #874 Launchd plist

Closes #869