### PR TITLE
test(ask): add comprehensive tests for ask service and ask_response trigger

### DIFF
--- a/crates/ask/src/api.rs
+++ b/crates/ask/src/api.rs
@@ -195,9 +195,9 @@ pub fn create_router_with_tracing(api_state: ApiState) -> Router {
     Router::new()
         .route("/health", get(health_handler))
         .route("/questions", post(create_question_handler).get(list_questions_handler))
-        .route("/questions/:id/answer", post(answer_question_handler))
-        .route("/questions/:id/dismiss", post(dismiss_question_handler))
-        .route("/questions/:id", get(get_question_handler))
+        .route("/questions/{id}/answer", post(answer_question_handler))
+        .route("/questions/{id}/dismiss", post(dismiss_question_handler))
+        .route("/questions/{id}", get(get_question_handler))
         .with_state(api_state)
         .layer(TraceLayer::new_for_http())
 }

--- a/crates/ask/src/storage.rs
+++ b/crates/ask/src/storage.rs
@@ -48,8 +48,11 @@ impl QuestionStorage {
         Ok(Self { db })
     }
 
-    /// Creates an in-memory storage instance for testing.
-    #[cfg(test)]
+    /// Creates an in-memory storage instance (for testing).
+    ///
+    /// Connects to `sqlite::memory:` — data is lost when the connection closes.
+    /// Suitable for unit tests, integration tests, and one-shot tooling.
+    #[allow(dead_code)]
     pub async fn in_memory() -> Result<Self> {
         use sea_orm::Database;
         let db = Database::connect("sqlite::memory:").await?;

--- a/crates/ask/tests/api_test.rs
+++ b/crates/ask/tests/api_test.rs
@@ -1,3 +1,509 @@
-// Integration tests for the ask service API.
-// Old check-based tests removed in issue #921.
-// New Q&A API integration tests added in issue #928.
+//! Integration tests for the ask service REST API.
+//!
+//! Uses Tower's `oneshot` helper to drive the Axum router in-process,
+//! without binding to a network port. A fresh in-memory SQLite database
+//! is used for each test.
+
+use ask::{
+    api::{create_router_with_tracing, ApiState},
+    state::AppState,
+    storage::QuestionStorage,
+    types::{
+        AnswerQuestionRequest, CreateQuestionRequest, Question, QuestionPriority, QuestionStatus,
+        QuestionsListResponse,
+    },
+};
+use axum::body::Body;
+use http_body_util::BodyExt;
+use hyper::{Request, StatusCode};
+use tower::ServiceExt;
+use uuid::Uuid;
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+async fn make_app() -> axum::Router {
+    let storage = QuestionStorage::in_memory().await.unwrap();
+    let app_state = AppState::new_with_storage(storage);
+    let api_state = ApiState { app_state, orchestrator_url: None };
+    create_router_with_tracing(api_state)
+}
+
+/// Deserialize a response body into T.
+async fn parse_body<T: serde::de::DeserializeOwned>(body: Body) -> T {
+    let bytes = body.collect().await.unwrap().to_bytes();
+    serde_json::from_slice(&bytes).unwrap()
+}
+
+fn create_question_request() -> CreateQuestionRequest {
+    CreateQuestionRequest {
+        agent_id: "dietician".to_string(),
+        workflow_id: None,
+        dispatch_id: None,
+        category: Some("health".to_string()),
+        question: "What did you eat yesterday?".to_string(),
+        context: None,
+        priority: Some(QuestionPriority::Normal),
+        expires_in_seconds: None,
+    }
+}
+
+/// POST /questions and return the created Question.
+async fn create_question(app: axum::Router, req: &CreateQuestionRequest) -> Question {
+    let body = serde_json::to_vec(req).unwrap();
+    let request = Request::builder()
+        .method("POST")
+        .uri("/questions")
+        .header("content-type", "application/json")
+        .body(Body::from(body))
+        .unwrap();
+    let response = app.oneshot(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::CREATED);
+    parse_body(response.into_body()).await
+}
+
+// ─── Health ─────────────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn health_returns_ok() {
+    let app = make_app().await;
+    let request = Request::builder().method("GET").uri("/health").body(Body::empty()).unwrap();
+    let response = app.oneshot(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let body: serde_json::Value = parse_body(response.into_body()).await;
+    assert_eq!(body["status"], "ok");
+    assert_eq!(body["service"], "agentd-ask");
+}
+
+// ─── POST /questions ─────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn create_question_returns_201() {
+    let app = make_app().await;
+    let req = create_question_request();
+    let q = create_question(app, &req).await;
+
+    assert_eq!(q.agent_id, "dietician");
+    assert_eq!(q.question, "What did you eat yesterday?");
+    assert_eq!(q.status, QuestionStatus::Pending);
+    assert_eq!(q.priority, QuestionPriority::Normal);
+    assert!(q.answer.is_none());
+}
+
+#[tokio::test]
+async fn create_question_with_all_fields() {
+    let app = make_app().await;
+    let wf_id = Uuid::new_v4();
+    let dp_id = Uuid::new_v4();
+    let req = CreateQuestionRequest {
+        agent_id: "test-agent".to_string(),
+        workflow_id: Some(wf_id),
+        dispatch_id: Some(dp_id),
+        category: Some("deployment".to_string()),
+        question: "Should I deploy?".to_string(),
+        context: Some("Staging passed.".to_string()),
+        priority: Some(QuestionPriority::High),
+        expires_in_seconds: Some(3600),
+    };
+    let q = create_question(app, &req).await;
+
+    assert_eq!(q.workflow_id, Some(wf_id));
+    assert_eq!(q.dispatch_id, Some(dp_id));
+    assert_eq!(q.category, Some("deployment".to_string()));
+    assert_eq!(q.priority, QuestionPriority::High);
+    assert!(q.expires_at.is_some());
+}
+
+#[tokio::test]
+async fn create_question_empty_agent_id_returns_400() {
+    let app = make_app().await;
+    let mut req = create_question_request();
+    req.agent_id = "".to_string();
+    let body = serde_json::to_vec(&req).unwrap();
+
+    let request = Request::builder()
+        .method("POST")
+        .uri("/questions")
+        .header("content-type", "application/json")
+        .body(Body::from(body))
+        .unwrap();
+    let response = app.oneshot(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn create_question_empty_question_text_returns_400() {
+    let app = make_app().await;
+    let mut req = create_question_request();
+    req.question = "".to_string();
+    let body = serde_json::to_vec(&req).unwrap();
+
+    let request = Request::builder()
+        .method("POST")
+        .uri("/questions")
+        .header("content-type", "application/json")
+        .body(Body::from(body))
+        .unwrap();
+    let response = app.oneshot(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}
+
+// ─── POST /questions/{id}/answer ─────────────────────────────────────────────
+
+#[tokio::test]
+async fn answer_question_returns_200() {
+    let app = make_app().await;
+    let q = create_question(app.clone(), &create_question_request()).await;
+
+    let answer_body =
+        serde_json::to_vec(&AnswerQuestionRequest { answer: "I had oatmeal.".to_string() })
+            .unwrap();
+    let request = Request::builder()
+        .method("POST")
+        .uri(format!("/questions/{}/answer", q.id))
+        .header("content-type", "application/json")
+        .body(Body::from(answer_body))
+        .unwrap();
+    let response = app.oneshot(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let updated: Question = parse_body(response.into_body()).await;
+    assert_eq!(updated.status, QuestionStatus::Answered);
+    assert_eq!(updated.answer, Some("I had oatmeal.".to_string()));
+    assert!(updated.answered_at.is_some());
+}
+
+#[tokio::test]
+async fn answer_question_empty_answer_returns_400() {
+    let app = make_app().await;
+    let q = create_question(app.clone(), &create_question_request()).await;
+
+    let answer_body =
+        serde_json::to_vec(&AnswerQuestionRequest { answer: "".to_string() }).unwrap();
+    let request = Request::builder()
+        .method("POST")
+        .uri(format!("/questions/{}/answer", q.id))
+        .header("content-type", "application/json")
+        .body(Body::from(answer_body))
+        .unwrap();
+    let response = app.oneshot(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn answer_question_nonexistent_returns_404() {
+    let app = make_app().await;
+    let answer_body =
+        serde_json::to_vec(&AnswerQuestionRequest { answer: "yes".to_string() }).unwrap();
+    let request = Request::builder()
+        .method("POST")
+        .uri(format!("/questions/{}/answer", Uuid::new_v4()))
+        .header("content-type", "application/json")
+        .body(Body::from(answer_body))
+        .unwrap();
+    let response = app.oneshot(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+
+#[tokio::test]
+async fn answer_already_answered_question_returns_409() {
+    let app = make_app().await;
+    let q = create_question(app.clone(), &create_question_request()).await;
+
+    // First answer — should succeed.
+    let body =
+        serde_json::to_vec(&AnswerQuestionRequest { answer: "first answer".to_string() }).unwrap();
+    let r1 = Request::builder()
+        .method("POST")
+        .uri(format!("/questions/{}/answer", q.id))
+        .header("content-type", "application/json")
+        .body(Body::from(body))
+        .unwrap();
+    let resp1 = app.clone().oneshot(r1).await.unwrap();
+    assert_eq!(resp1.status(), StatusCode::OK);
+
+    // Second answer — should fail with 409 Conflict.
+    let body2 =
+        serde_json::to_vec(&AnswerQuestionRequest { answer: "second answer".to_string() }).unwrap();
+    let r2 = Request::builder()
+        .method("POST")
+        .uri(format!("/questions/{}/answer", q.id))
+        .header("content-type", "application/json")
+        .body(Body::from(body2))
+        .unwrap();
+    let resp2 = app.oneshot(r2).await.unwrap();
+    assert_eq!(resp2.status(), StatusCode::CONFLICT);
+}
+
+// ─── POST /questions/{id}/dismiss ────────────────────────────────────────────
+
+#[tokio::test]
+async fn dismiss_question_returns_200() {
+    let app = make_app().await;
+    let q = create_question(app.clone(), &create_question_request()).await;
+
+    let request = Request::builder()
+        .method("POST")
+        .uri(format!("/questions/{}/dismiss", q.id))
+        .body(Body::empty())
+        .unwrap();
+    let response = app.oneshot(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let updated: Question = parse_body(response.into_body()).await;
+    assert_eq!(updated.status, QuestionStatus::Dismissed);
+    assert!(updated.answer.is_none());
+}
+
+#[tokio::test]
+async fn dismiss_already_answered_question_returns_409() {
+    let app = make_app().await;
+    let q = create_question(app.clone(), &create_question_request()).await;
+
+    // Answer it first.
+    let body = serde_json::to_vec(&AnswerQuestionRequest { answer: "yes".to_string() }).unwrap();
+    let r1 = Request::builder()
+        .method("POST")
+        .uri(format!("/questions/{}/answer", q.id))
+        .header("content-type", "application/json")
+        .body(Body::from(body))
+        .unwrap();
+    app.clone().oneshot(r1).await.unwrap();
+
+    // Now try to dismiss — should fail.
+    let r2 = Request::builder()
+        .method("POST")
+        .uri(format!("/questions/{}/dismiss", q.id))
+        .body(Body::empty())
+        .unwrap();
+    let resp = app.oneshot(r2).await.unwrap();
+    assert_eq!(resp.status(), StatusCode::CONFLICT);
+}
+
+// ─── GET /questions ───────────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn list_questions_returns_all() {
+    let app = make_app().await;
+
+    let mut req1 = create_question_request();
+    req1.agent_id = "agent-1".to_string();
+    let mut req2 = create_question_request();
+    req2.agent_id = "agent-2".to_string();
+    create_question(app.clone(), &req1).await;
+    create_question(app.clone(), &req2).await;
+
+    let request = Request::builder().method("GET").uri("/questions").body(Body::empty()).unwrap();
+    let response = app.oneshot(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let result: QuestionsListResponse = parse_body(response.into_body()).await;
+    assert_eq!(result.total, 2);
+    assert_eq!(result.questions.len(), 2);
+}
+
+#[tokio::test]
+async fn list_questions_filters_by_status() {
+    let app = make_app().await;
+    let q = create_question(app.clone(), &create_question_request()).await;
+
+    // Answer the question.
+    let body = serde_json::to_vec(&AnswerQuestionRequest { answer: "salad".to_string() }).unwrap();
+    let r = Request::builder()
+        .method("POST")
+        .uri(format!("/questions/{}/answer", q.id))
+        .header("content-type", "application/json")
+        .body(Body::from(body))
+        .unwrap();
+    app.clone().oneshot(r).await.unwrap();
+
+    // List pending — should be empty.
+    let r_pending = Request::builder()
+        .method("GET")
+        .uri("/questions?status=Pending")
+        .body(Body::empty())
+        .unwrap();
+    let resp = app.clone().oneshot(r_pending).await.unwrap();
+    let pending: QuestionsListResponse = parse_body(resp.into_body()).await;
+    assert_eq!(pending.total, 0);
+
+    // List answered — should have 1.
+    let r_answered = Request::builder()
+        .method("GET")
+        .uri("/questions?status=Answered")
+        .body(Body::empty())
+        .unwrap();
+    let resp2 = app.oneshot(r_answered).await.unwrap();
+    let answered: QuestionsListResponse = parse_body(resp2.into_body()).await;
+    assert_eq!(answered.total, 1);
+}
+
+#[tokio::test]
+async fn list_questions_filters_by_agent_id() {
+    let app = make_app().await;
+
+    let mut req1 = create_question_request();
+    req1.agent_id = "dietician".to_string();
+    let mut req2 = create_question_request();
+    req2.agent_id = "assistant".to_string();
+    create_question(app.clone(), &req1).await;
+    create_question(app.clone(), &req2).await;
+
+    let request = Request::builder()
+        .method("GET")
+        .uri("/questions?agent_id=dietician")
+        .body(Body::empty())
+        .unwrap();
+    let response = app.oneshot(request).await.unwrap();
+    let result: QuestionsListResponse = parse_body(response.into_body()).await;
+
+    assert_eq!(result.total, 1);
+    assert_eq!(result.questions[0].agent_id, "dietician");
+}
+
+#[tokio::test]
+async fn list_questions_filters_by_category() {
+    let app = make_app().await;
+
+    let mut req1 = create_question_request();
+    req1.category = Some("health".to_string());
+    let mut req2 = create_question_request();
+    req2.category = Some("deployment".to_string());
+    create_question(app.clone(), &req1).await;
+    create_question(app.clone(), &req2).await;
+
+    let request = Request::builder()
+        .method("GET")
+        .uri("/questions?category=health")
+        .body(Body::empty())
+        .unwrap();
+    let response = app.oneshot(request).await.unwrap();
+    let result: QuestionsListResponse = parse_body(response.into_body()).await;
+
+    assert_eq!(result.total, 1);
+    assert_eq!(result.questions[0].category, Some("health".to_string()));
+}
+
+#[tokio::test]
+async fn list_questions_invalid_status_returns_400() {
+    let app = make_app().await;
+    let request = Request::builder()
+        .method("GET")
+        .uri("/questions?status=NotAStatus")
+        .body(Body::empty())
+        .unwrap();
+    let response = app.oneshot(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}
+
+// ─── GET /questions/{id} ─────────────────────────────────────────────────────
+
+#[tokio::test]
+async fn get_question_returns_200() {
+    let app = make_app().await;
+    let q = create_question(app.clone(), &create_question_request()).await;
+
+    let request = Request::builder()
+        .method("GET")
+        .uri(format!("/questions/{}", q.id))
+        .body(Body::empty())
+        .unwrap();
+    let response = app.oneshot(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let fetched: Question = parse_body(response.into_body()).await;
+    assert_eq!(fetched.id, q.id);
+    assert_eq!(fetched.agent_id, "dietician");
+}
+
+#[tokio::test]
+async fn get_question_nonexistent_returns_404() {
+    let app = make_app().await;
+    let request = Request::builder()
+        .method("GET")
+        .uri(format!("/questions/{}", Uuid::new_v4()))
+        .body(Body::empty())
+        .unwrap();
+    let response = app.oneshot(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::NOT_FOUND);
+}
+
+// ─── Orchestrator callback (fire-and-forget) ─────────────────────────────────
+
+#[tokio::test]
+async fn answer_fires_orchestrator_callback() {
+    // Start a mock HTTP server to capture the callback.
+    let mut server = mockito::Server::new_async().await;
+    let mock =
+        server.mock("POST", "/events/ask").with_status(200).with_body("{}").create_async().await;
+
+    let storage = QuestionStorage::in_memory().await.unwrap();
+    let app_state = AppState::new_with_storage(storage);
+    let api_state = ApiState { app_state, orchestrator_url: Some(server.url()) };
+    let app = create_router_with_tracing(api_state);
+
+    let q = create_question(app.clone(), &create_question_request()).await;
+
+    let body =
+        serde_json::to_vec(&AnswerQuestionRequest { answer: "oatmeal".to_string() }).unwrap();
+    let request = Request::builder()
+        .method("POST")
+        .uri(format!("/questions/{}/answer", q.id))
+        .header("content-type", "application/json")
+        .body(Body::from(body))
+        .unwrap();
+    let response = app.oneshot(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    // Give the background task a moment to fire the callback.
+    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+    mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn dismiss_fires_orchestrator_callback() {
+    let mut server = mockito::Server::new_async().await;
+    let mock =
+        server.mock("POST", "/events/ask").with_status(200).with_body("{}").create_async().await;
+
+    let storage = QuestionStorage::in_memory().await.unwrap();
+    let app_state = AppState::new_with_storage(storage);
+    let api_state = ApiState { app_state, orchestrator_url: Some(server.url()) };
+    let app = create_router_with_tracing(api_state);
+
+    let q = create_question(app.clone(), &create_question_request()).await;
+
+    let request = Request::builder()
+        .method("POST")
+        .uri(format!("/questions/{}/dismiss", q.id))
+        .body(Body::empty())
+        .unwrap();
+    let response = app.oneshot(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+
+    tokio::time::sleep(tokio::time::Duration::from_millis(100)).await;
+    mock.assert_async().await;
+}
+
+#[tokio::test]
+async fn callback_failure_does_not_block_answer_response() {
+    // Point at a URL that will refuse the connection.
+    let storage = QuestionStorage::in_memory().await.unwrap();
+    let app_state = AppState::new_with_storage(storage);
+    let api_state =
+        ApiState { app_state, orchestrator_url: Some("http://127.0.0.1:19999".to_string()) };
+    let app = create_router_with_tracing(api_state);
+
+    let q = create_question(app.clone(), &create_question_request()).await;
+
+    // Answer — must still return 200 even though the callback will fail.
+    let body = serde_json::to_vec(&AnswerQuestionRequest { answer: "pasta".to_string() }).unwrap();
+    let request = Request::builder()
+        .method("POST")
+        .uri(format!("/questions/{}/answer", q.id))
+        .header("content-type", "application/json")
+        .body(Body::from(body))
+        .unwrap();
+    let response = app.oneshot(request).await.unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+}

--- a/crates/orchestrator/src/scheduler/strategy.rs
+++ b/crates/orchestrator/src/scheduler/strategy.rs
@@ -3022,4 +3022,265 @@ mod tests {
             tasks[0].metadata.get("queue_priority").expect("queue_priority should be in metadata");
         assert_eq!(priority, "99");
     }
+
+    // ── AskResponse EventStrategy tests ──────────────────────────────────
+
+    fn sample_ask_response_event(
+        agent_id: &str,
+        category: Option<&str>,
+        answer: Option<&str>,
+        event_type: &str,
+    ) -> SystemEvent {
+        SystemEvent::AskResponseReceived {
+            question_id: Uuid::new_v4(),
+            agent_id: agent_id.to_string(),
+            workflow_id: None,
+            dispatch_id: None,
+            category: category.map(str::to_string),
+            question: "What did you eat yesterday?".to_string(),
+            answer: answer.map(str::to_string),
+            event_type: event_type.to_string(),
+        }
+    }
+
+    #[tokio::test]
+    async fn ask_response_strategy_matches_any_event_with_no_filters() {
+        let bus = EventBus::shared(16);
+        let filter =
+            EventFilter::AskResponse { agent_id: None, category: None, response_pattern: None };
+        let mut strategy = EventStrategy::new(bus.clone(), filter);
+        let (_tx, rx) = watch::channel(false);
+
+        bus.publish(sample_ask_response_event(
+            "dietician",
+            Some("health"),
+            Some("oatmeal"),
+            "question_answered",
+        ));
+
+        let result = strategy.next_tasks(&rx).await.unwrap();
+        assert_eq!(result.len(), 1);
+        assert!(result[0].source_id.starts_with("ask:"));
+        assert_eq!(result[0].metadata.get("agent_id"), Some(&"dietician".to_string()));
+        assert_eq!(result[0].metadata.get("event_type"), Some(&"question_answered".to_string()));
+        assert_eq!(result[0].metadata.get("answer"), Some(&"oatmeal".to_string()));
+        assert_eq!(
+            result[0].metadata.get("question"),
+            Some(&"What did you eat yesterday?".to_string())
+        );
+        assert_eq!(result[0].metadata.get("category"), Some(&"health".to_string()));
+    }
+
+    #[tokio::test]
+    async fn ask_response_strategy_filters_by_agent_id() {
+        let bus = EventBus::shared(16);
+        let filter = EventFilter::AskResponse {
+            agent_id: Some("dietician".to_string()),
+            category: None,
+            response_pattern: None,
+        };
+        let mut strategy = EventStrategy::new(bus.clone(), filter);
+        let (_tx, rx) = watch::channel(false);
+
+        // Publish event from wrong agent — should not match.
+        bus.publish(sample_ask_response_event(
+            "assistant",
+            None,
+            Some("pasta"),
+            "question_answered",
+        ));
+        // Publish event from correct agent — should match.
+        bus.publish(sample_ask_response_event(
+            "dietician",
+            None,
+            Some("salad"),
+            "question_answered",
+        ));
+
+        let result = strategy.next_tasks(&rx).await.unwrap();
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].metadata.get("agent_id"), Some(&"dietician".to_string()));
+    }
+
+    #[tokio::test]
+    async fn ask_response_strategy_filters_by_category() {
+        let bus = EventBus::shared(16);
+        let filter = EventFilter::AskResponse {
+            agent_id: None,
+            category: Some("health".to_string()),
+            response_pattern: None,
+        };
+        let mut strategy = EventStrategy::new(bus.clone(), filter);
+        let (_tx, rx) = watch::channel(false);
+
+        // Wrong category — should not match.
+        bus.publish(sample_ask_response_event(
+            "agent-x",
+            Some("deployment"),
+            Some("yes"),
+            "question_answered",
+        ));
+        // Correct category — should match.
+        bus.publish(sample_ask_response_event(
+            "agent-x",
+            Some("health"),
+            Some("oatmeal"),
+            "question_answered",
+        ));
+
+        let result = strategy.next_tasks(&rx).await.unwrap();
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].metadata.get("category"), Some(&"health".to_string()));
+    }
+
+    #[tokio::test]
+    async fn ask_response_strategy_filters_by_response_pattern() {
+        let bus = EventBus::shared(16);
+        let filter = EventFilter::AskResponse {
+            agent_id: None,
+            category: None,
+            response_pattern: Some("yes|approve".to_string()),
+        };
+        let mut strategy = EventStrategy::new(bus.clone(), filter);
+        let (_tx, rx) = watch::channel(false);
+
+        // Answer that does not match the pattern — should not match.
+        bus.publish(sample_ask_response_event("deploy", None, Some("no"), "question_answered"));
+        // Answer that matches — should match.
+        bus.publish(sample_ask_response_event(
+            "deploy",
+            None,
+            Some("yes please"),
+            "question_answered",
+        ));
+
+        let result = strategy.next_tasks(&rx).await.unwrap();
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].metadata.get("answer"), Some(&"yes please".to_string()));
+    }
+
+    #[tokio::test]
+    async fn ask_response_strategy_matches_dismissed_event() {
+        let bus = EventBus::shared(16);
+        let filter =
+            EventFilter::AskResponse { agent_id: None, category: None, response_pattern: None };
+        let mut strategy = EventStrategy::new(bus.clone(), filter);
+        let (_tx, rx) = watch::channel(false);
+
+        // Dismissed question has no answer.
+        bus.publish(sample_ask_response_event(
+            "dietician",
+            Some("health"),
+            None,
+            "question_dismissed",
+        ));
+
+        let result = strategy.next_tasks(&rx).await.unwrap();
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].metadata.get("event_type"), Some(&"question_dismissed".to_string()));
+        assert_eq!(result[0].metadata.get("answer"), Some(&"".to_string()));
+    }
+
+    #[tokio::test]
+    async fn ask_response_strategy_response_pattern_ignores_dismissed_no_answer() {
+        let bus = EventBus::shared(16);
+        // Pattern requires "yes" — dismissed question has empty answer.
+        let filter = EventFilter::AskResponse {
+            agent_id: None,
+            category: None,
+            response_pattern: Some("yes".to_string()),
+        };
+        let mut strategy = EventStrategy::new(bus.clone(), filter);
+        let (_tx, rx) = watch::channel(false);
+
+        // Dismissed with no answer — regex won't match empty string.
+        bus.publish(sample_ask_response_event("deploy", None, None, "question_dismissed"));
+        // Answered with "yes" — should match.
+        bus.publish(sample_ask_response_event("deploy", None, Some("yes"), "question_answered"));
+
+        let result = strategy.next_tasks(&rx).await.unwrap();
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].metadata.get("answer"), Some(&"yes".to_string()));
+    }
+
+    #[tokio::test]
+    async fn ask_response_strategy_invalid_regex_does_not_match() {
+        let bus = EventBus::shared(16);
+        let filter = EventFilter::AskResponse {
+            agent_id: None,
+            category: None,
+            response_pattern: Some("[invalid regex".to_string()),
+        };
+        let mut strategy = EventStrategy::new(bus.clone(), filter);
+        let (_tx, _rx) = watch::channel(false);
+
+        bus.publish(sample_ask_response_event(
+            "agent-x",
+            None,
+            Some("any answer"),
+            "question_answered",
+        ));
+        // After one matched (skipped) event, publish a different event type to unblock.
+        bus.publish(SystemEvent::AgentConnected { agent_id: Uuid::new_v4() });
+
+        // Give strategy a timeout — should return empty since invalid regex skips all answers.
+        let (tx, rx2) = watch::channel(false);
+        tokio::spawn(async move {
+            tokio::time::sleep(Duration::from_millis(50)).await;
+            let _ = tx.send(true);
+        });
+        let result = strategy.next_tasks(&rx2).await.unwrap();
+        assert!(result.is_empty());
+    }
+
+    #[tokio::test]
+    async fn ask_response_strategy_template_metadata_has_question_id() {
+        let bus = EventBus::shared(16);
+        let filter =
+            EventFilter::AskResponse { agent_id: None, category: None, response_pattern: None };
+        let mut strategy = EventStrategy::new(bus.clone(), filter);
+        let (_tx, rx) = watch::channel(false);
+
+        let question_id = Uuid::new_v4();
+        bus.publish(SystemEvent::AskResponseReceived {
+            question_id,
+            agent_id: "dietician".to_string(),
+            workflow_id: None,
+            dispatch_id: None,
+            category: None,
+            question: "How are you?".to_string(),
+            answer: Some("Fine".to_string()),
+            event_type: "question_answered".to_string(),
+        });
+
+        let result = strategy.next_tasks(&rx).await.unwrap();
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].metadata.get("question_id"), Some(&question_id.to_string()));
+        assert!(result[0].source_id.contains(&question_id.to_string()));
+    }
+
+    #[tokio::test]
+    async fn ask_response_strategy_includes_workflow_id_when_present() {
+        let bus = EventBus::shared(16);
+        let filter =
+            EventFilter::AskResponse { agent_id: None, category: None, response_pattern: None };
+        let mut strategy = EventStrategy::new(bus.clone(), filter);
+        let (_tx, rx) = watch::channel(false);
+
+        let wf_id = Uuid::new_v4();
+        bus.publish(SystemEvent::AskResponseReceived {
+            question_id: Uuid::new_v4(),
+            agent_id: "worker".to_string(),
+            workflow_id: Some(wf_id),
+            dispatch_id: None,
+            category: Some("productivity".to_string()),
+            question: "How productive were you?".to_string(),
+            answer: Some("Very".to_string()),
+            event_type: "question_answered".to_string(),
+        });
+
+        let result = strategy.next_tasks(&rx).await.unwrap();
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].metadata.get("workflow_id"), Some(&wf_id.to_string()));
+    }
 }


### PR DESCRIPTION
Adds 21 API integration tests covering all ask service endpoints (create, answer, dismiss, list, get, health), error cases (400/404/409), and orchestrator fire-and-forget callbacks via mockito. Also adds 9 unit tests for the AskResponse EventStrategy (no-filter matching, agent_id filter, category filter, regex pattern filter, dismissed events, invalid regex skip, template metadata). Also fixes the Axum router to use `{id}` capture syntax and exposes `QuestionStorage::in_memory()` for integration test use.

Closes #928