### PR TITLE
feat(core): add OrganizationStorage and MembershipStorage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -38,14 +38,20 @@ version = "0.2.0"
 dependencies = [
  "agentd-common",
  "anyhow",
+ "argon2",
+ "async-trait",
  "axum",
  "chrono",
  "http-body-util",
  "hyper",
  "metrics",
  "metrics-exporter-prometheus",
+ "rand 0.8.5",
+ "sea-orm",
+ "sea-orm-migration",
  "serde",
  "serde_json",
+ "tempfile",
  "tokio",
  "tower",
  "tower-http",
@@ -206,6 +212,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a07d1f37ff60921c83bdfc7407723bdefe89b44b98a9b772f225c8f9d67141a6"
 dependencies = [
  "rustversion",
+]
+
+[[package]]
+name = "argon2"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c3610892ee6e0cbce8ae2700349fcf8f98adb0dbfbee85aec3c9179d29cc072"
+dependencies = [
+ "base64ct",
+ "blake2",
+ "cpufeatures",
+ "password-hash",
 ]
 
 [[package]]
@@ -4995,6 +5013,17 @@ dependencies = [
  "redox_syscall 0.5.18",
  "smallvec",
  "windows-link",
+]
+
+[[package]]
+name = "password-hash"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "346f04948ba92c43e8469c1ee6736c7563d71012b17d40745260fe106aac2166"
+dependencies = [
+ "base64ct",
+ "rand_core 0.6.4",
+ "subtle",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1073,6 +1073,7 @@ dependencies = [
  "communicate",
  "crossterm",
  "dialoguer",
+ "dirs 5.0.1",
  "futures-util",
  "hook",
  "memory",
@@ -2250,7 +2251,16 @@ version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16f5094c54661b38d03bd7e50df373292118db60b585c08a411c6d840017fe7d"
 dependencies = [
- "dirs-sys",
+ "dirs-sys 0.5.0",
+]
+
+[[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys 0.4.1",
 ]
 
 [[package]]
@@ -2259,7 +2269,7 @@ version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
 dependencies = [
- "dirs-sys",
+ "dirs-sys 0.5.0",
 ]
 
 [[package]]
@@ -2270,6 +2280,18 @@ checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
 dependencies = [
  "cfg-if",
  "dirs-sys-next",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users 0.4.6",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3815,7 +3837,7 @@ dependencies = [
  "datafusion-physical-expr",
  "datafusion-sql",
  "deepsize",
- "dirs",
+ "dirs 6.0.0",
  "fst",
  "futures",
  "half",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,6 +47,7 @@ dependencies = [
  "metrics",
  "metrics-exporter-prometheus",
  "rand 0.8.5",
+ "reqwest",
  "sea-orm",
  "sea-orm-migration",
  "serde",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -27,6 +27,7 @@ bytes = "1"
 serde_yaml = "0.9"
 urlencoding = "2.1"
 dialoguer = "0.11"
+dirs = "5"
 
 # Internal dependencies
 notify = { path = "../notify" }

--- a/crates/cli/src/commands/auth.rs
+++ b/crates/cli/src/commands/auth.rs
@@ -1,0 +1,432 @@
+//! Authentication command implementations.
+//!
+//! Provides CLI subcommands for interacting with the agentd-core authentication
+//! endpoints. The session token is stored at `~/.config/agentd/session` with
+//! file permissions restricted to 0600 (owner read/write only).
+//!
+//! # Available Commands
+//!
+//! - **register** — Create a new account (prompts for username, email, password)
+//! - **login**    — Authenticate with username or email + password
+//! - **logout**   — Invalidate the current session token
+//! - **status**   — Show currently logged-in user and active organization
+//!
+//! # Examples
+//!
+//! ```bash
+//! agent auth register
+//! agent auth login
+//! agent auth logout
+//! agent auth status
+//! ```
+
+use anyhow::{Context, Result};
+use clap::Subcommand;
+use colored::*;
+use dialoguer::{Input, Password};
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::path::PathBuf;
+
+// ---------------------------------------------------------------------------
+// Session storage helpers
+// ---------------------------------------------------------------------------
+
+/// Returns the path to the session token file: `~/.config/agentd/session`.
+pub fn session_path() -> Result<PathBuf> {
+    let config_dir = dirs::config_dir().context("cannot determine config directory")?;
+    Ok(config_dir.join("agentd").join("session"))
+}
+
+/// Load the session token from disk. Returns `None` if not found.
+pub fn load_token() -> Option<String> {
+    let path = session_path().ok()?;
+    fs::read_to_string(&path).ok().map(|s| s.trim().to_string()).filter(|s| !s.is_empty())
+}
+
+/// Persist the session token to `~/.config/agentd/session` with 0600 permissions.
+pub fn save_token(token: &str) -> Result<()> {
+    let path = session_path()?;
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create config dir: {}", parent.display()))?;
+    }
+    fs::write(&path, token)
+        .with_context(|| format!("failed to write session file: {}", path.display()))?;
+
+    // Restrict permissions to owner read/write (0600) on Unix
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o600))
+            .with_context(|| format!("failed to set permissions on: {}", path.display()))?;
+    }
+
+    Ok(())
+}
+
+/// Remove the session token from disk.
+pub fn clear_token() -> Result<()> {
+    let path = session_path()?;
+    if path.exists() {
+        fs::remove_file(&path)
+            .with_context(|| format!("failed to remove session file: {}", path.display()))?;
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// HTTP client helpers
+// ---------------------------------------------------------------------------
+
+fn core_base_url() -> String {
+    std::env::var("AGENTD_CORE_SERVICE_URL")
+        .unwrap_or_else(|_| "http://localhost:17007".to_string())
+}
+
+async fn post_json<B: Serialize, T: for<'de> Deserialize<'de>>(
+    path: &str,
+    body: &B,
+    token: Option<&str>,
+) -> Result<T> {
+    let url = format!("{}{}", core_base_url(), path);
+    let client = reqwest::Client::new();
+    let mut req = client.post(&url).json(body);
+    if let Some(t) = token {
+        req = req.bearer_auth(t);
+    }
+    let resp = req.send().await.with_context(|| format!("POST {url}"))?;
+    let status = resp.status();
+    if !status.is_success() {
+        let body: serde_json::Value = resp.json().await.unwrap_or_default();
+        let msg = body["error"].as_str().unwrap_or("unknown error");
+        anyhow::bail!("HTTP {}: {}", status, msg);
+    }
+    resp.json().await.context("deserializing response")
+}
+
+async fn get_json<T: for<'de> Deserialize<'de>>(path: &str, token: &str) -> Result<T> {
+    let url = format!("{}{}", core_base_url(), path);
+    let resp = reqwest::Client::new()
+        .get(&url)
+        .bearer_auth(token)
+        .send()
+        .await
+        .with_context(|| format!("GET {url}"))?;
+    let status = resp.status();
+    if !status.is_success() {
+        let body: serde_json::Value = resp.json().await.unwrap_or_default();
+        let msg = body["error"].as_str().unwrap_or("unknown error");
+        anyhow::bail!("HTTP {}: {}", status, msg);
+    }
+    resp.json().await.context("deserializing response")
+}
+
+// ---------------------------------------------------------------------------
+// Response types (mirrors core service API)
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize, Serialize)]
+struct UserResponse {
+    id: String,
+    username: Option<String>,
+    email: String,
+    display_name: Option<String>,
+    role: String,
+    active_organization_id: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct OrgResponse {
+    id: String,
+    name: String,
+    slug: String,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct LoginResponse {
+    token: String,
+    user: UserResponse,
+    active_organization: Option<OrgResponse>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct MeResponse {
+    user: UserResponse,
+    active_organization: Option<OrgResponse>,
+}
+
+// ---------------------------------------------------------------------------
+// Command definition
+// ---------------------------------------------------------------------------
+
+/// Subcommands for authentication with the core service.
+#[derive(Debug, Subcommand)]
+pub enum AuthCommand {
+    /// Create a new agentd account.
+    ///
+    /// Prompts for username, email, optional display name, and password
+    /// (with confirmation). Creates a default personal organization and
+    /// stores the session token for subsequent commands.
+    ///
+    /// # Examples
+    ///
+    /// ```bash
+    /// agent auth register
+    /// ```
+    Register,
+
+    /// Log in to agentd.
+    ///
+    /// Accepts username or email with password. Stores the session token
+    /// at `~/.config/agentd/session` for use by other commands.
+    ///
+    /// # Examples
+    ///
+    /// ```bash
+    /// agent auth login
+    /// agent auth login --username alice
+    /// agent auth login --email alice@example.com
+    /// ```
+    Login {
+        /// Login by username (optional — prompted if neither flag is given)
+        #[arg(long)]
+        username: Option<String>,
+        /// Login by email
+        #[arg(long)]
+        email: Option<String>,
+    },
+
+    /// Log out of agentd.
+    ///
+    /// Calls the logout endpoint to invalidate the session token on the
+    /// server, then removes the local token file.
+    ///
+    /// # Examples
+    ///
+    /// ```bash
+    /// agent auth logout
+    /// ```
+    Logout,
+
+    /// Show current authentication status.
+    ///
+    /// Displays the logged-in user and active organization if a valid
+    /// session token is found.
+    ///
+    /// # Examples
+    ///
+    /// ```bash
+    /// agent auth status
+    /// ```
+    Status,
+}
+
+impl AuthCommand {
+    pub async fn execute(&self, json: bool) -> Result<()> {
+        match self {
+            AuthCommand::Register => register_cmd(json).await,
+            AuthCommand::Login { username, email } => {
+                login_cmd(username.as_deref(), email.as_deref(), json).await
+            }
+            AuthCommand::Logout => logout_cmd(json).await,
+            AuthCommand::Status => status_cmd(json).await,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Handlers
+// ---------------------------------------------------------------------------
+
+async fn register_cmd(json: bool) -> Result<()> {
+    let username: String =
+        Input::new().with_prompt("Username").interact_text().context("reading username")?;
+    let email: String =
+        Input::new().with_prompt("Email").interact_text().context("reading email")?;
+    let display_name: String = Input::new()
+        .with_prompt("Display name (optional, press Enter to skip)")
+        .allow_empty(true)
+        .interact_text()
+        .context("reading display name")?;
+    let password = Password::new()
+        .with_prompt("Password")
+        .with_confirmation("Confirm password", "Passwords do not match")
+        .interact()
+        .context("reading password")?;
+
+    #[derive(Serialize)]
+    struct RegisterReq<'a> {
+        username: &'a str,
+        email: &'a str,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        display_name: Option<&'a str>,
+        password: &'a str,
+    }
+
+    let dn = if display_name.is_empty() { None } else { Some(display_name.as_str()) };
+    let resp: LoginResponse = post_json(
+        "/auth/register",
+        &RegisterReq { username: &username, email: &email, display_name: dn, password: &password },
+        None,
+    )
+    .await?;
+
+    save_token(&resp.token)?;
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&resp.user).unwrap_or_default());
+        return Ok(());
+    }
+
+    println!("{}", "✅ Account created and logged in".green().bold());
+    print_user_info(&resp.user, resp.active_organization.as_ref());
+    Ok(())
+}
+
+async fn login_cmd(username: Option<&str>, email: Option<&str>, json: bool) -> Result<()> {
+    #[derive(Serialize)]
+    struct LoginReq<'a> {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        username: Option<&'a str>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        email: Option<&'a str>,
+        password: &'a str,
+    }
+
+    // Determine identifier
+    let (resolved_username, resolved_email) = if username.is_some() || email.is_some() {
+        (username.map(str::to_string), email.map(str::to_string))
+    } else {
+        let input: String = Input::new()
+            .with_prompt("Username or email")
+            .interact_text()
+            .context("reading identifier")?;
+        if input.contains('@') {
+            (None, Some(input))
+        } else {
+            (Some(input), None)
+        }
+    };
+
+    let password =
+        Password::new().with_prompt("Password").interact().context("reading password")?;
+
+    let resp: LoginResponse = post_json(
+        "/auth/login",
+        &LoginReq {
+            username: resolved_username.as_deref(),
+            email: resolved_email.as_deref(),
+            password: &password,
+        },
+        None,
+    )
+    .await?;
+
+    save_token(&resp.token)?;
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&resp.user).unwrap_or_default());
+        return Ok(());
+    }
+
+    println!("{}", "✅ Logged in".green().bold());
+    print_user_info(&resp.user, resp.active_organization.as_ref());
+    Ok(())
+}
+
+async fn logout_cmd(json: bool) -> Result<()> {
+    let token = load_token().context("not logged in — no session token found")?;
+
+    #[derive(Serialize)]
+    struct Empty {}
+
+    // Best-effort server-side invalidation
+    let result: Result<serde_json::Value> =
+        post_json("/auth/logout", &Empty {}, Some(&token)).await;
+    if let Err(e) = result {
+        eprintln!("{} server logout failed: {}", "⚠".yellow(), e);
+    }
+
+    clear_token()?;
+
+    if json {
+        println!("{}", serde_json::json!({ "status": "logged_out" }));
+        return Ok(());
+    }
+
+    println!("{}", "✅ Logged out".green().bold());
+    Ok(())
+}
+
+async fn status_cmd(json: bool) -> Result<()> {
+    let token = match load_token() {
+        Some(t) => t,
+        None => {
+            if json {
+                println!("{}", serde_json::json!({ "status": "unauthenticated" }));
+            } else {
+                println!("{}", "Not logged in".yellow());
+            }
+            return Ok(());
+        }
+    };
+
+    let resp: MeResponse =
+        get_json("/auth/me", &token).await.context("failed to fetch session info")?;
+
+    if json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&serde_json::json!({
+                "user": {
+                    "id": resp.user.id,
+                    "username": resp.user.username,
+                    "email": resp.user.email,
+                    "display_name": resp.user.display_name,
+                    "role": resp.user.role,
+                    "active_organization_id": resp.user.active_organization_id,
+                },
+                "active_organization": resp.active_organization.as_ref().map(|o| serde_json::json!({
+                    "id": o.id,
+                    "name": o.name,
+                    "slug": o.slug,
+                })),
+            }))
+            .unwrap_or_default()
+        );
+        return Ok(());
+    }
+
+    println!("{}", "Auth Status".blue().bold());
+    println!("{}", "─".repeat(40).cyan());
+    print_user_info(&resp.user, resp.active_organization.as_ref());
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Display helpers
+// ---------------------------------------------------------------------------
+
+fn print_user_info(user: &UserResponse, org: Option<&OrgResponse>) {
+    println!(
+        "  {}  {}",
+        "User:".bright_black(),
+        user.username.as_deref().unwrap_or(&user.email).cyan().bold()
+    );
+    println!("  {}  {}", "Email:".bright_black(), user.email);
+    if let Some(dn) = &user.display_name {
+        println!("  {}  {}", "Name:".bright_black(), dn);
+    }
+    println!("  {}  {}", "Role:".bright_black(), user.role.yellow());
+    if let Some(o) = org {
+        println!(
+            "  {}  {} {}",
+            "Active org:".bright_black(),
+            o.name.green().bold(),
+            format!("({})", o.slug).bright_black()
+        );
+    } else {
+        println!("  {}  {}", "Active org:".bright_black(), "none".bright_black());
+    }
+}

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -30,19 +30,23 @@
 
 pub mod apply;
 pub mod ask;
+pub mod auth;
 pub mod communicate;
 pub mod index;
 pub mod memory;
 pub mod notify;
 pub mod orchestrator;
+pub mod org;
 pub mod prompt;
 pub mod wrap;
 
 pub use ask::AskCommand;
+pub use auth::AuthCommand;
 pub use communicate::CommunicateCommand;
 pub use index::IndexCommand;
 pub use memory::MemoryCommand;
 pub use notify::NotifyCommand;
 pub use orchestrator::OrchestratorCommand;
+pub use org::OrgCommand;
 pub use prompt::PromptCommand;
 pub use wrap::WrapCommand;

--- a/crates/cli/src/commands/org.rs
+++ b/crates/cli/src/commands/org.rs
@@ -1,0 +1,288 @@
+//! Organization management command implementations.
+//!
+//! Provides CLI subcommands for managing agentd organizations via the core service.
+//! All commands require a valid session token (stored by `agent auth login`).
+//!
+//! # Available Commands
+//!
+//! - **list**   — List all organizations the current user belongs to
+//! - **create** — Create a new organization
+//! - **switch** — Set the active organization by name or ID
+//!
+//! # Examples
+//!
+//! ```bash
+//! agent org list
+//! agent org create "Acme Corp" --slug acme-corp
+//! agent org switch acme-corp
+//! ```
+
+use anyhow::{Context, Result};
+use clap::Subcommand;
+use colored::*;
+use serde::{Deserialize, Serialize};
+
+use super::auth::load_token;
+
+// ---------------------------------------------------------------------------
+// HTTP helpers (mirrors auth.rs but for org endpoints)
+// ---------------------------------------------------------------------------
+
+fn core_base_url() -> String {
+    std::env::var("AGENTD_CORE_SERVICE_URL")
+        .unwrap_or_else(|_| "http://localhost:17007".to_string())
+}
+
+async fn get_json_auth<T: for<'de> Deserialize<'de>>(path: &str, token: &str) -> Result<T> {
+    let url = format!("{}{}", core_base_url(), path);
+    let resp = reqwest::Client::new()
+        .get(&url)
+        .bearer_auth(token)
+        .send()
+        .await
+        .with_context(|| format!("GET {url}"))?;
+    let status = resp.status();
+    if !status.is_success() {
+        let body: serde_json::Value = resp.json().await.unwrap_or_default();
+        let msg = body["error"].as_str().unwrap_or("unknown error");
+        anyhow::bail!("HTTP {}: {}", status, msg);
+    }
+    resp.json().await.context("deserializing response")
+}
+
+async fn post_json_auth<B: Serialize, T: for<'de> Deserialize<'de>>(
+    path: &str,
+    body: &B,
+    token: &str,
+) -> Result<T> {
+    let url = format!("{}{}", core_base_url(), path);
+    let resp = reqwest::Client::new()
+        .post(&url)
+        .bearer_auth(token)
+        .json(body)
+        .send()
+        .await
+        .with_context(|| format!("POST {url}"))?;
+    let status = resp.status();
+    if !status.is_success() {
+        let body: serde_json::Value = resp.json().await.unwrap_or_default();
+        let msg = body["error"].as_str().unwrap_or("unknown error");
+        anyhow::bail!("HTTP {}: {}", status, msg);
+    }
+    resp.json().await.context("deserializing response")
+}
+
+async fn put_json_auth<B: Serialize, T: for<'de> Deserialize<'de>>(
+    path: &str,
+    body: &B,
+    token: &str,
+) -> Result<T> {
+    let url = format!("{}{}", core_base_url(), path);
+    let resp = reqwest::Client::new()
+        .put(&url)
+        .bearer_auth(token)
+        .json(body)
+        .send()
+        .await
+        .with_context(|| format!("PUT {url}"))?;
+    let status = resp.status();
+    if !status.is_success() {
+        let body: serde_json::Value = resp.json().await.unwrap_or_default();
+        let msg = body["error"].as_str().unwrap_or("unknown error");
+        anyhow::bail!("HTTP {}: {}", status, msg);
+    }
+    resp.json().await.context("deserializing response")
+}
+
+// ---------------------------------------------------------------------------
+// Response types
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize, Serialize)]
+struct OrgResponse {
+    id: String,
+    name: String,
+    slug: String,
+    created_at: String,
+    updated_at: String,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct UserProfileResponse {
+    id: String,
+    username: Option<String>,
+    email: String,
+    active_organization_id: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Command definition
+// ---------------------------------------------------------------------------
+
+/// Subcommands for organization management.
+#[derive(Debug, Subcommand)]
+pub enum OrgCommand {
+    /// List all organizations you belong to.
+    ///
+    /// Requires an active session (run `agent auth login` first).
+    ///
+    /// # Examples
+    ///
+    /// ```bash
+    /// agent org list
+    /// agent org list --json
+    /// ```
+    List,
+
+    /// Create a new organization.
+    ///
+    /// You become the owner of the new organization. The `--slug` flag is
+    /// optional — if omitted it is derived from `name` by lowercasing and
+    /// replacing spaces with hyphens.
+    ///
+    /// # Examples
+    ///
+    /// ```bash
+    /// agent org create "Acme Corp"
+    /// agent org create "Acme Corp" --slug acme-corp
+    /// ```
+    Create {
+        /// Organization display name
+        name: String,
+        /// URL-safe slug (derived from name if omitted)
+        #[arg(long)]
+        slug: Option<String>,
+    },
+
+    /// Switch your active organization.
+    ///
+    /// Accepts an organization name or ID. The active organization is used
+    /// by the API gateway to scope requests to the correct tenant.
+    ///
+    /// # Examples
+    ///
+    /// ```bash
+    /// agent org switch acme-corp
+    /// agent org switch "Acme Corp"
+    /// ```
+    Switch {
+        /// Organization name or ID to switch to
+        name_or_id: String,
+    },
+}
+
+impl OrgCommand {
+    pub async fn execute(&self, json: bool) -> Result<()> {
+        match self {
+            OrgCommand::List => list_cmd(json).await,
+            OrgCommand::Create { name, slug } => create_cmd(name, slug.as_deref(), json).await,
+            OrgCommand::Switch { name_or_id } => switch_cmd(name_or_id, json).await,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Handlers
+// ---------------------------------------------------------------------------
+
+async fn list_cmd(json: bool) -> Result<()> {
+    let token = load_token().context("not logged in — run `agent auth login` first")?;
+    let orgs: Vec<OrgResponse> = get_json_auth("/api/v1/users/me/organizations", &token).await?;
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&orgs).unwrap_or_default());
+        return Ok(());
+    }
+
+    if orgs.is_empty() {
+        println!("{}", "No organizations found.".yellow());
+        return Ok(());
+    }
+
+    println!("{}", "Organizations".blue().bold());
+    println!("{}", "─".repeat(50).cyan());
+    for org in &orgs {
+        println!("  {} {}", org.name.cyan().bold(), format!("({})", org.slug).bright_black());
+        println!("    ID: {}", org.id.bright_black());
+    }
+    println!("\n  {} organizations", orgs.len().to_string().green().bold());
+    Ok(())
+}
+
+async fn create_cmd(name: &str, slug: Option<&str>, json: bool) -> Result<()> {
+    let token = load_token().context("not logged in — run `agent auth login` first")?;
+
+    // Derive slug from name if not provided
+    let derived_slug: String;
+    let slug = match slug {
+        Some(s) => s,
+        None => {
+            derived_slug = name
+                .chars()
+                .map(|c| if c.is_alphanumeric() { c.to_ascii_lowercase() } else { '-' })
+                .collect::<String>()
+                .trim_matches('-')
+                .to_string();
+            &derived_slug
+        }
+    };
+
+    #[derive(Serialize)]
+    struct CreateOrgReq<'a> {
+        name: &'a str,
+        slug: &'a str,
+    }
+
+    let org: OrgResponse =
+        post_json_auth("/api/v1/organizations", &CreateOrgReq { name, slug }, &token).await?;
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&org).unwrap_or_default());
+        return Ok(());
+    }
+
+    println!("{}", "✅ Organization created".green().bold());
+    println!("  {}  {}", "Name:".bright_black(), org.name.cyan().bold());
+    println!("  {}  {}", "Slug:".bright_black(), org.slug);
+    println!("  {}  {}", "ID:".bright_black(), org.id.bright_black());
+    Ok(())
+}
+
+async fn switch_cmd(name_or_id: &str, json: bool) -> Result<()> {
+    let token = load_token().context("not logged in — run `agent auth login` first")?;
+
+    // Fetch all orgs the user belongs to, then find by name or ID
+    let orgs: Vec<OrgResponse> = get_json_auth("/api/v1/users/me/organizations", &token).await?;
+
+    let target = orgs
+        .iter()
+        .find(|o| o.id == name_or_id || o.name == name_or_id || o.slug == name_or_id)
+        .with_context(|| {
+            format!(
+                "organization '{}' not found — use `agent org list` to see your organizations",
+                name_or_id
+            )
+        })?;
+
+    #[derive(Serialize)]
+    struct SwitchReq<'a> {
+        organization_id: &'a str,
+    }
+
+    let updated: UserProfileResponse = put_json_auth(
+        "/users/me/active-organization",
+        &SwitchReq { organization_id: &target.id },
+        &token,
+    )
+    .await?;
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&updated).unwrap_or_default());
+        return Ok(());
+    }
+
+    println!("{} Switched to {}", "✅".green(), target.name.cyan().bold());
+    println!("  {}  {}", "Slug:".bright_black(), target.slug);
+    println!("  {}  {}", "ID:".bright_black(), target.id.bright_black());
+    Ok(())
+}

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -83,8 +83,8 @@ use clap_complete::Shell;
 use colored::*;
 use commands::index::IndexClient;
 use commands::{
-    AskCommand, CommunicateCommand, IndexCommand, MemoryCommand, NotifyCommand,
-    OrchestratorCommand, PromptCommand, WrapCommand,
+    AskCommand, AuthCommand, CommunicateCommand, IndexCommand, MemoryCommand, NotifyCommand,
+    OrchestratorCommand, OrgCommand, PromptCommand, WrapCommand,
 };
 use communicate::client::CommunicateClient;
 use memory::client::MemoryClient;
