### PR TITLE
feat(core): add TenantContext middleware and active organization endpoint

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1073,6 +1073,7 @@ dependencies = [
  "communicate",
  "crossterm",
  "dialoguer",
+ "dirs 5.0.1",
  "futures-util",
  "hook",
  "memory",
@@ -2250,7 +2251,16 @@ version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16f5094c54661b38d03bd7e50df373292118db60b585c08a411c6d840017fe7d"
 dependencies = [
- "dirs-sys",
+ "dirs-sys 0.5.0",
+]
+
+[[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys 0.4.1",
 ]
 
 [[package]]
@@ -2259,7 +2269,7 @@ version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
 dependencies = [
- "dirs-sys",
+ "dirs-sys 0.5.0",
 ]
 
 [[package]]
@@ -2270,6 +2280,18 @@ checksum = "b98cf8ebf19c3d1b223e151f99a4f9f0690dca41414773390fc824184ac833e1"
 dependencies = [
  "cfg-if",
  "dirs-sys-next",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users 0.4.6",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3815,7 +3837,7 @@ dependencies = [
  "datafusion-physical-expr",
  "datafusion-sql",
  "deepsize",
- "dirs",
+ "dirs 6.0.0",
  "fst",
  "futures",
  "half",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,6 +47,7 @@ dependencies = [
  "metrics",
  "metrics-exporter-prometheus",
  "rand 0.8.5",
+ "reqwest",
  "sea-orm",
  "sea-orm-migration",
  "serde",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -27,6 +27,7 @@ bytes = "1"
 serde_yaml = "0.9"
 urlencoding = "2.1"
 dialoguer = "0.11"
+dirs = "5"
 
 # Internal dependencies
 notify = { path = "../notify" }

--- a/crates/cli/src/commands/auth.rs
+++ b/crates/cli/src/commands/auth.rs
@@ -1,0 +1,432 @@
+//! Authentication command implementations.
+//!
+//! Provides CLI subcommands for interacting with the agentd-core authentication
+//! endpoints. The session token is stored at `~/.config/agentd/session` with
+//! file permissions restricted to 0600 (owner read/write only).
+//!
+//! # Available Commands
+//!
+//! - **register** — Create a new account (prompts for username, email, password)
+//! - **login**    — Authenticate with username or email + password
+//! - **logout**   — Invalidate the current session token
+//! - **status**   — Show currently logged-in user and active organization
+//!
+//! # Examples
+//!
+//! ```bash
+//! agent auth register
+//! agent auth login
+//! agent auth logout
+//! agent auth status
+//! ```
+
+use anyhow::{Context, Result};
+use clap::Subcommand;
+use colored::*;
+use dialoguer::{Input, Password};
+use serde::{Deserialize, Serialize};
+use std::fs;
+use std::path::PathBuf;
+
+// ---------------------------------------------------------------------------
+// Session storage helpers
+// ---------------------------------------------------------------------------
+
+/// Returns the path to the session token file: `~/.config/agentd/session`.
+pub fn session_path() -> Result<PathBuf> {
+    let config_dir = dirs::config_dir().context("cannot determine config directory")?;
+    Ok(config_dir.join("agentd").join("session"))
+}
+
+/// Load the session token from disk. Returns `None` if not found.
+pub fn load_token() -> Option<String> {
+    let path = session_path().ok()?;
+    fs::read_to_string(&path).ok().map(|s| s.trim().to_string()).filter(|s| !s.is_empty())
+}
+
+/// Persist the session token to `~/.config/agentd/session` with 0600 permissions.
+pub fn save_token(token: &str) -> Result<()> {
+    let path = session_path()?;
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent)
+            .with_context(|| format!("failed to create config dir: {}", parent.display()))?;
+    }
+    fs::write(&path, token)
+        .with_context(|| format!("failed to write session file: {}", path.display()))?;
+
+    // Restrict permissions to owner read/write (0600) on Unix
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        fs::set_permissions(&path, fs::Permissions::from_mode(0o600))
+            .with_context(|| format!("failed to set permissions on: {}", path.display()))?;
+    }
+
+    Ok(())
+}
+
+/// Remove the session token from disk.
+pub fn clear_token() -> Result<()> {
+    let path = session_path()?;
+    if path.exists() {
+        fs::remove_file(&path)
+            .with_context(|| format!("failed to remove session file: {}", path.display()))?;
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// HTTP client helpers
+// ---------------------------------------------------------------------------
+
+fn core_base_url() -> String {
+    std::env::var("AGENTD_CORE_SERVICE_URL")
+        .unwrap_or_else(|_| "http://localhost:17007".to_string())
+}
+
+async fn post_json<B: Serialize, T: for<'de> Deserialize<'de>>(
+    path: &str,
+    body: &B,
+    token: Option<&str>,
+) -> Result<T> {
+    let url = format!("{}{}", core_base_url(), path);
+    let client = reqwest::Client::new();
+    let mut req = client.post(&url).json(body);
+    if let Some(t) = token {
+        req = req.bearer_auth(t);
+    }
+    let resp = req.send().await.with_context(|| format!("POST {url}"))?;
+    let status = resp.status();
+    if !status.is_success() {
+        let body: serde_json::Value = resp.json().await.unwrap_or_default();
+        let msg = body["error"].as_str().unwrap_or("unknown error");
+        anyhow::bail!("HTTP {}: {}", status, msg);
+    }
+    resp.json().await.context("deserializing response")
+}
+
+async fn get_json<T: for<'de> Deserialize<'de>>(path: &str, token: &str) -> Result<T> {
+    let url = format!("{}{}", core_base_url(), path);
+    let resp = reqwest::Client::new()
+        .get(&url)
+        .bearer_auth(token)
+        .send()
+        .await
+        .with_context(|| format!("GET {url}"))?;
+    let status = resp.status();
+    if !status.is_success() {
+        let body: serde_json::Value = resp.json().await.unwrap_or_default();
+        let msg = body["error"].as_str().unwrap_or("unknown error");
+        anyhow::bail!("HTTP {}: {}", status, msg);
+    }
+    resp.json().await.context("deserializing response")
+}
+
+// ---------------------------------------------------------------------------
+// Response types (mirrors core service API)
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize, Serialize)]
+struct UserResponse {
+    id: String,
+    username: Option<String>,
+    email: String,
+    display_name: Option<String>,
+    role: String,
+    active_organization_id: Option<String>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct OrgResponse {
+    id: String,
+    name: String,
+    slug: String,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct LoginResponse {
+    token: String,
+    user: UserResponse,
+    active_organization: Option<OrgResponse>,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct MeResponse {
+    user: UserResponse,
+    active_organization: Option<OrgResponse>,
+}
+
+// ---------------------------------------------------------------------------
+// Command definition
+// ---------------------------------------------------------------------------
+
+/// Subcommands for authentication with the core service.
+#[derive(Debug, Subcommand)]
+pub enum AuthCommand {
+    /// Create a new agentd account.
+    ///
+    /// Prompts for username, email, optional display name, and password
+    /// (with confirmation). Creates a default personal organization and
+    /// stores the session token for subsequent commands.
+    ///
+    /// # Examples
+    ///
+    /// ```bash
+    /// agent auth register
+    /// ```
+    Register,
+
+    /// Log in to agentd.
+    ///
+    /// Accepts username or email with password. Stores the session token
+    /// at `~/.config/agentd/session` for use by other commands.
+    ///
+    /// # Examples
+    ///
+    /// ```bash
+    /// agent auth login
+    /// agent auth login --username alice
+    /// agent auth login --email alice@example.com
+    /// ```
+    Login {
+        /// Login by username (optional — prompted if neither flag is given)
+        #[arg(long)]
+        username: Option<String>,
+        /// Login by email
+        #[arg(long)]
+        email: Option<String>,
+    },
+
+    /// Log out of agentd.
+    ///
+    /// Calls the logout endpoint to invalidate the session token on the
+    /// server, then removes the local token file.
+    ///
+    /// # Examples
+    ///
+    /// ```bash
+    /// agent auth logout
+    /// ```
+    Logout,
+
+    /// Show current authentication status.
+    ///
+    /// Displays the logged-in user and active organization if a valid
+    /// session token is found.
+    ///
+    /// # Examples
+    ///
+    /// ```bash
+    /// agent auth status
+    /// ```
+    Status,
+}
+
+impl AuthCommand {
+    pub async fn execute(&self, json: bool) -> Result<()> {
+        match self {
+            AuthCommand::Register => register_cmd(json).await,
+            AuthCommand::Login { username, email } => {
+                login_cmd(username.as_deref(), email.as_deref(), json).await
+            }
+            AuthCommand::Logout => logout_cmd(json).await,
+            AuthCommand::Status => status_cmd(json).await,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Handlers
+// ---------------------------------------------------------------------------
+
+async fn register_cmd(json: bool) -> Result<()> {
+    let username: String =
+        Input::new().with_prompt("Username").interact_text().context("reading username")?;
+    let email: String =
+        Input::new().with_prompt("Email").interact_text().context("reading email")?;
+    let display_name: String = Input::new()
+        .with_prompt("Display name (optional, press Enter to skip)")
+        .allow_empty(true)
+        .interact_text()
+        .context("reading display name")?;
+    let password = Password::new()
+        .with_prompt("Password")
+        .with_confirmation("Confirm password", "Passwords do not match")
+        .interact()
+        .context("reading password")?;
+
+    #[derive(Serialize)]
+    struct RegisterReq<'a> {
+        username: &'a str,
+        email: &'a str,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        display_name: Option<&'a str>,
+        password: &'a str,
+    }
+
+    let dn = if display_name.is_empty() { None } else { Some(display_name.as_str()) };
+    let resp: LoginResponse = post_json(
+        "/auth/register",
+        &RegisterReq { username: &username, email: &email, display_name: dn, password: &password },
+        None,
+    )
+    .await?;
+
+    save_token(&resp.token)?;
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&resp.user).unwrap_or_default());
+        return Ok(());
+    }
+
+    println!("{}", "✅ Account created and logged in".green().bold());
+    print_user_info(&resp.user, resp.active_organization.as_ref());
+    Ok(())
+}
+
+async fn login_cmd(username: Option<&str>, email: Option<&str>, json: bool) -> Result<()> {
+    #[derive(Serialize)]
+    struct LoginReq<'a> {
+        #[serde(skip_serializing_if = "Option::is_none")]
+        username: Option<&'a str>,
+        #[serde(skip_serializing_if = "Option::is_none")]
+        email: Option<&'a str>,
+        password: &'a str,
+    }
+
+    // Determine identifier
+    let (resolved_username, resolved_email) = if username.is_some() || email.is_some() {
+        (username.map(str::to_string), email.map(str::to_string))
+    } else {
+        let input: String = Input::new()
+            .with_prompt("Username or email")
+            .interact_text()
+            .context("reading identifier")?;
+        if input.contains('@') {
+            (None, Some(input))
+        } else {
+            (Some(input), None)
+        }
+    };
+
+    let password =
+        Password::new().with_prompt("Password").interact().context("reading password")?;
+
+    let resp: LoginResponse = post_json(
+        "/auth/login",
+        &LoginReq {
+            username: resolved_username.as_deref(),
+            email: resolved_email.as_deref(),
+            password: &password,
+        },
+        None,
+    )
+    .await?;
+
+    save_token(&resp.token)?;
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&resp.user).unwrap_or_default());
+        return Ok(());
+    }
+
+    println!("{}", "✅ Logged in".green().bold());
+    print_user_info(&resp.user, resp.active_organization.as_ref());
+    Ok(())
+}
+
+async fn logout_cmd(json: bool) -> Result<()> {
+    let token = load_token().context("not logged in — no session token found")?;
+
+    #[derive(Serialize)]
+    struct Empty {}
+
+    // Best-effort server-side invalidation
+    let result: Result<serde_json::Value> =
+        post_json("/auth/logout", &Empty {}, Some(&token)).await;
+    if let Err(e) = result {
+        eprintln!("{} server logout failed: {}", "⚠".yellow(), e);
+    }
+
+    clear_token()?;
+
+    if json {
+        println!("{}", serde_json::json!({ "status": "logged_out" }));
+        return Ok(());
+    }
+
+    println!("{}", "✅ Logged out".green().bold());
+    Ok(())
+}
+
+async fn status_cmd(json: bool) -> Result<()> {
+    let token = match load_token() {
+        Some(t) => t,
+        None => {
+            if json {
+                println!("{}", serde_json::json!({ "status": "unauthenticated" }));
+            } else {
+                println!("{}", "Not logged in".yellow());
+            }
+            return Ok(());
+        }
+    };
+
+    let resp: MeResponse =
+        get_json("/auth/me", &token).await.context("failed to fetch session info")?;
+
+    if json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(&serde_json::json!({
+                "user": {
+                    "id": resp.user.id,
+                    "username": resp.user.username,
+                    "email": resp.user.email,
+                    "display_name": resp.user.display_name,
+                    "role": resp.user.role,
+                    "active_organization_id": resp.user.active_organization_id,
+                },
+                "active_organization": resp.active_organization.as_ref().map(|o| serde_json::json!({
+                    "id": o.id,
+                    "name": o.name,
+                    "slug": o.slug,
+                })),
+            }))
+            .unwrap_or_default()
+        );
+        return Ok(());
+    }
+
+    println!("{}", "Auth Status".blue().bold());
+    println!("{}", "─".repeat(40).cyan());
+    print_user_info(&resp.user, resp.active_organization.as_ref());
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Display helpers
+// ---------------------------------------------------------------------------
+
+fn print_user_info(user: &UserResponse, org: Option<&OrgResponse>) {
+    println!(
+        "  {}  {}",
+        "User:".bright_black(),
+        user.username.as_deref().unwrap_or(&user.email).cyan().bold()
+    );
+    println!("  {}  {}", "Email:".bright_black(), user.email);
+    if let Some(dn) = &user.display_name {
+        println!("  {}  {}", "Name:".bright_black(), dn);
+    }
+    println!("  {}  {}", "Role:".bright_black(), user.role.yellow());
+    if let Some(o) = org {
+        println!(
+            "  {}  {} {}",
+            "Active org:".bright_black(),
+            o.name.green().bold(),
+            format!("({})", o.slug).bright_black()
+        );
+    } else {
+        println!("  {}  {}", "Active org:".bright_black(), "none".bright_black());
+    }
+}

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -30,19 +30,23 @@
 
 pub mod apply;
 pub mod ask;
