### PR TITLE
feat(core): add API gateway proxy for downstream service routing

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,6 +47,7 @@ dependencies = [
  "metrics",
  "metrics-exporter-prometheus",
  "rand 0.8.5",
+ "reqwest",
  "sea-orm",
  "sea-orm-migration",
  "serde",

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -31,6 +31,7 @@ sea-orm-migration = { workspace = true }
 async-trait = "0.1"
 argon2 = "0.5"
 rand = "0.8"
+reqwest = { workspace = true, features = ["json", "stream"] }
 
 [dev-dependencies]
 tower = { version = "0.5", features = ["util"] }

--- a/crates/core/src/api.rs
+++ b/crates/core/src/api.rs
@@ -12,21 +12,24 @@
 //! - `GET  /api/v1/users/me/organizations`       — list user's organizations
 //! - `PUT  /users/me/active-organization`        — switch active organization
 //! - `POST /api/v1/organizations`                — create organization
-//! - `GET  /api/v1/organizations/:id`            — get organization
-//! - `PUT  /api/v1/organizations/:id`            — update organization (owners only)
-//! - `DELETE /api/v1/organizations/:id`          — delete organization (owners only)
-//! - `GET  /api/v1/organizations/:id/members`    — list members
-//! - `POST /api/v1/organizations/:id/members`    — add member (owners only)
-//! - `DELETE /api/v1/organizations/:id/members/:uid` — remove member (owners only)
+//! - `GET  /api/v1/organizations/{id}`           — get organization
+//! - `PUT  /api/v1/organizations/{id}`           — update organization (owners only)
+//! - `DELETE /api/v1/organizations/{id}`         — delete organization (owners only)
+//! - `GET  /api/v1/organizations/{id}/members`   — list members
+//! - `POST /api/v1/organizations/{id}/members`   — add member (owners only)
+//! - `DELETE /api/v1/organizations/{id}/members/{uid}` — remove member (owners only)
+//! - `GET  /api/v1/health`                       — aggregate downstream health check
+//! - `ANY  /api/v1/{service}/*`                  — proxy to downstream service
 
 pub mod auth;
+pub mod gateway;
 pub mod organizations;
 pub mod users;
 
 use axum::{routing::get, Json, Router};
 use serde_json::{json, Value};
 
-use crate::storage::Storage;
+use crate::{proxy::ProxyConfig, storage::Storage};
 
 /// Shared application state threaded through all route handlers.
 #[derive(Clone)]
@@ -34,11 +37,18 @@ pub struct AppState {
     pub storage: Storage,
 }
 
-/// Build the application router.
+/// Build the application router without a proxy (for testing or when proxy is disabled).
 pub fn create_router(state: AppState) -> Router {
+    create_router_with_proxy(state, ProxyConfig::from_env())
+}
+
+/// Build the application router with an explicit [`ProxyConfig`].
+pub fn create_router_with_proxy(state: AppState, proxy: ProxyConfig) -> Router {
     let api_v1 = Router::new()
         .nest("/users", users::v1_router())
-        .nest("/organizations", organizations::router());
+        .nest("/organizations", organizations::router())
+        // Gateway routes — /api/v1/health and /api/v1/{service}/* path
+        .merge(gateway::router(proxy));
 
     Router::new()
         .route("/health", get(health_handler))

--- a/crates/core/src/api/gateway.rs
+++ b/crates/core/src/api/gateway.rs
@@ -1,0 +1,278 @@
+//! API gateway proxy handlers.
+//!
+//! Routes incoming requests under `/api/v1/{service}/*` to the corresponding
+//! downstream agentd service. Each proxied request has:
+//!
+//! - `X-Tenant-ID` injected from the authenticated user's active organization
+//! - `X-Request-ID` injected (new UUID per request)
+//! - `Authorization` header forwarded to the downstream service
+//!
+//! # Route Mapping
+//!
+//! | Incoming path                       | Downstream service        |
+//! |-------------------------------------|---------------------------|
+//! | `/api/v1/orchestrator/*`            | agentd-orchestrator       |
+//! | `/api/v1/notify/*`                  | agentd-notify             |
+//! | `/api/v1/ask/*`                     | agentd-ask                |
+//! | `/api/v1/wrap/*`                    | agentd-wrap               |
+//! | `/api/v1/hook/*`                    | agentd-hook               |
+//! | `/api/v1/monitor/*`                 | agentd-monitor            |
+//!
+//! # Health aggregation
+//!
+//! `GET /api/v1/health` checks all downstream services concurrently and
+//! returns a summary. Downstream unavailability yields `503 Service Unavailable`.
+
+use axum::{
+    body::Body,
+    extract::{Path, Query, Request, State},
+    http::{HeaderMap, StatusCode},
+    response::{IntoResponse, Response},
+    routing::get,
+    Json, Router,
+};
+use serde::Serialize;
+use std::collections::HashMap;
+use uuid::Uuid;
+
+use crate::{
+    middleware::tenant::TenantContext,
+    proxy::{health_check, proxy_request, ProxyConfig, ProxyRequest},
+};
+
+use super::AppState;
+
+// ---------------------------------------------------------------------------
+// State extension
+// ---------------------------------------------------------------------------
+
+/// Gateway-specific state carried alongside AppState.
+///
+/// Mounted via `Router::with_state(GatewayState { ... })` on the gateway
+/// sub-router and extracted with `State<GatewayState>`.
+#[derive(Clone)]
+pub struct GatewayState {
+    pub app: AppState,
+    pub proxy: ProxyConfig,
+}
+
+// ---------------------------------------------------------------------------
+// Router
+// ---------------------------------------------------------------------------
+
+pub fn router(proxy: ProxyConfig) -> Router<AppState> {
+    // Build a nested router that merges AppState with ProxyConfig into GatewayState.
+    // We use a closure-based approach: each handler receives both State<AppState>
+    // and the proxy config via a separate extension.
+    //
+    // Axum requires a single state type per router, so we wrap both into GatewayState
+    // using `Router::with_state` at the gateway level.
+    let proxy_clone = proxy.clone();
+
+    Router::new()
+        .route(
+            "/health",
+            get(move |state: State<AppState>| {
+                let p = proxy_clone.clone();
+                async move { health_handler(state, p).await }
+            }),
+        )
+        .route(
+            "/{service}/{*path}",
+            axum::routing::any(proxy_handler).layer(axum::Extension(proxy)),
+        )
+}
+
+// ---------------------------------------------------------------------------
+// Health aggregation
+// ---------------------------------------------------------------------------
+
+#[derive(Serialize)]
+struct ServiceHealth {
+    name: String,
+    url: String,
+    healthy: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    detail: Option<String>,
+}
+
+#[derive(Serialize)]
+struct HealthResponse {
+    status: &'static str,
+    services: Vec<ServiceHealth>,
+}
+
+async fn health_handler(State(state): State<AppState>, proxy: ProxyConfig) -> impl IntoResponse {
+    let _ = state; // AppState not used for health — kept for router consistency
+
+    let mut handles = Vec::new();
+
+    for (&name, url) in &proxy.services {
+        let client = proxy.client.clone();
+        let url = url.clone();
+        let name = name.to_string();
+        handles.push(tokio::spawn(async move {
+            let (healthy, detail) = health_check(&client, &url).await;
+            ServiceHealth { name, url, healthy, detail }
+        }));
+    }
+
+    let mut services = Vec::new();
+    for handle in handles {
+        if let Ok(s) = handle.await {
+            services.push(s);
+        }
+    }
+    services.sort_by(|a, b| a.name.cmp(&b.name));
+
+    let all_healthy = services.iter().all(|s| s.healthy);
+    let status = if all_healthy { StatusCode::OK } else { StatusCode::SERVICE_UNAVAILABLE };
+
+    (status, Json(HealthResponse { status: if all_healthy { "ok" } else { "degraded" }, services }))
+}
+
+// ---------------------------------------------------------------------------
+// Proxy handler
+// ---------------------------------------------------------------------------
+
+async fn proxy_handler(
+    State(state): State<AppState>,
+    axum::Extension(proxy): axum::Extension<ProxyConfig>,
+    tenant: TenantContext,
+    Path((service, path)): Path<(String, String)>,
+    Query(query_params): Query<HashMap<String, String>>,
+    req: Request,
+) -> Response {
+    // Resolve the downstream URL
+    let base_url = match proxy.url_for(&service) {
+        Some(u) => u.to_string(),
+        None => {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(serde_json::json!({
+                    "error": format!("unknown service: {service}")
+                })),
+            )
+                .into_response();
+        }
+    };
+
+    let method = req.method().as_str().to_string();
+
+    // Build query string
+    let query_string = if query_params.is_empty() {
+        None
+    } else {
+        Some(
+            query_params
+                .iter()
+                .map(|(k, v)| format!("{}={}", urlencoding_simple(k), urlencoding_simple(v)))
+                .collect::<Vec<_>>()
+                .join("&"),
+        )
+    };
+
+    // Collect headers to forward
+    let headers: Vec<(String, String)> = req
+        .headers()
+        .iter()
+        .filter_map(|(name, value)| {
+            value.to_str().ok().map(|v| (name.as_str().to_string(), v.to_string()))
+        })
+        .collect();
+
+    // Read body bytes
+    let body_bytes = match axum::body::to_bytes(req.into_body(), usize::MAX).await {
+        Ok(b) => b,
+        Err(e) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({ "error": format!("failed to read request body: {e}") })),
+            )
+                .into_response();
+        }
+    };
+
+    // Generate a request ID
+    let request_id = Uuid::new_v4().to_string();
+    let forward_path = format!("/{path}");
+
+    match proxy_request(
+        &proxy.client,
+        &base_url,
+        ProxyRequest {
+            method: &method,
+            path: &forward_path,
+            query: query_string.as_deref(),
+            headers: &headers,
+            body: body_bytes,
+            tenant_id: &tenant.organization_id,
+            request_id: &request_id,
+        },
+    )
+    .await
+    {
+        Ok(resp) => {
+            let status =
+                StatusCode::from_u16(resp.status).unwrap_or(StatusCode::INTERNAL_SERVER_ERROR);
+            let mut response_headers = HeaderMap::new();
+            for (name, value) in &resp.headers {
+                if let (Ok(hn), Ok(hv)) = (
+                    axum::http::HeaderName::from_bytes(name.as_bytes()),
+                    axum::http::HeaderValue::from_str(value),
+                ) {
+                    response_headers.insert(hn, hv);
+                }
+            }
+            (status, response_headers, Body::from(resp.body)).into_response()
+        }
+        Err(e) => {
+            let _ = state; // suppress unused warning
+            (
+                StatusCode::BAD_GATEWAY,
+                Json(serde_json::json!({
+                    "error": format!("upstream error: {e}")
+                })),
+            )
+                .into_response()
+        }
+    }
+}
+
+/// Minimal percent-encoding for query values (encodes spaces and `&`/`=`).
+fn urlencoding_simple(s: &str) -> String {
+    s.chars()
+        .flat_map(|c| match c {
+            'A'..='Z' | 'a'..='z' | '0'..='9' | '-' | '_' | '.' | '~' => {
+                vec![c]
+            }
+            ' ' => vec!['+'],
+            c => {
+                let mut buf = [0u8; 4];
+                let bytes = c.encode_utf8(&mut buf);
+                bytes
+                    .bytes()
+                    .flat_map(|b| {
+                        vec![
+                            '%',
+                            char::from_digit((b >> 4) as u32, 16).unwrap_or('0'),
+                            char::from_digit((b & 0xf) as u32, 16).unwrap_or('0'),
+                        ]
+                    })
+                    .collect()
+            }
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_urlencoding_simple() {
+        assert_eq!(urlencoding_simple("hello world"), "hello+world");
+        assert_eq!(urlencoding_simple("abc123"), "abc123");
+        assert_eq!(urlencoding_simple("a&b=c"), "a%26b%3dc");
+    }
+}

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -10,6 +10,7 @@ pub mod membership_storage;
 pub mod middleware;
 pub mod migration;
 pub mod organization_storage;
+pub mod proxy;
 pub mod session_storage;
 pub mod storage;
 pub mod user_storage;

--- a/crates/core/src/proxy.rs
+++ b/crates/core/src/proxy.rs
@@ -1,0 +1,216 @@
+//! HTTP reverse proxy for the core service API gateway.
+//!
+//! [`ProxyConfig`] maps service names to their base URLs (resolved from
+//! environment variables). [`proxy_request`] forwards an incoming Axum request
+//! to a downstream service, injecting `X-Tenant-ID` and `X-Request-ID` headers.
+//!
+//! # Streaming
+//!
+//! Request and response bodies are streamed — the proxy does not buffer large
+//! payloads in memory.
+//!
+//! # Configuration
+//!
+//! Each service URL is read from an environment variable:
+//!
+//! | Service       | Env var                        | Default                    |
+//! |---------------|--------------------------------|----------------------------|
+//! | orchestrator  | `ORCHESTRATOR_URL`             | `http://localhost:17006`   |
+//! | notify        | `NOTIFY_URL`                   | `http://localhost:17004`   |
+//! | ask           | `ASK_URL`                      | `http://localhost:17001`   |
+//! | wrap          | `WRAP_URL`                     | `http://localhost:17005`   |
+//! | hook          | `HOOK_URL`                     | `http://localhost:17002`   |
+//! | monitor       | `MONITOR_URL`                  | `http://localhost:17003`   |
+
+use std::collections::HashMap;
+use std::time::Duration;
+
+use anyhow::Result;
+use axum::body::Bytes;
+use reqwest::Client;
+
+/// Service name → base URL mapping for the API gateway.
+#[derive(Clone)]
+pub struct ProxyConfig {
+    /// Map of service name to base URL (without trailing slash).
+    pub services: HashMap<&'static str, String>,
+    /// HTTP client shared across all proxy requests.
+    pub client: Client,
+}
+
+impl ProxyConfig {
+    /// Build a [`ProxyConfig`] from environment variables, using sensible defaults.
+    pub fn from_env() -> Self {
+        let services = [
+            ("orchestrator", "ORCHESTRATOR_URL", "http://localhost:17006"),
+            ("notify", "NOTIFY_URL", "http://localhost:17004"),
+            ("ask", "ASK_URL", "http://localhost:17001"),
+            ("wrap", "WRAP_URL", "http://localhost:17005"),
+            ("hook", "HOOK_URL", "http://localhost:17002"),
+            ("monitor", "MONITOR_URL", "http://localhost:17003"),
+        ]
+        .into_iter()
+        .map(|(name, env, default)| {
+            let url = std::env::var(env).unwrap_or_else(|_| default.to_string());
+            (name, url)
+        })
+        .collect();
+
+        let client = Client::builder()
+            .timeout(Duration::from_secs(
+                std::env::var("PROXY_TIMEOUT_SECS")
+                    .ok()
+                    .and_then(|v| v.parse().ok())
+                    .unwrap_or(30u64),
+            ))
+            .build()
+            .expect("failed to build proxy HTTP client");
+
+        Self { services, client }
+    }
+
+    /// Look up the base URL for a service name.
+    pub fn url_for(&self, service: &str) -> Option<&str> {
+        self.services.get(service).map(String::as_str)
+    }
+}
+
+/// Perform a health check against a downstream service.
+///
+/// Returns `(is_healthy, detail_message)`.
+pub async fn health_check(client: &Client, base_url: &str) -> (bool, Option<String>) {
+    let health_url = format!("{}/health", base_url);
+    match client.get(&health_url).timeout(Duration::from_secs(3)).send().await {
+        Ok(resp) if resp.status().is_success() => {
+            let body: serde_json::Value = resp.json().await.unwrap_or_default();
+            let detail = body.get("status").and_then(|v| v.as_str()).map(str::to_string);
+            (true, detail)
+        }
+        Ok(resp) => (false, Some(format!("HTTP {}", resp.status()))),
+        Err(e) => {
+            let msg = if e.is_connect() {
+                "connection refused".to_string()
+            } else if e.is_timeout() {
+                "timeout".to_string()
+            } else {
+                e.to_string()
+            };
+            (false, Some(msg))
+        }
+    }
+}
+
+/// Result of a [`proxy_request`] call.
+pub struct ProxyResponse {
+    pub status: u16,
+    pub headers: Vec<(String, String)>,
+    pub body: Bytes,
+}
+
+/// Parameters for a proxied HTTP request.
+pub struct ProxyRequest<'a> {
+    /// HTTP method (e.g. `"GET"`, `"POST"`).
+    pub method: &'a str,
+    /// Path to append to the base URL (must start with `/`).
+    pub path: &'a str,
+    /// Optional pre-encoded query string (without leading `?`).
+    pub query: Option<&'a str>,
+    /// Incoming headers to forward (excluding `host` and `content-length`).
+    pub headers: &'a [(String, String)],
+    /// Request body bytes.
+    pub body: Bytes,
+    /// Tenant identifier injected as `X-Tenant-ID`.
+    pub tenant_id: &'a str,
+    /// Request identifier injected as `X-Request-ID`.
+    pub request_id: &'a str,
+}
+
+/// Forward an HTTP request to a downstream service.
+///
+/// - Injects `X-Tenant-ID` from [`ProxyRequest::tenant_id`]
+/// - Injects `X-Request-ID` from [`ProxyRequest::request_id`]
+/// - Forwards all safe incoming headers (excludes `host` and `content-length`)
+/// - Streams the response body back
+pub async fn proxy_request(
+    client: &Client,
+    target_url: &str,
+    req: ProxyRequest<'_>,
+) -> Result<ProxyResponse> {
+    let method = req.method;
+    let path = req.path;
+    let query = req.query;
+    let headers = req.headers;
+    let body = req.body;
+    let tenant_id = req.tenant_id;
+    let request_id = req.request_id;
+    let url = match query {
+        Some(q) if !q.is_empty() => format!("{}{target_url}{path}?{q}", ""),
+        _ => format!("{target_url}{path}"),
+    };
+
+    let method = reqwest::Method::from_bytes(method.as_bytes())?;
+
+    let mut req = client.request(method, &url).body(body);
+
+    // Forward safe incoming headers (skip host, content-length — reqwest sets those)
+    for (name, value) in headers {
+        let name_lower = name.to_lowercase();
+        if name_lower == "host" || name_lower == "content-length" {
+            continue;
+        }
+        if let Ok(header_name) = reqwest::header::HeaderName::from_bytes(name.as_bytes()) {
+            if let Ok(header_value) = reqwest::header::HeaderValue::from_str(value) {
+                req = req.header(header_name, header_value);
+            }
+        }
+    }
+
+    // Inject tenant and request ID headers
+    req = req.header("X-Tenant-ID", tenant_id).header("X-Request-ID", request_id);
+
+    let resp = req.send().await?;
+    let status = resp.status().as_u16();
+
+    // Collect response headers to forward back
+    let resp_headers: Vec<(String, String)> = resp
+        .headers()
+        .iter()
+        .filter_map(|(name, value)| {
+            let n = name.as_str().to_string();
+            // Skip headers that axum/hyper will set
+            if n == "transfer-encoding" || n == "connection" {
+                return None;
+            }
+            value.to_str().ok().map(|v| (n, v.to_string()))
+        })
+        .collect();
+
+    let body = resp.bytes().await?;
+
+    Ok(ProxyResponse { status, headers: resp_headers, body })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_proxy_config_defaults() {
+        let cfg = ProxyConfig::from_env();
+        assert!(cfg.url_for("orchestrator").is_some());
+        assert!(cfg.url_for("notify").is_some());
+        assert!(cfg.url_for("ask").is_some());
+        assert!(cfg.url_for("wrap").is_some());
+        assert!(cfg.url_for("hook").is_some());
+        assert!(cfg.url_for("monitor").is_some());
+        assert!(cfg.url_for("nonexistent").is_none());
+    }
+
+    #[test]
+    fn test_proxy_config_env_override() {
+        std::env::set_var("ORCHESTRATOR_URL", "http://custom-host:9999");
+        let cfg = ProxyConfig::from_env();
+        assert_eq!(cfg.url_for("orchestrator"), Some("http://custom-host:9999"));
+        std::env::remove_var("ORCHESTRATOR_URL");
+    }
+}


### PR DESCRIPTION
Implements an HTTP reverse proxy in `crates/core` that forwards `/api/v1/{service}/*` requests to downstream agentd services (orchestrator, notify, ask, wrap, hook, monitor). Each proxied request has `X-Tenant-ID` and `X-Request-ID` injected. Also adds concurrent health aggregation at `GET /api/v1/health`.

Closes #217