@@ -304,6 +304,41 @@ enum Commands {
         #[command(subcommand)]
         command: IndexCommand,
     },
+
+    /// Authenticate with the agentd core service.
+    ///
+    /// Register, log in, log out, and check auth status. The session token
+    /// is stored at `~/.config/agentd/session` with 0600 permissions.
+    ///
+    /// # Examples
+    ///
+    /// ```bash
+    /// agent auth register
+    /// agent auth login
+    /// agent auth logout
+    /// agent auth status
+    /// ```
+    Auth {
+        #[command(subcommand)]
+        command: AuthCommand,
+    },
+
+    /// Manage organizations in the agentd core service.
+    ///
+    /// List, create, and switch between organizations. Requires an active
+    /// session (run `agent auth login` first).
+    ///
+    /// # Examples
+    ///
+    /// ```bash
+    /// agent org list
+    /// agent org create "Acme Corp"
+    /// agent org switch acme-corp
+    /// ```
+    Org {
+        #[command(subcommand)]
+        command: OrgCommand,
+    },
 }
 
 /// Main entry point for the agent CLI.
@@ -429,6 +464,12 @@ async fn main() -> Result<()> {
             let client = IndexClient::new(url);
             command.execute(&client, cli.json).await?;
         }
+        Commands::Auth { command } => {
+            command.execute(cli.json).await?;
+        }
+        Commands::Org { command } => {
+            command.execute(cli.json).await?;
+        }
     }
 
     Ok(())