+pub mod auth;
 pub mod communicate;
 pub mod index;
 pub mod memory;
 pub mod notify;
 pub mod orchestrator;
+pub mod org;
 pub mod prompt;
 pub mod wrap;
 
 pub use ask::AskCommand;
+pub use auth::AuthCommand;
 pub use communicate::CommunicateCommand;
 pub use index::IndexCommand;
 pub use memory::MemoryCommand;
 pub use notify::NotifyCommand;
 pub use orchestrator::OrchestratorCommand;
+pub use org::OrgCommand;
 pub use prompt::PromptCommand;
 pub use wrap::WrapCommand;

--- a/crates/cli/src/commands/org.rs
+++ b/crates/cli/src/commands/org.rs
@@ -1,0 +1,288 @@
+//! Organization management command implementations.
+//!
+//! Provides CLI subcommands for managing agentd organizations via the core service.
+//! All commands require a valid session token (stored by `agent auth login`).
+//!
+//! # Available Commands
+//!
+//! - **list**   — List all organizations the current user belongs to
+//! - **create** — Create a new organization
+//! - **switch** — Set the active organization by name or ID
+//!
+//! # Examples
+//!
+//! ```bash
+//! agent org list
+//! agent org create "Acme Corp" --slug acme-corp
+//! agent org switch acme-corp
+//! ```
+
+use anyhow::{Context, Result};
+use clap::Subcommand;
+use colored::*;
+use serde::{Deserialize, Serialize};
+
+use super::auth::load_token;
+
+// ---------------------------------------------------------------------------
+// HTTP helpers (mirrors auth.rs but for org endpoints)
+// ---------------------------------------------------------------------------
+
+fn core_base_url() -> String {
+    std::env::var("AGENTD_CORE_SERVICE_URL")
+        .unwrap_or_else(|_| "http://localhost:17007".to_string())
+}
+
+async fn get_json_auth<T: for<'de> Deserialize<'de>>(path: &str, token: &str) -> Result<T> {
+    let url = format!("{}{}", core_base_url(), path);
+    let resp = reqwest::Client::new()
+        .get(&url)
+        .bearer_auth(token)
+        .send()
+        .await
+        .with_context(|| format!("GET {url}"))?;
+    let status = resp.status();
+    if !status.is_success() {
+        let body: serde_json::Value = resp.json().await.unwrap_or_default();
+        let msg = body["error"].as_str().unwrap_or("unknown error");
+        anyhow::bail!("HTTP {}: {}", status, msg);
+    }
+    resp.json().await.context("deserializing response")
+}
+
+async fn post_json_auth<B: Serialize, T: for<'de> Deserialize<'de>>(
+    path: &str,
+    body: &B,
+    token: &str,
+) -> Result<T> {
+    let url = format!("{}{}", core_base_url(), path);
+    let resp = reqwest::Client::new()
+        .post(&url)
+        .bearer_auth(token)
+        .json(body)
+        .send()
+        .await
+        .with_context(|| format!("POST {url}"))?;
+    let status = resp.status();
+    if !status.is_success() {
+        let body: serde_json::Value = resp.json().await.unwrap_or_default();
+        let msg = body["error"].as_str().unwrap_or("unknown error");
+        anyhow::bail!("HTTP {}: {}", status, msg);
+    }
+    resp.json().await.context("deserializing response")
+}
+
+async fn put_json_auth<B: Serialize, T: for<'de> Deserialize<'de>>(
+    path: &str,
+    body: &B,
+    token: &str,
+) -> Result<T> {
+    let url = format!("{}{}", core_base_url(), path);
+    let resp = reqwest::Client::new()
+        .put(&url)
+        .bearer_auth(token)
+        .json(body)
+        .send()
+        .await
+        .with_context(|| format!("PUT {url}"))?;
+    let status = resp.status();
+    if !status.is_success() {
+        let body: serde_json::Value = resp.json().await.unwrap_or_default();
+        let msg = body["error"].as_str().unwrap_or("unknown error");
+        anyhow::bail!("HTTP {}: {}", status, msg);
+    }
+    resp.json().await.context("deserializing response")
+}
+
+// ---------------------------------------------------------------------------
+// Response types
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize, Serialize)]
+struct OrgResponse {
+    id: String,
+    name: String,
+    slug: String,
+    created_at: String,
+    updated_at: String,
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+struct UserProfileResponse {
+    id: String,
+    username: Option<String>,
+    email: String,
+    active_organization_id: Option<String>,
+}
+
+// ---------------------------------------------------------------------------
+// Command definition
+// ---------------------------------------------------------------------------
+
+/// Subcommands for organization management.
+#[derive(Debug, Subcommand)]
+pub enum OrgCommand {
+    /// List all organizations you belong to.
+    ///
+    /// Requires an active session (run `agent auth login` first).
+    ///
+    /// # Examples
+    ///
+    /// ```bash
+    /// agent org list
+    /// agent org list --json
+    /// ```
+    List,
+
+    /// Create a new organization.
+    ///
+    /// You become the owner of the new organization. The `--slug` flag is
+    /// optional — if omitted it is derived from `name` by lowercasing and
+    /// replacing spaces with hyphens.
+    ///
+    /// # Examples
+    ///
+    /// ```bash
+    /// agent org create "Acme Corp"
+    /// agent org create "Acme Corp" --slug acme-corp
+    /// ```
+    Create {
+        /// Organization display name
+        name: String,
+        /// URL-safe slug (derived from name if omitted)
+        #[arg(long)]
+        slug: Option<String>,
+    },
+
+    /// Switch your active organization.
+    ///
+    /// Accepts an organization name or ID. The active organization is used
+    /// by the API gateway to scope requests to the correct tenant.
+    ///
+    /// # Examples
+    ///
+    /// ```bash
+    /// agent org switch acme-corp
+    /// agent org switch "Acme Corp"
+    /// ```
+    Switch {
+        /// Organization name or ID to switch to
+        name_or_id: String,
+    },
+}
+
+impl OrgCommand {
+    pub async fn execute(&self, json: bool) -> Result<()> {
+        match self {
+            OrgCommand::List => list_cmd(json).await,
+            OrgCommand::Create { name, slug } => create_cmd(name, slug.as_deref(), json).await,
+            OrgCommand::Switch { name_or_id } => switch_cmd(name_or_id, json).await,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Handlers
+// ---------------------------------------------------------------------------
+
+async fn list_cmd(json: bool) -> Result<()> {
+    let token = load_token().context("not logged in — run `agent auth login` first")?;
+    let orgs: Vec<OrgResponse> = get_json_auth("/api/v1/users/me/organizations", &token).await?;
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&orgs).unwrap_or_default());
+        return Ok(());
+    }
+
+    if orgs.is_empty() {
+        println!("{}", "No organizations found.".yellow());
+        return Ok(());
+    }
+
+    println!("{}", "Organizations".blue().bold());
+    println!("{}", "─".repeat(50).cyan());
+    for org in &orgs {
+        println!("  {} {}", org.name.cyan().bold(), format!("({})", org.slug).bright_black());
+        println!("    ID: {}", org.id.bright_black());
+    }
+    println!("\n  {} organizations", orgs.len().to_string().green().bold());
+    Ok(())
+}
+
+async fn create_cmd(name: &str, slug: Option<&str>, json: bool) -> Result<()> {
+    let token = load_token().context("not logged in — run `agent auth login` first")?;
+
+    // Derive slug from name if not provided
+    let derived_slug: String;
+    let slug = match slug {
+        Some(s) => s,
+        None => {
+            derived_slug = name
+                .chars()
+                .map(|c| if c.is_alphanumeric() { c.to_ascii_lowercase() } else { '-' })
+                .collect::<String>()
+                .trim_matches('-')
+                .to_string();
+            &derived_slug
+        }
+    };
+
+    #[derive(Serialize)]
+    struct CreateOrgReq<'a> {
+        name: &'a str,
+        slug: &'a str,
+    }
+
+    let org: OrgResponse =
+        post_json_auth("/api/v1/organizations", &CreateOrgReq { name, slug }, &token).await?;
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&org).unwrap_or_default());
+        return Ok(());
+    }
+
+    println!("{}", "✅ Organization created".green().bold());
+    println!("  {}  {}", "Name:".bright_black(), org.name.cyan().bold());
+    println!("  {}  {}", "Slug:".bright_black(), org.slug);
+    println!("  {}  {}", "ID:".bright_black(), org.id.bright_black());
+    Ok(())
+}
+
+async fn switch_cmd(name_or_id: &str, json: bool) -> Result<()> {
+    let token = load_token().context("not logged in — run `agent auth login` first")?;
+
+    // Fetch all orgs the user belongs to, then find by name or ID
+    let orgs: Vec<OrgResponse> = get_json_auth("/api/v1/users/me/organizations", &token).await?;
+
+    let target = orgs
+        .iter()
+        .find(|o| o.id == name_or_id || o.name == name_or_id || o.slug == name_or_id)
+        .with_context(|| {
+            format!(
+                "organization '{}' not found — use `agent org list` to see your organizations",
+                name_or_id
+            )
+        })?;
+
+    #[derive(Serialize)]
+    struct SwitchReq<'a> {
+        organization_id: &'a str,
+    }
+
+    let updated: UserProfileResponse = put_json_auth(
+        "/users/me/active-organization",
+        &SwitchReq { organization_id: &target.id },
+        &token,
+    )
+    .await?;
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&updated).unwrap_or_default());
+        return Ok(());
+    }
+
+    println!("{} Switched to {}", "✅".green(), target.name.cyan().bold());
+    println!("  {}  {}", "Slug:".bright_black(), target.slug);
+    println!("  {}  {}", "ID:".bright_black(), target.id.bright_black());
+    Ok(())
+}

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -83,8 +83,8 @@ use clap_complete::Shell;
 use colored::*;
 use commands::index::IndexClient;
 use commands::{
-    AskCommand, CommunicateCommand, IndexCommand, MemoryCommand, NotifyCommand,
-    OrchestratorCommand, PromptCommand, WrapCommand,
+    AskCommand, AuthCommand, CommunicateCommand, IndexCommand, MemoryCommand, NotifyCommand,
+    OrchestratorCommand, OrgCommand, PromptCommand, WrapCommand,
 };
 use communicate::client::CommunicateClient;
 use memory::client::MemoryClient;
