### PR TITLE
feat(index): dependency mapping for imports and cross-file relationships

### DIFF
--- a/crates/index/src/chunking/syntactic.rs
+++ b/crates/index/src/chunking/syntactic.rs
@@ -39,9 +39,19 @@ impl SyntacticChunker {
 
         // Attach file-level imports to every chunk in this file.
         let imports = extract_file_imports(tree.root_node(), source_bytes, language);
-        if !imports.is_empty() {
+
+        // Derive imported symbol names from the raw import strings.
+        let imported_symbols: Vec<String> = imports
+            .iter()
+            .flat_map(|imp| crate::dependencies::extract_symbols_from_import(imp, language))
+            .collect::<std::collections::HashSet<_>>()
+            .into_iter()
+            .collect();
+
+        if !imports.is_empty() || !imported_symbols.is_empty() {
             for chunk in &mut chunks {
                 chunk.metadata.imports = imports.clone();
+                chunk.metadata.imported_symbols = imported_symbols.clone();
             }
         }
 
@@ -274,7 +284,8 @@ fn extract_chunk_metadata(
         visibility: extract_visibility(node, source, language, symbol_name),
         parameters: extract_parameters(node, source, language),
         return_type: extract_return_type(node, source, language),
-        imports: Vec::new(), // populated by `chunk()` after the walk
+        imports: Vec::new(),          // populated by `chunk()` after the walk
+        imported_symbols: Vec::new(), // populated by `chunk()` after the walk
     }
 }
 

--- a/crates/index/src/dependencies.rs
+++ b/crates/index/src/dependencies.rs
@@ -1,0 +1,467 @@
+//! Dependency mapping and import relationship analysis.
+//!
+//! [`DependencyGraph`] tracks file-level import relationships so that agents
+//! can navigate "who imports this file" and "what does this file import".
+//!
+//! # Example
+//!
+//! ```rust
+//! use index::dependencies::{DependencyGraph, FileDependencies};
+//!
+//! let deps = vec![
+//!     FileDependencies {
+//!         file_path: "src/a.rs".to_string(),
+//!         imported_files: vec!["src/b.rs".to_string()],
+//!         imported_symbols: vec!["Foo".to_string()],
+//!     },
+//!     FileDependencies {
+//!         file_path: "src/b.rs".to_string(),
+//!         imported_files: vec![],
+//!         imported_symbols: vec![],
+//!     },
+//! ];
+//! let graph = DependencyGraph::build(&deps);
+//! assert_eq!(graph.get_importees("src/a.rs"), &["src/b.rs"]);
+//! assert_eq!(graph.get_importers("src/b.rs"), &["src/a.rs"]);
+//! ```
+
+use std::collections::HashMap;
+
+use crate::chunking::types::Language;
+use crate::store::traits::SearchResult;
+
+// ---------------------------------------------------------------------------
+// FileDependencies
+// ---------------------------------------------------------------------------
+
+/// Import relationship data for a single source file.
+#[derive(Debug, Clone, Default)]
+pub struct FileDependencies {
+    /// Path to the source file.
+    pub file_path: String,
+    /// Resolved or partial file paths that this file imports.
+    ///
+    /// For Rust `use` statements these are module paths (`"foo::bar"`).
+    /// For Python/JS/TS these are the module specifiers as written.
+    pub imported_files: Vec<String>,
+    /// Specific symbol names imported by this file (e.g. `Foo`, `bar`, `MyTrait`).
+    pub imported_symbols: Vec<String>,
+}
+
+// ---------------------------------------------------------------------------
+// DependencyGraph
+// ---------------------------------------------------------------------------
+
+/// A graph of file-level import relationships built from [`FileDependencies`].
+#[derive(Debug, Default)]
+pub struct DependencyGraph {
+    /// file -> files that this file imports (its dependencies / importees).
+    importees: HashMap<String, Vec<String>>,
+    /// file -> files that import this file (its dependents / importers).
+    importers: HashMap<String, Vec<String>>,
+}
+
+impl DependencyGraph {
+    /// Build a [`DependencyGraph`] from a slice of per-file dependency information.
+    pub fn build(deps: &[FileDependencies]) -> Self {
+        let mut graph = DependencyGraph::default();
+        for dep in deps {
+            let importees = dep.imported_files.clone();
+            for importee in &importees {
+                graph.importers.entry(importee.clone()).or_default().push(dep.file_path.clone());
+            }
+            graph.importees.entry(dep.file_path.clone()).or_default().extend(importees);
+        }
+        graph
+    }
+
+    /// Return the files that `file` imports (its direct dependencies).
+    pub fn get_importees(&self, file: &str) -> &[String] {
+        self.importees.get(file).map(|v| v.as_slice()).unwrap_or(&[])
+    }
+
+    /// Return the files that import `file` (its direct dependents).
+    pub fn get_importers(&self, file: &str) -> &[String] {
+        self.importers.get(file).map(|v| v.as_slice()).unwrap_or(&[])
+    }
+
+    /// Return all files directly related to `file` (importers + importees combined).
+    pub fn related_files(&self, file: &str) -> Vec<String> {
+        let mut related = Vec::new();
+        related.extend_from_slice(self.get_importees(file));
+        for imp in self.get_importers(file) {
+            if !related.contains(imp) {
+                related.push(imp.clone());
+            }
+        }
+        related
+    }
+
+    /// Return `true` when the graph contains no entries.
+    pub fn is_empty(&self) -> bool {
+        self.importees.is_empty() && self.importers.is_empty()
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Import symbol extraction
+// ---------------------------------------------------------------------------
+
+/// Extract imported symbol names from a raw import statement string.
+///
+/// Uses simple pattern matching on the import text rather than re-running the
+/// tree-sitter parser, since the text is already available from [`ChunkMetadata::imports`].
+///
+/// Returns an empty list for wildcard imports or statements that cannot be parsed.
+pub fn extract_symbols_from_import(import_text: &str, language: Language) -> Vec<String> {
+    let text = import_text.trim();
+    match language {
+        Language::Rust => extract_rust_symbols(text),
+        Language::Python => extract_python_symbols(text),
+        Language::JavaScript | Language::TypeScript => extract_js_symbols(text),
+    }
+}
+
+/// Extract symbols from a Rust `use` statement.
+///
+/// Examples:
+/// - `use foo::Bar;` -> `["Bar"]`
+/// - `use foo::{Bar, Baz};` -> `["Bar", "Baz"]`
+/// - `use foo::bar::*;` -> `[]` (wildcard)
+/// - `extern crate foo;` -> `["foo"]`
+/// - `mod foo;` -> `["foo"]`
+fn extract_rust_symbols(text: &str) -> Vec<String> {
+    if text.starts_with("extern crate ") {
+        let name =
+            text.trim_start_matches("extern crate ").trim_end_matches(';').trim().to_string();
+        return if name.is_empty() { vec![] } else { vec![name] };
+    }
+    if text.starts_with("mod ") && text.ends_with(';') {
+        let name = text.trim_start_matches("mod ").trim_end_matches(';').trim().to_string();
+        return if name.is_empty() { vec![] } else { vec![name] };
+    }
+    if !text.starts_with("use ") {
+        return vec![];
+    }
+    let body = text.trim_start_matches("use ").trim_end_matches(';');
+    // Wildcard import
+    if body.ends_with("::*") || body == "*" {
+        return vec![];
+    }
+    // Braced group: use foo::{Bar, Baz}
+    if let Some(brace_start) = body.rfind('{') {
+        if let Some(brace_end) = body.rfind('}') {
+            let inner = &body[brace_start + 1..brace_end];
+            return inner
+                .split(',')
+                .map(|s| s.trim().split(" as ").next().unwrap_or("").trim().to_string())
+                .filter(|s| !s.is_empty() && s != "*")
+                .collect();
+        }
+    }
+    // Single symbol: use foo::Bar or use foo::Bar as Alias
+    let last = body.rsplit("::").next().unwrap_or(body);
+    let name = last.split(" as ").next().unwrap_or("").trim().to_string();
+    if name.is_empty() || name == "*" {
+        vec![]
+    } else {
+        vec![name]
+    }
+}
+
+/// Extract symbols from a Python import statement.
+///
+/// Examples:
+/// - `import foo` -> `["foo"]`
+/// - `from foo import bar, baz` -> `["bar", "baz"]`
+/// - `from foo import *` -> `[]`
+fn extract_python_symbols(text: &str) -> Vec<String> {
+    if text.starts_with("from ") {
+        // `from foo import bar, baz` or `from foo import (bar, baz)`
+        if let Some(import_pos) = text.find(" import ") {
+            let after = text[import_pos + 8..].trim().trim_matches(|c| c == '(' || c == ')');
+            if after == "*" {
+                return vec![];
+            }
+            return after
+                .split(',')
+                .map(|s| s.trim().split(" as ").next().unwrap_or("").trim().to_string())
+                .filter(|s| !s.is_empty())
+                .collect();
+        }
+    } else if text.starts_with("import ") {
+        // `import foo` or `import foo as f, bar as b`
+        return text
+            .trim_start_matches("import ")
+            .split(',')
+            .map(|s| s.trim().split(" as ").next().unwrap_or("").trim().to_string())
+            .filter(|s| !s.is_empty())
+            .collect();
+    }
+    vec![]
+}
+
+/// Extract symbols from a JavaScript / TypeScript import statement.
+///
+/// Examples:
+/// - `import { foo, bar } from './module'` -> `["foo", "bar"]`
+/// - `import foo from './module'` -> `["foo"]`
+/// - `import * as ns from './module'` -> `[]` (namespace)
+/// - `const foo = require('./module')` -> `["foo"]`
+fn extract_js_symbols(text: &str) -> Vec<String> {
+    // Named imports: import { foo, bar } from '...'
+    if let Some(brace_start) = text.find('{') {
+        if let Some(brace_end) = text.find('}') {
+            let inner = &text[brace_start + 1..brace_end];
+            return inner
+                .split(',')
+                .map(|s| s.trim().split(" as ").next().unwrap_or("").trim().to_string())
+                .filter(|s| !s.is_empty())
+                .collect();
+        }
+    }
+    // Namespace import: import * as ns -- return empty (wildcard-like)
+    if text.contains("* as ") {
+        return vec![];
+    }
+    // Default import: import foo from '...'
+    if text.starts_with("import ") {
+        let after = text.trim_start_matches("import ").trim();
+        if let Some(from_pos) = after.find(" from ") {
+            let name = after[..from_pos].trim().to_string();
+            if !name.is_empty() && !name.starts_with('*') {
+                return vec![name];
+            }
+        }
+    }
+    vec![]
+}
+
+// ---------------------------------------------------------------------------
+// Dependency-aware search boost
+// ---------------------------------------------------------------------------
+
+/// Boost search result scores for files related to the top results via imports.
+///
+/// For each result in the top `top_n` results, files that import it or are
+/// imported by it receive a score boost of `boost_factor`.  Results are
+/// re-sorted by descending score after boosting.
+pub fn boost_results_by_dependencies(
+    mut results: Vec<SearchResult>,
+    graph: &DependencyGraph,
+    top_n: usize,
+    boost_factor: f32,
+) -> Vec<SearchResult> {
+    if graph.is_empty() || results.is_empty() {
+        return results;
+    }
+
+    // Collect file paths of the top results.
+    let top_files: std::collections::HashSet<String> =
+        results.iter().take(top_n).map(|r| r.chunk.chunk.file_path.clone()).collect();
+
+    // Collect related files.
+    let mut boost_files: std::collections::HashSet<String> = std::collections::HashSet::new();
+    for file in &top_files {
+        for related in graph.related_files(file) {
+            if !top_files.contains(&related) {
+                boost_files.insert(related);
+            }
+        }
+    }
+
+    // Apply boost.
+    for result in &mut results {
+        if boost_files.contains(&result.chunk.chunk.file_path) {
+            result.score += boost_factor;
+        }
+    }
+
+    // Re-sort descending.
+    results.sort_by(|a, b| b.score.partial_cmp(&a.score).unwrap_or(std::cmp::Ordering::Equal));
+    results
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -- extract_rust_symbols -----------------------------------------------
+
+    #[test]
+    fn rust_use_single_symbol() {
+        let syms = extract_symbols_from_import("use std::sync::Arc;", Language::Rust);
+        assert_eq!(syms, vec!["Arc"]);
+    }
+
+    #[test]
+    fn rust_use_braced_symbols() {
+        let syms = extract_symbols_from_import("use std::sync::{Arc, Mutex};", Language::Rust);
+        assert!(syms.contains(&"Arc".to_string()));
+        assert!(syms.contains(&"Mutex".to_string()));
+    }
+
+    #[test]
+    fn rust_use_wildcard_returns_empty() {
+        let syms = extract_symbols_from_import("use foo::*;", Language::Rust);
+        assert!(syms.is_empty());
+    }
+
+    #[test]
+    fn rust_extern_crate() {
+        let syms = extract_symbols_from_import("extern crate serde;", Language::Rust);
+        assert_eq!(syms, vec!["serde"]);
+    }
+
+    #[test]
+    fn rust_mod_declaration() {
+        let syms = extract_symbols_from_import("mod utils;", Language::Rust);
+        assert_eq!(syms, vec!["utils"]);
+    }
+
+    #[test]
+    fn rust_use_with_alias() {
+        let syms = extract_symbols_from_import("use foo::Bar as MyBar;", Language::Rust);
+        assert_eq!(syms, vec!["Bar"]);
+    }
+
+    // -- extract_python_symbols ---------------------------------------------
+
+    #[test]
+    fn python_from_import() {
+        let syms =
+            extract_symbols_from_import("from os.path import join, exists", Language::Python);
+        assert!(syms.contains(&"join".to_string()));
+        assert!(syms.contains(&"exists".to_string()));
+    }
+
+    #[test]
+    fn python_import_module() {
+        let syms = extract_symbols_from_import("import os", Language::Python);
+        assert_eq!(syms, vec!["os"]);
+    }
+
+    #[test]
+    fn python_import_wildcard_returns_empty() {
+        let syms = extract_symbols_from_import("from foo import *", Language::Python);
+        assert!(syms.is_empty());
+    }
+
+    #[test]
+    fn python_from_import_with_alias() {
+        let syms =
+            extract_symbols_from_import("from numpy import array as np_array", Language::Python);
+        assert_eq!(syms, vec!["array"]);
+    }
+
+    // -- extract_js_symbols ------------------------------------------------
+
+    #[test]
+    fn js_named_imports() {
+        let syms = extract_symbols_from_import(
+            "import { foo, bar } from './module'",
+            Language::JavaScript,
+        );
+        assert!(syms.contains(&"foo".to_string()));
+        assert!(syms.contains(&"bar".to_string()));
+    }
+
+    #[test]
+    fn js_default_import() {
+        let syms = extract_symbols_from_import("import React from 'react'", Language::JavaScript);
+        assert_eq!(syms, vec!["React"]);
+    }
+
+    #[test]
+    fn ts_named_imports() {
+        let syms = extract_symbols_from_import(
+            "import { Component, OnInit } from '@angular/core'",
+            Language::TypeScript,
+        );
+        assert!(syms.contains(&"Component".to_string()));
+        assert!(syms.contains(&"OnInit".to_string()));
+    }
+
+    #[test]
+    fn js_namespace_import_returns_empty() {
+        let syms =
+            extract_symbols_from_import("import * as utils from './utils'", Language::JavaScript);
+        assert!(syms.is_empty());
+    }
+
+    // -- DependencyGraph ---------------------------------------------------
+
+    fn make_deps() -> Vec<FileDependencies> {
+        vec![
+            FileDependencies {
+                file_path: "src/a.rs".to_string(),
+                imported_files: vec!["src/b.rs".to_string(), "src/c.rs".to_string()],
+                imported_symbols: vec!["Foo".to_string()],
+            },
+            FileDependencies {
+                file_path: "src/b.rs".to_string(),
+                imported_files: vec!["src/c.rs".to_string()],
+                imported_symbols: vec![],
+            },
+            FileDependencies {
+                file_path: "src/c.rs".to_string(),
+                imported_files: vec![],
+                imported_symbols: vec![],
+            },
+        ]
+    }
+
+    #[test]
+    fn graph_get_importees() {
+        let graph = DependencyGraph::build(&make_deps());
+        let importees = graph.get_importees("src/a.rs");
+        assert!(importees.contains(&"src/b.rs".to_string()));
+        assert!(importees.contains(&"src/c.rs".to_string()));
+    }
+
+    #[test]
+    fn graph_get_importers() {
+        let graph = DependencyGraph::build(&make_deps());
+        let importers = graph.get_importers("src/c.rs");
+        assert!(importers.contains(&"src/a.rs".to_string()));
+        assert!(importers.contains(&"src/b.rs".to_string()));
+    }
+
+    #[test]
+    fn graph_get_importees_empty_for_leaf() {
+        let graph = DependencyGraph::build(&make_deps());
+        assert!(graph.get_importees("src/c.rs").is_empty());
+    }
+
+    #[test]
+    fn graph_get_importers_empty_for_root() {
+        let graph = DependencyGraph::build(&make_deps());
+        assert!(graph.get_importers("src/a.rs").is_empty());
+    }
+
+    #[test]
+    fn graph_related_files_combines_both() {
+        let graph = DependencyGraph::build(&make_deps());
+        let related = graph.related_files("src/b.rs");
+        // b imports c, and a imports b
+        assert!(related.contains(&"src/c.rs".to_string()));
+        assert!(related.contains(&"src/a.rs".to_string()));
+    }
+
+    #[test]
+    fn graph_is_empty_for_default() {
+        let graph = DependencyGraph::default();
+        assert!(graph.is_empty());
+    }
+
+    #[test]
+    fn graph_unknown_file_returns_empty() {
+        let graph = DependencyGraph::build(&make_deps());
+        assert!(graph.get_importees("src/nonexistent.rs").is_empty());
+        assert!(graph.get_importers("src/nonexistent.rs").is_empty());
+    }
+}

--- a/crates/index/src/lib.rs
+++ b/crates/index/src/lib.rs
@@ -15,6 +15,7 @@
 pub mod api;
 pub mod chunking;
 pub mod config;
+pub mod dependencies;
 pub mod enrichment;
 pub mod error;
 pub mod indexer;

--- a/crates/index/src/metadata.rs
+++ b/crates/index/src/metadata.rs
@@ -16,6 +16,7 @@
 //!     ],
 //!     return_type: Some("i32".to_string()),
 //!     imports: vec!["use std::sync::Arc;".to_string()],
+//!     imported_symbols: vec!["Arc".to_string()],
 //! };
 //! assert_eq!(meta.visibility.unwrap().as_str(), "public");
 //! ```
@@ -112,6 +113,13 @@ pub struct ChunkMetadata {
     /// Import/use declarations found at the top level of the source file
     /// that contains this chunk.  Provides context about available symbols.
     pub imports: Vec<String>,
+
+    /// Specific symbol names imported by the file containing this chunk.
+    ///
+    /// Extracted by parsing the raw [`Self::imports`] statements.
+    /// Empty for chunks whose file has no imports or only wildcard imports.
+    #[serde(default)]
+    pub imported_symbols: Vec<String>,
 }
 
 // ---------------------------------------------------------------------------
@@ -206,6 +214,7 @@ mod tests {
             ],
             return_type: Some("bool".to_string()),
             imports: vec!["use std::sync::Arc;".to_string()],
+            imported_symbols: vec!["Arc".to_string()],
         };
         let json = serde_json::to_string(&meta).unwrap();
         let parsed: ChunkMetadata = serde_json::from_str(&json).unwrap();

--- a/crates/index/src/store/lance.rs
+++ b/crates/index/src/store/lance.rs
@@ -110,6 +110,7 @@ impl LanceStore {
             Field::new("parameters", DataType::Utf8, true), // JSON array
             Field::new("return_type", DataType::Utf8, true),
             Field::new("imports", DataType::Utf8, true), // JSON array
+            Field::new("imported_symbols", DataType::Utf8, true), // JSON array
             Field::new(
                 "vector",
                 DataType::FixedSizeList(Arc::new(Field::new("item", DataType::Float32, true)), dim),
@@ -171,6 +172,16 @@ impl LanceStore {
                 }
             })
             .collect();
+        let imported_symbols_strs: Vec<Option<String>> = chunks
+            .iter()
+            .map(|c| {
+                if c.metadata.imported_symbols.is_empty() {
+                    None
+                } else {
+                    serde_json::to_string(&c.metadata.imported_symbols).ok()
+                }
+            })
+            .collect();
 
         RecordBatch::try_new(
             schema,
@@ -211,6 +222,9 @@ impl LanceStore {
                 make_opt_str(return_type_strs),
                 Arc::new(StringArray::from(
                     imports_strs.iter().map(|i| i.as_deref()).collect::<Vec<_>>(),
+                )),
+                Arc::new(StringArray::from(
+                    imported_symbols_strs.iter().map(|s| s.as_deref()).collect::<Vec<_>>(),
                 )),
                 Arc::new(vector_array),
                 Arc::new(StringArray::from(vec![now; n])),
@@ -282,7 +296,11 @@ impl LanceStore {
                 .as_deref()
                 .and_then(|s| serde_json::from_str(s).ok())
                 .unwrap_or_default();
-            ChunkMetadata { visibility, parameters, return_type, imports }
+            let imported_symbols: Vec<String> = get_opt_str("imported_symbols")
+                .as_deref()
+                .and_then(|s| serde_json::from_str(s).ok())
+                .unwrap_or_default();
+            ChunkMetadata { visibility, parameters, return_type, imports, imported_symbols }
         };
 
         let chunk = CodeChunk {
@@ -646,6 +664,7 @@ mod tests {
             Field::new("parameters", DataType::Utf8, true),
             Field::new("return_type", DataType::Utf8, true),
             Field::new("imports", DataType::Utf8, true),
+            Field::new("imported_symbols", DataType::Utf8, true),
             Field::new(
                 "vector",
                 DataType::FixedSizeList(Arc::new(Field::new("item", DataType::Float32, true)), dim),
@@ -659,7 +678,7 @@ mod tests {
     #[test]
     fn schema_field_count() {
         let schema = make_schema(768);
-        assert_eq!(schema.fields().len(), 20);
+        assert_eq!(schema.fields().len(), 21);
     }
 
     #[test]
@@ -705,6 +724,7 @@ mod tests {
         assert!(schema.field_with_name("parameters").unwrap().is_nullable());
         assert!(schema.field_with_name("return_type").unwrap().is_nullable());
         assert!(schema.field_with_name("imports").unwrap().is_nullable());
+        assert!(schema.field_with_name("imported_symbols").unwrap().is_nullable());
     }
 
     #[test]
@@ -800,6 +820,7 @@ mod tests {
                 Arc::new(StringArray::from(vec![Some(params_json)])) as ArrayRef, // parameters
                 Arc::new(StringArray::from(vec![Some("u8")])) as ArrayRef,     // return_type
                 Arc::new(StringArray::from(vec![Some(imports_json)])) as ArrayRef, // imports
+                Arc::new(StringArray::from(vec![None::<&str>])) as ArrayRef,   // imported_symbols
                 Arc::new(
                     arrow_array::FixedSizeListArray::from_iter_primitive::<Float32Type, _, _>(
                         vec![Some(vec![Some(0.1), Some(0.2), Some(0.3)])],


### PR DESCRIPTION
Implements DependencyGraph for tracking file-level import relationships, extract_symbols_from_import for parsing Rust/Python/JS/TS imports, boost_results_by_dependencies for search result re-ranking, and adds imported_symbols field to ChunkMetadata.

Closes #948