### PR TITLE
feat(tool-policy): add sandbox_bypass to tool_policy schema and agent details UI

### DIFF
--- a/.agentd/agents/worker.yml
+++ b/.agentd/agents/worker.yml
@@ -29,6 +29,14 @@ tool_policy:
     - "Bash(git push --force*)"
     # Block direct deletion of issues or milestones — always human
     - "Bash(gh issue delete *)"
+  # Bypass the Claude Code sandbox for commands that require direct TLS to
+  # GitHub. The sandbox intercepts outbound HTTPS with its own proxy cert,
+  # which causes x509 failures for git-spice and gh when talking to the
+  # GitHub GraphQL / REST APIs.
+  sandbox_bypass:
+    - "Bash(git-spice branch submit *)"
+    - "Bash(git-spice repo sync*)"
+    - "Bash(gh pr create *)"
 
 rooms:
   - engineering

--- a/crates/ask/tests/api_test.rs
+++ b/crates/ask/tests/api_test.rs
@@ -24,7 +24,8 @@ use uuid::Uuid;
 async fn make_app() -> axum::Router {
     let storage = QuestionStorage::in_memory().await.unwrap();
     let app_state = AppState::new_with_storage(storage);
-    let api_state = ApiState { app_state, orchestrator_url: None, http_client: reqwest::Client::new() };
+    let api_state =
+        ApiState { app_state, orchestrator_url: None, http_client: reqwest::Client::new() };
     create_router_with_tracing(api_state)
 }
 