@@ -304,6 +304,41 @@ enum Commands {
         #[command(subcommand)]
         command: IndexCommand,
     },
+
+    /// Authenticate with the agentd core service.
+    ///
+    /// Register, log in, log out, and check auth status. The session token
+    /// is stored at `~/.config/agentd/session` with 0600 permissions.
+    ///
+    /// # Examples
+    ///
+    /// ```bash
+    /// agent auth register
+    /// agent auth login
+    /// agent auth logout
+    /// agent auth status
+    /// ```
+    Auth {
+        #[command(subcommand)]
+        command: AuthCommand,
+    },
+
+    /// Manage organizations in the agentd core service.
+    ///
+    /// List, create, and switch between organizations. Requires an active
+    /// session (run `agent auth login` first).
+    ///
+    /// # Examples
+    ///
+    /// ```bash
+    /// agent org list
+    /// agent org create "Acme Corp"
+    /// agent org switch acme-corp
+    /// ```
+    Org {
+        #[command(subcommand)]
+        command: OrgCommand,
+    },
 }
 
 /// Main entry point for the agent CLI.
@@ -429,6 +464,12 @@ async fn main() -> Result<()> {
             let client = IndexClient::new(url);
             command.execute(&client, cli.json).await?;
         }
+        Commands::Auth { command } => {
+            command.execute(cli.json).await?;
+        }
+        Commands::Org { command } => {
+            command.execute(cli.json).await?;
+        }
     }
 
     Ok(())