@@ -475,6 +516,11 @@ const SERVICES: &[ServiceDef] = &[
         name: "memory",
         env_var: "AGENTD_MEMORY_SERVICE_URL",
         default_url: "http://localhost:7008",
+    },
+    ServiceDef {
+        name: "core",
+        env_var: "AGENTD_CORE_SERVICE_URL",
+        default_url: "http://localhost:17007",
     },
     ServiceDef {
         name: "communicate",

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -29,6 +29,8 @@ metrics-exporter-prometheus = { workspace = true }
 sea-orm = { workspace = true }
 sea-orm-migration = { workspace = true }
 async-trait = "0.1"
+argon2 = "0.5"
+rand = "0.8"
 
 [dev-dependencies]
 tower = { version = "0.5", features = ["util"] }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -31,6 +31,7 @@ sea-orm-migration = { workspace = true }
 async-trait = "0.1"
 argon2 = "0.5"
 rand = "0.8"
+reqwest = { workspace = true, features = ["json", "stream"] }
 
 [dev-dependencies]
 tower = { version = "0.5", features = ["util"] }

--- a/crates/core/src/api.rs
+++ b/crates/core/src/api.rs
@@ -8,6 +8,7 @@
 //! - `GET  /auth/me`         — return current user + active organization
 
 pub mod auth;
+pub mod users;
 
 use axum::{routing::get, Json, Router};
 use serde_json::{json, Value};
@@ -25,6 +26,7 @@ pub fn create_router(state: AppState) -> Router {
     Router::new()
         .route("/health", get(health_handler))
         .nest("/auth", auth::router())
+        .nest("/users", users::router())
         .with_state(state)
 }
 

--- a/crates/core/src/api.rs
+++ b/crates/core/src/api.rs
@@ -12,21 +12,24 @@
 //! - `GET  /api/v1/users/me/organizations`       — list user's organizations
 //! - `PUT  /users/me/active-organization`        — switch active organization
 //! - `POST /api/v1/organizations`                — create organization
-//! - `GET  /api/v1/organizations/:id`            — get organization
-//! - `PUT  /api/v1/organizations/:id`            — update organization (owners only)
-//! - `DELETE /api/v1/organizations/:id`          — delete organization (owners only)
-//! - `GET  /api/v1/organizations/:id/members`    — list members
-//! - `POST /api/v1/organizations/:id/members`    — add member (owners only)
-//! - `DELETE /api/v1/organizations/:id/members/:uid` — remove member (owners only)
+//! - `GET  /api/v1/organizations/{id}`           — get organization
+//! - `PUT  /api/v1/organizations/{id}`           — update organization (owners only)
+//! - `DELETE /api/v1/organizations/{id}`         — delete organization (owners only)
+//! - `GET  /api/v1/organizations/{id}/members`   — list members
+//! - `POST /api/v1/organizations/{id}/members`   — add member (owners only)
+//! - `DELETE /api/v1/organizations/{id}/members/{uid}` — remove member (owners only)
+//! - `GET  /api/v1/health`                       — aggregate downstream health check
+//! - `ANY  /api/v1/{service}/*`                  — proxy to downstream service
 
 pub mod auth;
+pub mod gateway;
 pub mod organizations;
 pub mod users;
 
 use axum::{routing::get, Json, Router};
 use serde_json::{json, Value};
 
-use crate::storage::Storage;
+use crate::{proxy::ProxyConfig, storage::Storage};
 
 /// Shared application state threaded through all route handlers.
 #[derive(Clone)]
@@ -34,11 +37,18 @@ pub struct AppState {
     pub storage: Storage,
 }
 
-/// Build the application router.
+/// Build the application router without a proxy (for testing or when proxy is disabled).
 pub fn create_router(state: AppState) -> Router {
+    create_router_with_proxy(state, ProxyConfig::from_env())
+}
+
+/// Build the application router with an explicit [`ProxyConfig`].
+pub fn create_router_with_proxy(state: AppState, proxy: ProxyConfig) -> Router {
     let api_v1 = Router::new()
         .nest("/users", users::v1_router())
-        .nest("/organizations", organizations::router());
+        .nest("/organizations", organizations::router())
+        // Gateway routes — /api/v1/health and /api/v1/{service}/* path
+        .merge(gateway::router(proxy));
 
     Router::new()
         .route("/health", get(health_handler))

--- a/crates/core/src/api.rs
+++ b/crates/core/src/api.rs
@@ -1,14 +1,31 @@
 //! HTTP router for the core service.
 //!
 //! Endpoints:
-//! - `GET /health` — liveness probe; returns `{"status":"ok","service":"core"}`
+//! - `GET  /health`          — liveness probe
+//! - `POST /auth/register`   — create account + default personal org
+//! - `POST /auth/login`      — authenticate, return bearer token
+//! - `POST /auth/logout`     — invalidate bearer token
+//! - `GET  /auth/me`         — return current user + active organization
+
+pub mod auth;
 
 use axum::{routing::get, Json, Router};
 use serde_json::{json, Value};
 
+use crate::storage::Storage;
+
+/// Shared application state threaded through all route handlers.
+#[derive(Clone)]
+pub struct AppState {
+    pub storage: Storage,
+}
+
 /// Build the application router.
-pub fn create_router() -> Router {
-    Router::new().route("/health", get(health_handler))
+pub fn create_router(state: AppState) -> Router {
+    Router::new()
+        .route("/health", get(health_handler))
+        .nest("/auth", auth::router())
+        .with_state(state)
 }
 
 async fn health_handler() -> Json<Value> {
@@ -18,14 +35,21 @@ async fn health_handler() -> Json<Value> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use agentd_common::storage::create_test_connection;
     use axum::body::Body;
     use axum::http::{Request, StatusCode};
     use http_body_util::BodyExt;
     use tower::ServiceExt;
 
+    async fn test_app() -> Router {
+        let (conn, _tmp) = create_test_connection().await;
+        let storage = Storage::new(conn).await.unwrap();
+        create_router(AppState { storage })
+    }
+
     #[tokio::test]
     async fn health_returns_200() {
-        let app = create_router();
+        let app = test_app().await;
         let response = app
             .oneshot(Request::builder().uri("/health").body(Body::empty()).unwrap())
             .await
@@ -35,7 +59,7 @@ mod tests {
 
     #[tokio::test]
     async fn health_returns_json_body() {
-        let app = create_router();
+        let app = test_app().await;
         let response = app
             .oneshot(Request::builder().uri("/health").body(Body::empty()).unwrap())
             .await

--- a/crates/core/src/api.rs
+++ b/crates/core/src/api.rs
@@ -1,13 +1,26 @@
 //! HTTP router for the core service.
 //!
 //! Endpoints:
-//! - `GET  /health`          — liveness probe
-//! - `POST /auth/register`   — create account + default personal org
-//! - `POST /auth/login`      — authenticate, return bearer token
-//! - `POST /auth/logout`     — invalidate bearer token
-//! - `GET  /auth/me`         — return current user + active organization
+//! - `GET  /health`                              — liveness probe
+//! - `POST /auth/register`                       — create account + default personal org
+//! - `POST /auth/login`                          — authenticate, return bearer token
+//! - `POST /auth/logout`                         — invalidate bearer token
+//! - `GET  /auth/me`                             — return current user + active organization
+//! - `GET  /api/v1/users/me`                     — get current user profile
+//! - `PUT  /api/v1/users/me`                     — update profile (display_name, email)
+//! - `PUT  /api/v1/users/me/password`            — change password
+//! - `GET  /api/v1/users/me/organizations`       — list user's organizations
+//! - `PUT  /users/me/active-organization`        — switch active organization
+//! - `POST /api/v1/organizations`                — create organization
+//! - `GET  /api/v1/organizations/:id`            — get organization
+//! - `PUT  /api/v1/organizations/:id`            — update organization (owners only)
+//! - `DELETE /api/v1/organizations/:id`          — delete organization (owners only)
+//! - `GET  /api/v1/organizations/:id/members`    — list members
+//! - `POST /api/v1/organizations/:id/members`    — add member (owners only)
+//! - `DELETE /api/v1/organizations/:id/members/:uid` — remove member (owners only)
 
 pub mod auth;
+pub mod organizations;
 pub mod users;
 
 use axum::{routing::get, Json, Router};
@@ -23,10 +36,16 @@ pub struct AppState {
 
 /// Build the application router.
 pub fn create_router(state: AppState) -> Router {
+    let api_v1 = Router::new()
+        .nest("/users", users::v1_router())
+        .nest("/organizations", organizations::router());
+
     Router::new()
         .route("/health", get(health_handler))
         .nest("/auth", auth::router())
+        // Legacy active-org route (issue #216 spec)
         .nest("/users", users::router())
+        .nest("/api/v1", api_v1)
         .with_state(state)
 }
 

--- a/crates/core/src/api/auth.rs
+++ b/crates/core/src/api/auth.rs
@@ -1,0 +1,755 @@
+//! Authentication endpoint handlers.
+//!
+//! # Endpoints
+//!
+//! | Method | Path              | Auth required | Description                                     |
+//! |--------|-------------------|---------------|-------------------------------------------------|
+//! | POST   | `/auth/register`  | No            | Create account + default personal organization  |
+//! | POST   | `/auth/login`     | No            | Verify credentials, issue session token         |
+//! | POST   | `/auth/logout`    | Yes           | Delete current session                          |
+//! | GET    | `/auth/me`        | Yes           | Return current user + active organization       |
+//!
+//! Session tokens are 256-bit random hex strings stored in the `sessions` table.
+//! The default expiry is 24 hours, overridden by the `SESSION_EXPIRY_HOURS`
+//! environment variable.
+
+use axum::{
+    extract::State,
+    http::StatusCode,
+    response::IntoResponse,
+    routing::{get, post},
+    Json, Router,
+};
+use serde::{Deserialize, Serialize};
+
+use agentd_common::error::ApiError;
+
+use crate::{
+    entity::{organization, user},
+    middleware::auth::AuthUser,
+    session_storage::SessionStorage,
+    user_storage::UserStorage,
+};
+
+use super::AppState;
+
+// ---------------------------------------------------------------------------
+// Request / response types
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+pub struct RegisterRequest {
+    pub username: String,
+    pub email: String,
+    /// Optional human-readable display name (defaults to username).
+    pub display_name: Option<String>,
+    pub password: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct LoginRequest {
+    /// Login by username OR email — exactly one must be provided.
+    pub username: Option<String>,
+    pub email: Option<String>,
+    pub password: String,
+}
+
+/// Public representation of a user — never includes `password_hash`.
+#[derive(Debug, Serialize)]
+pub struct UserResponse {
+    pub id: String,
+    pub username: Option<String>,
+    pub email: String,
+    pub display_name: Option<String>,
+    pub role: String,
+    pub active_organization_id: Option<String>,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+impl From<user::Model> for UserResponse {
+    fn from(u: user::Model) -> Self {
+        Self {
+            id: u.id,
+            username: u.username,
+            email: u.email,
+            display_name: u.display_name,
+            role: u.role,
+            active_organization_id: u.active_organization_id,
+            created_at: u.created_at,
+            updated_at: u.updated_at,
+        }
+    }
+}
+
+/// Public representation of an organization.
+#[derive(Debug, Serialize)]
+pub struct OrgResponse {
+    pub id: String,
+    pub name: String,
+    pub slug: String,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+impl From<organization::Model> for OrgResponse {
+    fn from(o: organization::Model) -> Self {
+        Self {
+            id: o.id,
+            name: o.name,
+            slug: o.slug,
+            created_at: o.created_at,
+            updated_at: o.updated_at,
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+pub struct LoginResponse {
+    pub token: String,
+    pub user: UserResponse,
+    pub active_organization: Option<OrgResponse>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct MeResponse {
+    pub user: UserResponse,
+    pub active_organization: Option<OrgResponse>,
+}
+
+// ---------------------------------------------------------------------------
+// Router
+// ---------------------------------------------------------------------------
+
+pub fn router() -> Router<AppState> {
+    Router::new()
+        .route("/register", post(register_handler))
+        .route("/login", post(login_handler))
+        .route("/logout", post(logout_handler))
+        .route("/me", get(me_handler))
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Return session lifetime in hours from env, defaulting to 24.
+fn session_expiry_hours() -> i64 {
+    std::env::var("SESSION_EXPIRY_HOURS").ok().and_then(|v| v.parse().ok()).unwrap_or(24i64)
+}
+
+/// Build a session `expires_at` RFC 3339 string.
+fn session_expires_at() -> String {
+    (chrono::Utc::now() + chrono::Duration::hours(session_expiry_hours())).to_rfc3339()
+}
+
+/// Slugify a string for use as an organization slug.
+fn slugify(s: &str) -> String {
+    s.chars()
+        .map(|c| if c.is_alphanumeric() { c.to_ascii_lowercase() } else { '-' })
+        .collect::<String>()
+        .trim_matches('-')
+        .to_string()
+}
+
+/// Fetch the organization by ID, returning `None` if the ID is None or not found.
+async fn fetch_active_org(
+    state: &AppState,
+    org_id: Option<&str>,
+) -> Result<Option<OrgResponse>, ApiError> {
+    let Some(id) = org_id else { return Ok(None) };
+    let org = state.storage.organizations().get_by_id(id).await.map_err(ApiError::Internal)?;
+    Ok(org.map(OrgResponse::from))
+}
+
+// ---------------------------------------------------------------------------
+// Handlers
+// ---------------------------------------------------------------------------
+
+/// `POST /auth/register`
+///
+/// Creates a new user with a hashed password, a default personal organization,
+/// and an owner membership. Sets the new org as the user's `active_organization`.
+///
+/// Returns `201 Created` with a `LoginResponse` (token + user + active_org).
+async fn register_handler(
+    State(state): State<AppState>,
+    Json(body): Json<RegisterRequest>,
+) -> Result<impl IntoResponse, ApiError> {
+    if body.password.is_empty() {
+        return Err(ApiError::InvalidInput("password must not be empty".into()));
+    }
+
+    let users = state.storage.users();
+    let orgs = state.storage.organizations();
+    let memberships = state.storage.memberships();
+    let sessions = state.storage.sessions();
+
+    // Check uniqueness up-front for friendly errors (DB constraint would also
+    // catch duplicates, but the message would be opaque).
+    if users.get_by_email(&body.email).await.map_err(ApiError::Internal)?.is_some() {
+        return Err(ApiError::Conflict(format!("email already registered: {}", body.email)));
+    }
+    if users.get_by_username(&body.username).await.map_err(ApiError::Internal)?.is_some() {
+        return Err(ApiError::Conflict(format!("username already taken: {}", body.username)));
+    }
+
+    let display_name = body.display_name.as_deref().unwrap_or(&body.username);
+
+    // Create the user
+    let user = users
+        .create(Some(&body.username), &body.email, Some(display_name), &body.password, "user")
+        .await
+        .map_err(ApiError::Internal)?;
+
+    // Create a default personal organization: name = "<username>'s workspace"
+    let org_name = format!("{}'s workspace", body.username);
+    let org_slug = slugify(&format!("{}-workspace", body.username));
+
+    let org = orgs.create(&org_name, &org_slug).await.map_err(ApiError::Internal)?;
+
+    // Add the user as owner of their personal org
+    memberships.add_member(&user.id, &org.id, "owner").await.map_err(ApiError::Internal)?;
+
+    // Set the new org as the user's active organization
+    let user =
+        users.set_active_organization(&user.id, Some(&org.id)).await.map_err(ApiError::Internal)?;
+
+    // Create a session token
+    let token = SessionStorage::generate_token();
+    let expires_at = session_expires_at();
+    sessions.create(&user.id, &token, &expires_at).await.map_err(ApiError::Internal)?;
+
+    let active_org = Some(OrgResponse::from(org));
+
+    Ok((
+        StatusCode::CREATED,
+        Json(LoginResponse {
+            token,
+            user: UserResponse::from(user),
+            active_organization: active_org,
+        }),
+    ))
+}
+
+/// `POST /auth/login`
+///
+/// Accepts `{ username, password }` or `{ email, password }`. Verifies the
+/// password against the stored argon2 hash. Cleans up expired sessions for
+/// the user, then issues a fresh session token.
+///
+/// Returns `200 OK` with `{ token, user, active_organization }`.
+async fn login_handler(
+    State(state): State<AppState>,
+    Json(body): Json<LoginRequest>,
+) -> Result<impl IntoResponse, ApiError> {
+    let users = state.storage.users();
+    let sessions = state.storage.sessions();
+
+    // Resolve user by username or email
+    let user = match (body.username.as_deref(), body.email.as_deref()) {
+        (Some(u), _) => users
+            .get_by_username(u)
+            .await
+            .map_err(ApiError::Internal)?
+            .ok_or_else(|| ApiError::Unauthorized("invalid credentials".into()))?,
+        (_, Some(e)) => users
+            .get_by_email(e)
+            .await
+            .map_err(ApiError::Internal)?
+            .ok_or_else(|| ApiError::Unauthorized("invalid credentials".into()))?,
+        _ => {
+            return Err(ApiError::InvalidInput("one of `username` or `email` is required".into()));
+        }
+    };
+
+    // Verify password
+    let ok = UserStorage::verify_password(&body.password, &user.password_hash)
+        .map_err(ApiError::Internal)?;
+    if !ok {
+        return Err(ApiError::Unauthorized("invalid credentials".into()));
+    }
+
+    // Clean up expired sessions for this user
+    sessions.delete_expired_for_user(&user.id).await.map_err(ApiError::Internal)?;
+
+    // Issue a new session token
+    let token = SessionStorage::generate_token();
+    let expires_at = session_expires_at();
+    sessions.create(&user.id, &token, &expires_at).await.map_err(ApiError::Internal)?;
+
+    let active_org = fetch_active_org(&state, user.active_organization_id.as_deref()).await?;
+
+    Ok(Json(LoginResponse {
+        token,
+        user: UserResponse::from(user),
+        active_organization: active_org,
+    }))
+}
+
+/// `POST /auth/logout`
+///
+/// Requires `Authorization: Bearer <token>`. Deletes the current session.
+///
+/// Returns `204 No Content`.
+async fn logout_handler(
+    State(state): State<AppState>,
+    auth: AuthUser,
+) -> Result<impl IntoResponse, ApiError> {
+    state.storage.sessions().delete_by_token_hash(&auth.token).await.map_err(ApiError::Internal)?;
+
+    Ok(StatusCode::NO_CONTENT)
+}
+
+/// `GET /auth/me`
+///
+/// Requires `Authorization: Bearer <token>`. Returns current user info and
+/// the active organization (if set).
+///
+/// Returns `200 OK` with `{ user, active_organization }`.
+async fn me_handler(
+    State(state): State<AppState>,
+    auth: AuthUser,
+) -> Result<impl IntoResponse, ApiError> {
+    let active_org = fetch_active_org(&state, auth.user.active_organization_id.as_deref()).await?;
+
+    Ok(Json(MeResponse { user: UserResponse::from(auth.user), active_organization: active_org }))
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use agentd_common::storage::create_test_connection;
+    use axum::body::Body;
+    use axum::http::{header, Request, StatusCode};
+    use http_body_util::BodyExt;
+    use tower::ServiceExt;
+
+    async fn test_app() -> (Router, tempfile::TempDir) {
+        let (conn, tmp) = create_test_connection().await;
+        let storage = crate::storage::Storage::new(conn).await.unwrap();
+        let state = AppState { storage };
+        let app = crate::api::create_router(state);
+        (app, tmp)
+    }
+
+    async fn body_json(response: axum::response::Response) -> serde_json::Value {
+        let bytes = response.into_body().collect().await.unwrap().to_bytes();
+        serde_json::from_slice(&bytes).unwrap()
+    }
+
+    // -----------------------------------------------------------------------
+    // Register
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_register_success() {
+        let (app, _tmp) = test_app().await;
+        let payload = serde_json::json!({
+            "username": "alice",
+            "email": "alice@example.com",
+            "password": "secret123"
+        });
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/auth/register")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(payload.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::CREATED);
+        let body = body_json(response).await;
+        assert!(body["token"].as_str().is_some());
+        assert_eq!(body["user"]["username"], "alice");
+        assert_eq!(body["user"]["email"], "alice@example.com");
+        assert!(body["user"]["password_hash"].is_null());
+        assert!(body["active_organization"]["name"].as_str().is_some());
+        assert!(body["user"]["active_organization_id"].as_str().is_some());
+    }
+
+    #[tokio::test]
+    async fn test_register_duplicate_email() {
+        let (app, _tmp) = test_app().await;
+
+        // First registration
+        let payload = serde_json::json!({
+            "username": "bob",
+            "email": "bob@example.com",
+            "password": "pass"
+        });
+        app.clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/auth/register")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(payload.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        // Second registration with same email, different username
+        let payload2 = serde_json::json!({
+            "username": "bob2",
+            "email": "bob@example.com",
+            "password": "pass"
+        });
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/auth/register")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(payload2.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::CONFLICT);
+    }
+
+    #[tokio::test]
+    async fn test_register_duplicate_username() {
+        let (app, _tmp) = test_app().await;
+
+        let payload = serde_json::json!({
+            "username": "carol",
+            "email": "carol@example.com",
+            "password": "pass"
+        });
+        app.clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/auth/register")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(payload.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        let payload2 = serde_json::json!({
+            "username": "carol",
+            "email": "carol2@example.com",
+            "password": "pass"
+        });
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/auth/register")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(payload2.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::CONFLICT);
+    }
+
+    #[tokio::test]
+    async fn test_register_empty_password() {
+        let (app, _tmp) = test_app().await;
+        let payload = serde_json::json!({
+            "username": "dan",
+            "email": "dan@example.com",
+            "password": ""
+        });
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/auth/register")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(payload.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    // -----------------------------------------------------------------------
+    // Login
+    // -----------------------------------------------------------------------
+
+    async fn register_user(
+        app: &Router,
+        username: &str,
+        email: &str,
+        password: &str,
+    ) -> serde_json::Value {
+        let payload =
+            serde_json::json!({ "username": username, "email": email, "password": password });
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/auth/register")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(payload.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let bytes = response.into_body().collect().await.unwrap().to_bytes();
+        serde_json::from_slice(&bytes).unwrap()
+    }
+
+    #[tokio::test]
+    async fn test_login_by_username() {
+        let (app, _tmp) = test_app().await;
+        register_user(&app, "eve", "eve@example.com", "hunter2").await;
+
+        let payload = serde_json::json!({ "username": "eve", "password": "hunter2" });
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/auth/login")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(payload.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = body_json(response).await;
+        assert!(body["token"].as_str().is_some());
+        assert_eq!(body["user"]["username"], "eve");
+    }
+
+    #[tokio::test]
+    async fn test_login_by_email() {
+        let (app, _tmp) = test_app().await;
+        register_user(&app, "frank", "frank@example.com", "pass123").await;
+
+        let payload = serde_json::json!({ "email": "frank@example.com", "password": "pass123" });
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/auth/login")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(payload.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = body_json(response).await;
+        assert!(body["token"].as_str().is_some());
+        assert_eq!(body["user"]["email"], "frank@example.com");
+    }
+
+    #[tokio::test]
+    async fn test_login_wrong_password() {
+        let (app, _tmp) = test_app().await;
+        register_user(&app, "grace", "grace@example.com", "correct").await;
+
+        let payload = serde_json::json!({ "username": "grace", "password": "wrong" });
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/auth/login")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(payload.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn test_login_unknown_user() {
+        let (app, _tmp) = test_app().await;
+
+        let payload = serde_json::json!({ "username": "nobody", "password": "pass" });
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/auth/login")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(payload.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn test_login_missing_identifier() {
+        let (app, _tmp) = test_app().await;
+
+        let payload = serde_json::json!({ "password": "pass" });
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/auth/login")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(payload.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    // -----------------------------------------------------------------------
+    // Logout
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_logout_success() {
+        let (app, _tmp) = test_app().await;
+        let reg = register_user(&app, "henry", "henry@example.com", "pass").await;
+        let token = reg["token"].as_str().unwrap().to_string();
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/auth/logout")
+                    .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::NO_CONTENT);
+    }
+
+    #[tokio::test]
+    async fn test_logout_without_token() {
+        let (app, _tmp) = test_app().await;
+
+        let response = app
+            .oneshot(
+                Request::builder().method("POST").uri("/auth/logout").body(Body::empty()).unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn test_logout_invalid_token() {
+        let (app, _tmp) = test_app().await;
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/auth/logout")
+                    .header(header::AUTHORIZATION, "Bearer deadbeef")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    // -----------------------------------------------------------------------
+    // Me
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_me_success() {
+        let (app, _tmp) = test_app().await;
+        let reg = register_user(&app, "ida", "ida@example.com", "pass").await;
+        let token = reg["token"].as_str().unwrap().to_string();
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/auth/me")
+                    .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = body_json(response).await;
+        assert_eq!(body["user"]["username"], "ida");
+        assert!(body["active_organization"].is_object());
+    }
+
+    #[tokio::test]
+    async fn test_me_without_token() {
+        let (app, _tmp) = test_app().await;
+
+        let response = app
+            .oneshot(Request::builder().method("GET").uri("/auth/me").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn test_token_unusable_after_logout() {
+        let (app, _tmp) = test_app().await;
+        let reg = register_user(&app, "jack", "jack@example.com", "pass").await;
+        let token = reg["token"].as_str().unwrap().to_string();
+
+        // Logout
+        app.clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/auth/logout")
+                    .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        // Token should now be rejected on /me
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/auth/me")
+                    .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+}

--- a/crates/core/src/api/gateway.rs
+++ b/crates/core/src/api/gateway.rs
@@ -1,0 +1,278 @@
+//! API gateway proxy handlers.
+//!
+//! Routes incoming requests under `/api/v1/{service}/*` to the corresponding
+//! downstream agentd service. Each proxied request has:
+//!
+//! - `X-Tenant-ID` injected from the authenticated user's active organization
+//! - `X-Request-ID` injected (new UUID per request)
+//! - `Authorization` header forwarded to the downstream service
+//!
+//! # Route Mapping
+//!
+//! | Incoming path                       | Downstream service        |
+//! |-------------------------------------|---------------------------|
+//! | `/api/v1/orchestrator/*`            | agentd-orchestrator       |
+//! | `/api/v1/notify/*`                  | agentd-notify             |
+//! | `/api/v1/ask/*`                     | agentd-ask                |
+//! | `/api/v1/wrap/*`                    | agentd-wrap               |
+//! | `/api/v1/hook/*`                    | agentd-hook               |
+//! | `/api/v1/monitor/*`                 | agentd-monitor            |
+//!
+//! # Health aggregation
+//!
+//! `GET /api/v1/health` checks all downstream services concurrently and
+//! returns a summary. Downstream unavailability yields `503 Service Unavailable`.
+
+use axum::{
+    body::Body,
+    extract::{Path, Query, Request, State},
+    http::{HeaderMap, StatusCode},
+    response::{IntoResponse, Response},
+    routing::get,
+    Json, Router,
+};
+use serde::Serialize;
+use std::collections::HashMap;
+use uuid::Uuid;
+
+use crate::{
+    middleware::tenant::TenantContext,
+    proxy::{health_check, proxy_request, ProxyConfig, ProxyRequest},
+};
+
+use super::AppState;
+
+// ---------------------------------------------------------------------------
+// State extension
+// ---------------------------------------------------------------------------
+
+/// Gateway-specific state carried alongside AppState.
+///
+/// Mounted via `Router::with_state(GatewayState { ... })` on the gateway
+/// sub-router and extracted with `State<GatewayState>`.
+#[derive(Clone)]
+pub struct GatewayState {
+    pub app: AppState,
+    pub proxy: ProxyConfig,
+}
+
+// ---------------------------------------------------------------------------
+// Router
+// ---------------------------------------------------------------------------
+
+pub fn router(proxy: ProxyConfig) -> Router<AppState> {
+    // Build a nested router that merges AppState with ProxyConfig into GatewayState.
+    // We use a closure-based approach: each handler receives both State<AppState>
+    // and the proxy config via a separate extension.
+    //
+    // Axum requires a single state type per router, so we wrap both into GatewayState
+    // using `Router::with_state` at the gateway level.
+    let proxy_clone = proxy.clone();
+
+    Router::new()
+        .route(
+            "/health",
+            get(move |state: State<AppState>| {
+                let p = proxy_clone.clone();
+                async move { health_handler(state, p).await }
+            }),
+        )
+        .route(
+            "/{service}/{*path}",
+            axum::routing::any(proxy_handler).layer(axum::Extension(proxy)),
+        )
+}
+
+// ---------------------------------------------------------------------------
+// Health aggregation
+// ---------------------------------------------------------------------------
+
+#[derive(Serialize)]
+struct ServiceHealth {
+    name: String,
+    url: String,
+    healthy: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    detail: Option<String>,
+}
+
+#[derive(Serialize)]
+struct HealthResponse {
+    status: &'static str,
+    services: Vec<ServiceHealth>,
+}
+
+async fn health_handler(State(state): State<AppState>, proxy: ProxyConfig) -> impl IntoResponse {
+    let _ = state; // AppState not used for health — kept for router consistency
+
+    let mut handles = Vec::new();
+
+    for (&name, url) in &proxy.services {
+        let client = proxy.client.clone();
+        let url = url.clone();
+        let name = name.to_string();
+        handles.push(tokio::spawn(async move {
+            let (healthy, detail) = health_check(&client, &url).await;
+            ServiceHealth { name, url, healthy, detail }
+        }));
+    }
+
+    let mut services = Vec::new();
+    for handle in handles {
+        if let Ok(s) = handle.await {
+            services.push(s);
+        }
+    }
+    services.sort_by(|a, b| a.name.cmp(&b.name));
+
+    let all_healthy = services.iter().all(|s| s.healthy);
+    let status = if all_healthy { StatusCode::OK } else { StatusCode::SERVICE_UNAVAILABLE };
+
+    (status, Json(HealthResponse { status: if all_healthy { "ok" } else { "degraded" }, services }))
+}
+
+// ---------------------------------------------------------------------------
+// Proxy handler
+// ---------------------------------------------------------------------------
+
+async fn proxy_handler(
+    State(state): State<AppState>,
+    axum::Extension(proxy): axum::Extension<ProxyConfig>,
+    tenant: TenantContext,
+    Path((service, path)): Path<(String, String)>,
+    Query(query_params): Query<HashMap<String, String>>,
+    req: Request,
+) -> Response {
+    // Resolve the downstream URL
+    let base_url = match proxy.url_for(&service) {
+        Some(u) => u.to_string(),
+        None => {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(serde_json::json!({
+                    "error": format!("unknown service: {service}")
+                })),
+            )
+                .into_response();
+        }
+    };
+
+    let method = req.method().as_str().to_string();
+
+    // Build query string
+    let query_string = if query_params.is_empty() {
+        None
+    } else {
+        Some(
+            query_params
+                .iter()
+                .map(|(k, v)| format!("{}={}", urlencoding_simple(k), urlencoding_simple(v)))
+                .collect::<Vec<_>>()
+                .join("&"),
+        )
+    };
+
+    // Collect headers to forward
+    let headers: Vec<(String, String)> = req
+        .headers()
+        .iter()
+        .filter_map(|(name, value)| {
+            value.to_str().ok().map(|v| (name.as_str().to_string(), v.to_string()))
+        })
+        .collect();
+
+    // Read body bytes
+    let body_bytes = match axum::body::to_bytes(req.into_body(), usize::MAX).await {
+        Ok(b) => b,
+        Err(e) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({ "error": format!("failed to read request body: {e}") })),
+            )
+                .into_response();
+        }
+    };
+
+    // Generate a request ID
+    let request_id = Uuid::new_v4().to_string();
+    let forward_path = format!("/{path}");
+
+    match proxy_request(
+        &proxy.client,
+        &base_url,
+        ProxyRequest {
+            method: &method,
+            path: &forward_path,
+            query: query_string.as_deref(),
+            headers: &headers,
+            body: body_bytes,
+            tenant_id: &tenant.organization_id,
+            request_id: &request_id,
+        },
+    )
+    .await
+    {
+        Ok(resp) => {
+            let status =
+                StatusCode::from_u16(resp.status).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
+            let mut response_headers = HeaderMap::new();
+            for (name, value) in &resp.headers {
+                if let (Ok(hn), Ok(hv)) = (
+                    axum::http::HeaderName::from_bytes(name.as_bytes()),
+                    axum::http::HeaderValue::from_str(value),
+                ) {
+                    response_headers.insert(hn, hv);
+                }
+            }
+            (status, response_headers, Body::from(resp.body)).into_response()
+        }
+        Err(e) => {
+            let _ = state; // suppress unused warning
+            (
+                StatusCode::BAD_GATEWAY,
+                Json(serde_json::json!({
+                    "error": format!("upstream error: {e}")
+                })),
+            )
+                .into_response()
+        }
+    }
+}
+
+/// Minimal percent-encoding for query values (encodes spaces and `&`/`=`).
+fn urlencoding_simple(s: &str) -> String {
+    s.chars()
+        .flat_map(|c| match c {
+            'A'..='Z' | 'a'..='z' | '0'..='9' | '-' | '_' | '.' | '~' => {
+                vec![c]
+            }
+            ' ' => vec!['+'],
+            c => {
+                let mut buf = [0u8; 4];
+                let bytes = c.encode_utf8(&mut buf);
+                bytes
+                    .bytes()
+                    .flat_map(|b| {
+                        vec![
+                            '%',
+                            char::from_digit((b >> 4) as u32, 16).unwrap_or('0'),
+                            char::from_digit((b & 0xf) as u32, 16).unwrap_or('0'),
+                        ]
+                    })
+                    .collect()
+            }
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_urlencoding_simple() {
+        assert_eq!(urlencoding_simple("hello world"), "hello+world");
+        assert_eq!(urlencoding_simple("abc123"), "abc123");
+        assert_eq!(urlencoding_simple("a&b=c"), "a%26b%3dc");
+    }
+}

--- a/crates/core/src/api/organizations.rs
+++ b/crates/core/src/api/organizations.rs
@@ -1,0 +1,803 @@
+//! Organization management endpoint handlers.
+//!
+//! # Endpoints
+//!
+//! | Method | Path                                    | Auth | Role   | Description                      |
+//! |--------|-----------------------------------------|------|--------|----------------------------------|
+//! | POST   | `/api/v1/organizations`                 | Yes  | any    | Create org (creator = owner)     |
+//! | GET    | `/api/v1/organizations/:id`             | Yes  | member | Get org details                  |
+//! | PUT    | `/api/v1/organizations/:id`             | Yes  | owner  | Update org name                  |
+//! | DELETE | `/api/v1/organizations/:id`             | Yes  | owner  | Delete org                       |
+//! | GET    | `/api/v1/organizations/:id/members`     | Yes  | member | List members with roles          |
+//! | POST   | `/api/v1/organizations/:id/members`     | Yes  | owner  | Add member                       |
+//! | DELETE | `/api/v1/organizations/:id/members/:uid`| Yes  | owner  | Remove member                    |
+
+use axum::{
+    extract::{Path, State},
+    http::StatusCode,
+    response::IntoResponse,
+    routing::{delete, get, post, put},
+    Json, Router,
+};
+use serde::{Deserialize, Serialize};
+
+use agentd_common::error::ApiError;
+
+use crate::middleware::auth::AuthUser;
+
+use super::AppState;
+
+// ---------------------------------------------------------------------------
+// Request / response types
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+pub struct CreateOrganizationRequest {
+    pub name: String,
+    pub slug: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct UpdateOrganizationRequest {
+    pub name: Option<String>,
+    pub slug: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct AddMemberRequest {
+    pub user_id: String,
+    pub role: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct OrganizationResponse {
+    pub id: String,
+    pub name: String,
+    pub slug: String,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct MemberResponse {
+    pub id: String,
+    pub user_id: String,
+    pub organization_id: String,
+    pub role: String,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+// ---------------------------------------------------------------------------
+// Router
+// ---------------------------------------------------------------------------
+
+pub fn router() -> Router<AppState> {
+    Router::new()
+        .route("/", post(create_org_handler))
+        .route("/{id}", get(get_org_handler))
+        .route("/{id}", put(update_org_handler))
+        .route("/{id}", delete(delete_org_handler))
+        .route("/{id}/members", get(list_members_handler))
+        .route("/{id}/members", post(add_member_handler))
+        .route("/{id}/members/{user_id}", delete(remove_member_handler))
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Require that the caller is a member of the given org.
+///
+/// Returns `403 Forbidden` if not a member.
+async fn require_member(
+    state: &AppState,
+    user_id: &str,
+    org_id: &str,
+) -> Result<crate::entity::membership::Model, ApiError> {
+    state
+        .storage
+        .memberships()
+        .get_membership(user_id, org_id)
+        .await
+        .map_err(ApiError::Internal)?
+        .ok_or_else(|| {
+            ApiError::Forbidden(format!("user is not a member of organization {org_id}"))
+        })
+}
+
+/// Require that the caller is an owner of the given org.
+///
+/// Returns `403 Forbidden` if not an owner.
+async fn require_owner(state: &AppState, user_id: &str, org_id: &str) -> Result<(), ApiError> {
+    let mem = require_member(state, user_id, org_id).await?;
+    if mem.role != "owner" {
+        return Err(ApiError::Forbidden(format!("only owners may modify organization {org_id}")));
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Handlers
+// ---------------------------------------------------------------------------
+
+/// `POST /api/v1/organizations`
+///
+/// Creates a new organization. The calling user becomes the owner and their
+/// active organization is switched to the new org.
+///
+/// Returns `201 Created` with the organization payload.
+async fn create_org_handler(
+    State(state): State<AppState>,
+    auth: AuthUser,
+    Json(body): Json<CreateOrganizationRequest>,
+) -> Result<impl IntoResponse, ApiError> {
+    let org = state
+        .storage
+        .organizations()
+        .create(&body.name, &body.slug)
+        .await
+        .map_err(ApiError::Internal)?;
+
+    state
+        .storage
+        .memberships()
+        .add_member(&auth.user.id, &org.id, "owner")
+        .await
+        .map_err(ApiError::Internal)?;
+
+    Ok((
+        StatusCode::CREATED,
+        Json(OrganizationResponse {
+            id: org.id,
+            name: org.name,
+            slug: org.slug,
+            created_at: org.created_at,
+            updated_at: org.updated_at,
+        }),
+    ))
+}
+
+/// `GET /api/v1/organizations/:id`
+///
+/// Returns organization details. Requires caller to be a member.
+async fn get_org_handler(
+    State(state): State<AppState>,
+    auth: AuthUser,
+    Path(id): Path<String>,
+) -> Result<impl IntoResponse, ApiError> {
+    require_member(&state, &auth.user.id, &id).await?;
+
+    let org = state
+        .storage
+        .organizations()
+        .get_by_id(&id)
+        .await
+        .map_err(ApiError::Internal)?
+        .ok_or(ApiError::NotFound)?;
+
+    Ok(Json(OrganizationResponse {
+        id: org.id,
+        name: org.name,
+        slug: org.slug,
+        created_at: org.created_at,
+        updated_at: org.updated_at,
+    }))
+}
+
+/// `PUT /api/v1/organizations/:id`
+///
+/// Updates organization name and/or slug. Requires owner role.
+async fn update_org_handler(
+    State(state): State<AppState>,
+    auth: AuthUser,
+    Path(id): Path<String>,
+    Json(body): Json<UpdateOrganizationRequest>,
+) -> Result<impl IntoResponse, ApiError> {
+    require_owner(&state, &auth.user.id, &id).await?;
+
+    let org = state
+        .storage
+        .organizations()
+        .update(&id, body.name.as_deref(), body.slug.as_deref())
+        .await
+        .map_err(ApiError::Internal)?;
+
+    Ok(Json(OrganizationResponse {
+        id: org.id,
+        name: org.name,
+        slug: org.slug,
+        created_at: org.created_at,
+        updated_at: org.updated_at,
+    }))
+}
+
+/// `DELETE /api/v1/organizations/:id`
+///
+/// Deletes the organization. Requires owner role. Clears `active_organization_id`
+/// for all users who had this as their active org.
+///
+/// Returns `204 No Content`.
+async fn delete_org_handler(
+    State(state): State<AppState>,
+    auth: AuthUser,
+    Path(id): Path<String>,
+) -> Result<impl IntoResponse, ApiError> {
+    require_owner(&state, &auth.user.id, &id).await?;
+
+    // Clear active_organization_id for affected users before deleting
+    state
+        .storage
+        .users()
+        .clear_active_organization_for_org(&id)
+        .await
+        .map_err(ApiError::Internal)?;
+
+    let deleted = state.storage.organizations().delete(&id).await.map_err(ApiError::Internal)?;
+
+    if !deleted {
+        return Err(ApiError::NotFound);
+    }
+
+    Ok(StatusCode::NO_CONTENT)
+}
+
+/// `GET /api/v1/organizations/:id/members`
+///
+/// Lists all members of the organization. Requires caller to be a member.
+async fn list_members_handler(
+    State(state): State<AppState>,
+    auth: AuthUser,
+    Path(id): Path<String>,
+) -> Result<impl IntoResponse, ApiError> {
+    require_member(&state, &auth.user.id, &id).await?;
+
+    let members =
+        state.storage.memberships().list_members(&id).await.map_err(ApiError::Internal)?;
+
+    let response: Vec<MemberResponse> = members
+        .into_iter()
+        .map(|m| MemberResponse {
+            id: m.id,
+            user_id: m.user_id,
+            organization_id: m.organization_id,
+            role: m.role,
+            created_at: m.created_at,
+            updated_at: m.updated_at,
+        })
+        .collect();
+
+    Ok(Json(response))
+}
+
+/// `POST /api/v1/organizations/:id/members`
+///
+/// Adds a user to the organization. Requires owner role.
+///
+/// Returns `201 Created` with the membership record.
+async fn add_member_handler(
+    State(state): State<AppState>,
+    auth: AuthUser,
+    Path(id): Path<String>,
+    Json(body): Json<AddMemberRequest>,
+) -> Result<impl IntoResponse, ApiError> {
+    require_owner(&state, &auth.user.id, &id).await?;
+
+    // Verify the target user exists
+    state
+        .storage
+        .users()
+        .get_by_id(&body.user_id)
+        .await
+        .map_err(ApiError::Internal)?
+        .ok_or(ApiError::NotFound)?;
+
+    let mem = state
+        .storage
+        .memberships()
+        .add_member(&body.user_id, &id, &body.role)
+        .await
+        .map_err(ApiError::Internal)?;
+
+    Ok((
+        StatusCode::CREATED,
+        Json(MemberResponse {
+            id: mem.id,
+            user_id: mem.user_id,
+            organization_id: mem.organization_id,
+            role: mem.role,
+            created_at: mem.created_at,
+            updated_at: mem.updated_at,
+        }),
+    ))
+}
+
+/// `DELETE /api/v1/organizations/:id/members/:user_id`
+///
+/// Removes a user from the organization. Requires owner role. Returns `403` if
+/// the caller tries to remove themselves as the last owner.
+///
+/// Returns `204 No Content`.
+async fn remove_member_handler(
+    State(state): State<AppState>,
+    auth: AuthUser,
+    Path((id, target_user_id)): Path<(String, String)>,
+) -> Result<impl IntoResponse, ApiError> {
+    require_owner(&state, &auth.user.id, &id).await?;
+
+    // Prevent removing the last owner
+    if target_user_id == auth.user.id {
+        let all_members =
+            state.storage.memberships().list_members(&id).await.map_err(ApiError::Internal)?;
+        let owner_count = all_members.iter().filter(|m| m.role == "owner").count();
+        if owner_count <= 1 {
+            return Err(ApiError::Forbidden(
+                "cannot remove the last owner from an organization".into(),
+            ));
+        }
+    }
+
+    let removed = state
+        .storage
+        .memberships()
+        .remove_member(&target_user_id, &id)
+        .await
+        .map_err(ApiError::Internal)?;
+
+    if !removed {
+        return Err(ApiError::NotFound);
+    }
+
+    Ok(StatusCode::NO_CONTENT)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use crate::api::AppState;
+    use crate::storage::Storage;
+    use agentd_common::storage::create_test_connection;
+    use axum::{
+        body::Body,
+        http::{header, Request, StatusCode},
+        Router,
+    };
+    use http_body_util::BodyExt;
+    use tower::ServiceExt;
+
+    async fn test_app() -> (Router, tempfile::TempDir) {
+        let (conn, tmp) = create_test_connection().await;
+        let storage = Storage::new(conn).await.unwrap();
+        let state = AppState { storage };
+        let app = crate::api::create_router(state);
+        (app, tmp)
+    }
+
+    async fn body_json(response: axum::response::Response) -> serde_json::Value {
+        let bytes = response.into_body().collect().await.unwrap().to_bytes();
+        serde_json::from_slice(&bytes).unwrap()
+    }
+
+    async fn register(app: &Router, username: &str, email: &str) -> (String, String) {
+        let payload =
+            serde_json::json!({ "username": username, "email": email, "password": "testpass" });
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/auth/register")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(payload.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let body = body_json(response).await;
+        let token = body["token"].as_str().unwrap().to_string();
+        let user_id = body["user"]["id"].as_str().unwrap().to_string();
+        (token, user_id)
+    }
+
+    // -----------------------------------------------------------------------
+    // Create org
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_create_org_success() {
+        let (app, _tmp) = test_app().await;
+        let (token, _) = register(&app, "alice", "alice@example.com").await;
+
+        let payload = serde_json::json!({ "name": "Test Corp", "slug": "test-corp" });
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/organizations")
+                    .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(payload.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::CREATED);
+        let body = body_json(response).await;
+        assert_eq!(body["name"], "Test Corp");
+        assert_eq!(body["slug"], "test-corp");
+    }
+
+    #[tokio::test]
+    async fn test_create_org_unauthenticated() {
+        let (app, _tmp) = test_app().await;
+
+        let payload = serde_json::json!({ "name": "Test", "slug": "test" });
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/organizations")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(payload.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    // -----------------------------------------------------------------------
+    // Get org
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_get_org_as_member() {
+        let (app, _tmp) = test_app().await;
+        let (token, _) = register(&app, "bob", "bob@example.com").await;
+
+        // Get the personal org created during registration
+        let me_resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/auth/me")
+                    .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let me_body = body_json(me_resp).await;
+        let org_id = me_body["active_organization"]["id"].as_str().unwrap().to_string();
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri(format!("/api/v1/organizations/{org_id}"))
+                    .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = body_json(response).await;
+        assert_eq!(body["id"], org_id.as_str());
+    }
+
+    #[tokio::test]
+    async fn test_get_org_not_member() {
+        let (app, _tmp) = test_app().await;
+        let (token_a, _) = register(&app, "carol", "carol@example.com").await;
+        let (token_b, _) = register(&app, "dan", "dan@example.com").await;
+
+        // Get carol's personal org
+        let me_resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/auth/me")
+                    .header(header::AUTHORIZATION, format!("Bearer {token_a}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let me_body = body_json(me_resp).await;
+        let carol_org_id = me_body["active_organization"]["id"].as_str().unwrap().to_string();
+
+        // Dan tries to get Carol's org
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri(format!("/api/v1/organizations/{carol_org_id}"))
+                    .header(header::AUTHORIZATION, format!("Bearer {token_b}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    }
+
+    // -----------------------------------------------------------------------
+    // Update org
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_update_org_as_owner() {
+        let (app, _tmp) = test_app().await;
+        let (token, _) = register(&app, "eve", "eve@example.com").await;
+
+        let me_resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/auth/me")
+                    .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let me_body = body_json(me_resp).await;
+        let org_id = me_body["active_organization"]["id"].as_str().unwrap().to_string();
+
+        let payload = serde_json::json!({ "name": "Updated Name" });
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("PUT")
+                    .uri(format!("/api/v1/organizations/{org_id}"))
+                    .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(payload.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = body_json(response).await;
+        assert_eq!(body["name"], "Updated Name");
+    }
+
+    // -----------------------------------------------------------------------
+    // Delete org
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_delete_org_as_owner() {
+        let (app, _tmp) = test_app().await;
+        let (token, _) = register(&app, "frank", "frank@example.com").await;
+
+        let me_resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/auth/me")
+                    .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let me_body = body_json(me_resp).await;
+        let org_id = me_body["active_organization"]["id"].as_str().unwrap().to_string();
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("DELETE")
+                    .uri(format!("/api/v1/organizations/{org_id}"))
+                    .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::NO_CONTENT);
+    }
+
+    #[tokio::test]
+    async fn test_delete_org_not_owner() {
+        let (app, _tmp) = test_app().await;
+        let (token_a, _) = register(&app, "grace", "grace@example.com").await;
+        let (token_b, _) = register(&app, "henry", "henry@example.com").await;
+
+        let me_resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/auth/me")
+                    .header(header::AUTHORIZATION, format!("Bearer {token_a}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let me_body = body_json(me_resp).await;
+        let grace_org_id = me_body["active_organization"]["id"].as_str().unwrap().to_string();
+
+        // First get henry's user_id via /auth/me
+        let henry_me = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/auth/me")
+                    .header(header::AUTHORIZATION, format!("Bearer {token_b}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let henry_body = body_json(henry_me).await;
+        let henry_id = henry_body["user"]["id"].as_str().unwrap().to_string();
+
+        // Grace adds henry as member
+        let add_payload = serde_json::json!({ "user_id": henry_id, "role": "member" });
+        app.clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!("/api/v1/organizations/{grace_org_id}/members"))
+                    .header(header::AUTHORIZATION, format!("Bearer {token_a}"))
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(add_payload.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        // Henry tries to delete grace's org — should be forbidden
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("DELETE")
+                    .uri(format!("/api/v1/organizations/{grace_org_id}"))
+                    .header(header::AUTHORIZATION, format!("Bearer {token_b}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    }
+
+    // -----------------------------------------------------------------------
+    // Members
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_list_members() {
+        let (app, _tmp) = test_app().await;
+        let (token, _) = register(&app, "ida", "ida@example.com").await;
+
+        let me_resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/auth/me")
+                    .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let me_body = body_json(me_resp).await;
+        let org_id = me_body["active_organization"]["id"].as_str().unwrap().to_string();
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri(format!("/api/v1/organizations/{org_id}/members"))
+                    .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = body_json(response).await;
+        let members = body.as_array().unwrap();
+        assert_eq!(members.len(), 1);
+        assert_eq!(members[0]["role"], "owner");
+    }
+
+    #[tokio::test]
+    async fn test_add_member() {
+        let (app, _tmp) = test_app().await;
+        let (token_owner, _) = register(&app, "jack", "jack@example.com").await;
+        let (_, user_b_id) = register(&app, "kate", "kate@example.com").await;
+
+        let me_resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/auth/me")
+                    .header(header::AUTHORIZATION, format!("Bearer {token_owner}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let me_body = body_json(me_resp).await;
+        let org_id = me_body["active_organization"]["id"].as_str().unwrap().to_string();
+
+        let payload = serde_json::json!({ "user_id": user_b_id, "role": "member" });
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!("/api/v1/organizations/{org_id}/members"))
+                    .header(header::AUTHORIZATION, format!("Bearer {token_owner}"))
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(payload.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::CREATED);
+        let body = body_json(response).await;
+        assert_eq!(body["user_id"], user_b_id.as_str());
+        assert_eq!(body["role"], "member");
+    }
+
+    #[tokio::test]
+    async fn test_remove_last_owner_blocked() {
+        let (app, _tmp) = test_app().await;
+        let (token, user_id) = register(&app, "liam", "liam@example.com").await;
+
+        let me_resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/auth/me")
+                    .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let me_body = body_json(me_resp).await;
+        let org_id = me_body["active_organization"]["id"].as_str().unwrap().to_string();
+
+        // Liam tries to remove himself as the only owner
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("DELETE")
+                    .uri(format!("/api/v1/organizations/{org_id}/members/{user_id}"))
+                    .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    }
+}

--- a/crates/core/src/api/users.rs
+++ b/crates/core/src/api/users.rs
@@ -1,43 +1,193 @@
 //! User profile endpoint handlers.
 //!
-//! # Endpoints
+//! # Endpoints (from issue #216 and #218)
 //!
-//! | Method | Path                              | Auth | Description                          |
-//! |--------|-----------------------------------|------|--------------------------------------|
-//! | PUT    | `/users/me/active-organization`   | Yes  | Switch the user's active organization |
+//! | Method | Path                                 | Auth | Description                             |
+//! |--------|--------------------------------------|------|-----------------------------------------|
+//! | GET    | `/api/v1/users/me`                   | Yes  | Get current user profile                |
+//! | PUT    | `/api/v1/users/me`                   | Yes  | Update profile (display_name, email)    |
+//! | PUT    | `/api/v1/users/me/password`          | Yes  | Change password (requires current pass) |
+//! | GET    | `/api/v1/users/me/organizations`     | Yes  | List user's organizations               |
+//! | PUT    | `/users/me/active-organization`      | Yes  | Switch active organization              |
 //!
-//! All endpoints require a valid `Authorization: Bearer <token>` header via
-//! the [`crate::middleware::auth::AuthUser`] extractor.
+//! All endpoints require a valid `Authorization: Bearer <token>` header.
 
-use axum::{extract::State, response::IntoResponse, routing::put, Json, Router};
-use serde::Deserialize;
+use axum::{
+    extract::State,
+    http::StatusCode,
+    response::IntoResponse,
+    routing::{get, put},
+    Json, Router,
+};
+use serde::{Deserialize, Serialize};
 
 use agentd_common::error::ApiError;
 
-use crate::middleware::auth::AuthUser;
+use crate::{api::auth::OrgResponse, middleware::auth::AuthUser, user_storage::UserStorage};
 
 use super::AppState;
 
 // ---------------------------------------------------------------------------
-// Request types
+// Request / response types
 // ---------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+pub struct UpdateProfileRequest {
+    pub display_name: Option<String>,
+    pub email: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ChangePasswordRequest {
+    pub current_password: String,
+    pub new_password: String,
+}
 
 #[derive(Debug, Deserialize)]
 pub struct SetActiveOrganizationRequest {
     pub organization_id: String,
 }
 
+#[derive(Debug, Serialize)]
+pub struct UserProfileResponse {
+    pub id: String,
+    pub username: Option<String>,
+    pub email: String,
+    pub display_name: Option<String>,
+    pub role: String,
+    pub active_organization_id: Option<String>,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+impl From<crate::entity::user::Model> for UserProfileResponse {
+    fn from(u: crate::entity::user::Model) -> Self {
+        Self {
+            id: u.id,
+            username: u.username,
+            email: u.email,
+            display_name: u.display_name,
+            role: u.role,
+            active_organization_id: u.active_organization_id,
+            created_at: u.created_at,
+            updated_at: u.updated_at,
+        }
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Router
 // ---------------------------------------------------------------------------
 
+/// Routes mounted at `/users` (legacy path, issue #216).
 pub fn router() -> Router<AppState> {
     Router::new().route("/me/active-organization", put(set_active_organization_handler))
+}
+
+/// Routes mounted at `/api/v1/users` (issue #218).
+pub fn v1_router() -> Router<AppState> {
+    Router::new()
+        .route("/me", get(get_me_handler).put(update_profile_handler))
+        .route("/me/password", put(change_password_handler))
+        .route("/me/organizations", get(list_my_organizations_handler))
+        .route("/me/active-organization", put(set_active_organization_handler))
 }
 
 // ---------------------------------------------------------------------------
 // Handlers
 // ---------------------------------------------------------------------------
+
+/// `GET /api/v1/users/me`
+///
+/// Returns the current user's profile without `password_hash`.
+async fn get_me_handler(auth: AuthUser) -> impl IntoResponse {
+    Json(UserProfileResponse::from(auth.user))
+}
+
+/// `PUT /api/v1/users/me`
+///
+/// Updates `display_name` and/or `email`. Fields set to `null` or omitted are
+/// left unchanged.
+///
+/// Returns `200 OK` with the updated profile.
+async fn update_profile_handler(
+    State(state): State<AppState>,
+    auth: AuthUser,
+    Json(body): Json<UpdateProfileRequest>,
+) -> Result<impl IntoResponse, ApiError> {
+    let users = state.storage.users();
+    let mut user = auth.user;
+
+    // Update display_name if provided
+    if body.display_name.is_some() || body.email.is_some() {
+        if let Some(dn) = &body.display_name {
+            user = users
+                .update(&user.id, None, Some(dn.as_str()), None)
+                .await
+                .map_err(ApiError::Internal)?;
+        }
+        if let Some(email) = &body.email {
+            // Check email uniqueness before update
+            if let Some(existing) = users.get_by_email(email).await.map_err(ApiError::Internal)? {
+                if existing.id != user.id {
+                    return Err(ApiError::Conflict(format!("email already in use: {email}")));
+                }
+            }
+            user = users.update_email(&user.id, email).await.map_err(ApiError::Internal)?;
+        }
+    }
+
+    Ok(Json(UserProfileResponse::from(user)))
+}
+
+/// `PUT /api/v1/users/me/password`
+///
+/// Changes the user's password. Requires the current password for verification.
+///
+/// Returns `204 No Content`.
+async fn change_password_handler(
+    State(state): State<AppState>,
+    auth: AuthUser,
+    Json(body): Json<ChangePasswordRequest>,
+) -> Result<impl IntoResponse, ApiError> {
+    if body.new_password.is_empty() {
+        return Err(ApiError::InvalidInput("new password must not be empty".into()));
+    }
+
+    // Verify current password
+    let ok = UserStorage::verify_password(&body.current_password, &auth.user.password_hash)
+        .map_err(ApiError::Internal)?;
+    if !ok {
+        return Err(ApiError::Unauthorized("current password is incorrect".into()));
+    }
+
+    state
+        .storage
+        .users()
+        .update_password(&auth.user.id, &body.new_password)
+        .await
+        .map_err(ApiError::Internal)?;
+
+    Ok(StatusCode::NO_CONTENT)
+}
+
+/// `GET /api/v1/users/me/organizations`
+///
+/// Returns all organizations the current user belongs to.
+async fn list_my_organizations_handler(
+    State(state): State<AppState>,
+    auth: AuthUser,
+) -> Result<impl IntoResponse, ApiError> {
+    let orgs = state
+        .storage
+        .memberships()
+        .list_user_organizations(&auth.user.id)
+        .await
+        .map_err(ApiError::Internal)?;
+
+    let response: Vec<OrgResponse> = orgs.into_iter().map(OrgResponse::from).collect();
+    Ok(Json(response))
+}
 
 /// `PUT /users/me/active-organization`
 ///
@@ -73,8 +223,7 @@ async fn set_active_organization_handler(
         .await
         .map_err(ApiError::Internal)?;
 
-    // Return the updated user without password_hash
-    Ok(Json(crate::api::auth::UserResponse::from(updated)))
+    Ok(Json(UserProfileResponse::from(updated)))
 }
 
 // ---------------------------------------------------------------------------
@@ -83,7 +232,7 @@ async fn set_active_organization_handler(
 
 #[cfg(test)]
 mod tests {
-    use crate::api::{auth::UserResponse, AppState};
+    use crate::api::AppState;
     use crate::storage::Storage;
     use agentd_common::storage::create_test_connection;
     use axum::{
@@ -102,13 +251,14 @@ mod tests {
         (app, tmp)
     }
 
-    /// Register a user and return `(token, user_id)`.
-    async fn register_and_login(app: &Router, username: &str, email: &str) -> (String, String) {
-        let payload = serde_json::json!({
-            "username": username,
-            "email": email,
-            "password": "testpass"
-        });
+    async fn body_json(response: axum::response::Response) -> serde_json::Value {
+        let bytes = response.into_body().collect().await.unwrap().to_bytes();
+        serde_json::from_slice(&bytes).unwrap()
+    }
+
+    async fn register(app: &Router, username: &str, email: &str) -> (String, String) {
+        let payload =
+            serde_json::json!({ "username": username, "email": email, "password": "testpass" });
         let response = app
             .clone()
             .oneshot(
@@ -121,21 +271,198 @@ mod tests {
             )
             .await
             .unwrap();
-        let bytes = response.into_body().collect().await.unwrap().to_bytes();
-        let body: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        let body = body_json(response).await;
         let token = body["token"].as_str().unwrap().to_string();
         let user_id = body["user"]["id"].as_str().unwrap().to_string();
         (token, user_id)
     }
 
+    // -----------------------------------------------------------------------
+    // GET /api/v1/users/me
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_get_me() {
+        let (app, _tmp) = test_app().await;
+        let (token, _) = register(&app, "alice", "alice@example.com").await;
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/api/v1/users/me")
+                    .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = body_json(response).await;
+        assert_eq!(body["username"], "alice");
+        assert_eq!(body["email"], "alice@example.com");
+        assert!(body.get("password_hash").is_none());
+    }
+
+    #[tokio::test]
+    async fn test_get_me_unauthenticated() {
+        let (app, _tmp) = test_app().await;
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/api/v1/users/me")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    // -----------------------------------------------------------------------
+    // PUT /api/v1/users/me
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_update_profile_display_name() {
+        let (app, _tmp) = test_app().await;
+        let (token, _) = register(&app, "bob", "bob@example.com").await;
+
+        let payload = serde_json::json!({ "display_name": "Robert" });
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("PUT")
+                    .uri("/api/v1/users/me")
+                    .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(payload.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = body_json(response).await;
+        assert_eq!(body["display_name"], "Robert");
+    }
+
+    #[tokio::test]
+    async fn test_update_email_conflict() {
+        let (app, _tmp) = test_app().await;
+        register(&app, "carol", "carol@example.com").await;
+        let (token_d, _) = register(&app, "dan", "dan@example.com").await;
+
+        let payload = serde_json::json!({ "email": "carol@example.com" });
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("PUT")
+                    .uri("/api/v1/users/me")
+                    .header(header::AUTHORIZATION, format!("Bearer {token_d}"))
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(payload.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::CONFLICT);
+    }
+
+    // -----------------------------------------------------------------------
+    // PUT /api/v1/users/me/password
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_change_password_success() {
+        let (app, _tmp) = test_app().await;
+        let (token, _) = register(&app, "eve", "eve@example.com").await;
+
+        let payload =
+            serde_json::json!({ "current_password": "testpass", "new_password": "newpass123" });
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("PUT")
+                    .uri("/api/v1/users/me/password")
+                    .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(payload.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::NO_CONTENT);
+    }
+
+    #[tokio::test]
+    async fn test_change_password_wrong_current() {
+        let (app, _tmp) = test_app().await;
+        let (token, _) = register(&app, "frank", "frank@example.com").await;
+
+        let payload =
+            serde_json::json!({ "current_password": "wrongpass", "new_password": "newpass" });
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("PUT")
+                    .uri("/api/v1/users/me/password")
+                    .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(payload.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    // -----------------------------------------------------------------------
+    // GET /api/v1/users/me/organizations
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_list_my_organizations() {
+        let (app, _tmp) = test_app().await;
+        let (token, _) = register(&app, "grace", "grace@example.com").await;
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/api/v1/users/me/organizations")
+                    .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = body_json(response).await;
+        let orgs = body.as_array().unwrap();
+        // Registration creates one personal org
+        assert_eq!(orgs.len(), 1);
+        assert!(orgs[0]["name"].as_str().unwrap().contains("grace"));
+    }
+
+    // -----------------------------------------------------------------------
+    // PUT /users/me/active-organization
+    // -----------------------------------------------------------------------
+
     #[tokio::test]
     async fn test_set_active_organization_success() {
         let (app, _tmp) = test_app().await;
 
-        // Register user (creates personal org and sets it as active)
-        let (token, _user_id) = register_and_login(&app, "alice", "alice@example.com").await;
+        let (token, _) = register(&app, "henry", "henry@example.com").await;
 
-        // Get current active org
         let me_resp = app
             .clone()
             .oneshot(
@@ -148,11 +475,9 @@ mod tests {
             )
             .await
             .unwrap();
-        let me_bytes = me_resp.into_body().collect().await.unwrap().to_bytes();
-        let me_body: serde_json::Value = serde_json::from_slice(&me_bytes).unwrap();
+        let me_body = body_json(me_resp).await;
         let org_id = me_body["active_organization"]["id"].as_str().unwrap().to_string();
 
-        // Switch back to the same org (idempotent)
         let payload = serde_json::json!({ "organization_id": org_id });
         let response = app
             .oneshot(
@@ -168,9 +493,7 @@ mod tests {
             .unwrap();
 
         assert_eq!(response.status(), StatusCode::OK);
-        let bytes = response.into_body().collect().await.unwrap().to_bytes();
-        let body: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
-        // Response is UserResponse — no password_hash field
+        let body = body_json(response).await;
         assert!(body.get("password_hash").is_none());
         assert_eq!(body["active_organization_id"].as_str().unwrap(), org_id);
     }
@@ -179,9 +502,8 @@ mod tests {
     async fn test_set_active_organization_not_member() {
         let (app, _tmp) = test_app().await;
 
-        let (token, _) = register_and_login(&app, "bob", "bob@example.com").await;
+        let (token, _) = register(&app, "ida", "ida@example.com").await;
 
-        // Use a random UUID that doesn't correspond to any org the user is in
         let fake_org_id = uuid::Uuid::new_v4().to_string();
         let payload = serde_json::json!({ "organization_id": fake_org_id });
         let response = app
@@ -221,17 +543,12 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_set_active_org_allows_second_org() {
+    async fn test_set_active_org_cross_user_forbidden() {
         let (app, _tmp) = test_app().await;
 
-        // Register Alice (gets personal org automatically)
-        let (token_a, user_a_id) = register_and_login(&app, "alice2", "alice2@example.com").await;
-        let _ = user_a_id;
+        let (token_a, _) = register(&app, "jack", "jack@example.com").await;
+        let (token_b, _) = register(&app, "kate", "kate@example.com").await;
 
-        // Register Bob (we'll use his personal org for the cross-org test)
-        let (token_b, _) = register_and_login(&app, "bob2", "bob2@example.com").await;
-
-        // Get Bob's personal org id
         let me_resp = app
             .clone()
             .oneshot(
@@ -244,12 +561,10 @@ mod tests {
             )
             .await
             .unwrap();
-        let me_bytes = me_resp.into_body().collect().await.unwrap().to_bytes();
-        let me_body: serde_json::Value = serde_json::from_slice(&me_bytes).unwrap();
-        let bob_org_id = me_body["active_organization"]["id"].as_str().unwrap().to_string();
+        let me_body = body_json(me_resp).await;
+        let kate_org_id = me_body["active_organization"]["id"].as_str().unwrap().to_string();
 
-        // Alice tries to switch to Bob's org (she's not a member)
-        let payload = serde_json::json!({ "organization_id": bob_org_id });
+        let payload = serde_json::json!({ "organization_id": kate_org_id });
         let response = app
             .oneshot(
                 Request::builder()
@@ -265,8 +580,4 @@ mod tests {
 
         assert_eq!(response.status(), StatusCode::FORBIDDEN);
     }
-
-    // Keep the compiler happy with unused import
-    #[allow(dead_code)]
-    fn _use_user_response(_: UserResponse) {}
 }

--- a/crates/core/src/api/users.rs
+++ b/crates/core/src/api/users.rs
@@ -1,0 +1,272 @@
+//! User profile endpoint handlers.
+//!
+//! # Endpoints
+//!
+//! | Method | Path                              | Auth | Description                          |
+//! |--------|-----------------------------------|------|--------------------------------------|
+//! | PUT    | `/users/me/active-organization`   | Yes  | Switch the user's active organization |
+//!
+//! All endpoints require a valid `Authorization: Bearer <token>` header via
+//! the [`crate::middleware::auth::AuthUser`] extractor.
+
+use axum::{extract::State, response::IntoResponse, routing::put, Json, Router};
+use serde::Deserialize;
+
+use agentd_common::error::ApiError;
+
+use crate::middleware::auth::AuthUser;
+
+use super::AppState;
+
+// ---------------------------------------------------------------------------
+// Request types
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+pub struct SetActiveOrganizationRequest {
+    pub organization_id: String,
+}
+
+// ---------------------------------------------------------------------------
+// Router
+// ---------------------------------------------------------------------------
+
+pub fn router() -> Router<AppState> {
+    Router::new().route("/me/active-organization", put(set_active_organization_handler))
+}
+
+// ---------------------------------------------------------------------------
+// Handlers
+// ---------------------------------------------------------------------------
+
+/// `PUT /users/me/active-organization`
+///
+/// Switches the authenticated user's active organization. The user must be a
+/// member of the specified organization; non-members receive `403 Forbidden`.
+///
+/// Returns `200 OK` with the updated user profile (no password hash).
+async fn set_active_organization_handler(
+    State(state): State<AppState>,
+    auth: AuthUser,
+    Json(body): Json<SetActiveOrganizationRequest>,
+) -> Result<impl IntoResponse, ApiError> {
+    // Verify membership — only members of the org may activate it.
+    let membership = state
+        .storage
+        .memberships()
+        .get_membership(&auth.user.id, &body.organization_id)
+        .await
+        .map_err(ApiError::Internal)?;
+
+    if membership.is_none() {
+        return Err(ApiError::Forbidden(format!(
+            "user is not a member of organization {}",
+            body.organization_id
+        )));
+    }
+
+    // Update the user's active organization
+    let updated = state
+        .storage
+        .users()
+        .set_active_organization(&auth.user.id, Some(&body.organization_id))
+        .await
+        .map_err(ApiError::Internal)?;
+
+    // Return the updated user without password_hash
+    Ok(Json(crate::api::auth::UserResponse::from(updated)))
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use crate::api::{auth::UserResponse, AppState};
+    use crate::storage::Storage;
+    use agentd_common::storage::create_test_connection;
+    use axum::{
+        body::Body,
+        http::{header, Request, StatusCode},
+        Router,
+    };
+    use http_body_util::BodyExt;
+    use tower::ServiceExt;
+
+    async fn test_app() -> (Router, tempfile::TempDir) {
+        let (conn, tmp) = create_test_connection().await;
+        let storage = Storage::new(conn).await.unwrap();
+        let state = AppState { storage };
+        let app = crate::api::create_router(state);
+        (app, tmp)
+    }
+
+    /// Register a user and return `(token, user_id)`.
+    async fn register_and_login(app: &Router, username: &str, email: &str) -> (String, String) {
+        let payload = serde_json::json!({
+            "username": username,
+            "email": email,
+            "password": "testpass"
+        });
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/auth/register")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(payload.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let bytes = response.into_body().collect().await.unwrap().to_bytes();
+        let body: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        let token = body["token"].as_str().unwrap().to_string();
+        let user_id = body["user"]["id"].as_str().unwrap().to_string();
+        (token, user_id)
+    }
+
+    #[tokio::test]
+    async fn test_set_active_organization_success() {
+        let (app, _tmp) = test_app().await;
+
+        // Register user (creates personal org and sets it as active)
+        let (token, _user_id) = register_and_login(&app, "alice", "alice@example.com").await;
+
+        // Get current active org
+        let me_resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/auth/me")
+                    .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let me_bytes = me_resp.into_body().collect().await.unwrap().to_bytes();
+        let me_body: serde_json::Value = serde_json::from_slice(&me_bytes).unwrap();
+        let org_id = me_body["active_organization"]["id"].as_str().unwrap().to_string();
+
+        // Switch back to the same org (idempotent)
+        let payload = serde_json::json!({ "organization_id": org_id });
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("PUT")
+                    .uri("/users/me/active-organization")
+                    .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(payload.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let bytes = response.into_body().collect().await.unwrap().to_bytes();
+        let body: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        // Response is UserResponse — no password_hash field
+        assert!(body.get("password_hash").is_none());
+        assert_eq!(body["active_organization_id"].as_str().unwrap(), org_id);
+    }
+
+    #[tokio::test]
+    async fn test_set_active_organization_not_member() {
+        let (app, _tmp) = test_app().await;
+
+        let (token, _) = register_and_login(&app, "bob", "bob@example.com").await;
+
+        // Use a random UUID that doesn't correspond to any org the user is in
+        let fake_org_id = uuid::Uuid::new_v4().to_string();
+        let payload = serde_json::json!({ "organization_id": fake_org_id });
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("PUT")
+                    .uri("/users/me/active-organization")
+                    .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(payload.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn test_set_active_organization_unauthenticated() {
+        let (app, _tmp) = test_app().await;
+
+        let payload = serde_json::json!({ "organization_id": "any-id" });
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("PUT")
+                    .uri("/users/me/active-organization")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(payload.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn test_set_active_org_allows_second_org() {
+        let (app, _tmp) = test_app().await;
+
+        // Register Alice (gets personal org automatically)
+        let (token_a, user_a_id) = register_and_login(&app, "alice2", "alice2@example.com").await;
+        let _ = user_a_id;
+
+        // Register Bob (we'll use his personal org for the cross-org test)
+        let (token_b, _) = register_and_login(&app, "bob2", "bob2@example.com").await;
+
+        // Get Bob's personal org id
+        let me_resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/auth/me")
+                    .header(header::AUTHORIZATION, format!("Bearer {token_b}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let me_bytes = me_resp.into_body().collect().await.unwrap().to_bytes();
+        let me_body: serde_json::Value = serde_json::from_slice(&me_bytes).unwrap();
+        let bob_org_id = me_body["active_organization"]["id"].as_str().unwrap().to_string();
+
+        // Alice tries to switch to Bob's org (she's not a member)
+        let payload = serde_json::json!({ "organization_id": bob_org_id });
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("PUT")
+                    .uri("/users/me/active-organization")
+                    .header(header::AUTHORIZATION, format!("Bearer {token_a}"))
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(payload.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    }
+
+    // Keep the compiler happy with unused import
+    #[allow(dead_code)]
+    fn _use_user_response(_: UserResponse) {}
+}

--- a/crates/core/src/entity/organization.rs
+++ b/crates/core/src/entity/organization.rs
@@ -70,10 +70,12 @@ mod tests {
         let now = chrono::Utc::now().to_rfc3339();
         user::ActiveModel {
             id: Set(uuid::Uuid::new_v4().to_string()),
+            username: Set(None),
             email: Set(email.to_string()),
             password_hash: Set("hash".to_string()),
             display_name: Set(None),
             role: Set("user".to_string()),
+            active_organization_id: Set(None),
             created_at: Set(now.clone()),
             updated_at: Set(now),
         }

--- a/crates/core/src/entity/session.rs
+++ b/crates/core/src/entity/session.rs
@@ -62,10 +62,12 @@ mod tests {
         let now = chrono::Utc::now().to_rfc3339();
         user::ActiveModel {
             id: Set(user_id.to_string()),
+            username: Set(None),
             email: Set(format!("{}@example.com", &user_id[..8])),
             password_hash: Set("hash".to_string()),
             display_name: Set(None),
             role: Set("user".to_string()),
+            active_organization_id: Set(None),
             created_at: Set(now.clone()),
             updated_at: Set(now),
         }

--- a/crates/core/src/entity/user.rs
+++ b/crates/core/src/entity/user.rs
@@ -12,12 +12,17 @@ use sea_orm::entity::prelude::*;
 pub struct Model {
     #[sea_orm(primary_key, auto_increment = false)]
     pub id: String,
+    /// Unique human-readable login identifier (added in migration 2).
+    #[sea_orm(unique)]
+    pub username: Option<String>,
     #[sea_orm(unique)]
     pub email: String,
     pub password_hash: String,
     pub display_name: Option<String>,
     /// Role string — `"admin"` or `"user"`.
     pub role: String,
+    /// The organization the user is currently operating as (nullable).
+    pub active_organization_id: Option<String>,
     pub created_at: String,
     pub updated_at: String,
 }
@@ -82,10 +87,12 @@ mod tests {
         let now = chrono::Utc::now().to_rfc3339();
         let user = ActiveModel {
             id: Set(id.clone()),
+            username: Set(None),
             email: Set("alice@example.com".to_string()),
             password_hash: Set("hashed_password".to_string()),
             display_name: Set(Some("Alice".to_string())),
             role: Set("user".to_string()),
+            active_organization_id: Set(None),
             created_at: Set(now.clone()),
             updated_at: Set(now),
         };

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -6,5 +6,7 @@
 
 pub mod api;
 pub mod entity;
+pub mod membership_storage;
 pub mod migration;
+pub mod organization_storage;
 pub mod storage;

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -10,3 +10,4 @@ pub mod membership_storage;
 pub mod migration;
 pub mod organization_storage;
 pub mod storage;
+pub mod user_storage;

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -10,6 +10,7 @@ pub mod membership_storage;
 pub mod middleware;
 pub mod migration;
 pub mod organization_storage;
+pub mod proxy;
 pub mod session_storage;
 pub mod storage;
 pub mod user_storage;

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -7,7 +7,9 @@
 pub mod api;
 pub mod entity;
 pub mod membership_storage;
+pub mod middleware;
 pub mod migration;
 pub mod organization_storage;
+pub mod session_storage;
 pub mod storage;
 pub mod user_storage;

--- a/crates/core/src/main.rs
+++ b/crates/core/src/main.rs
@@ -4,16 +4,14 @@
 //!
 //! # Environment Variables
 //!
-//! | Variable          | Default   | Description             |
-//! |-------------------|-----------|-------------------------|
-//! | `AGENTD_PORT`     | `17007`   | HTTP listen port        |
-//! | `RUST_LOG`        | `info`    | Log level / filter      |
-//! | `AGENTD_LOG_FORMAT` | (text)  | Set to `json` for JSON  |
+//! | Variable            | Default | Description            |
+//! |---------------------|---------|------------------------|
+//! | `AGENTD_PORT`       | `17007` | HTTP listen port       |
+//! | `RUST_LOG`          | `info`  | Log level / filter     |
+//! | `AGENTD_LOG_FORMAT` | (text)  | Set to `json` for JSON |
 //!
 //! Note: port 17007 was chosen because 17010 (specified in issue #212) is
 //! already used by the communicate service.
-
-mod api;
 
 use axum::{extract::State, response::IntoResponse, routing::get};
 use metrics_exporter_prometheus::PrometheusHandle;
@@ -48,7 +46,7 @@ async fn main() -> anyhow::Result<()> {
 
     let db_path = agentd_common::storage::get_db_path("agentd-core", "core.db")?;
     let db = agentd_common::storage::create_connection(&db_path).await?;
-    let _storage = agentd_core::storage::Storage::new(db).await?;
+    let storage = agentd_core::storage::Storage::new(db).await?;
     info!("Database migrations applied");
 
     let metrics_handle = init_metrics();
@@ -56,7 +54,9 @@ async fn main() -> anyhow::Result<()> {
     let metrics_router =
         axum::Router::new().route("/metrics", get(metrics_handler)).with_state(metrics_handle);
 
-    let app = api::create_router()
+    let state = agentd_core::api::AppState { storage };
+
+    let app = agentd_core::api::create_router(state)
         .merge(metrics_router)
         .layer(agentd_common::server::metrics_layer())
         .layer(agentd_common::server::trace_layer())

--- a/crates/core/src/membership_storage.rs
+++ b/crates/core/src/membership_storage.rs
@@ -1,0 +1,273 @@
+//! SeaORM-based storage for membership records.
+//!
+//! [`MembershipStorage`] manages the many-to-many relationship between users
+//! and organizations through the `memberships` junction table. It holds a
+//! [`DatabaseConnection`] shared with the parent [`crate::storage::Storage`].
+
+use anyhow::{anyhow, Result};
+use sea_orm::{
+    ActiveModelTrait, ColumnTrait, DatabaseConnection, EntityTrait, ModelTrait, QueryFilter, Set,
+};
+use uuid::Uuid;
+
+use crate::entity::{membership, organization};
+
+/// Storage operations for the `memberships` junction table.
+#[derive(Clone)]
+pub struct MembershipStorage {
+    db: DatabaseConnection,
+}
+
+impl MembershipStorage {
+    pub fn new(db: DatabaseConnection) -> Self {
+        Self { db }
+    }
+
+    /// Add a user to an organization with the given role.
+    ///
+    /// Returns an error if the `(user_id, org_id)` pair already exists
+    /// (unique constraint on the junction table).
+    pub async fn add_member(
+        &self,
+        user_id: &str,
+        org_id: &str,
+        role: &str,
+    ) -> Result<membership::Model> {
+        let now = chrono::Utc::now().to_rfc3339();
+        let model = membership::ActiveModel {
+            id: Set(Uuid::new_v4().to_string()),
+            user_id: Set(user_id.to_string()),
+            organization_id: Set(org_id.to_string()),
+            role: Set(role.to_string()),
+            created_at: Set(now.clone()),
+            updated_at: Set(now),
+        }
+        .insert(&self.db)
+        .await?;
+        Ok(model)
+    }
+
+    /// Remove a user from an organization.
+    ///
+    /// Returns `true` if a membership row was deleted, `false` if not found.
+    pub async fn remove_member(&self, user_id: &str, org_id: &str) -> Result<bool> {
+        let mem = membership::Entity::find()
+            .filter(membership::Column::UserId.eq(user_id))
+            .filter(membership::Column::OrganizationId.eq(org_id))
+            .one(&self.db)
+            .await?;
+
+        match mem {
+            None => Ok(false),
+            Some(m) => {
+                m.delete(&self.db).await?;
+                Ok(true)
+            }
+        }
+    }
+
+    /// Return all membership records for the given organization.
+    pub async fn list_members(&self, org_id: &str) -> Result<Vec<membership::Model>> {
+        Ok(membership::Entity::find()
+            .filter(membership::Column::OrganizationId.eq(org_id))
+            .all(&self.db)
+            .await?)
+    }
+
+    /// Return all organizations a user belongs to.
+    pub async fn list_user_organizations(&self, user_id: &str) -> Result<Vec<organization::Model>> {
+        Ok(organization::Entity::find()
+            .inner_join(membership::Entity)
+            .filter(membership::Column::UserId.eq(user_id))
+            .all(&self.db)
+            .await?)
+    }
+
+    /// Return the membership for `(user_id, org_id)`, or `None` if not found.
+    pub async fn get_membership(
+        &self,
+        user_id: &str,
+        org_id: &str,
+    ) -> Result<Option<membership::Model>> {
+        Ok(membership::Entity::find()
+            .filter(membership::Column::UserId.eq(user_id))
+            .filter(membership::Column::OrganizationId.eq(org_id))
+            .one(&self.db)
+            .await?)
+    }
+
+    /// Update the role of an existing membership.
+    ///
+    /// Returns an error if the membership does not exist.
+    pub async fn update_role(
+        &self,
+        user_id: &str,
+        org_id: &str,
+        role: &str,
+    ) -> Result<membership::Model> {
+        let mem = membership::Entity::find()
+            .filter(membership::Column::UserId.eq(user_id))
+            .filter(membership::Column::OrganizationId.eq(org_id))
+            .one(&self.db)
+            .await?
+            .ok_or_else(|| {
+                anyhow!("membership not found for user {} in org {}", user_id, org_id)
+            })?;
+
+        let mut active: membership::ActiveModel = mem.into();
+        active.role = Set(role.to_string());
+        active.updated_at = Set(chrono::Utc::now().to_rfc3339());
+        Ok(active.update(&self.db).await?)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::entity::user;
+    use crate::migration::Migrator;
+    use agentd_common::storage::create_test_connection;
+    use sea_orm::{ActiveModelTrait, Set};
+    use sea_orm_migration::MigratorTrait;
+
+    async fn setup() -> (MembershipStorage, sea_orm::DatabaseConnection, tempfile::TempDir) {
+        let (conn, tmp) = create_test_connection().await;
+        Migrator::up(&conn, None).await.unwrap();
+        let storage = MembershipStorage::new(conn.clone());
+        (storage, conn, tmp)
+    }
+
+    async fn insert_user(db: &sea_orm::DatabaseConnection, email: &str) -> user::Model {
+        let now = chrono::Utc::now().to_rfc3339();
+        user::ActiveModel {
+            id: Set(Uuid::new_v4().to_string()),
+            email: Set(email.to_string()),
+            password_hash: Set("hash".to_string()),
+            display_name: Set(None),
+            role: Set("user".to_string()),
+            created_at: Set(now.clone()),
+            updated_at: Set(now),
+        }
+        .insert(db)
+        .await
+        .unwrap()
+    }
+
+    async fn insert_org(
+        db: &sea_orm::DatabaseConnection,
+        name: &str,
+        slug: &str,
+    ) -> organization::Model {
+        let now = chrono::Utc::now().to_rfc3339();
+        organization::ActiveModel {
+            id: Set(Uuid::new_v4().to_string()),
+            name: Set(name.to_string()),
+            slug: Set(slug.to_string()),
+            created_at: Set(now.clone()),
+            updated_at: Set(now),
+        }
+        .insert(db)
+        .await
+        .unwrap()
+    }
+
+    #[tokio::test]
+    async fn test_add_and_get_membership() {
+        let (storage, db, _tmp) = setup().await;
+        let user = insert_user(&db, "alice@example.com").await;
+        let org = insert_org(&db, "Org A", "org-a").await;
+
+        let mem = storage.add_member(&user.id, &org.id, "owner").await.unwrap();
+        assert_eq!(mem.user_id, user.id);
+        assert_eq!(mem.organization_id, org.id);
+        assert_eq!(mem.role, "owner");
+
+        let found = storage.get_membership(&user.id, &org.id).await.unwrap().unwrap();
+        assert_eq!(found.id, mem.id);
+    }
+
+    #[tokio::test]
+    async fn test_remove_member() {
+        let (storage, db, _tmp) = setup().await;
+        let user = insert_user(&db, "bob@example.com").await;
+        let org = insert_org(&db, "Org B", "org-b").await;
+        storage.add_member(&user.id, &org.id, "member").await.unwrap();
+
+        let removed = storage.remove_member(&user.id, &org.id).await.unwrap();
+        assert!(removed);
+
+        let found = storage.get_membership(&user.id, &org.id).await.unwrap();
+        assert!(found.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_remove_member_not_found() {
+        let (storage, db, _tmp) = setup().await;
+        let user = insert_user(&db, "carol@example.com").await;
+        let org = insert_org(&db, "Org C", "org-c").await;
+
+        let result = storage.remove_member(&user.id, &org.id).await.unwrap();
+        assert!(!result);
+    }
+
+    #[tokio::test]
+    async fn test_list_members() {
+        let (storage, db, _tmp) = setup().await;
+        let u1 = insert_user(&db, "dan@example.com").await;
+        let u2 = insert_user(&db, "eve@example.com").await;
+        let org = insert_org(&db, "Org D", "org-d").await;
+        storage.add_member(&u1.id, &org.id, "owner").await.unwrap();
+        storage.add_member(&u2.id, &org.id, "member").await.unwrap();
+
+        let members = storage.list_members(&org.id).await.unwrap();
+        assert_eq!(members.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_list_user_organizations() {
+        let (storage, db, _tmp) = setup().await;
+        let user = insert_user(&db, "frank@example.com").await;
+        let org1 = insert_org(&db, "Org E", "org-e").await;
+        let org2 = insert_org(&db, "Org F", "org-f").await;
+        storage.add_member(&user.id, &org1.id, "owner").await.unwrap();
+        storage.add_member(&user.id, &org2.id, "member").await.unwrap();
+
+        let orgs = storage.list_user_organizations(&user.id).await.unwrap();
+        assert_eq!(orgs.len(), 2);
+        let mut slugs: Vec<&str> = orgs.iter().map(|o| o.slug.as_str()).collect();
+        slugs.sort_unstable();
+        assert_eq!(slugs, ["org-e", "org-f"]);
+    }
+
+    #[tokio::test]
+    async fn test_get_membership_not_found() {
+        let (storage, db, _tmp) = setup().await;
+        let user = insert_user(&db, "grace@example.com").await;
+        let org = insert_org(&db, "Org G", "org-g").await;
+
+        let result = storage.get_membership(&user.id, &org.id).await.unwrap();
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_update_role() {
+        let (storage, db, _tmp) = setup().await;
+        let user = insert_user(&db, "henry@example.com").await;
+        let org = insert_org(&db, "Org H", "org-h").await;
+        storage.add_member(&user.id, &org.id, "member").await.unwrap();
+
+        let updated = storage.update_role(&user.id, &org.id, "admin").await.unwrap();
+        assert_eq!(updated.role, "admin");
+    }
+
+    #[tokio::test]
+    async fn test_duplicate_membership_rejected() {
+        let (storage, db, _tmp) = setup().await;
+        let user = insert_user(&db, "ida@example.com").await;
+        let org = insert_org(&db, "Org I", "org-i").await;
+        storage.add_member(&user.id, &org.id, "member").await.unwrap();
+
+        let result = storage.add_member(&user.id, &org.id, "owner").await;
+        assert!(result.is_err(), "duplicate membership should be rejected");
+    }
+}

--- a/crates/core/src/membership_storage.rs
+++ b/crates/core/src/membership_storage.rs
@@ -141,10 +141,12 @@ mod tests {
         let now = chrono::Utc::now().to_rfc3339();
         user::ActiveModel {
             id: Set(Uuid::new_v4().to_string()),
+            username: Set(None),
             email: Set(email.to_string()),
             password_hash: Set("hash".to_string()),
             display_name: Set(None),
             role: Set("user".to_string()),
+            active_organization_id: Set(None),
             created_at: Set(now.clone()),
             updated_at: Set(now),
         }

--- a/crates/core/src/middleware/auth.rs
+++ b/crates/core/src/middleware/auth.rs
@@ -1,0 +1,101 @@
+//! Auth middleware extractor for protected routes.
+//!
+//! [`AuthUser`] implements [`axum::extract::FromRequestParts`] and can be used
+//! as a function parameter in any Axum handler to require a valid session token.
+//!
+//! # Example
+//!
+//! ```rust,ignore
+//! async fn protected(auth: AuthUser) -> impl IntoResponse {
+//!     Json(json!({ "user_id": auth.user.id }))
+//! }
+//! ```
+
+use axum::{
+    extract::FromRequestParts,
+    http::{request::Parts, StatusCode},
+    response::{IntoResponse, Response},
+    Json,
+};
+use serde_json::json;
+
+use crate::{api::AppState, entity::user};
+
+/// Authenticated user extracted from a valid `Authorization: Bearer <token>` header.
+pub struct AuthUser {
+    /// The authenticated user model.
+    pub user: user::Model,
+    /// The raw session token (not stored — passed through for logout etc.).
+    pub token: String,
+}
+
+/// Extractor error returned when authentication fails.
+pub enum AuthError {
+    MissingToken,
+    InvalidToken,
+    ExpiredToken,
+    InternalError,
+}
+
+impl IntoResponse for AuthError {
+    fn into_response(self) -> Response {
+        let (status, msg) = match self {
+            AuthError::MissingToken => (StatusCode::UNAUTHORIZED, "missing authorization token"),
+            AuthError::InvalidToken => (StatusCode::UNAUTHORIZED, "invalid or unknown token"),
+            AuthError::ExpiredToken => (StatusCode::UNAUTHORIZED, "session expired"),
+            AuthError::InternalError => {
+                (StatusCode::INTERNAL_SERVER_ERROR, "internal server error")
+            }
+        };
+        (status, Json(json!({ "error": msg }))).into_response()
+    }
+}
+
+impl FromRequestParts<AppState> for AuthUser {
+    type Rejection = AuthError;
+
+    async fn from_request_parts(
+        parts: &mut Parts,
+        state: &AppState,
+    ) -> Result<Self, Self::Rejection> {
+        // Extract "Authorization: Bearer <token>"
+        let auth_header = parts
+            .headers
+            .get(axum::http::header::AUTHORIZATION)
+            .and_then(|v| v.to_str().ok())
+            .ok_or(AuthError::MissingToken)?;
+
+        let token =
+            auth_header.strip_prefix("Bearer ").ok_or(AuthError::InvalidToken)?.trim().to_string();
+
+        if token.is_empty() {
+            return Err(AuthError::InvalidToken);
+        }
+
+        // Look up the session
+        let session = state
+            .storage
+            .sessions()
+            .get_by_token_hash(&token)
+            .await
+            .map_err(|_| AuthError::InternalError)?
+            .ok_or(AuthError::InvalidToken)?;
+
+        // Check expiry
+        let now = chrono::Utc::now().to_rfc3339();
+        if session.expires_at <= now {
+            return Err(AuthError::ExpiredToken);
+        }
+
+        // Fetch the associated user
+        let user = state
+            .storage
+            .users()
+            .get_by_id(&session.user_id)
+            .await
+            .map_err(|_| AuthError::InternalError)?
+            .ok_or(AuthError::InvalidToken)?;
+
+        Ok(AuthUser { user, token })
+    }
+}

--- a/crates/core/src/middleware/mod.rs
+++ b/crates/core/src/middleware/mod.rs
@@ -1,3 +1,4 @@
 //! Axum middleware and request extractors for the core service.
 
 pub mod auth;
+pub mod tenant;

--- a/crates/core/src/middleware/mod.rs
+++ b/crates/core/src/middleware/mod.rs
@@ -1,0 +1,3 @@
+//! Axum middleware and request extractors for the core service.
+
+pub mod auth;

--- a/crates/core/src/middleware/tenant.rs
+++ b/crates/core/src/middleware/tenant.rs
@@ -1,0 +1,117 @@
+//! Tenant context extractor for multi-tenant request isolation.
+//!
+//! [`TenantContext`] implements [`axum::extract::FromRequestParts`] and resolves
+//! the authenticated user's active organization for every request. It is more
+//! strict than [`super::auth::AuthUser`]: a valid session is required **and**
+//! the user must have an active organization set. Requests without an active
+//! org receive `403 Forbidden`.
+//!
+//! # Usage
+//!
+//! ```rust,ignore
+//! async fn my_handler(ctx: TenantContext) -> impl IntoResponse {
+//!     Json(json!({ "org": ctx.organization_id, "user": ctx.user_id }))
+//! }
+//! ```
+//!
+//! # X-Tenant-ID header injection
+//!
+//! The `organization_id` field is intended to be forwarded as an
+//! `X-Tenant-ID` header when proxying requests to downstream services.
+//! Downstream services can then use this header to scope their queries
+//! without implementing their own auth stack.
+
+use axum::{
+    extract::FromRequestParts,
+    http::{request::Parts, StatusCode},
+    response::{IntoResponse, Response},
+    Json,
+};
+use serde_json::json;
+
+use crate::api::AppState;
+
+/// Per-request tenant context resolved from the active session + organization.
+pub struct TenantContext {
+    /// The authenticated user's ID.
+    pub user_id: String,
+    /// The organization the user is currently acting as.
+    pub organization_id: String,
+    /// Raw bearer token — available for forwarding or invalidation.
+    pub session_token: String,
+}
+
+/// Extractor rejection for failed tenant resolution.
+pub enum TenantError {
+    /// No `Authorization` header or unparseable value.
+    MissingToken,
+    /// Token not found in sessions table or session is expired.
+    InvalidSession,
+    /// Valid session but the user has no `active_organization_id` set.
+    NoActiveOrganization,
+    /// Internal storage error.
+    InternalError,
+}
+
+impl IntoResponse for TenantError {
+    fn into_response(self) -> Response {
+        let (status, msg) = match self {
+            TenantError::MissingToken => (StatusCode::UNAUTHORIZED, "missing authorization token"),
+            TenantError::InvalidSession => (StatusCode::UNAUTHORIZED, "invalid or expired session"),
+            TenantError::NoActiveOrganization => {
+                (StatusCode::FORBIDDEN, "no active organization set for this user")
+            }
+            TenantError::InternalError => {
+                (StatusCode::INTERNAL_SERVER_ERROR, "internal server error")
+            }
+        };
+        (status, Json(json!({ "error": msg }))).into_response()
+    }
+}
+
+impl FromRequestParts<AppState> for TenantContext {
+    type Rejection = TenantError;
+
+    async fn from_request_parts(
+        parts: &mut Parts,
+        state: &AppState,
+    ) -> Result<Self, Self::Rejection> {
+        // Extract bearer token
+        let token = parts
+            .headers
+            .get(axum::http::header::AUTHORIZATION)
+            .and_then(|v| v.to_str().ok())
+            .and_then(|v| v.strip_prefix("Bearer "))
+            .map(|t| t.trim().to_string())
+            .filter(|t| !t.is_empty())
+            .ok_or(TenantError::MissingToken)?;
+
+        // Look up session and check expiry
+        let session = state
+            .storage
+            .sessions()
+            .get_by_token_hash(&token)
+            .await
+            .map_err(|_| TenantError::InternalError)?
+            .ok_or(TenantError::InvalidSession)?;
+
+        let now = chrono::Utc::now().to_rfc3339();
+        if session.expires_at <= now {
+            return Err(TenantError::InvalidSession);
+        }
+
+        // Fetch the user and require an active organization
+        let user = state
+            .storage
+            .users()
+            .get_by_id(&session.user_id)
+            .await
+            .map_err(|_| TenantError::InternalError)?
+            .ok_or(TenantError::InvalidSession)?;
+
+        let organization_id =
+            user.active_organization_id.ok_or(TenantError::NoActiveOrganization)?;
+
+        Ok(TenantContext { user_id: user.id, organization_id, session_token: token })
+    }
+}

--- a/crates/core/src/migration/m20260408_000002_add_username_to_users.rs
+++ b/crates/core/src/migration/m20260408_000002_add_username_to_users.rs
@@ -1,0 +1,75 @@
+//! Migration: add `username` and `active_organization_id` columns to `users`.
+//!
+//! `username` is a unique human-readable identifier used alongside email for
+//! login. `active_organization_id` tracks the organization a user is currently
+//! operating as, enabling per-request tenant isolation.
+//!
+//! Both columns are added as nullable so the migration is backwards-compatible
+//! with any existing rows.
+
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Users::Table)
+                    .add_column(ColumnDef::new(Users::Username).string().null())
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Users::Table)
+                    .add_column(ColumnDef::new(Users::ActiveOrganizationId).string().null())
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx_users_username")
+                    .table(Users::Table)
+                    .col(Users::Username)
+                    .unique()
+                    .if_not_exists()
+                    .to_owned(),
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        // SQLite does not support DROP COLUMN in older versions; use raw SQL
+        // for the down migration to ensure compatibility.
+        manager
+            .get_connection()
+            .execute_unprepared(
+                "CREATE TABLE users_backup AS SELECT id, email, password_hash, \
+                 display_name, role, created_at, updated_at FROM users",
+            )
+            .await?;
+        manager.get_connection().execute_unprepared("DROP TABLE users").await?;
+        manager
+            .get_connection()
+            .execute_unprepared("ALTER TABLE users_backup RENAME TO users")
+            .await?;
+        Ok(())
+    }
+}
+
+#[derive(DeriveIden)]
+enum Users {
+    Table,
+    Username,
+    ActiveOrganizationId,
+}

--- a/crates/core/src/migration/mod.rs
+++ b/crates/core/src/migration/mod.rs
@@ -12,6 +12,7 @@
 pub use sea_orm_migration::prelude::*;
 
 mod m20260305_000001_create_core_tables;
+mod m20260408_000002_add_username_to_users;
 
 /// The migration runner — applies all known migrations in order.
 pub struct Migrator;
@@ -19,6 +20,9 @@ pub struct Migrator;
 #[async_trait::async_trait]
 impl MigratorTrait for Migrator {
     fn migrations() -> Vec<Box<dyn MigrationTrait>> {
-        vec![Box::new(m20260305_000001_create_core_tables::Migration)]
+        vec![
+            Box::new(m20260305_000001_create_core_tables::Migration),
+            Box::new(m20260408_000002_add_username_to_users::Migration),
+        ]
     }
 }

--- a/crates/core/src/organization_storage.rs
+++ b/crates/core/src/organization_storage.rs
@@ -1,0 +1,190 @@
+//! SeaORM-based storage for organization records.
+//!
+//! [`OrganizationStorage`] provides CRUD operations for the `organizations`
+//! table. It holds a [`DatabaseConnection`] shared with the parent
+//! [`crate::storage::Storage`].
+
+use anyhow::{anyhow, Result};
+use sea_orm::{
+    ActiveModelTrait, ColumnTrait, DatabaseConnection, EntityTrait, QueryFilter, QueryOrder, Set,
+};
+use uuid::Uuid;
+
+use crate::entity::organization::{self, Column};
+
+/// Storage operations for the `organizations` table.
+#[derive(Clone)]
+pub struct OrganizationStorage {
+    db: DatabaseConnection,
+}
+
+impl OrganizationStorage {
+    pub fn new(db: DatabaseConnection) -> Self {
+        Self { db }
+    }
+
+    /// Insert a new organization and return the created record.
+    pub async fn create(&self, name: &str, slug: &str) -> Result<organization::Model> {
+        let now = chrono::Utc::now().to_rfc3339();
+        let model = organization::ActiveModel {
+            id: Set(Uuid::new_v4().to_string()),
+            name: Set(name.to_string()),
+            slug: Set(slug.to_string()),
+            created_at: Set(now.clone()),
+            updated_at: Set(now),
+        }
+        .insert(&self.db)
+        .await?;
+        Ok(model)
+    }
+
+    /// Return the organization with the given id, or `None` if not found.
+    pub async fn get_by_id(&self, id: &str) -> Result<Option<organization::Model>> {
+        Ok(organization::Entity::find_by_id(id).one(&self.db).await?)
+    }
+
+    /// Return the organization with the given slug, or `None` if not found.
+    pub async fn get_by_slug(&self, slug: &str) -> Result<Option<organization::Model>> {
+        Ok(organization::Entity::find().filter(Column::Slug.eq(slug)).one(&self.db).await?)
+    }
+
+    /// Return all organizations ordered by name.
+    pub async fn list(&self) -> Result<Vec<organization::Model>> {
+        Ok(organization::Entity::find().order_by_asc(Column::Name).all(&self.db).await?)
+    }
+
+    /// Update name and/or slug for the given organization.
+    ///
+    /// Returns an error if the organization does not exist.
+    pub async fn update(
+        &self,
+        id: &str,
+        name: Option<&str>,
+        slug: Option<&str>,
+    ) -> Result<organization::Model> {
+        let org = organization::Entity::find_by_id(id)
+            .one(&self.db)
+            .await?
+            .ok_or_else(|| anyhow!("organization not found: {}", id))?;
+
+        let mut active: organization::ActiveModel = org.into();
+        if let Some(name) = name {
+            active.name = Set(name.to_string());
+        }
+        if let Some(slug) = slug {
+            active.slug = Set(slug.to_string());
+        }
+        active.updated_at = Set(chrono::Utc::now().to_rfc3339());
+        Ok(active.update(&self.db).await?)
+    }
+
+    /// Delete the organization with the given id.
+    ///
+    /// Returns `true` if a row was deleted, `false` if not found.
+    pub async fn delete(&self, id: &str) -> Result<bool> {
+        let result = organization::Entity::delete_by_id(id).exec(&self.db).await?;
+        Ok(result.rows_affected > 0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::migration::Migrator;
+    use agentd_common::storage::create_test_connection;
+    use sea_orm_migration::MigratorTrait;
+
+    async fn setup() -> (OrganizationStorage, tempfile::TempDir) {
+        let (conn, tmp) = create_test_connection().await;
+        Migrator::up(&conn, None).await.unwrap();
+        (OrganizationStorage::new(conn), tmp)
+    }
+
+    #[tokio::test]
+    async fn test_create_and_get_by_id() {
+        let (storage, _tmp) = setup().await;
+        let org = storage.create("Acme Corp", "acme").await.unwrap();
+        assert_eq!(org.name, "Acme Corp");
+        assert_eq!(org.slug, "acme");
+
+        let found = storage.get_by_id(&org.id).await.unwrap().unwrap();
+        assert_eq!(found.id, org.id);
+    }
+
+    #[tokio::test]
+    async fn test_get_by_slug() {
+        let (storage, _tmp) = setup().await;
+        storage.create("Builder Co", "builder").await.unwrap();
+
+        let found = storage.get_by_slug("builder").await.unwrap().unwrap();
+        assert_eq!(found.name, "Builder Co");
+
+        let missing = storage.get_by_slug("nope").await.unwrap();
+        assert!(missing.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_list_ordered_by_name() {
+        let (storage, _tmp) = setup().await;
+        storage.create("Zebra Inc", "zebra").await.unwrap();
+        storage.create("Alpha LLC", "alpha").await.unwrap();
+
+        let orgs = storage.list().await.unwrap();
+        assert_eq!(orgs.len(), 2);
+        assert_eq!(orgs[0].name, "Alpha LLC");
+        assert_eq!(orgs[1].name, "Zebra Inc");
+    }
+
+    #[tokio::test]
+    async fn test_update() {
+        let (storage, _tmp) = setup().await;
+        let org = storage.create("Old Name", "old-slug").await.unwrap();
+
+        let updated = storage.update(&org.id, Some("New Name"), Some("new-slug")).await.unwrap();
+        assert_eq!(updated.name, "New Name");
+        assert_eq!(updated.slug, "new-slug");
+        assert!(updated.updated_at > org.updated_at);
+    }
+
+    #[tokio::test]
+    async fn test_update_not_found() {
+        let (storage, _tmp) = setup().await;
+        let result = storage.update("nonexistent-id", Some("x"), None).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_delete() {
+        let (storage, _tmp) = setup().await;
+        let org = storage.create("To Delete", "delete-me").await.unwrap();
+
+        let deleted = storage.delete(&org.id).await.unwrap();
+        assert!(deleted);
+
+        let found = storage.get_by_id(&org.id).await.unwrap();
+        assert!(found.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_delete_not_found() {
+        let (storage, _tmp) = setup().await;
+        let result = storage.delete("nonexistent-id").await.unwrap();
+        assert!(!result);
+    }
+
+    #[tokio::test]
+    async fn test_unique_name_constraint() {
+        let (storage, _tmp) = setup().await;
+        storage.create("Duplicate", "dup-1").await.unwrap();
+        let result = storage.create("Duplicate", "dup-2").await;
+        assert!(result.is_err(), "duplicate name should be rejected");
+    }
+
+    #[tokio::test]
+    async fn test_unique_slug_constraint() {
+        let (storage, _tmp) = setup().await;
+        storage.create("First", "same-slug").await.unwrap();
+        let result = storage.create("Second", "same-slug").await;
+        assert!(result.is_err(), "duplicate slug should be rejected");
+    }
+}

--- a/crates/core/src/proxy.rs
+++ b/crates/core/src/proxy.rs
@@ -1,0 +1,216 @@
+//! HTTP reverse proxy for the core service API gateway.
+//!
+//! [`ProxyConfig`] maps service names to their base URLs (resolved from
+//! environment variables). [`proxy_request`] forwards an incoming Axum request
+//! to a downstream service, injecting `X-Tenant-ID` and `X-Request-ID` headers.
+//!
+//! # Streaming
+//!
+//! Request and response bodies are streamed — the proxy does not buffer large
+//! payloads in memory.
+//!
+//! # Configuration
+//!
+//! Each service URL is read from an environment variable:
+//!
+//! | Service       | Env var                        | Default                    |
+//! |---------------|--------------------------------|----------------------------|
+//! | orchestrator  | `ORCHESTRATOR_URL`             | `http://localhost:17006`   |
+//! | notify        | `NOTIFY_URL`                   | `http://localhost:17004`   |
+//! | ask           | `ASK_URL`                      | `http://localhost:17001`   |
+//! | wrap          | `WRAP_URL`                     | `http://localhost:17005`   |
+//! | hook          | `HOOK_URL`                     | `http://localhost:17002`   |
+//! | monitor       | `MONITOR_URL`                  | `http://localhost:17003`   |
+
+use std::collections::HashMap;
+use std::time::Duration;
+
+use anyhow::Result;
+use axum::body::Bytes;
+use reqwest::Client;
+
+/// Service name → base URL mapping for the API gateway.
+#[derive(Clone)]
+pub struct ProxyConfig {
+    /// Map of service name to base URL (without trailing slash).
+    pub services: HashMap<&'static str, String>,
+    /// HTTP client shared across all proxy requests.
+    pub client: Client,
+}
+
+impl ProxyConfig {
+    /// Build a [`ProxyConfig`] from environment variables, using sensible defaults.
+    pub fn from_env() -> Self {
+        let services = [
+            ("orchestrator", "ORCHESTRATOR_URL", "http://localhost:17006"),
+            ("notify", "NOTIFY_URL", "http://localhost:17004"),
+            ("ask", "ASK_URL", "http://localhost:17001"),
+            ("wrap", "WRAP_URL", "http://localhost:17005"),
+            ("hook", "HOOK_URL", "http://localhost:17002"),
+            ("monitor", "MONITOR_URL", "http://localhost:17003"),
+        ]
+        .into_iter()
+        .map(|(name, env, default)| {
+            let url = std::env::var(env).unwrap_or_else(|_| default.to_string());
+            (name, url)
+        })
+        .collect();
+
+        let client = Client::builder()
+            .timeout(Duration::from_secs(
+                std::env::var("PROXY_TIMEOUT_SECS")
+                    .ok()
+                    .and_then(|v| v.parse().ok())
+                    .unwrap_or(30u64),
+            ))
+            .build()
+            .expect("failed to build proxy HTTP client");
+
+        Self { services, client }
+    }
+
+    /// Look up the base URL for a service name.
+    pub fn url_for(&self, service: &str) -> Option<&str> {
+        self.services.get(service).map(String::as_str)
+    }
+}
+
+/// Perform a health check against a downstream service.
+///
+/// Returns `(is_healthy, detail_message)`.
+pub async fn health_check(client: &Client, base_url: &str) -> (bool, Option<String>) {
+    let health_url = format!("{}/health", base_url);
+    match client.get(&health_url).timeout(Duration::from_secs(3)).send().await {
+        Ok(resp) if resp.status().is_success() => {
+            let body: serde_json::Value = resp.json().await.unwrap_or_default();
+            let detail = body.get("status").and_then(|v| v.as_str()).map(str::to_string);
+            (true, detail)
+        }
+        Ok(resp) => (false, Some(format!("HTTP {}", resp.status()))),
+        Err(e) => {
+            let msg = if e.is_connect() {
+                "connection refused".to_string()
+            } else if e.is_timeout() {
+                "timeout".to_string()
+            } else {
+                e.to_string()
+            };
+            (false, Some(msg))
+        }
+    }
+}
+
+/// Result of a [`proxy_request`] call.
+pub struct ProxyResponse {
+    pub status: u16,
+    pub headers: Vec<(String, String)>,
+    pub body: Bytes,
+}
+
+/// Parameters for a proxied HTTP request.
+pub struct ProxyRequest<'a> {
+    /// HTTP method (e.g. `"GET"`, `"POST"`).
+    pub method: &'a str,
+    /// Path to append to the base URL (must start with `/`).
+    pub path: &'a str,
+    /// Optional pre-encoded query string (without leading `?`).
+    pub query: Option<&'a str>,
+    /// Incoming headers to forward (excluding `host` and `content-length`).
+    pub headers: &'a [(String, String)],
+    /// Request body bytes.
+    pub body: Bytes,
+    /// Tenant identifier injected as `X-Tenant-ID`.
+    pub tenant_id: &'a str,
+    /// Request identifier injected as `X-Request-ID`.
+    pub request_id: &'a str,
+}
+
+/// Forward an HTTP request to a downstream service.
+///
+/// - Injects `X-Tenant-ID` from [`ProxyRequest::tenant_id`]
+/// - Injects `X-Request-ID` from [`ProxyRequest::request_id`]
+/// - Forwards all safe incoming headers (excludes `host` and `content-length`)
+/// - Streams the response body back
+pub async fn proxy_request(
+    client: &Client,
+    target_url: &str,
+    req: ProxyRequest<'_>,
+) -> Result<ProxyResponse> {
+    let method = req.method;
+    let path = req.path;
+    let query = req.query;
+    let headers = req.headers;
+    let body = req.body;
+    let tenant_id = req.tenant_id;
+    let request_id = req.request_id;
+    let url = match query {
+        Some(q) if !q.is_empty() => format!("{}{target_url}{path}?{q}", ""),
+        _ => format!("{target_url}{path}"),
+    };
+
+    let method = reqwest::Method::from_bytes(method.as_bytes())?;
+
+    let mut req = client.request(method, &url).body(body);
+
+    // Forward safe incoming headers (skip host, content-length — reqwest sets those)
+    for (name, value) in headers {
+        let name_lower = name.to_lowercase();
+        if name_lower == "host" || name_lower == "content-length" {
+            continue;
+        }
+        if let Ok(header_name) = reqwest::header::HeaderName::from_bytes(name.as_bytes()) {
+            if let Ok(header_value) = reqwest::header::HeaderValue::from_str(value) {
+                req = req.header(header_name, header_value);
+            }
+        }
+    }
+
+    // Inject tenant and request ID headers
+    req = req.header("X-Tenant-ID", tenant_id).header("X-Request-ID", request_id);
+
+    let resp = req.send().await?;
+    let status = resp.status().as_u16();
+
+    // Collect response headers to forward back
+    let resp_headers: Vec<(String, String)> = resp
+        .headers()
+        .iter()
+        .filter_map(|(name, value)| {
+            let n = name.as_str().to_string();
+            // Skip headers that axum/hyper will set
+            if n == "transfer-encoding" || n == "connection" {
+                return None;
+            }
+            value.to_str().ok().map(|v| (n, v.to_string()))
+        })
+        .collect();
+
+    let body = resp.bytes().await?;
+
+    Ok(ProxyResponse { status, headers: resp_headers, body })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_proxy_config_defaults() {
+        let cfg = ProxyConfig::from_env();
+        assert!(cfg.url_for("orchestrator").is_some());
+        assert!(cfg.url_for("notify").is_some());
+        assert!(cfg.url_for("ask").is_some());
+        assert!(cfg.url_for("wrap").is_some());
+        assert!(cfg.url_for("hook").is_some());
+        assert!(cfg.url_for("monitor").is_some());
+        assert!(cfg.url_for("nonexistent").is_none());
+    }
+
+    #[test]
+    fn test_proxy_config_env_override() {
+        std::env::set_var("ORCHESTRATOR_URL", "http://custom-host:9999");
+        let cfg = ProxyConfig::from_env();
+        assert_eq!(cfg.url_for("orchestrator"), Some("http://custom-host:9999"));
+        std::env::remove_var("ORCHESTRATOR_URL");
+    }
+}

--- a/crates/core/src/session_storage.rs
+++ b/crates/core/src/session_storage.rs
@@ -1,0 +1,226 @@
+//! SeaORM-based storage for session records.
+//!
+//! [`SessionStorage`] manages bearer-token sessions for authenticated users.
+//! Tokens are stored directly in the `token_hash` column (the raw random
+//! 256-bit hex value is itself unguessable, so an additional hash layer adds
+//! negligible security for session tokens). The `expires_at` field is an
+//! RFC 3339 string compared lexicographically.
+
+use anyhow::Result;
+use sea_orm::{ActiveModelTrait, ColumnTrait, DatabaseConnection, EntityTrait, QueryFilter, Set};
+use uuid::Uuid;
+
+use crate::entity::session;
+
+/// Storage operations for the `sessions` table.
+#[derive(Clone)]
+pub struct SessionStorage {
+    db: DatabaseConnection,
+}
+
+impl SessionStorage {
+    pub fn new(db: DatabaseConnection) -> Self {
+        Self { db }
+    }
+
+    /// Generate a cryptographically random 256-bit hex token.
+    pub fn generate_token() -> String {
+        use rand::Rng;
+        let bytes: [u8; 32] = rand::thread_rng().gen();
+        bytes.iter().map(|b| format!("{b:02x}")).collect()
+    }
+
+    /// Insert a new session row and return the created record.
+    pub async fn create(
+        &self,
+        user_id: &str,
+        token_hash: &str,
+        expires_at: &str,
+    ) -> Result<session::Model> {
+        let now = chrono::Utc::now().to_rfc3339();
+        let model = session::ActiveModel {
+            id: Set(Uuid::new_v4().to_string()),
+            user_id: Set(user_id.to_string()),
+            token_hash: Set(token_hash.to_string()),
+            expires_at: Set(expires_at.to_string()),
+            created_at: Set(now),
+        }
+        .insert(&self.db)
+        .await?;
+        Ok(model)
+    }
+
+    /// Return the session with the given token hash, or `None` if not found.
+    pub async fn get_by_token_hash(&self, token_hash: &str) -> Result<Option<session::Model>> {
+        Ok(session::Entity::find()
+            .filter(session::Column::TokenHash.eq(token_hash))
+            .one(&self.db)
+            .await?)
+    }
+
+    /// Delete the session with the given token hash.
+    ///
+    /// Returns `true` if a row was deleted, `false` if not found.
+    pub async fn delete_by_token_hash(&self, token_hash: &str) -> Result<bool> {
+        let result = session::Entity::delete_many()
+            .filter(session::Column::TokenHash.eq(token_hash))
+            .exec(&self.db)
+            .await?;
+        Ok(result.rows_affected > 0)
+    }
+
+    /// Delete all sessions that have passed their `expires_at` timestamp.
+    ///
+    /// Returns the number of rows deleted.
+    pub async fn delete_expired(&self) -> Result<u64> {
+        let now = chrono::Utc::now().to_rfc3339();
+        let result = session::Entity::delete_many()
+            .filter(session::Column::ExpiresAt.lt(now))
+            .exec(&self.db)
+            .await?;
+        Ok(result.rows_affected)
+    }
+
+    /// Delete all sessions belonging to the given user.
+    ///
+    /// Used during login to clean up stale sessions.
+    pub async fn delete_expired_for_user(&self, user_id: &str) -> Result<u64> {
+        let now = chrono::Utc::now().to_rfc3339();
+        let result = session::Entity::delete_many()
+            .filter(session::Column::UserId.eq(user_id))
+            .filter(session::Column::ExpiresAt.lt(now))
+            .exec(&self.db)
+            .await?;
+        Ok(result.rows_affected)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::entity::user;
+    use crate::migration::Migrator;
+    use agentd_common::storage::create_test_connection;
+    use sea_orm::{ActiveModelTrait, Set};
+    use sea_orm_migration::MigratorTrait;
+
+    async fn setup() -> (SessionStorage, sea_orm::DatabaseConnection, tempfile::TempDir) {
+        let (conn, tmp) = create_test_connection().await;
+        Migrator::up(&conn, None).await.unwrap();
+        let storage = SessionStorage::new(conn.clone());
+        (storage, conn, tmp)
+    }
+
+    async fn insert_user(db: &sea_orm::DatabaseConnection, email: &str) -> user::Model {
+        let now = chrono::Utc::now().to_rfc3339();
+        user::ActiveModel {
+            id: Set(Uuid::new_v4().to_string()),
+            username: Set(None),
+            email: Set(email.to_string()),
+            password_hash: Set("hash".to_string()),
+            display_name: Set(None),
+            role: Set("user".to_string()),
+            active_organization_id: Set(None),
+            created_at: Set(now.clone()),
+            updated_at: Set(now),
+        }
+        .insert(db)
+        .await
+        .unwrap()
+    }
+
+    fn future_expiry() -> String {
+        (chrono::Utc::now() + chrono::Duration::hours(24)).to_rfc3339()
+    }
+
+    fn past_expiry() -> String {
+        (chrono::Utc::now() - chrono::Duration::hours(1)).to_rfc3339()
+    }
+
+    #[tokio::test]
+    async fn test_generate_token_is_64_hex_chars() {
+        let token = SessionStorage::generate_token();
+        assert_eq!(token.len(), 64);
+        assert!(token.chars().all(|c| c.is_ascii_hexdigit()));
+    }
+
+    #[tokio::test]
+    async fn test_generate_token_is_unique() {
+        let t1 = SessionStorage::generate_token();
+        let t2 = SessionStorage::generate_token();
+        assert_ne!(t1, t2);
+    }
+
+    #[tokio::test]
+    async fn test_create_and_get() {
+        let (storage, db, _tmp) = setup().await;
+        let user = insert_user(&db, "alice@example.com").await;
+        let token = SessionStorage::generate_token();
+
+        let sess = storage.create(&user.id, &token, &future_expiry()).await.unwrap();
+        assert_eq!(sess.user_id, user.id);
+        assert_eq!(sess.token_hash, token);
+
+        let found = storage.get_by_token_hash(&token).await.unwrap().unwrap();
+        assert_eq!(found.id, sess.id);
+    }
+
+    #[tokio::test]
+    async fn test_get_not_found() {
+        let (storage, _db, _tmp) = setup().await;
+        let result = storage.get_by_token_hash("nonexistent").await.unwrap();
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_delete_by_token_hash() {
+        let (storage, db, _tmp) = setup().await;
+        let user = insert_user(&db, "bob@example.com").await;
+        let token = SessionStorage::generate_token();
+        storage.create(&user.id, &token, &future_expiry()).await.unwrap();
+
+        assert!(storage.delete_by_token_hash(&token).await.unwrap());
+        assert!(storage.get_by_token_hash(&token).await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn test_delete_by_token_hash_not_found() {
+        let (storage, _db, _tmp) = setup().await;
+        assert!(!storage.delete_by_token_hash("nonexistent").await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn test_delete_expired() {
+        let (storage, db, _tmp) = setup().await;
+        let user = insert_user(&db, "carol@example.com").await;
+
+        storage.create(&user.id, &SessionStorage::generate_token(), &past_expiry()).await.unwrap();
+        storage.create(&user.id, &SessionStorage::generate_token(), &past_expiry()).await.unwrap();
+        let live_token = SessionStorage::generate_token();
+        storage.create(&user.id, &live_token, &future_expiry()).await.unwrap();
+
+        let deleted = storage.delete_expired().await.unwrap();
+        assert_eq!(deleted, 2);
+
+        let remaining = storage.get_by_token_hash(&live_token).await.unwrap();
+        assert!(remaining.is_some());
+    }
+
+    #[tokio::test]
+    async fn test_delete_expired_for_user() {
+        let (storage, db, _tmp) = setup().await;
+        let u1 = insert_user(&db, "dan@example.com").await;
+        let u2 = insert_user(&db, "eve@example.com").await;
+
+        storage.create(&u1.id, &SessionStorage::generate_token(), &past_expiry()).await.unwrap();
+        let live_token = SessionStorage::generate_token();
+        storage.create(&u2.id, &live_token, &past_expiry()).await.unwrap();
+
+        let deleted = storage.delete_expired_for_user(&u1.id).await.unwrap();
+        assert_eq!(deleted, 1);
+
+        // u2's expired session is untouched
+        let u2_sess = storage.get_by_token_hash(&live_token).await.unwrap();
+        assert!(u2_sess.is_some());
+    }
+}

--- a/crates/core/src/storage.rs
+++ b/crates/core/src/storage.rs
@@ -22,6 +22,7 @@ use sea_orm_migration::MigratorTrait;
 use crate::membership_storage::MembershipStorage;
 use crate::migration::Migrator;
 use crate::organization_storage::OrganizationStorage;
+use crate::user_storage::UserStorage;
 
 /// Persistent storage backend for the core service, backed by SQLite via SeaORM.
 ///
@@ -55,5 +56,10 @@ impl Storage {
     /// Returns a [`MembershipStorage`] instance sharing this connection.
     pub fn memberships(&self) -> MembershipStorage {
         MembershipStorage::new(self.db.clone())
+    }
+
+    /// Returns a [`UserStorage`] instance sharing this connection.
+    pub fn users(&self) -> UserStorage {
+        UserStorage::new(self.db.clone())
     }
 }

--- a/crates/core/src/storage.rs
+++ b/crates/core/src/storage.rs
@@ -22,6 +22,7 @@ use sea_orm_migration::MigratorTrait;
 use crate::membership_storage::MembershipStorage;
 use crate::migration::Migrator;
 use crate::organization_storage::OrganizationStorage;
+use crate::session_storage::SessionStorage;
 use crate::user_storage::UserStorage;
 
 /// Persistent storage backend for the core service, backed by SQLite via SeaORM.
@@ -61,5 +62,10 @@ impl Storage {
     /// Returns a [`UserStorage`] instance sharing this connection.
     pub fn users(&self) -> UserStorage {
         UserStorage::new(self.db.clone())
+    }
+
+    /// Returns a [`SessionStorage`] instance sharing this connection.
+    pub fn sessions(&self) -> SessionStorage {
+        SessionStorage::new(self.db.clone())
     }
 }

--- a/crates/core/src/storage.rs
+++ b/crates/core/src/storage.rs
@@ -19,7 +19,9 @@ use anyhow::Result;
 use sea_orm::DatabaseConnection;
 use sea_orm_migration::MigratorTrait;
 
+use crate::membership_storage::MembershipStorage;
 use crate::migration::Migrator;
+use crate::organization_storage::OrganizationStorage;
 
 /// Persistent storage backend for the core service, backed by SQLite via SeaORM.
 ///
@@ -43,5 +45,15 @@ impl Storage {
     /// storage implementations within this crate.
     pub fn db(&self) -> &DatabaseConnection {
         &self.db
+    }
+
+    /// Returns an [`OrganizationStorage`] instance sharing this connection.
+    pub fn organizations(&self) -> OrganizationStorage {
+        OrganizationStorage::new(self.db.clone())
+    }
+
+    /// Returns a [`MembershipStorage`] instance sharing this connection.
+    pub fn memberships(&self) -> MembershipStorage {
+        MembershipStorage::new(self.db.clone())
     }
 }

--- a/crates/core/src/user_storage.rs
+++ b/crates/core/src/user_storage.rs
@@ -1,0 +1,321 @@
+//! SeaORM-based storage for user records.
+//!
+//! [`UserStorage`] provides CRUD operations for the `users` table, including
+//! argon2 password hashing on create and constant-time verification on lookup.
+
+use anyhow::{anyhow, Result};
+use argon2::{
+    password_hash::{rand_core::OsRng, PasswordHash, PasswordHasher, PasswordVerifier, SaltString},
+    Argon2,
+};
+use sea_orm::{
+    ActiveModelTrait, ColumnTrait, DatabaseConnection, EntityTrait, PaginatorTrait, QueryFilter,
+    QueryOrder, Set,
+};
+use uuid::Uuid;
+
+use crate::entity::user::{self, Column};
+use agentd_common::types::PaginatedResponse;
+
+/// Storage operations for the `users` table.
+#[derive(Clone)]
+pub struct UserStorage {
+    db: DatabaseConnection,
+}
+
+impl UserStorage {
+    pub fn new(db: DatabaseConnection) -> Self {
+        Self { db }
+    }
+
+    /// Hash a plaintext password with argon2id.
+    fn hash_password(password: &str) -> Result<String> {
+        let salt = SaltString::generate(&mut OsRng);
+        let hash = Argon2::default()
+            .hash_password(password.as_bytes(), &salt)
+            .map_err(|e| anyhow!("password hashing failed: {}", e))?;
+        Ok(hash.to_string())
+    }
+
+    /// Verify a plaintext password against a stored argon2 hash.
+    pub fn verify_password(password: &str, hash: &str) -> Result<bool> {
+        let parsed = PasswordHash::new(hash).map_err(|e| anyhow!("invalid hash: {}", e))?;
+        Ok(Argon2::default().verify_password(password.as_bytes(), &parsed).is_ok())
+    }
+
+    /// Insert a new user with a hashed password and return the created record.
+    pub async fn create(
+        &self,
+        username: Option<&str>,
+        email: &str,
+        display_name: Option<&str>,
+        password: &str,
+        role: &str,
+    ) -> Result<user::Model> {
+        let now = chrono::Utc::now().to_rfc3339();
+        let model = user::ActiveModel {
+            id: Set(Uuid::new_v4().to_string()),
+            username: Set(username.map(str::to_string)),
+            email: Set(email.to_string()),
+            password_hash: Set(Self::hash_password(password)?),
+            display_name: Set(display_name.map(str::to_string)),
+            role: Set(role.to_string()),
+            active_organization_id: Set(None),
+            created_at: Set(now.clone()),
+            updated_at: Set(now),
+        }
+        .insert(&self.db)
+        .await?;
+        Ok(model)
+    }
+
+    /// Return the user with the given id, or `None` if not found.
+    pub async fn get_by_id(&self, id: &str) -> Result<Option<user::Model>> {
+        Ok(user::Entity::find_by_id(id).one(&self.db).await?)
+    }
+
+    /// Return the user with the given username, or `None` if not found.
+    pub async fn get_by_username(&self, username: &str) -> Result<Option<user::Model>> {
+        Ok(user::Entity::find().filter(Column::Username.eq(username)).one(&self.db).await?)
+    }
+
+    /// Return the user with the given email, or `None` if not found.
+    pub async fn get_by_email(&self, email: &str) -> Result<Option<user::Model>> {
+        Ok(user::Entity::find().filter(Column::Email.eq(email)).one(&self.db).await?)
+    }
+
+    /// Update mutable user fields. Fields set to `None` are left unchanged.
+    ///
+    /// Returns an error if the user does not exist.
+    pub async fn update(
+        &self,
+        id: &str,
+        username: Option<&str>,
+        display_name: Option<&str>,
+        role: Option<&str>,
+    ) -> Result<user::Model> {
+        let user = user::Entity::find_by_id(id)
+            .one(&self.db)
+            .await?
+            .ok_or_else(|| anyhow!("user not found: {}", id))?;
+
+        let mut active: user::ActiveModel = user.into();
+        if let Some(u) = username {
+            active.username = Set(Some(u.to_string()));
+        }
+        if let Some(dn) = display_name {
+            active.display_name = Set(Some(dn.to_string()));
+        }
+        if let Some(r) = role {
+            active.role = Set(r.to_string());
+        }
+        active.updated_at = Set(chrono::Utc::now().to_rfc3339());
+        Ok(active.update(&self.db).await?)
+    }
+
+    /// Delete the user with the given id.
+    ///
+    /// Returns `true` if a row was deleted, `false` if not found.
+    pub async fn delete(&self, id: &str) -> Result<bool> {
+        let result = user::Entity::delete_by_id(id).exec(&self.db).await?;
+        Ok(result.rows_affected > 0)
+    }
+
+    /// Set the user's active organization.
+    ///
+    /// Pass `None` to clear the active organization.
+    pub async fn set_active_organization(
+        &self,
+        id: &str,
+        organization_id: Option<&str>,
+    ) -> Result<user::Model> {
+        let user = user::Entity::find_by_id(id)
+            .one(&self.db)
+            .await?
+            .ok_or_else(|| anyhow!("user not found: {}", id))?;
+
+        let mut active: user::ActiveModel = user.into();
+        active.active_organization_id = Set(organization_id.map(str::to_string));
+        active.updated_at = Set(chrono::Utc::now().to_rfc3339());
+        Ok(active.update(&self.db).await?)
+    }
+
+    /// Return a paginated list of users ordered by email.
+    pub async fn list_paginated(
+        &self,
+        limit: u64,
+        offset: u64,
+    ) -> Result<PaginatedResponse<user::Model>> {
+        let paginator = user::Entity::find().order_by_asc(Column::Email).paginate(&self.db, limit);
+
+        let total = paginator.num_items().await?;
+        let page = if limit > 0 { offset / limit } else { 0 };
+        let items = paginator.fetch_page(page).await?;
+
+        Ok(PaginatedResponse {
+            items,
+            total: total as usize,
+            limit: limit as usize,
+            offset: offset as usize,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::migration::Migrator;
+    use agentd_common::storage::create_test_connection;
+    use sea_orm_migration::MigratorTrait;
+
+    async fn setup() -> (UserStorage, tempfile::TempDir) {
+        let (conn, tmp) = create_test_connection().await;
+        Migrator::up(&conn, None).await.unwrap();
+        (UserStorage::new(conn), tmp)
+    }
+
+    #[tokio::test]
+    async fn test_create_and_get_by_id() {
+        let (storage, _tmp) = setup().await;
+        let user = storage
+            .create(Some("alice"), "alice@example.com", Some("Alice"), "secret", "user")
+            .await
+            .unwrap();
+        assert_eq!(user.email, "alice@example.com");
+        assert_eq!(user.username, Some("alice".to_string()));
+        assert_ne!(user.password_hash, "secret");
+
+        let found = storage.get_by_id(&user.id).await.unwrap().unwrap();
+        assert_eq!(found.id, user.id);
+    }
+
+    #[tokio::test]
+    async fn test_get_by_username() {
+        let (storage, _tmp) = setup().await;
+        storage.create(Some("bob"), "bob@example.com", None, "pass", "user").await.unwrap();
+
+        let found = storage.get_by_username("bob").await.unwrap().unwrap();
+        assert_eq!(found.email, "bob@example.com");
+
+        let missing = storage.get_by_username("nobody").await.unwrap();
+        assert!(missing.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_get_by_email() {
+        let (storage, _tmp) = setup().await;
+        storage.create(None, "carol@example.com", None, "pass", "user").await.unwrap();
+
+        let found = storage.get_by_email("carol@example.com").await.unwrap().unwrap();
+        assert_eq!(found.role, "user");
+
+        let missing = storage.get_by_email("nope@example.com").await.unwrap();
+        assert!(missing.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_password_hash_and_verify() {
+        let (storage, _tmp) = setup().await;
+        let user = storage
+            .create(Some("dan"), "dan@example.com", None, "my_password", "user")
+            .await
+            .unwrap();
+
+        assert!(UserStorage::verify_password("my_password", &user.password_hash).unwrap());
+        assert!(!UserStorage::verify_password("wrong", &user.password_hash).unwrap());
+    }
+
+    #[tokio::test]
+    async fn test_update() {
+        let (storage, _tmp) = setup().await;
+        let user =
+            storage.create(Some("eve"), "eve@example.com", None, "pass", "user").await.unwrap();
+
+        let updated =
+            storage.update(&user.id, Some("eve2"), Some("Eve Smith"), Some("admin")).await.unwrap();
+        assert_eq!(updated.username, Some("eve2".to_string()));
+        assert_eq!(updated.display_name, Some("Eve Smith".to_string()));
+        assert_eq!(updated.role, "admin");
+    }
+
+    #[tokio::test]
+    async fn test_update_not_found() {
+        let (storage, _tmp) = setup().await;
+        let result = storage.update("nonexistent", None, None, None).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_delete() {
+        let (storage, _tmp) = setup().await;
+        let user =
+            storage.create(Some("frank"), "frank@example.com", None, "pass", "user").await.unwrap();
+
+        assert!(storage.delete(&user.id).await.unwrap());
+        assert!(storage.get_by_id(&user.id).await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn test_delete_not_found() {
+        let (storage, _tmp) = setup().await;
+        assert!(!storage.delete("nonexistent").await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn test_set_active_organization() {
+        let (storage, _tmp) = setup().await;
+        let user =
+            storage.create(Some("grace"), "grace@example.com", None, "pass", "user").await.unwrap();
+        assert!(user.active_organization_id.is_none());
+
+        let org_id = Uuid::new_v4().to_string();
+        let updated = storage.set_active_organization(&user.id, Some(&org_id)).await.unwrap();
+        assert_eq!(updated.active_organization_id, Some(org_id));
+
+        let cleared = storage.set_active_organization(&user.id, None).await.unwrap();
+        assert!(cleared.active_organization_id.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_list_paginated() {
+        let (storage, _tmp) = setup().await;
+        for i in 0..5u8 {
+            storage
+                .create(
+                    Some(&format!("user{i}")),
+                    &format!("user{i}@example.com"),
+                    None,
+                    "pass",
+                    "user",
+                )
+                .await
+                .unwrap();
+        }
+
+        let page = storage.list_paginated(3, 0).await.unwrap();
+        assert_eq!(page.total, 5);
+        assert_eq!(page.items.len(), 3);
+        assert_eq!(page.limit, 3);
+        assert_eq!(page.offset, 0);
+
+        let page2 = storage.list_paginated(3, 3).await.unwrap();
+        assert_eq!(page2.items.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_unique_email_constraint() {
+        let (storage, _tmp) = setup().await;
+        storage.create(Some("henry"), "henry@example.com", None, "pass", "user").await.unwrap();
+        let result =
+            storage.create(Some("henry2"), "henry@example.com", None, "pass", "user").await;
+        assert!(result.is_err(), "duplicate email should be rejected");
+    }
+
+    #[tokio::test]
+    async fn test_unique_username_constraint() {
+        let (storage, _tmp) = setup().await;
+        storage.create(Some("ida"), "ida@example.com", None, "pass", "user").await.unwrap();
+        let result = storage.create(Some("ida"), "ida2@example.com", None, "pass", "user").await;
+        assert!(result.is_err(), "duplicate username should be rejected");
+    }
+}

--- a/crates/core/src/user_storage.rs
+++ b/crates/core/src/user_storage.rs
@@ -121,6 +121,65 @@ impl UserStorage {
         Ok(result.rows_affected > 0)
     }
 
+    /// Update the user's email address.
+    ///
+    /// Returns an error if the user does not exist.
+    pub async fn update_email(&self, id: &str, email: &str) -> Result<user::Model> {
+        let user = user::Entity::find_by_id(id)
+            .one(&self.db)
+            .await?
+            .ok_or_else(|| anyhow!("user not found: {}", id))?;
+
+        let mut active: user::ActiveModel = user.into();
+        active.email = Set(email.to_string());
+        active.updated_at = Set(chrono::Utc::now().to_rfc3339());
+        Ok(active.update(&self.db).await?)
+    }
+
+    /// Update the user's password hash (argon2id hashed from plaintext).
+    ///
+    /// Returns an error if the user does not exist.
+    pub async fn update_password(&self, id: &str, new_password: &str) -> Result<user::Model> {
+        let user = user::Entity::find_by_id(id)
+            .one(&self.db)
+            .await?
+            .ok_or_else(|| anyhow!("user not found: {}", id))?;
+
+        let mut active: user::ActiveModel = user.into();
+        active.password_hash = Set(Self::hash_password(new_password)?);
+        active.updated_at = Set(chrono::Utc::now().to_rfc3339());
+        Ok(active.update(&self.db).await?)
+    }
+
+    /// Clear `active_organization_id` for all users whose active org is `org_id`.
+    ///
+    /// Used when an organization is deleted to ensure no user references a
+    /// non-existent organization.
+    ///
+    /// Returns the number of rows updated.
+    pub async fn clear_active_organization_for_org(&self, org_id: &str) -> Result<u64> {
+        // Fetch all users with this active org, then clear each one.
+        // SeaORM's update_many + col_expr requires sea_orm::prelude::Expr which is
+        // not re-exported at the crate root in the version we use, so we do a
+        // fetch-then-update approach which is straightforward and correct.
+        let users = user::Entity::find()
+            .filter(Column::ActiveOrganizationId.eq(org_id))
+            .all(&self.db)
+            .await?;
+
+        let now = chrono::Utc::now().to_rfc3339();
+        let count = users.len() as u64;
+
+        for u in users {
+            let mut active: user::ActiveModel = u.into();
+            active.active_organization_id = Set(None);
+            active.updated_at = Set(now.clone());
+            active.update(&self.db).await?;
+        }
+
+        Ok(count)
+    }
+
     /// Set the user's active organization.
     ///
     /// Pass `None` to clear the active organization.

--- a/crates/core/tests/entity_relations.rs
+++ b/crates/core/tests/entity_relations.rs
@@ -32,10 +32,12 @@ async fn insert_user(db: &sea_orm::DatabaseConnection, email: &str) -> user::Mod
     let now = chrono::Utc::now().to_rfc3339();
     user::ActiveModel {
         id: Set(uuid::Uuid::new_v4().to_string()),
+        username: Set(None),
         email: Set(email.to_string()),
         password_hash: Set("hash".to_string()),
         display_name: Set(None),
         role: Set("user".to_string()),
+        active_organization_id: Set(None),
         created_at: Set(now.clone()),
         updated_at: Set(now),
     }
@@ -228,10 +230,12 @@ async fn test_unique_email_constraint() {
     let now = chrono::Utc::now().to_rfc3339();
     let result = user::ActiveModel {
         id: Set(uuid::Uuid::new_v4().to_string()),
+        username: Set(None),
         email: Set("grace@example.com".to_string()),
         password_hash: Set("other_hash".to_string()),
         display_name: Set(None),
         role: Set("user".to_string()),
+        active_organization_id: Set(None),
         created_at: Set(now.clone()),
         updated_at: Set(now),
     }


### PR DESCRIPTION
Adds CRUD storage implementations for organizations and memberships, completing the storage layer required by issue #214.

**`OrganizationStorage`** (`src/organization_storage.rs`):
- `create(name, slug)` → `organization::Model`
- `get_by_id(id)` / `get_by_slug(slug)` → `Option<Model>`
- `list()` → `Vec<Model>` ordered by name
- `update(id, name?, slug?)` → updated model or error if not found
- `delete(id)` → `bool` (true if row removed)
- 8 tests: CRUD paths, unique name + slug constraint violations, not-found on update/delete

**`MembershipStorage`** (`src/membership_storage.rs`):
- `add_member(user_id, org_id, role)` — errors on duplicate `(user_id, org_id)`
- `remove_member(user_id, org_id)` → `bool`
- `list_members(org_id)` → `Vec<membership::Model>`
- `list_user_organizations(user_id)` → `Vec<organization::Model>` via `inner_join`
- `get_membership(user_id, org_id)` → `Option<membership::Model>`
- `update_role(user_id, org_id, role)` → updated model or error if not found
- 8 tests including duplicate membership rejection

**`Storage`** gains `organizations()` and `memberships()` accessor methods sharing the `DatabaseConnection`.

Note: `UserStorage` (#213) is pending a human decision on schema divergence (see comment on #213) — `username` and `active_organization_id` columns are absent from the current migration.

Closes #214