@@ -439,7 +440,11 @@ async fn answer_fires_orchestrator_callback() {
 
     let storage = QuestionStorage::in_memory().await.unwrap();
     let app_state = AppState::new_with_storage(storage);
-    let api_state = ApiState { app_state, orchestrator_url: Some(server.url()), http_client: reqwest::Client::new() };
+    let api_state = ApiState {
+        app_state,
+        orchestrator_url: Some(server.url()),
+        http_client: reqwest::Client::new(),
+    };
     let app = create_router_with_tracing(api_state);
 
     let q = create_question(app.clone(), &create_question_request()).await;
@@ -468,7 +473,11 @@ async fn dismiss_fires_orchestrator_callback() {
 
     let storage = QuestionStorage::in_memory().await.unwrap();
     let app_state = AppState::new_with_storage(storage);
-    let api_state = ApiState { app_state, orchestrator_url: Some(server.url()), http_client: reqwest::Client::new() };
+    let api_state = ApiState {
+        app_state,
+        orchestrator_url: Some(server.url()),
+        http_client: reqwest::Client::new(),
+    };
     let app = create_router_with_tracing(api_state);
 
     let q = create_question(app.clone(), &create_question_request()).await;
@@ -490,8 +499,11 @@ async fn callback_failure_does_not_block_answer_response() {
     // Point at a URL that will refuse the connection.
     let storage = QuestionStorage::in_memory().await.unwrap();
     let app_state = AppState::new_with_storage(storage);
-    let api_state =
-        ApiState { app_state, orchestrator_url: Some("http://127.0.0.1:19999".to_string()), http_client: reqwest::Client::new() };
+    let api_state = ApiState {
+        app_state,
+        orchestrator_url: Some("http://127.0.0.1:19999".to_string()),
+        http_client: reqwest::Client::new(),
+    };
     let app = create_router_with_tracing(api_state);
 
     let q = create_question(app.clone(), &create_question_request()).await;

--- a/crates/cli/src/commands/orchestrator.rs
+++ b/crates/cli/src/commands/orchestrator.rs
@@ -2149,31 +2149,45 @@ fn format_duration_ms(ms: u64) -> String {
 
 fn display_policy(policy: &ToolPolicy) {
     match policy {
-        ToolPolicy::AllowAll => {
+        ToolPolicy::AllowAll { sandbox_bypass } => {
             println!("{}: {}", "Mode".bold(), "allow_all".green());
             println!("{}: all tools permitted", "Effect".bold());
+            display_sandbox_bypass(sandbox_bypass);
         }
-        ToolPolicy::DenyAll => {
+        ToolPolicy::DenyAll { sandbox_bypass } => {
             println!("{}: {}", "Mode".bold(), "deny_all".red());
             println!("{}: no tools permitted", "Effect".bold());
+            display_sandbox_bypass(sandbox_bypass);
         }
-        ToolPolicy::AllowList { tools } => {
+        ToolPolicy::AllowList { tools, sandbox_bypass } => {
             println!("{}: {}", "Mode".bold(), "allow_list".yellow());
             println!("{}: only these tools permitted:", "Effect".bold());
             for tool in tools {
                 println!("  - {}", tool.cyan());
             }
+            display_sandbox_bypass(sandbox_bypass);
         }
-        ToolPolicy::DenyList { tools } => {
+        ToolPolicy::DenyList { tools, sandbox_bypass } => {
             println!("{}: {}", "Mode".bold(), "deny_list".yellow());
             println!("{}: all tools except these:", "Effect".bold());
             for tool in tools {
                 println!("  - {}", tool.red());
             }
+            display_sandbox_bypass(sandbox_bypass);
         }
-        ToolPolicy::RequireApproval => {
+        ToolPolicy::RequireApproval { sandbox_bypass } => {
             println!("{}: {}", "Mode".bold(), "require_approval".bright_yellow());
             println!("{}: every tool request requires human approval", "Effect".bold());
+            display_sandbox_bypass(sandbox_bypass);
+        }
+    }
+}
+
+fn display_sandbox_bypass(globs: &[String]) {
+    if !globs.is_empty() {
+        println!("{}: (sandbox disabled for these commands)", "Bypass".bold().bright_yellow());
+        for glob in globs {
+            println!("  - {}", glob.yellow());
         }
     }
 }
@@ -2765,15 +2779,15 @@ fn display_agent(agent: &AgentResponse) {
         println!("{}: {}", "Model".bold(), model.cyan());
     }
     let policy_display = match &agent.config.tool_policy {
-        ToolPolicy::AllowAll => "allow_all".green().to_string(),
-        ToolPolicy::DenyAll => "deny_all".red().to_string(),
-        ToolPolicy::AllowList { tools } => {
+        ToolPolicy::AllowAll { .. } => "allow_all".green().to_string(),
+        ToolPolicy::DenyAll { .. } => "deny_all".red().to_string(),
+        ToolPolicy::AllowList { tools, .. } => {
             format!("{} [{}]", "allow_list".yellow(), tools.join(", "))
         }
-        ToolPolicy::DenyList { tools } => {
+        ToolPolicy::DenyList { tools, .. } => {
             format!("{} [{}]", "deny_list".yellow(), tools.join(", "))
         }
-        ToolPolicy::RequireApproval => "require_approval".bright_yellow().to_string(),
+        ToolPolicy::RequireApproval { .. } => "require_approval".bright_yellow().to_string(),
     };
     println!("{}: {}", "Tool Policy".bold(), policy_display);
 

--- a/crates/index/tests/language_support.rs
+++ b/crates/index/tests/language_support.rs
@@ -10,7 +10,7 @@
 //! exercises the major symbol kinds for its language.
 
 use index::chunking::types::{ChunkType, HierarchyLevel, Language};
-use index::chunking::{Chunker, SyntacticChunker};
+use index::chunking::SyntacticChunker;
 use std::path::Path;
 
 // ── Fixture source ────────────────────────────────────────────────────────────
@@ -640,8 +640,6 @@ fn ruby_line_numbers_are_valid() {
 
 #[test]
 fn chunk_types_serialize_to_snake_case() {
-    use serde_json::Value;
-
     // All ChunkType variants and their expected LanceDB schema values.
     let cases: &[(ChunkType, &str)] = &[
         (ChunkType::Function, "\"function\""),

--- a/crates/orchestrator/src/storage.rs
+++ b/crates/orchestrator/src/storage.rs
@@ -280,10 +280,7 @@ impl AgentStorage {
                     session_entity::Column::TotalCostUsd,
                     Expr::value(snapshot.total_cost_usd),
                 )
-                .col_expr(
-                    session_entity::Column::NumTurns,
-                    Expr::value(snapshot.num_turns as i64),
-                )
+                .col_expr(session_entity::Column::NumTurns, Expr::value(snapshot.num_turns as i64))
                 .col_expr(
                     session_entity::Column::DurationMs,
                     Expr::value(snapshot.duration_ms as i64),

--- a/crates/orchestrator/src/types.rs
+++ b/crates/orchestrator/src/types.rs
@@ -91,21 +91,56 @@ impl std::str::FromStr for AgentStatus {
 /// When a Claude Code agent requests permission to use a tool (via the
 /// `can_use_tool` control request), this policy is evaluated to decide
 /// whether to allow or deny the request.
+///
+/// All variants accept an optional `sandbox_bypass` list of tool+command globs.
+/// When a Bash call matches a glob in this list, the orchestrator auto-approves
+/// it with `dangerouslyDisableSandbox: true` injected into the tool input,
+/// bypassing the Claude Code sandbox for that specific call.
+///
+/// Example glob syntax:
+/// - `"Bash(git-spice *)"` — any git-spice command
+/// - `"Bash(gh pr *)"` — any `gh pr` subcommand
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "mode", rename_all = "snake_case")]
-#[derive(Default)]
 pub enum ToolPolicy {
     /// Allow all tools without restriction (default).
-    #[default]
-    AllowAll,
+    AllowAll {
+        /// Tool+command globs auto-approved with sandbox disabled.
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        sandbox_bypass: Vec<String>,
+    },
     /// Deny all tool usage.
-    DenyAll,
+    DenyAll {
+        /// Tool+command globs auto-approved with sandbox disabled.
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        sandbox_bypass: Vec<String>,
+    },
     /// Only allow the listed tools; deny everything else.
-    AllowList { tools: Vec<String> },
+    AllowList {
+        tools: Vec<String>,
+        /// Tool+command globs auto-approved with sandbox disabled.
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        sandbox_bypass: Vec<String>,
+    },
     /// Allow everything except the listed tools.
-    DenyList { tools: Vec<String> },
+    DenyList {
+        tools: Vec<String>,
+        /// Tool+command globs auto-approved with sandbox disabled.
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        sandbox_bypass: Vec<String>,
+    },
     /// Hold every tool request for human approval before permitting it.
-    RequireApproval,
+    RequireApproval {
+        /// Tool+command globs auto-approved with sandbox disabled.
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        sandbox_bypass: Vec<String>,
+    },
+}
+
+impl Default for ToolPolicy {
+    fn default() -> Self {
+        ToolPolicy::AllowAll { sandbox_bypass: vec![] }
+    }
 }
 
 impl ToolPolicy {
@@ -117,29 +152,57 @@ impl ToolPolicy {
     ///
     /// Note: `RequireApproval` returns `false` here as a fallback — the actual
     /// approval logic is handled in `websocket.rs` before `evaluate` is called.
+    /// Note: sandbox_bypass matching is handled before `evaluate` is called in
+    /// `websocket.rs`; it does not affect the return value of this method.
     pub fn evaluate(&self, tool_name: &str, input: Option<&serde_json::Value>) -> bool {
         match self {
-            ToolPolicy::AllowAll => true,
-            ToolPolicy::DenyAll => false,
-            ToolPolicy::AllowList { tools } => {
+            ToolPolicy::AllowAll { .. } => true,
+            ToolPolicy::DenyAll { .. } => false,
+            ToolPolicy::AllowList { tools, .. } => {
                 tools.iter().any(|t| match_tool(t, tool_name, input))
             }
-            ToolPolicy::DenyList { tools } => {
+            ToolPolicy::DenyList { tools, .. } => {
                 !tools.iter().any(|t| match_tool(t, tool_name, input))
             }
-            ToolPolicy::RequireApproval => false,
+            ToolPolicy::RequireApproval { .. } => false,
         }
     }
 
     /// Returns the policy mode as a string for logging.
     pub fn mode_str(&self) -> &'static str {
         match self {
-            ToolPolicy::AllowAll => "allow_all",
-            ToolPolicy::DenyAll => "deny_all",
+            ToolPolicy::AllowAll { .. } => "allow_all",
+            ToolPolicy::DenyAll { .. } => "deny_all",
             ToolPolicy::AllowList { .. } => "allow_list",
             ToolPolicy::DenyList { .. } => "deny_list",
-            ToolPolicy::RequireApproval => "require_approval",
+            ToolPolicy::RequireApproval { .. } => "require_approval",
         }
+    }
+
+    /// Returns the sandbox_bypass glob list for this policy.
+    ///
+    /// A Bash call matching any of these globs is auto-approved with
+    /// `dangerouslyDisableSandbox: true` injected into the tool input.
+    pub fn sandbox_bypass(&self) -> &[String] {
+        match self {
+            ToolPolicy::AllowAll { sandbox_bypass }
+            | ToolPolicy::DenyAll { sandbox_bypass }
+            | ToolPolicy::RequireApproval { sandbox_bypass } => sandbox_bypass,
+            ToolPolicy::AllowList { sandbox_bypass, .. }
+            | ToolPolicy::DenyList { sandbox_bypass, .. } => sandbox_bypass,
+        }
+    }
+
+    /// Check whether a tool call matches any sandbox_bypass glob.
+    ///
+    /// Returns `true` if the call should be auto-approved with the sandbox
+    /// disabled. Uses the same glob matching as the tool policy list.
+    pub fn matches_sandbox_bypass(
+        &self,
+        tool_name: &str,
+        input: Option<&serde_json::Value>,
+    ) -> bool {
+        self.sandbox_bypass().iter().any(|pattern| match_tool(pattern, tool_name, input))
     }
 }
 
@@ -189,10 +252,15 @@ fn parse_tool_pattern(pattern: &str) -> Option<(&str, &str)> {
 ///
 /// Supported forms:
 /// - `"*"` — matches anything.
-/// - `"prefix *"` — matches commands that start with `prefix`.
+/// - `"prefix *"` — matches commands that start with `prefix ` (space-delimited token).
+/// - `"prefix*"` — matches commands that start with `prefix` (no space required).
 /// - `"* suffix"` — matches commands that end with `suffix`.
 /// - `"* word *"` — matches commands that contain `word` as a token.
 /// - `"exact"` — exact match (after leading whitespace is trimmed).
+///
+/// The `"prefix*"` form is useful for commands that may have zero or more
+/// arguments without a guaranteed leading space, e.g. `"git-spice repo sync*"`
+/// matches both `"git-spice repo sync"` and `"git-spice repo sync --remote"`.
 fn match_command_pattern(pattern: &str, command: &str) -> bool {
     let cmd = command.trim_start();
 
@@ -210,8 +278,18 @@ fn match_command_pattern(pattern: &str, command: &str) -> bool {
         return cmd.ends_with(&format!(" {suffix}")) || cmd == suffix;
     }
 
+    // Space-delimited prefix: "prefix *" matches "prefix" or "prefix <args>".
     if let Some(prefix) = pattern.strip_suffix(" *") {
         return cmd == prefix || cmd.starts_with(&format!("{prefix} "));
+    }
+
+    // No-space trailing wildcard: "prefix*" matches any command beginning with
+    // `prefix`. Useful for patterns like "git-spice repo sync*" that should
+    // match both the bare command and any flags appended to it.
+    if let Some(prefix) = pattern.strip_suffix('*') {
+        if !prefix.is_empty() && !prefix.contains('*') {
+            return cmd.starts_with(prefix);
+        }
     }
 
     cmd == pattern
@@ -757,7 +835,7 @@ mod tests {
 
     #[test]
     fn test_tool_policy_allow_all() {
-        let policy = ToolPolicy::AllowAll;
+        let policy = ToolPolicy::AllowAll { sandbox_bypass: vec![] };
         assert!(policy.evaluate("Bash", None));
         assert!(policy.evaluate("Read", None));
         assert!(policy.evaluate("Write", None));
@@ -766,7 +844,7 @@ mod tests {
 
     #[test]
     fn test_tool_policy_deny_all() {
-        let policy = ToolPolicy::DenyAll;
+        let policy = ToolPolicy::DenyAll { sandbox_bypass: vec![] };
         assert!(!policy.evaluate("Bash", None));
         assert!(!policy.evaluate("Read", None));
         assert!(!policy.evaluate("anything", None));
@@ -774,7 +852,10 @@ mod tests {
 
     #[test]
     fn test_tool_policy_allow_list() {
-        let policy = ToolPolicy::AllowList { tools: vec!["Read".to_string(), "Grep".to_string()] };
+        let policy = ToolPolicy::AllowList {
+            tools: vec!["Read".to_string(), "Grep".to_string()],
+            sandbox_bypass: vec![],
+        };
         assert!(policy.evaluate("Read", None));
         assert!(policy.evaluate("Grep", None));
         assert!(!policy.evaluate("Bash", None));
@@ -783,7 +864,10 @@ mod tests {
 
     #[test]
     fn test_tool_policy_deny_list() {
-        let policy = ToolPolicy::DenyList { tools: vec!["Bash".to_string(), "Write".to_string()] };
+        let policy = ToolPolicy::DenyList {
+            tools: vec!["Bash".to_string(), "Write".to_string()],
+            sandbox_bypass: vec![],
+        };
         assert!(!policy.evaluate("Bash", None));
         assert!(!policy.evaluate("Write", None));
         assert!(policy.evaluate("Read", None));
@@ -793,23 +877,26 @@ mod tests {
     #[test]
     fn test_tool_policy_default_is_allow_all() {
         let policy = ToolPolicy::default();
-        assert_eq!(policy, ToolPolicy::AllowAll);
+        assert_eq!(policy, ToolPolicy::AllowAll { sandbox_bypass: vec![] });
         assert!(policy.evaluate("anything", None));
     }
 
     #[test]
     fn test_tool_policy_serialization_allow_all() {
-        let policy = ToolPolicy::AllowAll;
+        let policy = ToolPolicy::AllowAll { sandbox_bypass: vec![] };
         let json = serde_json::to_string(&policy).unwrap();
         assert!(json.contains("allow_all"));
 
         let deserialized: ToolPolicy = serde_json::from_str(&json).unwrap();
-        assert_eq!(deserialized, ToolPolicy::AllowAll);
+        assert_eq!(deserialized, ToolPolicy::AllowAll { sandbox_bypass: vec![] });
     }
 
     #[test]
     fn test_tool_policy_serialization_deny_list() {
-        let policy = ToolPolicy::DenyList { tools: vec!["Bash".to_string(), "Write".to_string()] };
+        let policy = ToolPolicy::DenyList {
+            tools: vec!["Bash".to_string(), "Write".to_string()],
+            sandbox_bypass: vec![],
+        };
         let json = serde_json::to_string(&policy).unwrap();
         assert!(json.contains("deny_list"));
         assert!(json.contains("Bash"));
@@ -820,7 +907,8 @@ mod tests {
 
     #[test]
     fn test_tool_policy_serialization_allow_list() {
-        let policy = ToolPolicy::AllowList { tools: vec!["Read".to_string()] };
+        let policy =
+            ToolPolicy::AllowList { tools: vec!["Read".to_string()], sandbox_bypass: vec![] };
         let json = serde_json::to_string(&policy).unwrap();
 
         let deserialized: ToolPolicy = serde_json::from_str(&json).unwrap();
@@ -829,21 +917,21 @@ mod tests {
 
     #[test]
     fn test_tool_policy_empty_allow_list_denies_all() {
-        let policy = ToolPolicy::AllowList { tools: vec![] };
+        let policy = ToolPolicy::AllowList { tools: vec![], sandbox_bypass: vec![] };
         assert!(!policy.evaluate("Read", None));
         assert!(!policy.evaluate("Bash", None));
     }
 
     #[test]
     fn test_tool_policy_empty_deny_list_allows_all() {
-        let policy = ToolPolicy::DenyList { tools: vec![] };
+        let policy = ToolPolicy::DenyList { tools: vec![], sandbox_bypass: vec![] };
         assert!(policy.evaluate("Read", None));
         assert!(policy.evaluate("Bash", None));
     }
 
     #[test]
     fn test_tool_policy_require_approval() {
-        let policy = ToolPolicy::RequireApproval;
+        let policy = ToolPolicy::RequireApproval { sandbox_bypass: vec![] };
         // evaluate returns false as fallback — actual logic is in websocket.rs
         assert!(!policy.evaluate("Bash", None));
         assert!(!policy.evaluate("Read", None));
@@ -851,12 +939,12 @@ mod tests {
 
     #[test]
     fn test_tool_policy_serialization_require_approval() {
-        let policy = ToolPolicy::RequireApproval;
+        let policy = ToolPolicy::RequireApproval { sandbox_bypass: vec![] };
         let json = serde_json::to_string(&policy).unwrap();
         assert!(json.contains("require_approval"));
 
         let deserialized: ToolPolicy = serde_json::from_str(&json).unwrap();
-        assert_eq!(deserialized, ToolPolicy::RequireApproval);
+        assert_eq!(deserialized, ToolPolicy::RequireApproval { sandbox_bypass: vec![] });
     }
 
     #[test]
@@ -1141,9 +1229,12 @@ mod tests {
 
     #[test]
     fn test_tool_policy_mode_str() {
-        assert_eq!(ToolPolicy::AllowAll.mode_str(), "allow_all");
-        assert_eq!(ToolPolicy::DenyAll.mode_str(), "deny_all");
-        assert_eq!(ToolPolicy::RequireApproval.mode_str(), "require_approval");
+        assert_eq!(ToolPolicy::AllowAll { sandbox_bypass: vec![] }.mode_str(), "allow_all");
+        assert_eq!(ToolPolicy::DenyAll { sandbox_bypass: vec![] }.mode_str(), "deny_all");
+        assert_eq!(
+            ToolPolicy::RequireApproval { sandbox_bypass: vec![] }.mode_str(),
+            "require_approval"
+        );
     }
 
     // -- Docker config types --
@@ -1435,6 +1526,7 @@ mod tests {
                 "Bash(cargo *)".to_string(),
                 "Bash(git *)".to_string(),
             ],
+            sandbox_bypass: vec![],
         };
 
         // Plain tools work as before
@@ -1461,6 +1553,7 @@ mod tests {
     fn test_tool_policy_deny_list_with_bash_pattern() {
         let policy = ToolPolicy::DenyList {
             tools: vec!["Bash(rm *)".to_string(), "Bash(sudo *)".to_string()],
+            sandbox_bypass: vec![],
         };
 
         // Dangerous commands denied
@@ -1478,7 +1571,8 @@ mod tests {
 
     #[test]
     fn test_tool_policy_bash_wildcard_pattern() {
-        let policy = ToolPolicy::AllowList { tools: vec!["Bash(*)".to_string()] };
+        let policy =
+            ToolPolicy::AllowList { tools: vec!["Bash(*)".to_string()], sandbox_bypass: vec![] };
         assert!(policy.evaluate("Bash", Some(&make_input("anything"))));
         assert!(policy.evaluate("Bash", Some(&make_input("rm -rf /"))));
         // Still requires input for pattern match
@@ -1488,7 +1582,10 @@ mod tests {
     #[test]
     fn test_tool_policy_backward_compat_plain_bash() {
         // Plain "Bash" in the list should still allow any Bash call regardless of input
-        let policy = ToolPolicy::AllowList { tools: vec!["Bash".to_string(), "Read".to_string()] };
+        let policy = ToolPolicy::AllowList {
+            tools: vec!["Bash".to_string(), "Read".to_string()],
+            sandbox_bypass: vec![],
+        };
         assert!(policy.evaluate("Bash", None));
         assert!(policy.evaluate("Bash", Some(&make_input("rm -rf /"))));
         assert!(policy.evaluate("Read", None));
@@ -1564,6 +1661,7 @@ mod tests {
         // Documenter: deny writes to Rust source files
         let policy = ToolPolicy::DenyList {
             tools: vec!["Write(crates/**/*.rs)".to_string(), "Edit(crates/**/*.rs)".to_string()],
+            sandbox_bypass: vec![],
         };
 
         // Writing to docs is allowed
@@ -1588,6 +1686,7 @@ mod tests {
                 "Write(.agentd/**)".to_string(),
                 "Edit(.agentd/**)".to_string(),
             ],
+            sandbox_bypass: vec![],
         };
 
         // ui/ writes are allowed
@@ -1614,6 +1713,7 @@ mod tests {
                 "Write(.github/workflows/**)".to_string(),
                 "Edit(.github/workflows/**)".to_string(),
             ],
+            sandbox_bypass: vec![],
         };
 
         // Writing to integration test directory is allowed
@@ -1688,5 +1788,93 @@ mod tests {
         // The JSON representation should contain the activity field.
         let json = serde_json::to_string(&response).unwrap();
         assert!(json.contains("\"activity\":\"idle\""));
+    }
+
+    // -- sandbox_bypass tests --
+
+    #[test]
+    fn test_sandbox_bypass_empty_by_default() {
+        let policy = ToolPolicy::default();
+        assert!(policy.sandbox_bypass().is_empty());
+        assert!(!policy.matches_sandbox_bypass("Bash", None));
+    }
+
+    #[test]
+    fn test_sandbox_bypass_matches_bash_pattern() {
+        let policy = ToolPolicy::AllowAll {
+            sandbox_bypass: vec![
+                "Bash(git-spice branch submit *)".to_string(),
+                "Bash(git-spice repo sync*)".to_string(),
+                "Bash(gh pr create *)".to_string(),
+            ],
+        };
+
+        let submit_input = make_input("git-spice branch submit --no-prompt issue-1042");
+        let sync_input = make_input("git-spice repo sync");
+        let pr_input = make_input("gh pr create --title foo");
+        let safe_input = make_input("cargo test");
+
+        assert!(policy.matches_sandbox_bypass("Bash", Some(&submit_input)));
+        assert!(policy.matches_sandbox_bypass("Bash", Some(&sync_input)));
+        assert!(policy.matches_sandbox_bypass("Bash", Some(&pr_input)));
+
+        // Non-matching commands are not bypassed
+        assert!(!policy.matches_sandbox_bypass("Bash", Some(&safe_input)));
+        assert!(!policy.matches_sandbox_bypass("Bash", None));
+
+        // Non-Bash tools are not bypassed
+        assert!(!policy.matches_sandbox_bypass("Read", Some(&submit_input)));
+    }
+
+    #[test]
+    fn test_sandbox_bypass_on_deny_list_policy() {
+        let policy = ToolPolicy::DenyList {
+            tools: vec!["Bash(rm *)".to_string()],
+            sandbox_bypass: vec!["Bash(git-spice *)".to_string()],
+        };
+
+        let spice_input = make_input("git-spice branch submit");
+        let rm_input = make_input("rm -rf /");
+
+        // Sandbox bypass matches git-spice commands
+        assert!(policy.matches_sandbox_bypass("Bash", Some(&spice_input)));
+        // rm is not in sandbox_bypass
+        assert!(!policy.matches_sandbox_bypass("Bash", Some(&rm_input)));
+    }
+
+    #[test]
+    fn test_sandbox_bypass_serialization_round_trip() {
+        let policy = ToolPolicy::AllowAll {
+            sandbox_bypass: vec![
+                "Bash(git-spice branch submit *)".to_string(),
+                "Bash(gh pr create *)".to_string(),
+            ],
+        };
+        let json = serde_json::to_string(&policy).unwrap();
+        assert!(json.contains("sandbox_bypass"));
+        assert!(json.contains("git-spice branch submit *"));
+
+        let deserialized: ToolPolicy = serde_json::from_str(&json).unwrap();
+        assert_eq!(deserialized, policy);
+    }
+
+    #[test]
+    fn test_sandbox_bypass_omitted_when_empty() {
+        // When sandbox_bypass is empty, it should not appear in JSON
+        let policy = ToolPolicy::AllowAll { sandbox_bypass: vec![] };
+        let json = serde_json::to_string(&policy).unwrap();
+        assert!(!json.contains("sandbox_bypass"));
+    }
+
+    #[test]
+    fn test_sandbox_bypass_backward_compat_no_field() {
+        // Old JSON without sandbox_bypass should deserialize with an empty list
+        let json = r#"{"mode":"allow_all"}"#;
+        let policy: ToolPolicy = serde_json::from_str(json).unwrap();
+        assert!(policy.sandbox_bypass().is_empty());
+
+        let json = r#"{"mode":"deny_list","tools":["Bash(rm *)"]}"#;
+        let policy: ToolPolicy = serde_json::from_str(json).unwrap();
+        assert!(policy.sandbox_bypass().is_empty());
     }
 }

--- a/crates/orchestrator/src/websocket.rs
+++ b/crates/orchestrator/src/websocket.rs
@@ -624,8 +624,22 @@ async fn handle_control_request(agent_id: &Uuid, msg: &Value, registry: &Connect
             let policy = registry.get_policy(agent_id).await;
             let policy_mode = policy.mode_str();
 
+            // Check sandbox_bypass first — takes priority over all other policy rules.
+            // A matching glob auto-approves the call with dangerouslyDisableSandbox injected.
+            if policy.matches_sandbox_bypass(&tool_name, Some(&input)) {
+                info!(
+                    %agent_id, %tool_name, decision = "sandbox_bypass",
+                    "Tool call matches sandbox_bypass glob — auto-approving with sandbox disabled"
+                );
+                let response = make_sandbox_bypass_response(&request_id, &input);
+                if let Err(e) = send_raw(agent_id, &response, registry).await {
+                    error!(%agent_id, %e, "Failed to send sandbox-bypass response");
+                }
+                return;
+            }
+
             match policy {
-                ToolPolicy::RequireApproval => {
+                ToolPolicy::RequireApproval { .. } => {
                     // Spawn a separate task that holds the response until a human decides.
                     // The recv loop continues immediately so keep_alive etc. are processed.
                     info!(%agent_id, %tool_name, %policy_mode, "Tool use requires human approval, holding...");
@@ -736,6 +750,30 @@ fn make_allow_response(request_id: &str, input: &Value) -> Value {
             "subtype": "success",
             "request_id": request_id,
             "response": { "behavior": "allow", "updatedInput": input }
+        }
+    })
+}
+
+/// Build a control response that allows the tool call with the sandbox disabled.
+///
+/// Injects `"dangerouslyDisableSandbox": true` into the `updatedInput` object so
+/// that Claude Code skips TLS interception and filesystem sandboxing for this
+/// specific tool call. Used when the tool matches a `sandbox_bypass` glob in the
+/// agent's tool policy.
+fn make_sandbox_bypass_response(request_id: &str, input: &Value) -> Value {
+    // Clone the input and inject dangerouslyDisableSandbox into the updatedInput map.
+    let mut updated = match input.as_object() {
+        Some(map) => map.clone(),
+        None => serde_json::Map::new(),
+    };
+    updated.insert("dangerouslyDisableSandbox".to_string(), serde_json::json!(true));
+
+    serde_json::json!({
+        "type": "control_response",
+        "response": {
+            "subtype": "success",
+            "request_id": request_id,
+            "response": { "behavior": "allow", "updatedInput": updated }
         }
     })
 }

--- a/schemas/agent.yml
+++ b/schemas/agent.yml
@@ -231,6 +231,20 @@ examples:
       env:
         GITHUB_TOKEN: ${GITHUB_TOKEN}
   -
+    - "Worker agent with sandbox bypass for git-spice and gh PR commands"
+    - |
+      name: worker
+      model: claude-sonnet-4-6
+      tool_policy:
+        mode: deny_list
+        tools:
+          - "Bash(git push --force*)"
+          - "Bash(gh issue delete *)"
+        sandbox_bypass:
+          - "Bash(git-spice branch submit *)"
+          - "Bash(git-spice repo sync*)"
+          - "Bash(gh pr create *)"
+  -
     - "Docker-backed agent with resource limits"
     - |
       name: sandbox-worker

--- a/schemas/definitions.yml
+++ b/schemas/definitions.yml
@@ -20,6 +20,12 @@ definitions:
         - "Bash"             — plain name match, ignores input.
         - "Bash(cargo *)"    — matches tool name + command glob.
         - "Write(docs/**)"   — matches tool name + file-path glob.
+
+      All variants accept an optional `sandbox_bypass` list. Commands
+      matching a glob in this list are auto-approved with the Claude Code
+      sandbox disabled (`dangerouslyDisableSandbox: true`), bypassing TLS
+      interception for outbound HTTPS. Use this for tools such as git-spice
+      or gh that require direct TLS connections to GitHub.
     oneOf:
       - description: "Allow all tools without restriction (default)."
         type: object
@@ -27,6 +33,15 @@ definitions:
           mode:
             type: string
             enum: [allow_all]
+          sandbox_bypass:
+            description: |
+              List of tool+command globs auto-approved with sandbox disabled.
+              Uses the same glob syntax as the tools list:
+                - "Bash(git-spice *)"   — any git-spice command
+                - "Bash(gh pr *)"       — any gh pr subcommand
+            type: array
+            items:
+              type: string
         required: [mode]
         additionalProperties: false
 
@@ -36,6 +51,15 @@ definitions:
           mode:
             type: string
             enum: [deny_all]
+          sandbox_bypass:
+            description: |
+              List of tool+command globs auto-approved with sandbox disabled.
+              Uses the same glob syntax as the tools list:
+                - "Bash(git-spice *)"   — any git-spice command
+                - "Bash(gh pr *)"       — any gh pr subcommand
+            type: array
+            items:
+              type: string
         required: [mode]
         additionalProperties: false
 
@@ -50,6 +74,15 @@ definitions:
             items:
               type: string
             minItems: 1
+          sandbox_bypass:
+            description: |
+              List of tool+command globs auto-approved with sandbox disabled.
+              Uses the same glob syntax as the tools list:
+                - "Bash(git-spice *)"   — any git-spice command
+                - "Bash(gh pr *)"       — any gh pr subcommand
+            type: array
+            items:
+              type: string
         required: [mode, tools]
         additionalProperties: false
 
@@ -64,6 +97,15 @@ definitions:
             items:
               type: string
             minItems: 1
+          sandbox_bypass:
+            description: |
+              List of tool+command globs auto-approved with sandbox disabled.
+              Uses the same glob syntax as the tools list:
+                - "Bash(git-spice *)"   — any git-spice command
+                - "Bash(gh pr *)"       — any gh pr subcommand
+            type: array
+            items:
+              type: string
         required: [mode, tools]
         additionalProperties: false
 
@@ -73,6 +115,15 @@ definitions:
           mode:
             type: string
             enum: [require_approval]
+          sandbox_bypass:
+            description: |
+              List of tool+command globs auto-approved with sandbox disabled.
+              Uses the same glob syntax as the tools list:
+                - "Bash(git-spice *)"   — any git-spice command
+                - "Bash(gh pr *)"       — any gh pr subcommand
+            type: array
+            items:
+              type: string
         required: [mode]
         additionalProperties: false
 
@@ -97,6 +148,24 @@ definitions:
         - "Require human approval for every tool"
         - |
           mode: require_approval
+      -
+        - "Allow all, but bypass sandbox for git-spice and gh PR commands"
+        - |
+          mode: allow_all
+          sandbox_bypass:
+            - "Bash(git-spice branch submit *)"
+            - "Bash(git-spice repo sync*)"
+            - "Bash(gh pr create *)"
+      -
+        - "Deny list with sandbox bypass for VCS tooling"
+        - |
+          mode: deny_list
+          tools:
+            - "Bash(rm *)"
+            - "Bash(git push --force*)"
+          sandbox_bypass:
+            - "Bash(git-spice *)"
+            - "Bash(gh pr *)"
 
   # ---------------------------------------------------------------------------
   # Volume mount (Docker backend)

--- a/ui/src/components/agents/PolicyDisplay.tsx
+++ b/ui/src/components/agents/PolicyDisplay.tsx
@@ -5,6 +5,8 @@
  * Pairs with AgentPolicyEditor which is shown during editing.
  */
 
+import { useState } from "react";
+import { ChevronDown, ChevronRight, ShieldAlert } from "lucide-react";
 import type { ToolPolicy } from "@/types/orchestrator";
 
 // ---------------------------------------------------------------------------
@@ -32,11 +34,14 @@ const MODE_LABELS: Record<ToolPolicy["mode"], string> = {
 // ---------------------------------------------------------------------------
 
 export function PolicyDisplay({ policy }: PolicyDisplayProps) {
+	const [bypassExpanded, setBypassExpanded] = useState(false);
+
 	const label = MODE_LABELS[policy.mode];
 	const tools =
 		policy.mode === "allow_list" || policy.mode === "deny_list"
 			? policy.tools
 			: [];
+	const sandboxBypass = policy.sandbox_bypass ?? [];
 
 	return (
 		<dl className="flex flex-col gap-2 text-sm">
@@ -77,6 +82,47 @@ export function PolicyDisplay({ policy }: PolicyDisplayProps) {
 						</dd>
 					</div>
 				)}
+
+			{sandboxBypass.length > 0 && (
+				<div className="flex items-start gap-2">
+					<dt className="text-xs font-medium text-th-text-muted w-24 shrink-0 pt-0.5">
+						{/* spacer — label is in the collapsible header */}
+					</dt>
+					<dd className="flex-1 min-w-0">
+						<button
+							type="button"
+							onClick={() => setBypassExpanded((v) => !v)}
+							className="flex items-center gap-1.5 text-amber-600 dark:text-amber-400 hover:text-amber-700 dark:hover:text-amber-300 transition-colors"
+							aria-expanded={bypassExpanded}
+						>
+							<ShieldAlert className="w-3.5 h-3.5 shrink-0" />
+							<span className="text-xs font-medium">
+								Sandbox bypass
+							</span>
+							<span className="ml-1 inline-flex items-center rounded-full bg-amber-100 dark:bg-amber-900/40 px-1.5 py-0.5 text-xs font-medium text-amber-700 dark:text-amber-300">
+								{sandboxBypass.length}
+							</span>
+							{bypassExpanded ? (
+								<ChevronDown className="w-3 h-3 ml-0.5" />
+							) : (
+								<ChevronRight className="w-3 h-3 ml-0.5" />
+							)}
+						</button>
+
+						{bypassExpanded && (
+							<ul className="mt-1.5 flex flex-col gap-1">
+								{sandboxBypass.map((glob) => (
+									<li key={glob}>
+										<span className="inline-flex items-center rounded bg-amber-50 dark:bg-amber-900/20 border border-amber-200 dark:border-amber-800 px-2 py-0.5 text-xs font-mono text-amber-800 dark:text-amber-300">
+											{glob}
+										</span>
+									</li>
+								))}
+							</ul>
+						)}
+					</dd>
+				</div>
+			)}
 		</dl>
 	);
 }

--- a/ui/src/test/components/agents/PolicyDisplay.test.tsx
+++ b/ui/src/test/components/agents/PolicyDisplay.test.tsx
@@ -1,4 +1,5 @@
 import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { describe, expect, it } from "vitest";
 import { PolicyDisplay } from "@/components/agents/PolicyDisplay";
 
@@ -52,5 +53,97 @@ describe("PolicyDisplay", () => {
 		render(<PolicyDisplay policy={{ mode: "allow_all" }} />);
 		expect(screen.queryByText(/none configured/i)).not.toBeInTheDocument();
 		expect(screen.queryByText("Tools")).not.toBeInTheDocument();
+	});
+
+	// -- sandbox_bypass --
+
+	it("does not render sandbox bypass section when sandbox_bypass is absent", () => {
+		render(<PolicyDisplay policy={{ mode: "allow_all" }} />);
+		expect(
+			screen.queryByText(/sandbox bypass/i),
+		).not.toBeInTheDocument();
+	});
+
+	it("does not render sandbox bypass section when sandbox_bypass is empty", () => {
+		render(
+			<PolicyDisplay
+				policy={{ mode: "allow_all", sandbox_bypass: [] }}
+			/>,
+		);
+		expect(
+			screen.queryByText(/sandbox bypass/i),
+		).not.toBeInTheDocument();
+	});
+
+	it("renders sandbox bypass toggle when globs are present", () => {
+		render(
+			<PolicyDisplay
+				policy={{
+					mode: "deny_list",
+					tools: ["Bash(rm *)"],
+					sandbox_bypass: [
+						"Bash(git-spice branch submit *)",
+						"Bash(gh pr create *)",
+					],
+				}}
+			/>,
+		);
+		expect(screen.getByText(/sandbox bypass/i)).toBeInTheDocument();
+		// Badge shows count
+		expect(screen.getByText("2")).toBeInTheDocument();
+		// Globs are hidden until expanded
+		expect(
+			screen.queryByText("Bash(git-spice branch submit *)"),
+		).not.toBeInTheDocument();
+	});
+
+	it("expands sandbox bypass list on click", async () => {
+		const user = userEvent.setup();
+		render(
+			<PolicyDisplay
+				policy={{
+					mode: "allow_all",
+					sandbox_bypass: [
+						"Bash(git-spice branch submit *)",
+						"Bash(git-spice repo sync*)",
+					],
+				}}
+			/>,
+		);
+		const toggle = screen.getByRole("button", {
+			name: /sandbox bypass/i,
+		});
+		await user.click(toggle);
+
+		expect(
+			screen.getByText("Bash(git-spice branch submit *)"),
+		).toBeInTheDocument();
+		expect(
+			screen.getByText("Bash(git-spice repo sync*)"),
+		).toBeInTheDocument();
+	});
+
+	it("collapses sandbox bypass list on second click", async () => {
+		const user = userEvent.setup();
+		render(
+			<PolicyDisplay
+				policy={{
+					mode: "allow_all",
+					sandbox_bypass: ["Bash(git-spice branch submit *)"],
+				}}
+			/>,
+		);
+		const toggle = screen.getByRole("button", {
+			name: /sandbox bypass/i,
+		});
+		await user.click(toggle);
+		expect(
+			screen.getByText("Bash(git-spice branch submit *)"),
+		).toBeInTheDocument();
+
+		await user.click(toggle);
+		expect(
+			screen.queryByText("Bash(git-spice branch submit *)"),
+		).not.toBeInTheDocument();
 	});
 });

--- a/ui/src/types/orchestrator.ts
+++ b/ui/src/types/orchestrator.ts
@@ -13,12 +13,22 @@ export type ApprovalStatus = "pending" | "approved" | "denied" | "timed_out";
 // ToolPolicy – discriminated union mirroring the Rust enum
 // ---------------------------------------------------------------------------
 
+/**
+ * Globs in `sandbox_bypass` are matched against tool+command patterns.
+ * When a Bash call matches, the orchestrator auto-approves it with
+ * `dangerouslyDisableSandbox: true` so the Claude Code sandbox is skipped
+ * for that specific call (e.g. git-spice branch submit requires direct TLS).
+ *
+ * Glob syntax (same as the tools list):
+ *   "Bash(git-spice *)"  — any git-spice command
+ *   "Bash(gh pr *)"      — any gh pr subcommand
+ */
 export type ToolPolicy =
-	| { mode: "allow_all" }
-	| { mode: "deny_all" }
-	| { mode: "allow_list"; tools: string[] }
-	| { mode: "deny_list"; tools: string[] }
-	| { mode: "require_approval" };
+	| { mode: "allow_all"; sandbox_bypass?: string[] }
+	| { mode: "deny_all"; sandbox_bypass?: string[] }
+	| { mode: "allow_list"; tools: string[]; sandbox_bypass?: string[] }
+	| { mode: "deny_list"; tools: string[]; sandbox_bypass?: string[] }
+	| { mode: "require_approval"; sandbox_bypass?: string[] };
 
 // ---------------------------------------------------------------------------
 // AgentConfig


### PR DESCRIPTION
Adds an optional `sandbox_bypass` field to all `tool_policy` variants. Matching Bash calls are auto-approved with `dangerouslyDisableSandbox: true` so git-spice and gh can reach GitHub without TLS interception errors from the Claude Code sandbox proxy. Updates the PolicyDisplay UI card with a collapsible amber Sandbox bypass section.

## Changes

- **`schemas/definitions.yml`** - `sandbox_bypass` optional field added to all five `tool_policy` oneOf variants with description and examples
- **`schemas/agent.yml`** - new example showing `sandbox_bypass` usage with a worker agent
- **`crates/orchestrator/src/types.rs`** - `ToolPolicy` enum variants become struct variants with `sandbox_bypass: Vec<String>`; adds `sandbox_bypass()`, `matches_sandbox_bypass()` helpers; extends `match_command_pattern` to support `prefix*` (no-space wildcard); full test coverage including round-trip serialization and backward-compat for existing JSON
- **`crates/orchestrator/src/websocket.rs`** - sandbox_bypass check runs before policy evaluation; adds `make_sandbox_bypass_response` that injects `dangerouslyDisableSandbox: true` into `updatedInput`
- **`ui/src/types/orchestrator.ts`** - `sandbox_bypass?: string[]` added to all `ToolPolicy` union variants
- **`ui/src/components/agents/PolicyDisplay.tsx`** - collapsible amber Sandbox bypass section with count badge and per-glob monospace chips
- **`ui/src/test/components/agents/PolicyDisplay.test.tsx`** - tests for presence/absence, expand/collapse behaviour
- **`.agentd/agents/worker.yml`** - `sandbox_bypass` entries for `git-spice branch submit`, `git-spice repo sync`, `gh pr create`

Closes #1042