@@ -475,6 +516,11 @@ const SERVICES: &[ServiceDef] = &[
         name: "memory",
         env_var: "AGENTD_MEMORY_SERVICE_URL",
         default_url: "http://localhost:7008",
+    },
+    ServiceDef {
+        name: "core",
+        env_var: "AGENTD_CORE_SERVICE_URL",
+        default_url: "http://localhost:17007",
     },
     ServiceDef {
         name: "communicate",

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -31,6 +31,7 @@ sea-orm-migration = { workspace = true }
 async-trait = "0.1"
 argon2 = "0.5"
 rand = "0.8"
+reqwest = { workspace = true, features = ["json", "stream"] }
 
 [dev-dependencies]
 tower = { version = "0.5", features = ["util"] }

--- a/crates/core/src/api.rs
+++ b/crates/core/src/api.rs
@@ -8,6 +8,7 @@
 //! - `GET  /auth/me`         — return current user + active organization
 
 pub mod auth;
+pub mod users;
 
 use axum::{routing::get, Json, Router};
 use serde_json::{json, Value};
@@ -25,6 +26,7 @@ pub fn create_router(state: AppState) -> Router {
     Router::new()
         .route("/health", get(health_handler))
         .nest("/auth", auth::router())
+        .nest("/users", users::router())
         .with_state(state)
 }
 

--- a/crates/core/src/api.rs
+++ b/crates/core/src/api.rs
@@ -12,21 +12,24 @@
 //! - `GET  /api/v1/users/me/organizations`       — list user's organizations
 //! - `PUT  /users/me/active-organization`        — switch active organization
 //! - `POST /api/v1/organizations`                — create organization
-//! - `GET  /api/v1/organizations/:id`            — get organization
-//! - `PUT  /api/v1/organizations/:id`            — update organization (owners only)
-//! - `DELETE /api/v1/organizations/:id`          — delete organization (owners only)
-//! - `GET  /api/v1/organizations/:id/members`    — list members
-//! - `POST /api/v1/organizations/:id/members`    — add member (owners only)
-//! - `DELETE /api/v1/organizations/:id/members/:uid` — remove member (owners only)
+//! - `GET  /api/v1/organizations/{id}`           — get organization
+//! - `PUT  /api/v1/organizations/{id}`           — update organization (owners only)
+//! - `DELETE /api/v1/organizations/{id}`         — delete organization (owners only)
+//! - `GET  /api/v1/organizations/{id}/members`   — list members
+//! - `POST /api/v1/organizations/{id}/members`   — add member (owners only)
+//! - `DELETE /api/v1/organizations/{id}/members/{uid}` — remove member (owners only)
+//! - `GET  /api/v1/health`                       — aggregate downstream health check
+//! - `ANY  /api/v1/{service}/*`                  — proxy to downstream service
 
 pub mod auth;
+pub mod gateway;
 pub mod organizations;
 pub mod users;
 
 use axum::{routing::get, Json, Router};
 use serde_json::{json, Value};
 
-use crate::storage::Storage;
+use crate::{proxy::ProxyConfig, storage::Storage};
 
 /// Shared application state threaded through all route handlers.
 #[derive(Clone)]
@@ -34,11 +37,18 @@ pub struct AppState {
     pub storage: Storage,
 }
 
-/// Build the application router.
+/// Build the application router without a proxy (for testing or when proxy is disabled).
 pub fn create_router(state: AppState) -> Router {
+    create_router_with_proxy(state, ProxyConfig::from_env())
+}
+
+/// Build the application router with an explicit [`ProxyConfig`].
+pub fn create_router_with_proxy(state: AppState, proxy: ProxyConfig) -> Router {
     let api_v1 = Router::new()
         .nest("/users", users::v1_router())
-        .nest("/organizations", organizations::router());
+        .nest("/organizations", organizations::router())
+        // Gateway routes — /api/v1/health and /api/v1/{service}/* path
+        .merge(gateway::router(proxy));
 
     Router::new()
         .route("/health", get(health_handler))

--- a/crates/core/src/api.rs
+++ b/crates/core/src/api.rs
@@ -1,13 +1,26 @@
 //! HTTP router for the core service.
 //!
 //! Endpoints:
-//! - `GET  /health`          — liveness probe
-//! - `POST /auth/register`   — create account + default personal org
-//! - `POST /auth/login`      — authenticate, return bearer token
-//! - `POST /auth/logout`     — invalidate bearer token
-//! - `GET  /auth/me`         — return current user + active organization
+//! - `GET  /health`                              — liveness probe
+//! - `POST /auth/register`                       — create account + default personal org
+//! - `POST /auth/login`                          — authenticate, return bearer token
+//! - `POST /auth/logout`                         — invalidate bearer token
+//! - `GET  /auth/me`                             — return current user + active organization
+//! - `GET  /api/v1/users/me`                     — get current user profile
+//! - `PUT  /api/v1/users/me`                     — update profile (display_name, email)
+//! - `PUT  /api/v1/users/me/password`            — change password
+//! - `GET  /api/v1/users/me/organizations`       — list user's organizations
+//! - `PUT  /users/me/active-organization`        — switch active organization
+//! - `POST /api/v1/organizations`                — create organization
+//! - `GET  /api/v1/organizations/:id`            — get organization
+//! - `PUT  /api/v1/organizations/:id`            — update organization (owners only)
+//! - `DELETE /api/v1/organizations/:id`          — delete organization (owners only)
+//! - `GET  /api/v1/organizations/:id/members`    — list members
+//! - `POST /api/v1/organizations/:id/members`    — add member (owners only)
+//! - `DELETE /api/v1/organizations/:id/members/:uid` — remove member (owners only)
 
 pub mod auth;
+pub mod organizations;
 pub mod users;
 
 use axum::{routing::get, Json, Router};
@@ -23,10 +36,16 @@ pub struct AppState {
 
 /// Build the application router.
 pub fn create_router(state: AppState) -> Router {
+    let api_v1 = Router::new()
+        .nest("/users", users::v1_router())
+        .nest("/organizations", organizations::router());
+
     Router::new()
         .route("/health", get(health_handler))
         .nest("/auth", auth::router())
+        // Legacy active-org route (issue #216 spec)
         .nest("/users", users::router())
+        .nest("/api/v1", api_v1)
         .with_state(state)
 }
 

--- a/crates/core/src/api/gateway.rs
+++ b/crates/core/src/api/gateway.rs
@@ -1,0 +1,278 @@
+//! API gateway proxy handlers.
+//!
+//! Routes incoming requests under `/api/v1/{service}/*` to the corresponding
+//! downstream agentd service. Each proxied request has:
+//!
+//! - `X-Tenant-ID` injected from the authenticated user's active organization
+//! - `X-Request-ID` injected (new UUID per request)
+//! - `Authorization` header forwarded to the downstream service
+//!
+//! # Route Mapping
+//!
+//! | Incoming path                       | Downstream service        |
+//! |-------------------------------------|---------------------------|
+//! | `/api/v1/orchestrator/*`            | agentd-orchestrator       |
+//! | `/api/v1/notify/*`                  | agentd-notify             |
+//! | `/api/v1/ask/*`                     | agentd-ask                |
+//! | `/api/v1/wrap/*`                    | agentd-wrap               |
+//! | `/api/v1/hook/*`                    | agentd-hook               |
+//! | `/api/v1/monitor/*`                 | agentd-monitor            |
+//!
+//! # Health aggregation
+//!
+//! `GET /api/v1/health` checks all downstream services concurrently and
+//! returns a summary. Downstream unavailability yields `503 Service Unavailable`.
+
+use axum::{
+    body::Body,
+    extract::{Path, Query, Request, State},
+    http::{HeaderMap, StatusCode},
+    response::{IntoResponse, Response},
+    routing::get,
+    Json, Router,
+};
+use serde::Serialize;
+use std::collections::HashMap;
+use uuid::Uuid;
+
+use crate::{
+    middleware::tenant::TenantContext,
+    proxy::{health_check, proxy_request, ProxyConfig, ProxyRequest},
+};
+
+use super::AppState;
+
+// ---------------------------------------------------------------------------
+// State extension
+// ---------------------------------------------------------------------------
+
+/// Gateway-specific state carried alongside AppState.
+///
+/// Mounted via `Router::with_state(GatewayState { ... })` on the gateway
+/// sub-router and extracted with `State<GatewayState>`.
+#[derive(Clone)]
+pub struct GatewayState {
+    pub app: AppState,
+    pub proxy: ProxyConfig,
+}
+
+// ---------------------------------------------------------------------------
+// Router
+// ---------------------------------------------------------------------------
+
+pub fn router(proxy: ProxyConfig) -> Router<AppState> {
+    // Build a nested router that merges AppState with ProxyConfig into GatewayState.
+    // We use a closure-based approach: each handler receives both State<AppState>
+    // and the proxy config via a separate extension.
+    //
+    // Axum requires a single state type per router, so we wrap both into GatewayState
+    // using `Router::with_state` at the gateway level.
+    let proxy_clone = proxy.clone();
+
+    Router::new()
+        .route(
+            "/health",
+            get(move |state: State<AppState>| {
+                let p = proxy_clone.clone();
+                async move { health_handler(state, p).await }
+            }),
+        )
+        .route(
+            "/{service}/{*path}",
+            axum::routing::any(proxy_handler).layer(axum::Extension(proxy)),
+        )
+}
+
+// ---------------------------------------------------------------------------
+// Health aggregation
+// ---------------------------------------------------------------------------
+
+#[derive(Serialize)]
+struct ServiceHealth {
+    name: String,
+    url: String,
+    healthy: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    detail: Option<String>,
+}
+
+#[derive(Serialize)]
+struct HealthResponse {
+    status: &'static str,
+    services: Vec<ServiceHealth>,
+}
+
+async fn health_handler(State(state): State<AppState>, proxy: ProxyConfig) -> impl IntoResponse {
+    let _ = state; // AppState not used for health — kept for router consistency
+
+    let mut handles = Vec::new();
+
+    for (&name, url) in &proxy.services {
+        let client = proxy.client.clone();
+        let url = url.clone();
+        let name = name.to_string();
+        handles.push(tokio::spawn(async move {
+            let (healthy, detail) = health_check(&client, &url).await;
+            ServiceHealth { name, url, healthy, detail }
+        }));
+    }
+
+    let mut services = Vec::new();
+    for handle in handles {
+        if let Ok(s) = handle.await {
+            services.push(s);
+        }
+    }
+    services.sort_by(|a, b| a.name.cmp(&b.name));
+
+    let all_healthy = services.iter().all(|s| s.healthy);
+    let status = if all_healthy { StatusCode::OK } else { StatusCode::SERVICE_UNAVAILABLE };
+
+    (status, Json(HealthResponse { status: if all_healthy { "ok" } else { "degraded" }, services }))
+}
+
+// ---------------------------------------------------------------------------
+// Proxy handler
+// ---------------------------------------------------------------------------
+
+async fn proxy_handler(
+    State(state): State<AppState>,
+    axum::Extension(proxy): axum::Extension<ProxyConfig>,
+    tenant: TenantContext,
+    Path((service, path)): Path<(String, String)>,
+    Query(query_params): Query<HashMap<String, String>>,
+    req: Request,
+) -> Response {
+    // Resolve the downstream URL
+    let base_url = match proxy.url_for(&service) {
+        Some(u) => u.to_string(),
+        None => {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(serde_json::json!({
+                    "error": format!("unknown service: {service}")
+                })),
+            )
+                .into_response();
+        }
+    };
+
+    let method = req.method().as_str().to_string();
+
+    // Build query string
+    let query_string = if query_params.is_empty() {
+        None
+    } else {
+        Some(
+            query_params
+                .iter()
+                .map(|(k, v)| format!("{}={}", urlencoding_simple(k), urlencoding_simple(v)))
+                .collect::<Vec<_>>()
+                .join("&"),
+        )
+    };
+
+    // Collect headers to forward
+    let headers: Vec<(String, String)> = req
+        .headers()
+        .iter()
+        .filter_map(|(name, value)| {
+            value.to_str().ok().map(|v| (name.as_str().to_string(), v.to_string()))
+        })
+        .collect();
+
+    // Read body bytes
+    let body_bytes = match axum::body::to_bytes(req.into_body(), usize::MAX).await {
+        Ok(b) => b,
+        Err(e) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({ "error": format!("failed to read request body: {e}") })),
+            )
+                .into_response();
+        }
+    };
+
+    // Generate a request ID
+    let request_id = Uuid::new_v4().to_string();
+    let forward_path = format!("/{path}");
+
+    match proxy_request(
+        &proxy.client,
+        &base_url,
+        ProxyRequest {
+            method: &method,
+            path: &forward_path,
+            query: query_string.as_deref(),
+            headers: &headers,
+            body: body_bytes,
+            tenant_id: &tenant.organization_id,
+            request_id: &request_id,
+        },
+    )
+    .await
+    {
+        Ok(resp) => {
+            let status =
+                StatusCode::from_u16(resp.status).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
+            let mut response_headers = HeaderMap::new();
+            for (name, value) in &resp.headers {
+                if let (Ok(hn), Ok(hv)) = (
+                    axum::http::HeaderName::from_bytes(name.as_bytes()),
+                    axum::http::HeaderValue::from_str(value),
+                ) {
+                    response_headers.insert(hn, hv);
+                }
+            }
+            (status, response_headers, Body::from(resp.body)).into_response()
+        }
+        Err(e) => {
+            let _ = state; // suppress unused warning
+            (
+                StatusCode::BAD_GATEWAY,
+                Json(serde_json::json!({
+                    "error": format!("upstream error: {e}")
+                })),
+            )
+                .into_response()
+        }
+    }
+}
+
+/// Minimal percent-encoding for query values (encodes spaces and `&`/`=`).
+fn urlencoding_simple(s: &str) -> String {
+    s.chars()
+        .flat_map(|c| match c {
+            'A'..='Z' | 'a'..='z' | '0'..='9' | '-' | '_' | '.' | '~' => {
+                vec![c]
+            }
+            ' ' => vec!['+'],
+            c => {
+                let mut buf = [0u8; 4];
+                let bytes = c.encode_utf8(&mut buf);
+                bytes
+                    .bytes()
+                    .flat_map(|b| {
+                        vec![
+                            '%',
+                            char::from_digit((b >> 4) as u32, 16).unwrap_or('0'),
+                            char::from_digit((b & 0xf) as u32, 16).unwrap_or('0'),
+                        ]
+                    })
+                    .collect()
+            }
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_urlencoding_simple() {
+        assert_eq!(urlencoding_simple("hello world"), "hello+world");
+        assert_eq!(urlencoding_simple("abc123"), "abc123");
+        assert_eq!(urlencoding_simple("a&b=c"), "a%26b%3dc");
+    }
+}

--- a/crates/core/src/api/organizations.rs
+++ b/crates/core/src/api/organizations.rs
@@ -1,0 +1,803 @@
+//! Organization management endpoint handlers.
+//!
+//! # Endpoints
+//!
+//! | Method | Path                                    | Auth | Role   | Description                      |
+//! |--------|-----------------------------------------|------|--------|----------------------------------|
+//! | POST   | `/api/v1/organizations`                 | Yes  | any    | Create org (creator = owner)     |
+//! | GET    | `/api/v1/organizations/:id`             | Yes  | member | Get org details                  |
+//! | PUT    | `/api/v1/organizations/:id`             | Yes  | owner  | Update org name                  |
+//! | DELETE | `/api/v1/organizations/:id`             | Yes  | owner  | Delete org                       |
+//! | GET    | `/api/v1/organizations/:id/members`     | Yes  | member | List members with roles          |
+//! | POST   | `/api/v1/organizations/:id/members`     | Yes  | owner  | Add member                       |
+//! | DELETE | `/api/v1/organizations/:id/members/:uid`| Yes  | owner  | Remove member                    |
+
+use axum::{
+    extract::{Path, State},
+    http::StatusCode,
+    response::IntoResponse,
+    routing::{delete, get, post, put},
+    Json, Router,
+};
+use serde::{Deserialize, Serialize};
+
+use agentd_common::error::ApiError;
+
+use crate::middleware::auth::AuthUser;
+
+use super::AppState;
+
+// ---------------------------------------------------------------------------
+// Request / response types
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+pub struct CreateOrganizationRequest {
+    pub name: String,
+    pub slug: String,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct UpdateOrganizationRequest {
+    pub name: Option<String>,
+    pub slug: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct AddMemberRequest {
+    pub user_id: String,
+    pub role: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct OrganizationResponse {
+    pub id: String,
+    pub name: String,
+    pub slug: String,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct MemberResponse {
+    pub id: String,
+    pub user_id: String,
+    pub organization_id: String,
+    pub role: String,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+// ---------------------------------------------------------------------------
+// Router
+// ---------------------------------------------------------------------------
+
+pub fn router() -> Router<AppState> {
+    Router::new()
+        .route("/", post(create_org_handler))
+        .route("/{id}", get(get_org_handler))
+        .route("/{id}", put(update_org_handler))
+        .route("/{id}", delete(delete_org_handler))
+        .route("/{id}/members", get(list_members_handler))
+        .route("/{id}/members", post(add_member_handler))
+        .route("/{id}/members/{user_id}", delete(remove_member_handler))
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Require that the caller is a member of the given org.
+///
+/// Returns `403 Forbidden` if not a member.
+async fn require_member(
+    state: &AppState,
+    user_id: &str,
+    org_id: &str,
+) -> Result<crate::entity::membership::Model, ApiError> {
+    state
+        .storage
+        .memberships()
+        .get_membership(user_id, org_id)
+        .await
+        .map_err(ApiError::Internal)?
+        .ok_or_else(|| {
+            ApiError::Forbidden(format!("user is not a member of organization {org_id}"))
+        })
+}
+
+/// Require that the caller is an owner of the given org.
+///
+/// Returns `403 Forbidden` if not an owner.
+async fn require_owner(state: &AppState, user_id: &str, org_id: &str) -> Result<(), ApiError> {
+    let mem = require_member(state, user_id, org_id).await?;
+    if mem.role != "owner" {
+        return Err(ApiError::Forbidden(format!("only owners may modify organization {org_id}")));
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Handlers
+// ---------------------------------------------------------------------------
+
+/// `POST /api/v1/organizations`
+///
+/// Creates a new organization. The calling user becomes the owner and their
+/// active organization is switched to the new org.
+///
+/// Returns `201 Created` with the organization payload.
+async fn create_org_handler(
+    State(state): State<AppState>,
+    auth: AuthUser,
+    Json(body): Json<CreateOrganizationRequest>,
+) -> Result<impl IntoResponse, ApiError> {
+    let org = state
+        .storage
+        .organizations()
+        .create(&body.name, &body.slug)
+        .await
+        .map_err(ApiError::Internal)?;
+
+    state
+        .storage
+        .memberships()
+        .add_member(&auth.user.id, &org.id, "owner")
+        .await
+        .map_err(ApiError::Internal)?;
+
+    Ok((
+        StatusCode::CREATED,
+        Json(OrganizationResponse {
+            id: org.id,
+            name: org.name,
+            slug: org.slug,
+            created_at: org.created_at,
+            updated_at: org.updated_at,
+        }),
+    ))
+}
+
+/// `GET /api/v1/organizations/:id`
+///
+/// Returns organization details. Requires caller to be a member.
+async fn get_org_handler(
+    State(state): State<AppState>,
+    auth: AuthUser,
+    Path(id): Path<String>,
+) -> Result<impl IntoResponse, ApiError> {
+    require_member(&state, &auth.user.id, &id).await?;
+
+    let org = state
+        .storage
+        .organizations()
+        .get_by_id(&id)
+        .await
+        .map_err(ApiError::Internal)?
+        .ok_or(ApiError::NotFound)?;
+
+    Ok(Json(OrganizationResponse {
+        id: org.id,
+        name: org.name,
+        slug: org.slug,
+        created_at: org.created_at,
+        updated_at: org.updated_at,
+    }))
+}
+
+/// `PUT /api/v1/organizations/:id`
+///
+/// Updates organization name and/or slug. Requires owner role.
+async fn update_org_handler(
+    State(state): State<AppState>,
+    auth: AuthUser,
+    Path(id): Path<String>,
+    Json(body): Json<UpdateOrganizationRequest>,
+) -> Result<impl IntoResponse, ApiError> {
+    require_owner(&state, &auth.user.id, &id).await?;
+
+    let org = state
+        .storage
+        .organizations()
+        .update(&id, body.name.as_deref(), body.slug.as_deref())
+        .await
+        .map_err(ApiError::Internal)?;
+
+    Ok(Json(OrganizationResponse {
+        id: org.id,
+        name: org.name,
+        slug: org.slug,
+        created_at: org.created_at,
+        updated_at: org.updated_at,
+    }))
+}
+
+/// `DELETE /api/v1/organizations/:id`
+///
+/// Deletes the organization. Requires owner role. Clears `active_organization_id`
+/// for all users who had this as their active org.
+///
+/// Returns `204 No Content`.
+async fn delete_org_handler(
+    State(state): State<AppState>,
+    auth: AuthUser,
+    Path(id): Path<String>,
+) -> Result<impl IntoResponse, ApiError> {
+    require_owner(&state, &auth.user.id, &id).await?;
+
+    // Clear active_organization_id for affected users before deleting
+    state
+        .storage
+        .users()
+        .clear_active_organization_for_org(&id)
+        .await
+        .map_err(ApiError::Internal)?;
+
+    let deleted = state.storage.organizations().delete(&id).await.map_err(ApiError::Internal)?;
+
+    if !deleted {
+        return Err(ApiError::NotFound);
+    }
+
+    Ok(StatusCode::NO_CONTENT)
+}
+
+/// `GET /api/v1/organizations/:id/members`
+///
+/// Lists all members of the organization. Requires caller to be a member.
+async fn list_members_handler(
+    State(state): State<AppState>,
+    auth: AuthUser,
+    Path(id): Path<String>,
+) -> Result<impl IntoResponse, ApiError> {
+    require_member(&state, &auth.user.id, &id).await?;
+
+    let members =
+        state.storage.memberships().list_members(&id).await.map_err(ApiError::Internal)?;
+
+    let response: Vec<MemberResponse> = members
+        .into_iter()
+        .map(|m| MemberResponse {
+            id: m.id,
+            user_id: m.user_id,
+            organization_id: m.organization_id,
+            role: m.role,
+            created_at: m.created_at,
+            updated_at: m.updated_at,
+        })
+        .collect();
+
+    Ok(Json(response))
+}
+
+/// `POST /api/v1/organizations/:id/members`
+///
+/// Adds a user to the organization. Requires owner role.
+///
+/// Returns `201 Created` with the membership record.
+async fn add_member_handler(
+    State(state): State<AppState>,
+    auth: AuthUser,
+    Path(id): Path<String>,
+    Json(body): Json<AddMemberRequest>,
+) -> Result<impl IntoResponse, ApiError> {
+    require_owner(&state, &auth.user.id, &id).await?;
+
+    // Verify the target user exists
+    state
+        .storage
+        .users()
+        .get_by_id(&body.user_id)
+        .await
+        .map_err(ApiError::Internal)?
+        .ok_or(ApiError::NotFound)?;
+
+    let mem = state
+        .storage
+        .memberships()
+        .add_member(&body.user_id, &id, &body.role)
+        .await
+        .map_err(ApiError::Internal)?;
+
+    Ok((
+        StatusCode::CREATED,
+        Json(MemberResponse {
+            id: mem.id,
+            user_id: mem.user_id,
+            organization_id: mem.organization_id,
+            role: mem.role,
+            created_at: mem.created_at,
+            updated_at: mem.updated_at,
+        }),
+    ))
+}
+
+/// `DELETE /api/v1/organizations/:id/members/:user_id`
+///
+/// Removes a user from the organization. Requires owner role. Returns `403` if
+/// the caller tries to remove themselves as the last owner.
+///
+/// Returns `204 No Content`.
+async fn remove_member_handler(
+    State(state): State<AppState>,
+    auth: AuthUser,
+    Path((id, target_user_id)): Path<(String, String)>,
+) -> Result<impl IntoResponse, ApiError> {
+    require_owner(&state, &auth.user.id, &id).await?;
+
+    // Prevent removing the last owner
+    if target_user_id == auth.user.id {
+        let all_members =
+            state.storage.memberships().list_members(&id).await.map_err(ApiError::Internal)?;
+        let owner_count = all_members.iter().filter(|m| m.role == "owner").count();
+        if owner_count <= 1 {
+            return Err(ApiError::Forbidden(
+                "cannot remove the last owner from an organization".into(),
+            ));
+        }
+    }
+
+    let removed = state
+        .storage
+        .memberships()
+        .remove_member(&target_user_id, &id)
+        .await
+        .map_err(ApiError::Internal)?;
+
+    if !removed {
+        return Err(ApiError::NotFound);
+    }
+
+    Ok(StatusCode::NO_CONTENT)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use crate::api::AppState;
+    use crate::storage::Storage;
+    use agentd_common::storage::create_test_connection;
+    use axum::{
+        body::Body,
+        http::{header, Request, StatusCode},
+        Router,
+    };
+    use http_body_util::BodyExt;
+    use tower::ServiceExt;
+
+    async fn test_app() -> (Router, tempfile::TempDir) {
+        let (conn, tmp) = create_test_connection().await;
+        let storage = Storage::new(conn).await.unwrap();
+        let state = AppState { storage };
+        let app = crate::api::create_router(state);
+        (app, tmp)
+    }
+
+    async fn body_json(response: axum::response::Response) -> serde_json::Value {
+        let bytes = response.into_body().collect().await.unwrap().to_bytes();
+        serde_json::from_slice(&bytes).unwrap()
+    }
+
+    async fn register(app: &Router, username: &str, email: &str) -> (String, String) {
+        let payload =
+            serde_json::json!({ "username": username, "email": email, "password": "testpass" });
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/auth/register")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(payload.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let body = body_json(response).await;
+        let token = body["token"].as_str().unwrap().to_string();
+        let user_id = body["user"]["id"].as_str().unwrap().to_string();
+        (token, user_id)
+    }
+
+    // -----------------------------------------------------------------------
+    // Create org
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_create_org_success() {
+        let (app, _tmp) = test_app().await;
+        let (token, _) = register(&app, "alice", "alice@example.com").await;
+
+        let payload = serde_json::json!({ "name": "Test Corp", "slug": "test-corp" });
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/organizations")
+                    .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(payload.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::CREATED);
+        let body = body_json(response).await;
+        assert_eq!(body["name"], "Test Corp");
+        assert_eq!(body["slug"], "test-corp");
+    }
+
+    #[tokio::test]
+    async fn test_create_org_unauthenticated() {
+        let (app, _tmp) = test_app().await;
+
+        let payload = serde_json::json!({ "name": "Test", "slug": "test" });
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/organizations")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(payload.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    // -----------------------------------------------------------------------
+    // Get org
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_get_org_as_member() {
+        let (app, _tmp) = test_app().await;
+        let (token, _) = register(&app, "bob", "bob@example.com").await;
+
+        // Get the personal org created during registration
+        let me_resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/auth/me")
+                    .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let me_body = body_json(me_resp).await;
+        let org_id = me_body["active_organization"]["id"].as_str().unwrap().to_string();
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri(format!("/api/v1/organizations/{org_id}"))
+                    .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = body_json(response).await;
+        assert_eq!(body["id"], org_id.as_str());
+    }
+
+    #[tokio::test]
+    async fn test_get_org_not_member() {
+        let (app, _tmp) = test_app().await;
+        let (token_a, _) = register(&app, "carol", "carol@example.com").await;
+        let (token_b, _) = register(&app, "dan", "dan@example.com").await;
+
+        // Get carol's personal org
+        let me_resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/auth/me")
+                    .header(header::AUTHORIZATION, format!("Bearer {token_a}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let me_body = body_json(me_resp).await;
+        let carol_org_id = me_body["active_organization"]["id"].as_str().unwrap().to_string();
+
+        // Dan tries to get Carol's org
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri(format!("/api/v1/organizations/{carol_org_id}"))
+                    .header(header::AUTHORIZATION, format!("Bearer {token_b}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    }
+
+    // -----------------------------------------------------------------------
+    // Update org
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_update_org_as_owner() {
+        let (app, _tmp) = test_app().await;
+        let (token, _) = register(&app, "eve", "eve@example.com").await;
+
+        let me_resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/auth/me")
+                    .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let me_body = body_json(me_resp).await;
+        let org_id = me_body["active_organization"]["id"].as_str().unwrap().to_string();
+
+        let payload = serde_json::json!({ "name": "Updated Name" });
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("PUT")
+                    .uri(format!("/api/v1/organizations/{org_id}"))
+                    .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(payload.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = body_json(response).await;
+        assert_eq!(body["name"], "Updated Name");
+    }
+
+    // -----------------------------------------------------------------------
+    // Delete org
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_delete_org_as_owner() {
+        let (app, _tmp) = test_app().await;
+        let (token, _) = register(&app, "frank", "frank@example.com").await;
+
+        let me_resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/auth/me")
+                    .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let me_body = body_json(me_resp).await;
+        let org_id = me_body["active_organization"]["id"].as_str().unwrap().to_string();
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("DELETE")
+                    .uri(format!("/api/v1/organizations/{org_id}"))
+                    .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::NO_CONTENT);
+    }
+
+    #[tokio::test]
+    async fn test_delete_org_not_owner() {
+        let (app, _tmp) = test_app().await;
+        let (token_a, _) = register(&app, "grace", "grace@example.com").await;
+        let (token_b, _) = register(&app, "henry", "henry@example.com").await;
+
+        let me_resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/auth/me")
+                    .header(header::AUTHORIZATION, format!("Bearer {token_a}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let me_body = body_json(me_resp).await;
+        let grace_org_id = me_body["active_organization"]["id"].as_str().unwrap().to_string();
+
+        // First get henry's user_id via /auth/me
+        let henry_me = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/auth/me")
+                    .header(header::AUTHORIZATION, format!("Bearer {token_b}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let henry_body = body_json(henry_me).await;
+        let henry_id = henry_body["user"]["id"].as_str().unwrap().to_string();
+
+        // Grace adds henry as member
+        let add_payload = serde_json::json!({ "user_id": henry_id, "role": "member" });
+        app.clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!("/api/v1/organizations/{grace_org_id}/members"))
+                    .header(header::AUTHORIZATION, format!("Bearer {token_a}"))
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(add_payload.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        // Henry tries to delete grace's org — should be forbidden
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("DELETE")
+                    .uri(format!("/api/v1/organizations/{grace_org_id}"))
+                    .header(header::AUTHORIZATION, format!("Bearer {token_b}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    }
+
+    // -----------------------------------------------------------------------
+    // Members
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_list_members() {
+        let (app, _tmp) = test_app().await;
+        let (token, _) = register(&app, "ida", "ida@example.com").await;
+
+        let me_resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/auth/me")
+                    .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let me_body = body_json(me_resp).await;
+        let org_id = me_body["active_organization"]["id"].as_str().unwrap().to_string();
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri(format!("/api/v1/organizations/{org_id}/members"))
+                    .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = body_json(response).await;
+        let members = body.as_array().unwrap();
+        assert_eq!(members.len(), 1);
+        assert_eq!(members[0]["role"], "owner");
+    }
+
+    #[tokio::test]
+    async fn test_add_member() {
+        let (app, _tmp) = test_app().await;
+        let (token_owner, _) = register(&app, "jack", "jack@example.com").await;
+        let (_, user_b_id) = register(&app, "kate", "kate@example.com").await;
+
+        let me_resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/auth/me")
+                    .header(header::AUTHORIZATION, format!("Bearer {token_owner}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let me_body = body_json(me_resp).await;
+        let org_id = me_body["active_organization"]["id"].as_str().unwrap().to_string();
+
+        let payload = serde_json::json!({ "user_id": user_b_id, "role": "member" });
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(format!("/api/v1/organizations/{org_id}/members"))
+                    .header(header::AUTHORIZATION, format!("Bearer {token_owner}"))
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(payload.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::CREATED);
+        let body = body_json(response).await;
+        assert_eq!(body["user_id"], user_b_id.as_str());
+        assert_eq!(body["role"], "member");
+    }
+
+    #[tokio::test]
+    async fn test_remove_last_owner_blocked() {
+        let (app, _tmp) = test_app().await;
+        let (token, user_id) = register(&app, "liam", "liam@example.com").await;
+
+        let me_resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/auth/me")
+                    .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let me_body = body_json(me_resp).await;
+        let org_id = me_body["active_organization"]["id"].as_str().unwrap().to_string();
+
+        // Liam tries to remove himself as the only owner
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("DELETE")
+                    .uri(format!("/api/v1/organizations/{org_id}/members/{user_id}"))
+                    .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    }
+}

--- a/crates/core/src/api/users.rs
+++ b/crates/core/src/api/users.rs
@@ -1,43 +1,193 @@
 //! User profile endpoint handlers.
 //!
-//! # Endpoints
+//! # Endpoints (from issue #216 and #218)
 //!
-//! | Method | Path                              | Auth | Description                          |
-//! |--------|-----------------------------------|------|--------------------------------------|
-//! | PUT    | `/users/me/active-organization`   | Yes  | Switch the user's active organization |
+//! | Method | Path                                 | Auth | Description                             |
+//! |--------|--------------------------------------|------|-----------------------------------------|
+//! | GET    | `/api/v1/users/me`                   | Yes  | Get current user profile                |
+//! | PUT    | `/api/v1/users/me`                   | Yes  | Update profile (display_name, email)    |
+//! | PUT    | `/api/v1/users/me/password`          | Yes  | Change password (requires current pass) |
+//! | GET    | `/api/v1/users/me/organizations`     | Yes  | List user's organizations               |
+//! | PUT    | `/users/me/active-organization`      | Yes  | Switch active organization              |
 //!
-//! All endpoints require a valid `Authorization: Bearer <token>` header via
-//! the [`crate::middleware::auth::AuthUser`] extractor.
+//! All endpoints require a valid `Authorization: Bearer <token>` header.
 
-use axum::{extract::State, response::IntoResponse, routing::put, Json, Router};
-use serde::Deserialize;
+use axum::{
+    extract::State,
+    http::StatusCode,
+    response::IntoResponse,
+    routing::{get, put},
+    Json, Router,
+};
+use serde::{Deserialize, Serialize};
 
 use agentd_common::error::ApiError;
 
-use crate::middleware::auth::AuthUser;
+use crate::{api::auth::OrgResponse, middleware::auth::AuthUser, user_storage::UserStorage};
 
 use super::AppState;
 
 // ---------------------------------------------------------------------------
-// Request types
+// Request / response types
 // ---------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+pub struct UpdateProfileRequest {
+    pub display_name: Option<String>,
+    pub email: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ChangePasswordRequest {
+    pub current_password: String,
+    pub new_password: String,
+}
 
 #[derive(Debug, Deserialize)]
 pub struct SetActiveOrganizationRequest {
     pub organization_id: String,
 }
 
+#[derive(Debug, Serialize)]
+pub struct UserProfileResponse {
+    pub id: String,
+    pub username: Option<String>,
+    pub email: String,
+    pub display_name: Option<String>,
+    pub role: String,
+    pub active_organization_id: Option<String>,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+impl From<crate::entity::user::Model> for UserProfileResponse {
+    fn from(u: crate::entity::user::Model) -> Self {
+        Self {
+            id: u.id,
+            username: u.username,
+            email: u.email,
+            display_name: u.display_name,
+            role: u.role,
+            active_organization_id: u.active_organization_id,
+            created_at: u.created_at,
+            updated_at: u.updated_at,
+        }
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Router
 // ---------------------------------------------------------------------------
 
+/// Routes mounted at `/users` (legacy path, issue #216).
 pub fn router() -> Router<AppState> {
     Router::new().route("/me/active-organization", put(set_active_organization_handler))
+}
+
+/// Routes mounted at `/api/v1/users` (issue #218).
+pub fn v1_router() -> Router<AppState> {
+    Router::new()
+        .route("/me", get(get_me_handler).put(update_profile_handler))
+        .route("/me/password", put(change_password_handler))
+        .route("/me/organizations", get(list_my_organizations_handler))
+        .route("/me/active-organization", put(set_active_organization_handler))
 }
 
 // ---------------------------------------------------------------------------
 // Handlers
 // ---------------------------------------------------------------------------
+
+/// `GET /api/v1/users/me`
+///
+/// Returns the current user's profile without `password_hash`.
+async fn get_me_handler(auth: AuthUser) -> impl IntoResponse {
+    Json(UserProfileResponse::from(auth.user))
+}
+
+/// `PUT /api/v1/users/me`
+///
+/// Updates `display_name` and/or `email`. Fields set to `null` or omitted are
+/// left unchanged.
+///
+/// Returns `200 OK` with the updated profile.
+async fn update_profile_handler(
+    State(state): State<AppState>,
+    auth: AuthUser,
+    Json(body): Json<UpdateProfileRequest>,
+) -> Result<impl IntoResponse, ApiError> {
+    let users = state.storage.users();
+    let mut user = auth.user;
+
+    // Update display_name if provided
+    if body.display_name.is_some() || body.email.is_some() {
+        if let Some(dn) = &body.display_name {
+            user = users
+                .update(&user.id, None, Some(dn.as_str()), None)
+                .await
+                .map_err(ApiError::Internal)?;
+        }
+        if let Some(email) = &body.email {
+            // Check email uniqueness before update
+            if let Some(existing) = users.get_by_email(email).await.map_err(ApiError::Internal)? {
+                if existing.id != user.id {
+                    return Err(ApiError::Conflict(format!("email already in use: {email}")));
+                }
+            }
+            user = users.update_email(&user.id, email).await.map_err(ApiError::Internal)?;
+        }
+    }
+
+    Ok(Json(UserProfileResponse::from(user)))
+}
+
+/// `PUT /api/v1/users/me/password`
+///
+/// Changes the user's password. Requires the current password for verification.
+///
+/// Returns `204 No Content`.
+async fn change_password_handler(
+    State(state): State<AppState>,
+    auth: AuthUser,
+    Json(body): Json<ChangePasswordRequest>,
+) -> Result<impl IntoResponse, ApiError> {
+    if body.new_password.is_empty() {
+        return Err(ApiError::InvalidInput("new password must not be empty".into()));
+    }
+
+    // Verify current password
+    let ok = UserStorage::verify_password(&body.current_password, &auth.user.password_hash)
+        .map_err(ApiError::Internal)?;
+    if !ok {
+        return Err(ApiError::Unauthorized("current password is incorrect".into()));
+    }
+
+    state
+        .storage
+        .users()
+        .update_password(&auth.user.id, &body.new_password)
+        .await
+        .map_err(ApiError::Internal)?;
+
+    Ok(StatusCode::NO_CONTENT)
+}
+
+/// `GET /api/v1/users/me/organizations`
+///
+/// Returns all organizations the current user belongs to.
+async fn list_my_organizations_handler(
+    State(state): State<AppState>,
+    auth: AuthUser,
+) -> Result<impl IntoResponse, ApiError> {
+    let orgs = state
+        .storage
+        .memberships()
+        .list_user_organizations(&auth.user.id)
+        .await
+        .map_err(ApiError::Internal)?;
+
+    let response: Vec<OrgResponse> = orgs.into_iter().map(OrgResponse::from).collect();
+    Ok(Json(response))
+}
 
 /// `PUT /users/me/active-organization`
 ///
@@ -73,8 +223,7 @@ async fn set_active_organization_handler(
         .await
         .map_err(ApiError::Internal)?;
 
-    // Return the updated user without password_hash
-    Ok(Json(crate::api::auth::UserResponse::from(updated)))
+    Ok(Json(UserProfileResponse::from(updated)))
 }
 
 // ---------------------------------------------------------------------------
@@ -83,7 +232,7 @@ async fn set_active_organization_handler(
 
 #[cfg(test)]
 mod tests {
-    use crate::api::{auth::UserResponse, AppState};
+    use crate::api::AppState;
     use crate::storage::Storage;
     use agentd_common::storage::create_test_connection;
     use axum::{
@@ -102,13 +251,14 @@ mod tests {
         (app, tmp)
     }
 
-    /// Register a user and return `(token, user_id)`.
-    async fn register_and_login(app: &Router, username: &str, email: &str) -> (String, String) {
-        let payload = serde_json::json!({
-            "username": username,
-            "email": email,
-            "password": "testpass"
-        });
+    async fn body_json(response: axum::response::Response) -> serde_json::Value {
+        let bytes = response.into_body().collect().await.unwrap().to_bytes();
+        serde_json::from_slice(&bytes).unwrap()
+    }
+
+    async fn register(app: &Router, username: &str, email: &str) -> (String, String) {
+        let payload =
+            serde_json::json!({ "username": username, "email": email, "password": "testpass" });
         let response = app
             .clone()
             .oneshot(
@@ -121,21 +271,198 @@ mod tests {
             )
             .await
             .unwrap();
-        let bytes = response.into_body().collect().await.unwrap().to_bytes();
-        let body: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        let body = body_json(response).await;
         let token = body["token"].as_str().unwrap().to_string();
         let user_id = body["user"]["id"].as_str().unwrap().to_string();
         (token, user_id)
     }
 
+    // -----------------------------------------------------------------------
+    // GET /api/v1/users/me
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_get_me() {
+        let (app, _tmp) = test_app().await;
+        let (token, _) = register(&app, "alice", "alice@example.com").await;
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/api/v1/users/me")
+                    .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = body_json(response).await;
+        assert_eq!(body["username"], "alice");
+        assert_eq!(body["email"], "alice@example.com");
+        assert!(body.get("password_hash").is_none());
+    }
+
+    #[tokio::test]
+    async fn test_get_me_unauthenticated() {
+        let (app, _tmp) = test_app().await;
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/api/v1/users/me")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    // -----------------------------------------------------------------------
+    // PUT /api/v1/users/me
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_update_profile_display_name() {
+        let (app, _tmp) = test_app().await;
+        let (token, _) = register(&app, "bob", "bob@example.com").await;
+
+        let payload = serde_json::json!({ "display_name": "Robert" });
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("PUT")
+                    .uri("/api/v1/users/me")
+                    .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(payload.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = body_json(response).await;
+        assert_eq!(body["display_name"], "Robert");
+    }
+
+    #[tokio::test]
+    async fn test_update_email_conflict() {
+        let (app, _tmp) = test_app().await;
+        register(&app, "carol", "carol@example.com").await;
+        let (token_d, _) = register(&app, "dan", "dan@example.com").await;
+
+        let payload = serde_json::json!({ "email": "carol@example.com" });
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("PUT")
+                    .uri("/api/v1/users/me")
+                    .header(header::AUTHORIZATION, format!("Bearer {token_d}"))
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(payload.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::CONFLICT);
+    }
+
+    // -----------------------------------------------------------------------
+    // PUT /api/v1/users/me/password
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_change_password_success() {
+        let (app, _tmp) = test_app().await;
+        let (token, _) = register(&app, "eve", "eve@example.com").await;
+
+        let payload =
+            serde_json::json!({ "current_password": "testpass", "new_password": "newpass123" });
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("PUT")
+                    .uri("/api/v1/users/me/password")
+                    .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(payload.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::NO_CONTENT);
+    }
+
+    #[tokio::test]
+    async fn test_change_password_wrong_current() {
+        let (app, _tmp) = test_app().await;
+        let (token, _) = register(&app, "frank", "frank@example.com").await;
+
+        let payload =
+            serde_json::json!({ "current_password": "wrongpass", "new_password": "newpass" });
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("PUT")
+                    .uri("/api/v1/users/me/password")
+                    .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(payload.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    // -----------------------------------------------------------------------
+    // GET /api/v1/users/me/organizations
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_list_my_organizations() {
+        let (app, _tmp) = test_app().await;
+        let (token, _) = register(&app, "grace", "grace@example.com").await;
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/api/v1/users/me/organizations")
+                    .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = body_json(response).await;
+        let orgs = body.as_array().unwrap();
+        // Registration creates one personal org
+        assert_eq!(orgs.len(), 1);
+        assert!(orgs[0]["name"].as_str().unwrap().contains("grace"));
+    }
+
+    // -----------------------------------------------------------------------
+    // PUT /users/me/active-organization
+    // -----------------------------------------------------------------------
+
     #[tokio::test]
     async fn test_set_active_organization_success() {
         let (app, _tmp) = test_app().await;
 
-        // Register user (creates personal org and sets it as active)
-        let (token, _user_id) = register_and_login(&app, "alice", "alice@example.com").await;
+        let (token, _) = register(&app, "henry", "henry@example.com").await;
 
-        // Get current active org
         let me_resp = app
             .clone()
             .oneshot(
@@ -148,11 +475,9 @@ mod tests {
             )
             .await
             .unwrap();
-        let me_bytes = me_resp.into_body().collect().await.unwrap().to_bytes();
-        let me_body: serde_json::Value = serde_json::from_slice(&me_bytes).unwrap();
+        let me_body = body_json(me_resp).await;
         let org_id = me_body["active_organization"]["id"].as_str().unwrap().to_string();
 
-        // Switch back to the same org (idempotent)
         let payload = serde_json::json!({ "organization_id": org_id });
         let response = app
             .oneshot(
@@ -168,9 +493,7 @@ mod tests {
             .unwrap();
 
         assert_eq!(response.status(), StatusCode::OK);
-        let bytes = response.into_body().collect().await.unwrap().to_bytes();
-        let body: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
-        // Response is UserResponse — no password_hash field
+        let body = body_json(response).await;
         assert!(body.get("password_hash").is_none());
         assert_eq!(body["active_organization_id"].as_str().unwrap(), org_id);
     }
@@ -179,9 +502,8 @@ mod tests {
     async fn test_set_active_organization_not_member() {
         let (app, _tmp) = test_app().await;
 
-        let (token, _) = register_and_login(&app, "bob", "bob@example.com").await;
+        let (token, _) = register(&app, "ida", "ida@example.com").await;
 
-        // Use a random UUID that doesn't correspond to any org the user is in
         let fake_org_id = uuid::Uuid::new_v4().to_string();
         let payload = serde_json::json!({ "organization_id": fake_org_id });
         let response = app
@@ -221,17 +543,12 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_set_active_org_allows_second_org() {
+    async fn test_set_active_org_cross_user_forbidden() {
         let (app, _tmp) = test_app().await;
 
-        // Register Alice (gets personal org automatically)
-        let (token_a, user_a_id) = register_and_login(&app, "alice2", "alice2@example.com").await;
-        let _ = user_a_id;
+        let (token_a, _) = register(&app, "jack", "jack@example.com").await;
+        let (token_b, _) = register(&app, "kate", "kate@example.com").await;
 
-        // Register Bob (we'll use his personal org for the cross-org test)
-        let (token_b, _) = register_and_login(&app, "bob2", "bob2@example.com").await;
-
-        // Get Bob's personal org id
         let me_resp = app
             .clone()
             .oneshot(
@@ -244,12 +561,10 @@ mod tests {
             )
             .await
             .unwrap();
-        let me_bytes = me_resp.into_body().collect().await.unwrap().to_bytes();
-        let me_body: serde_json::Value = serde_json::from_slice(&me_bytes).unwrap();
-        let bob_org_id = me_body["active_organization"]["id"].as_str().unwrap().to_string();
+        let me_body = body_json(me_resp).await;
+        let kate_org_id = me_body["active_organization"]["id"].as_str().unwrap().to_string();
 
-        // Alice tries to switch to Bob's org (she's not a member)
-        let payload = serde_json::json!({ "organization_id": bob_org_id });
+        let payload = serde_json::json!({ "organization_id": kate_org_id });
         let response = app
             .oneshot(
                 Request::builder()
@@ -265,8 +580,4 @@ mod tests {
 
         assert_eq!(response.status(), StatusCode::FORBIDDEN);
     }
-
-    // Keep the compiler happy with unused import
-    #[allow(dead_code)]
-    fn _use_user_response(_: UserResponse) {}
 }

--- a/crates/core/src/api/users.rs
+++ b/crates/core/src/api/users.rs
@@ -1,0 +1,272 @@
+//! User profile endpoint handlers.
+//!
+//! # Endpoints
+//!
+//! | Method | Path                              | Auth | Description                          |
+//! |--------|-----------------------------------|------|--------------------------------------|
+//! | PUT    | `/users/me/active-organization`   | Yes  | Switch the user's active organization |
+//!
+//! All endpoints require a valid `Authorization: Bearer <token>` header via
+//! the [`crate::middleware::auth::AuthUser`] extractor.
+
+use axum::{extract::State, response::IntoResponse, routing::put, Json, Router};
+use serde::Deserialize;
+
+use agentd_common::error::ApiError;
+
+use crate::middleware::auth::AuthUser;
+
+use super::AppState;
+
+// ---------------------------------------------------------------------------
+// Request types
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+pub struct SetActiveOrganizationRequest {
+    pub organization_id: String,
+}
+
+// ---------------------------------------------------------------------------
+// Router
+// ---------------------------------------------------------------------------
+
+pub fn router() -> Router<AppState> {
+    Router::new().route("/me/active-organization", put(set_active_organization_handler))
+}
+
+// ---------------------------------------------------------------------------
+// Handlers
+// ---------------------------------------------------------------------------
+
+/// `PUT /users/me/active-organization`
+///
+/// Switches the authenticated user's active organization. The user must be a
+/// member of the specified organization; non-members receive `403 Forbidden`.
+///
+/// Returns `200 OK` with the updated user profile (no password hash).
+async fn set_active_organization_handler(
+    State(state): State<AppState>,
+    auth: AuthUser,
+    Json(body): Json<SetActiveOrganizationRequest>,
+) -> Result<impl IntoResponse, ApiError> {
+    // Verify membership — only members of the org may activate it.
+    let membership = state
+        .storage
+        .memberships()
+        .get_membership(&auth.user.id, &body.organization_id)
+        .await
+        .map_err(ApiError::Internal)?;
+
+    if membership.is_none() {
+        return Err(ApiError::Forbidden(format!(
+            "user is not a member of organization {}",
+            body.organization_id
+        )));
+    }
+
+    // Update the user's active organization
+    let updated = state
+        .storage
+        .users()
+        .set_active_organization(&auth.user.id, Some(&body.organization_id))
+        .await
+        .map_err(ApiError::Internal)?;
+
+    // Return the updated user without password_hash
+    Ok(Json(crate::api::auth::UserResponse::from(updated)))
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use crate::api::{auth::UserResponse, AppState};
+    use crate::storage::Storage;
+    use agentd_common::storage::create_test_connection;
+    use axum::{
+        body::Body,
+        http::{header, Request, StatusCode},
+        Router,
+    };
+    use http_body_util::BodyExt;
+    use tower::ServiceExt;
+
+    async fn test_app() -> (Router, tempfile::TempDir) {
+        let (conn, tmp) = create_test_connection().await;
+        let storage = Storage::new(conn).await.unwrap();
+        let state = AppState { storage };
+        let app = crate::api::create_router(state);
+        (app, tmp)
+    }
+
+    /// Register a user and return `(token, user_id)`.
+    async fn register_and_login(app: &Router, username: &str, email: &str) -> (String, String) {
+        let payload = serde_json::json!({
+            "username": username,
+            "email": email,
+            "password": "testpass"
+        });
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/auth/register")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(payload.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let bytes = response.into_body().collect().await.unwrap().to_bytes();
+        let body: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        let token = body["token"].as_str().unwrap().to_string();
+        let user_id = body["user"]["id"].as_str().unwrap().to_string();
+        (token, user_id)
+    }
+
+    #[tokio::test]
+    async fn test_set_active_organization_success() {
+        let (app, _tmp) = test_app().await;
+
+        // Register user (creates personal org and sets it as active)
+        let (token, _user_id) = register_and_login(&app, "alice", "alice@example.com").await;
+
+        // Get current active org
+        let me_resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/auth/me")
+                    .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let me_bytes = me_resp.into_body().collect().await.unwrap().to_bytes();
+        let me_body: serde_json::Value = serde_json::from_slice(&me_bytes).unwrap();
+        let org_id = me_body["active_organization"]["id"].as_str().unwrap().to_string();
+
+        // Switch back to the same org (idempotent)
+        let payload = serde_json::json!({ "organization_id": org_id });
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("PUT")
+                    .uri("/users/me/active-organization")
+                    .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(payload.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let bytes = response.into_body().collect().await.unwrap().to_bytes();
+        let body: serde_json::Value = serde_json::from_slice(&bytes).unwrap();
+        // Response is UserResponse — no password_hash field
+        assert!(body.get("password_hash").is_none());
+        assert_eq!(body["active_organization_id"].as_str().unwrap(), org_id);
+    }
+
+    #[tokio::test]
+    async fn test_set_active_organization_not_member() {
+        let (app, _tmp) = test_app().await;
+
+        let (token, _) = register_and_login(&app, "bob", "bob@example.com").await;
+
+        // Use a random UUID that doesn't correspond to any org the user is in
+        let fake_org_id = uuid::Uuid::new_v4().to_string();
+        let payload = serde_json::json!({ "organization_id": fake_org_id });
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("PUT")
+                    .uri("/users/me/active-organization")
+                    .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(payload.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn test_set_active_organization_unauthenticated() {
+        let (app, _tmp) = test_app().await;
+
+        let payload = serde_json::json!({ "organization_id": "any-id" });
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("PUT")
+                    .uri("/users/me/active-organization")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(payload.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn test_set_active_org_allows_second_org() {
+        let (app, _tmp) = test_app().await;
+
+        // Register Alice (gets personal org automatically)
+        let (token_a, user_a_id) = register_and_login(&app, "alice2", "alice2@example.com").await;
+        let _ = user_a_id;
+
+        // Register Bob (we'll use his personal org for the cross-org test)
+        let (token_b, _) = register_and_login(&app, "bob2", "bob2@example.com").await;
+
+        // Get Bob's personal org id
+        let me_resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/auth/me")
+                    .header(header::AUTHORIZATION, format!("Bearer {token_b}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let me_bytes = me_resp.into_body().collect().await.unwrap().to_bytes();
+        let me_body: serde_json::Value = serde_json::from_slice(&me_bytes).unwrap();
+        let bob_org_id = me_body["active_organization"]["id"].as_str().unwrap().to_string();
+
+        // Alice tries to switch to Bob's org (she's not a member)
+        let payload = serde_json::json!({ "organization_id": bob_org_id });
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("PUT")
+                    .uri("/users/me/active-organization")
+                    .header(header::AUTHORIZATION, format!("Bearer {token_a}"))
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(payload.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+    }
+
+    // Keep the compiler happy with unused import
+    #[allow(dead_code)]
+    fn _use_user_response(_: UserResponse) {}
+}

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -10,6 +10,7 @@ pub mod membership_storage;
 pub mod middleware;
 pub mod migration;
 pub mod organization_storage;
+pub mod proxy;
 pub mod session_storage;
 pub mod storage;
 pub mod user_storage;

--- a/crates/core/src/middleware/mod.rs
+++ b/crates/core/src/middleware/mod.rs
@@ -1,3 +1,4 @@
 //! Axum middleware and request extractors for the core service.
 
 pub mod auth;
+pub mod tenant;

--- a/crates/core/src/middleware/tenant.rs
+++ b/crates/core/src/middleware/tenant.rs
@@ -1,0 +1,117 @@
+//! Tenant context extractor for multi-tenant request isolation.
+//!
+//! [`TenantContext`] implements [`axum::extract::FromRequestParts`] and resolves
+//! the authenticated user's active organization for every request. It is more
+//! strict than [`super::auth::AuthUser`]: a valid session is required **and**
+//! the user must have an active organization set. Requests without an active
+//! org receive `403 Forbidden`.
+//!
+//! # Usage
+//!
+//! ```rust,ignore
+//! async fn my_handler(ctx: TenantContext) -> impl IntoResponse {
+//!     Json(json!({ "org": ctx.organization_id, "user": ctx.user_id }))
+//! }
+//! ```
+//!
+//! # X-Tenant-ID header injection
+//!
+//! The `organization_id` field is intended to be forwarded as an
+//! `X-Tenant-ID` header when proxying requests to downstream services.
+//! Downstream services can then use this header to scope their queries
+//! without implementing their own auth stack.
+
+use axum::{
+    extract::FromRequestParts,
+    http::{request::Parts, StatusCode},
+    response::{IntoResponse, Response},
+    Json,
+};
+use serde_json::json;
+
+use crate::api::AppState;
+
+/// Per-request tenant context resolved from the active session + organization.
+pub struct TenantContext {
+    /// The authenticated user's ID.
+    pub user_id: String,
+    /// The organization the user is currently acting as.
+    pub organization_id: String,
+    /// Raw bearer token — available for forwarding or invalidation.
+    pub session_token: String,
+}
+
+/// Extractor rejection for failed tenant resolution.
+pub enum TenantError {
+    /// No `Authorization` header or unparseable value.
+    MissingToken,
+    /// Token not found in sessions table or session is expired.
+    InvalidSession,
+    /// Valid session but the user has no `active_organization_id` set.
+    NoActiveOrganization,
+    /// Internal storage error.
+    InternalError,
+}
+
+impl IntoResponse for TenantError {
+    fn into_response(self) -> Response {
+        let (status, msg) = match self {
+            TenantError::MissingToken => (StatusCode::UNAUTHORIZED, "missing authorization token"),
+            TenantError::InvalidSession => (StatusCode::UNAUTHORIZED, "invalid or expired session"),
+            TenantError::NoActiveOrganization => {
+                (StatusCode::FORBIDDEN, "no active organization set for this user")
+            }
+            TenantError::InternalError => {
+                (StatusCode::INTERNAL_SERVER_ERROR, "internal server error")
+            }
+        };
+        (status, Json(json!({ "error": msg }))).into_response()
+    }
+}
+
+impl FromRequestParts<AppState> for TenantContext {
+    type Rejection = TenantError;
+
+    async fn from_request_parts(
+        parts: &mut Parts,
+        state: &AppState,
+    ) -> Result<Self, Self::Rejection> {
+        // Extract bearer token
+        let token = parts
+            .headers
+            .get(axum::http::header::AUTHORIZATION)
+            .and_then(|v| v.to_str().ok())
+            .and_then(|v| v.strip_prefix("Bearer "))
+            .map(|t| t.trim().to_string())
+            .filter(|t| !t.is_empty())
+            .ok_or(TenantError::MissingToken)?;
+
+        // Look up session and check expiry
+        let session = state
+            .storage
+            .sessions()
+            .get_by_token_hash(&token)
+            .await
+            .map_err(|_| TenantError::InternalError)?
+            .ok_or(TenantError::InvalidSession)?;
+
+        let now = chrono::Utc::now().to_rfc3339();
+        if session.expires_at <= now {
+            return Err(TenantError::InvalidSession);
+        }
+
+        // Fetch the user and require an active organization
+        let user = state
+            .storage
+            .users()
+            .get_by_id(&session.user_id)
+            .await
+            .map_err(|_| TenantError::InternalError)?
+            .ok_or(TenantError::InvalidSession)?;
+
+        let organization_id =
+            user.active_organization_id.ok_or(TenantError::NoActiveOrganization)?;
+
+        Ok(TenantContext { user_id: user.id, organization_id, session_token: token })
+    }
+}

--- a/crates/core/src/proxy.rs
+++ b/crates/core/src/proxy.rs
@@ -1,0 +1,216 @@
+//! HTTP reverse proxy for the core service API gateway.
+//!
+//! [`ProxyConfig`] maps service names to their base URLs (resolved from
+//! environment variables). [`proxy_request`] forwards an incoming Axum request
+//! to a downstream service, injecting `X-Tenant-ID` and `X-Request-ID` headers.
+//!
+//! # Streaming
+//!
+//! Request and response bodies are streamed — the proxy does not buffer large
+//! payloads in memory.
+//!
+//! # Configuration
+//!
+//! Each service URL is read from an environment variable:
+//!
+//! | Service       | Env var                        | Default                    |
+//! |---------------|--------------------------------|----------------------------|
+//! | orchestrator  | `ORCHESTRATOR_URL`             | `http://localhost:17006`   |
+//! | notify        | `NOTIFY_URL`                   | `http://localhost:17004`   |
+//! | ask           | `ASK_URL`                      | `http://localhost:17001`   |
+//! | wrap          | `WRAP_URL`                     | `http://localhost:17005`   |
+//! | hook          | `HOOK_URL`                     | `http://localhost:17002`   |
+//! | monitor       | `MONITOR_URL`                  | `http://localhost:17003`   |
+
+use std::collections::HashMap;
+use std::time::Duration;
+
+use anyhow::Result;
+use axum::body::Bytes;
+use reqwest::Client;
+
+/// Service name → base URL mapping for the API gateway.
+#[derive(Clone)]
+pub struct ProxyConfig {
+    /// Map of service name to base URL (without trailing slash).
+    pub services: HashMap<&'static str, String>,
+    /// HTTP client shared across all proxy requests.
+    pub client: Client,
+}
+
+impl ProxyConfig {
+    /// Build a [`ProxyConfig`] from environment variables, using sensible defaults.
+    pub fn from_env() -> Self {
+        let services = [
+            ("orchestrator", "ORCHESTRATOR_URL", "http://localhost:17006"),
+            ("notify", "NOTIFY_URL", "http://localhost:17004"),
+            ("ask", "ASK_URL", "http://localhost:17001"),
+            ("wrap", "WRAP_URL", "http://localhost:17005"),
+            ("hook", "HOOK_URL", "http://localhost:17002"),
+            ("monitor", "MONITOR_URL", "http://localhost:17003"),
+        ]
+        .into_iter()
+        .map(|(name, env, default)| {
+            let url = std::env::var(env).unwrap_or_else(|_| default.to_string());
+            (name, url)
+        })
+        .collect();
+
+        let client = Client::builder()
+            .timeout(Duration::from_secs(
+                std::env::var("PROXY_TIMEOUT_SECS")
+                    .ok()
+                    .and_then(|v| v.parse().ok())
+                    .unwrap_or(30u64),
+            ))
+            .build()
+            .expect("failed to build proxy HTTP client");
+
+        Self { services, client }
+    }
+
+    /// Look up the base URL for a service name.
+    pub fn url_for(&self, service: &str) -> Option<&str> {
+        self.services.get(service).map(String::as_str)
+    }
+}
+
+/// Perform a health check against a downstream service.
+///
+/// Returns `(is_healthy, detail_message)`.
+pub async fn health_check(client: &Client, base_url: &str) -> (bool, Option<String>) {
+    let health_url = format!("{}/health", base_url);
+    match client.get(&health_url).timeout(Duration::from_secs(3)).send().await {
+        Ok(resp) if resp.status().is_success() => {
+            let body: serde_json::Value = resp.json().await.unwrap_or_default();
+            let detail = body.get("status").and_then(|v| v.as_str()).map(str::to_string);
+            (true, detail)
+        }
+        Ok(resp) => (false, Some(format!("HTTP {}", resp.status()))),
+        Err(e) => {
+            let msg = if e.is_connect() {
+                "connection refused".to_string()
+            } else if e.is_timeout() {
+                "timeout".to_string()
+            } else {
+                e.to_string()
+            };
+            (false, Some(msg))
+        }
+    }
+}
+
+/// Result of a [`proxy_request`] call.
+pub struct ProxyResponse {
+    pub status: u16,
+    pub headers: Vec<(String, String)>,
+    pub body: Bytes,
+}
+
+/// Parameters for a proxied HTTP request.
+pub struct ProxyRequest<'a> {
+    /// HTTP method (e.g. `"GET"`, `"POST"`).
+    pub method: &'a str,
+    /// Path to append to the base URL (must start with `/`).
+    pub path: &'a str,
+    /// Optional pre-encoded query string (without leading `?`).
+    pub query: Option<&'a str>,
+    /// Incoming headers to forward (excluding `host` and `content-length`).
+    pub headers: &'a [(String, String)],
+    /// Request body bytes.
+    pub body: Bytes,
+    /// Tenant identifier injected as `X-Tenant-ID`.
+    pub tenant_id: &'a str,
+    /// Request identifier injected as `X-Request-ID`.
+    pub request_id: &'a str,
+}
+
+/// Forward an HTTP request to a downstream service.
+///
+/// - Injects `X-Tenant-ID` from [`ProxyRequest::tenant_id`]
+/// - Injects `X-Request-ID` from [`ProxyRequest::request_id`]
+/// - Forwards all safe incoming headers (excludes `host` and `content-length`)
+/// - Streams the response body back
+pub async fn proxy_request(
+    client: &Client,
+    target_url: &str,
+    req: ProxyRequest<'_>,
+) -> Result<ProxyResponse> {
+    let method = req.method;
+    let path = req.path;
+    let query = req.query;
+    let headers = req.headers;
+    let body = req.body;
+    let tenant_id = req.tenant_id;
+    let request_id = req.request_id;
+    let url = match query {
+        Some(q) if !q.is_empty() => format!("{}{target_url}{path}?{q}", ""),
+        _ => format!("{target_url}{path}"),
+    };
+
+    let method = reqwest::Method::from_bytes(method.as_bytes())?;
+
+    let mut req = client.request(method, &url).body(body);
+
+    // Forward safe incoming headers (skip host, content-length — reqwest sets those)
+    for (name, value) in headers {
+        let name_lower = name.to_lowercase();
+        if name_lower == "host" || name_lower == "content-length" {
+            continue;
+        }
+        if let Ok(header_name) = reqwest::header::HeaderName::from_bytes(name.as_bytes()) {
+            if let Ok(header_value) = reqwest::header::HeaderValue::from_str(value) {
+                req = req.header(header_name, header_value);
+            }
+        }
+    }
+
+    // Inject tenant and request ID headers
+    req = req.header("X-Tenant-ID", tenant_id).header("X-Request-ID", request_id);
+
+    let resp = req.send().await?;
+    let status = resp.status().as_u16();
+
+    // Collect response headers to forward back
+    let resp_headers: Vec<(String, String)> = resp
+        .headers()
+        .iter()
+        .filter_map(|(name, value)| {
+            let n = name.as_str().to_string();
+            // Skip headers that axum/hyper will set
+            if n == "transfer-encoding" || n == "connection" {
+                return None;
+            }
+            value.to_str().ok().map(|v| (n, v.to_string()))
+        })
+        .collect();
+
+    let body = resp.bytes().await?;
+
+    Ok(ProxyResponse { status, headers: resp_headers, body })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_proxy_config_defaults() {
+        let cfg = ProxyConfig::from_env();
+        assert!(cfg.url_for("orchestrator").is_some());
+        assert!(cfg.url_for("notify").is_some());
+        assert!(cfg.url_for("ask").is_some());
+        assert!(cfg.url_for("wrap").is_some());
+        assert!(cfg.url_for("hook").is_some());
+        assert!(cfg.url_for("monitor").is_some());
+        assert!(cfg.url_for("nonexistent").is_none());
+    }
+
+    #[test]
+    fn test_proxy_config_env_override() {
+        std::env::set_var("ORCHESTRATOR_URL", "http://custom-host:9999");
+        let cfg = ProxyConfig::from_env();
+        assert_eq!(cfg.url_for("orchestrator"), Some("http://custom-host:9999"));
+        std::env::remove_var("ORCHESTRATOR_URL");
+    }
+}

--- a/crates/core/src/user_storage.rs
+++ b/crates/core/src/user_storage.rs
@@ -121,6 +121,65 @@ impl UserStorage {
         Ok(result.rows_affected > 0)
     }
 
+    /// Update the user's email address.
+    ///
+    /// Returns an error if the user does not exist.
+    pub async fn update_email(&self, id: &str, email: &str) -> Result<user::Model> {
+        let user = user::Entity::find_by_id(id)
+            .one(&self.db)
+            .await?
+            .ok_or_else(|| anyhow!("user not found: {}", id))?;
+
+        let mut active: user::ActiveModel = user.into();
+        active.email = Set(email.to_string());
+        active.updated_at = Set(chrono::Utc::now().to_rfc3339());
+        Ok(active.update(&self.db).await?)
+    }
+
+    /// Update the user's password hash (argon2id hashed from plaintext).
+    ///
+    /// Returns an error if the user does not exist.
+    pub async fn update_password(&self, id: &str, new_password: &str) -> Result<user::Model> {
+        let user = user::Entity::find_by_id(id)
+            .one(&self.db)
+            .await?
+            .ok_or_else(|| anyhow!("user not found: {}", id))?;
+
+        let mut active: user::ActiveModel = user.into();
+        active.password_hash = Set(Self::hash_password(new_password)?);
+        active.updated_at = Set(chrono::Utc::now().to_rfc3339());
+        Ok(active.update(&self.db).await?)
+    }
+
+    /// Clear `active_organization_id` for all users whose active org is `org_id`.
+    ///
+    /// Used when an organization is deleted to ensure no user references a
+    /// non-existent organization.
+    ///
+    /// Returns the number of rows updated.
+    pub async fn clear_active_organization_for_org(&self, org_id: &str) -> Result<u64> {
+        // Fetch all users with this active org, then clear each one.
+        // SeaORM's update_many + col_expr requires sea_orm::prelude::Expr which is
+        // not re-exported at the crate root in the version we use, so we do a
+        // fetch-then-update approach which is straightforward and correct.
+        let users = user::Entity::find()
+            .filter(Column::ActiveOrganizationId.eq(org_id))
+            .all(&self.db)
+            .await?;
+
+        let now = chrono::Utc::now().to_rfc3339();
+        let count = users.len() as u64;
+
+        for u in users {
+            let mut active: user::ActiveModel = u.into();
+            active.active_organization_id = Set(None);
+            active.updated_at = Set(now.clone());
+            active.update(&self.db).await?;
+        }
+
+        Ok(count)
+    }
+
     /// Set the user's active organization.
     ///
     /// Pass `None` to clear the active organization.


### PR DESCRIPTION
Adds multi-tenant request isolation infrastructure:

- `TenantContext` extractor (`middleware/tenant.rs`) — resolves session → user → active org per-request; returns 401 for missing/expired sessions and 403 if no active organization is set. Designed to forward `organization_id` as `X-Tenant-ID` to downstream services.
- `PUT /users/me/active-organization` (`api/users.rs`) — validates the requesting user is a member of the target org (403 if not), then updates `active_organization_id`. Returns the updated user profile without `password_hash`.
- 4 endpoint tests: success, not-a-member (403), unauthenticated (401), cross-user org isolation

Closes #216