### PR TITLE
feat(projects): add project_id FK to agents, workflows, and rooms tables

### DIFF
--- a/crates/cli/src/commands/apply.rs
+++ b/crates/cli/src/commands/apply.rs
@@ -748,6 +748,7 @@ async fn apply_room(
                 description: tmpl.description.clone(),
                 room_type,
                 created_by: creator,
+                project_id: None,
             };
             // Use create_room_or_conflict to gracefully handle a race (or the
             // get_room_by_name 500-room page cap) where the room already exists

--- a/crates/cli/src/commands/communicate.rs
+++ b/crates/cli/src/commands/communicate.rs
@@ -421,6 +421,7 @@ async fn create_room(
             description: description.map(str::to_string),
             room_type,
             created_by: created_by.to_string(),
+            project_id: None,
         })
         .await
         .context("Failed to create room")?;

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -37,6 +37,7 @@ pub mod memory;
 pub mod notify;
 pub mod orchestrator;
 pub mod org;
+pub mod project;
 pub mod prompt;
 pub mod wrap;
 
@@ -48,5 +49,6 @@ pub use memory::MemoryCommand;
 pub use notify::NotifyCommand;
 pub use orchestrator::OrchestratorCommand;
 pub use org::OrgCommand;
+pub use project::ProjectCommand;
 pub use prompt::PromptCommand;
 pub use wrap::WrapCommand;

--- a/crates/cli/src/commands/project.rs
+++ b/crates/cli/src/commands/project.rs
@@ -1,0 +1,480 @@
+//! Project management command implementations.
+//!
+//! This module implements all subcommands for managing projects via the
+//! orchestrator service. Projects group agents and workflows together for
+//! organisational purposes.
+//!
+//! # Available Commands
+//!
+//! - **list**: List all projects
+//! - **create**: Create a new project
+//! - **show**: Show details of a specific project (by name or UUID)
+//! - **update**: Update a project's name or description
+//! - **delete**: Delete a project
+//! - **add-agent**: Associate an agent with a project
+//! - **remove-agent**: Remove an agent from a project
+//! - **add-workflow**: Associate a workflow with a project
+//! - **remove-workflow**: Remove a workflow from a project
+//!
+//! # Examples
+//!
+//! ```bash
+//! agent project list
+//! agent project create my-project --description "Work items"
+//! agent project show my-project
+//! agent project add-agent my-project <agent-id>
+//! agent project remove-agent my-project <agent-id>
+//! ```
+
+use anyhow::{bail, Context, Result};
+use clap::Subcommand;
+use colored::*;
+use uuid::Uuid;
+
+use orchestrator::client::OrchestratorClient;
+use orchestrator::types::{CreateProjectRequest, UpdateProjectRequest};
+
+/// Project management subcommands.
+#[derive(Subcommand)]
+pub enum ProjectCommand {
+    /// List all projects.
+    ///
+    /// # Examples
+    ///
+    /// ```bash
+    /// agent project list
+    /// ```
+    List,
+
+    /// Create a new project.
+    ///
+    /// # Examples
+    ///
+    /// ```bash
+    /// agent project create my-project
+    /// agent project create my-project --description "Description of the project"
+    /// ```
+    Create {
+        /// Project name (must be unique)
+        name: String,
+
+        /// Optional description
+        #[arg(long)]
+        description: Option<String>,
+    },
+
+    /// Show details of a project by name or UUID.
+    ///
+    /// Displays the project details including associated agent and workflow counts.
+    ///
+    /// # Examples
+    ///
+    /// ```bash
+    /// agent project show my-project
+    /// agent project show 550e8400-e29b-41d4-a716-446655440000
+    /// ```
+    Show {
+        /// Project name or UUID
+        id_or_name: String,
+    },
+
+    /// Update a project's name or description.
+    ///
+    /// # Examples
+    ///
+    /// ```bash
+    /// agent project update my-project --name new-name
+    /// agent project update my-project --description "Updated description"
+    /// ```
+    Update {
+        /// Project name or UUID
+        id_or_name: String,
+
+        /// New name for the project
+        #[arg(long)]
+        name: Option<String>,
+
+        /// New description for the project
+        #[arg(long)]
+        description: Option<String>,
+    },
+
+    /// Delete a project.
+    ///
+    /// Fails if agents or workflows are still associated with the project.
+    /// Dissociate them first with `remove-agent` and `remove-workflow`.
+    ///
+    /// # Examples
+    ///
+    /// ```bash
+    /// agent project delete my-project
+    /// ```
+    Delete {
+        /// Project name or UUID
+        id_or_name: String,
+    },
+
+    /// Associate an agent with a project.
+    ///
+    /// # Examples
+    ///
+    /// ```bash
+    /// agent project add-agent my-project 550e8400-e29b-41d4-a716-446655440000
+    /// ```
+    AddAgent {
+        /// Project name or UUID
+        project: String,
+
+        /// Agent UUID
+        agent_id: String,
+    },
+
+    /// Remove an agent from a project.
+    ///
+    /// # Examples
+    ///
+    /// ```bash
+    /// agent project remove-agent my-project 550e8400-e29b-41d4-a716-446655440000
+    /// ```
+    RemoveAgent {
+        /// Project name or UUID
+        project: String,
+
+        /// Agent UUID
+        agent_id: String,
+    },
+
+    /// Associate a workflow with a project.
+    ///
+    /// # Examples
+    ///
+    /// ```bash
+    /// agent project add-workflow my-project 550e8400-e29b-41d4-a716-446655440000
+    /// ```
+    AddWorkflow {
+        /// Project name or UUID
+        project: String,
+
+        /// Workflow UUID
+        workflow_id: String,
+    },
+
+    /// Remove a workflow from a project.
+    ///
+    /// # Examples
+    ///
+    /// ```bash
+    /// agent project remove-workflow my-project 550e8400-e29b-41d4-a716-446655440000
+    /// ```
+    RemoveWorkflow {
+        /// Project name or UUID
+        project: String,
+
+        /// Workflow UUID
+        workflow_id: String,
+    },
+}
+
+impl ProjectCommand {
+    /// Execute the project command.
+    pub async fn execute(&self, client: &OrchestratorClient, json: bool) -> Result<()> {
+        match self {
+            ProjectCommand::List => list_projects(client, json).await,
+            ProjectCommand::Create { name, description } => {
+                create_project(client, name, description.as_deref(), json).await
+            }
+            ProjectCommand::Show { id_or_name } => show_project(client, id_or_name, json).await,
+            ProjectCommand::Update { id_or_name, name, description } => {
+                update_project(client, id_or_name, name.as_deref(), description.as_deref(), json)
+                    .await
+            }
+            ProjectCommand::Delete { id_or_name } => delete_project(client, id_or_name, json).await,
+            ProjectCommand::AddAgent { project, agent_id } => {
+                add_agent(client, project, agent_id, json).await
+            }
+            ProjectCommand::RemoveAgent { project, agent_id } => {
+                remove_agent(client, project, agent_id, json).await
+            }
+            ProjectCommand::AddWorkflow { project, workflow_id } => {
+                add_workflow(client, project, workflow_id, json).await
+            }
+            ProjectCommand::RemoveWorkflow { project, workflow_id } => {
+                remove_workflow(client, project, workflow_id, json).await
+            }
+        }
+    }
+}
+
+/// Resolve a project name or UUID string to a project UUID.
+///
+/// If the string parses as a UUID it is used directly; otherwise a name lookup
+/// is performed against the orchestrator.
+async fn resolve_project_id(client: &OrchestratorClient, id_or_name: &str) -> Result<Uuid> {
+    if let Ok(id) = Uuid::parse_str(id_or_name) {
+        return Ok(id);
+    }
+    match client.get_project_by_name(id_or_name).await? {
+        Some(p) => Ok(p.id),
+        None => bail!("No project found with name {:?}", id_or_name),
+    }
+}
+
+async fn list_projects(client: &OrchestratorClient, json: bool) -> Result<()> {
+    let resp = client.list_projects().await.context("Failed to list projects")?;
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&resp.items)?);
+        return Ok(());
+    }
+
+    if resp.items.is_empty() {
+        println!("{}", "No projects found.".yellow());
+        return Ok(());
+    }
+
+    println!("{}", "Projects".blue().bold());
+    println!("{}", "=".repeat(60).cyan());
+    for project in &resp.items {
+        let desc = project.description.as_deref().unwrap_or("-");
+        println!(
+            "  {} | {} | {}",
+            project.id.to_string().bright_black(),
+            project.name.bold(),
+            desc
+        );
+    }
+    println!();
+    println!("Total: {}", resp.total.to_string().green().bold());
+
+    Ok(())
+}
+
+async fn create_project(
+    client: &OrchestratorClient,
+    name: &str,
+    description: Option<&str>,
+    json: bool,
+) -> Result<()> {
+    let req = CreateProjectRequest {
+        name: name.to_string(),
+        description: description.map(|s| s.to_string()),
+    };
+    let project = client.create_project(&req).await.context("Failed to create project")?;
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&project)?);
+        return Ok(());
+    }
+
+    println!("{}", "Project created".green().bold());
+    println!("  ID:          {}", project.id.to_string().bright_black());
+    println!("  Name:        {}", project.name.bold());
+    if let Some(desc) = &project.description {
+        println!("  Description: {}", desc);
+    }
+
+    Ok(())
+}
+
+async fn show_project(client: &OrchestratorClient, id_or_name: &str, json: bool) -> Result<()> {
+    let id = resolve_project_id(client, id_or_name).await?;
+    let project = client.get_project(&id).await.context("Failed to get project")?;
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&project)?);
+        return Ok(());
+    }
+
+    println!("{}", "Project".blue().bold());
+    println!("{}", "=".repeat(60).cyan());
+    println!("  ID:          {}", project.id.to_string().bright_black());
+    println!("  Name:        {}", project.name.bold());
+    if let Some(desc) = &project.description {
+        println!("  Description: {}", desc);
+    }
+    println!("  Agents:      {}", project.agent_count);
+    println!("  Workflows:   {}", project.workflow_count);
+    println!("  Created:     {}", project.created_at.format("%Y-%m-%d %H:%M:%S UTC"));
+    println!("  Updated:     {}", project.updated_at.format("%Y-%m-%d %H:%M:%S UTC"));
+
+    Ok(())
+}
+
+async fn update_project(
+    client: &OrchestratorClient,
+    id_or_name: &str,
+    name: Option<&str>,
+    description: Option<&str>,
+    json: bool,
+) -> Result<()> {
+    if name.is_none() && description.is_none() {
+        bail!("Provide at least one of --name or --description to update");
+    }
+
+    let id = resolve_project_id(client, id_or_name).await?;
+    let req = UpdateProjectRequest {
+        name: name.map(|s| s.to_string()),
+        description: description.map(|s| s.to_string()),
+    };
+    let project = client.update_project(&id, &req).await.context("Failed to update project")?;
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&project)?);
+        return Ok(());
+    }
+
+    println!("{}", "Project updated".green().bold());
+    println!("  ID:          {}", project.id.to_string().bright_black());
+    println!("  Name:        {}", project.name.bold());
+    if let Some(desc) = &project.description {
+        println!("  Description: {}", desc);
+    }
+
+    Ok(())
+}
+
+async fn delete_project(client: &OrchestratorClient, id_or_name: &str, json: bool) -> Result<()> {
+    let id = resolve_project_id(client, id_or_name).await?;
+    client.delete_project(&id).await.context("Failed to delete project")?;
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&serde_json::json!({"deleted": id}))?);
+        return Ok(());
+    }
+
+    println!("{} {}", "Deleted project".green().bold(), id.to_string().bright_black());
+
+    Ok(())
+}
+
+async fn add_agent(
+    client: &OrchestratorClient,
+    project: &str,
+    agent_id: &str,
+    json: bool,
+) -> Result<()> {
+    let project_id = resolve_project_id(client, project).await?;
+    let agent_uuid = Uuid::parse_str(agent_id).context("Invalid agent UUID")?;
+    client
+        .associate_project_agent(&project_id, &agent_uuid)
+        .await
+        .context("Failed to add agent to project")?;
+
+    if json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(
+                &serde_json::json!({"project_id": project_id, "agent_id": agent_uuid})
+            )?
+        );
+        return Ok(());
+    }
+
+    println!(
+        "{} agent {} to project {}",
+        "Added".green().bold(),
+        agent_uuid.to_string().bright_black(),
+        project_id.to_string().bright_black()
+    );
+
+    Ok(())
+}
+
+async fn remove_agent(
+    client: &OrchestratorClient,
+    project: &str,
+    agent_id: &str,
+    json: bool,
+) -> Result<()> {
+    let project_id = resolve_project_id(client, project).await?;
+    let agent_uuid = Uuid::parse_str(agent_id).context("Invalid agent UUID")?;
+    client
+        .dissociate_project_agent(&project_id, &agent_uuid)
+        .await
+        .context("Failed to remove agent from project")?;
+
+    if json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(
+                &serde_json::json!({"project_id": project_id, "agent_id": agent_uuid})
+            )?
+        );
+        return Ok(());
+    }
+
+    println!(
+        "{} agent {} from project {}",
+        "Removed".green().bold(),
+        agent_uuid.to_string().bright_black(),
+        project_id.to_string().bright_black()
+    );
+
+    Ok(())
+}
+
+async fn add_workflow(
+    client: &OrchestratorClient,
+    project: &str,
+    workflow_id: &str,
+    json: bool,
+) -> Result<()> {
+    let project_id = resolve_project_id(client, project).await?;
+    let workflow_uuid = Uuid::parse_str(workflow_id).context("Invalid workflow UUID")?;
+    client
+        .associate_project_workflow(&project_id, &workflow_uuid)
+        .await
+        .context("Failed to add workflow to project")?;
+
+    if json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(
+                &serde_json::json!({"project_id": project_id, "workflow_id": workflow_uuid})
+            )?
+        );
+        return Ok(());
+    }
+
+    println!(
+        "{} workflow {} to project {}",
+        "Added".green().bold(),
+        workflow_uuid.to_string().bright_black(),
+        project_id.to_string().bright_black()
+    );
+
+    Ok(())
+}
+
+async fn remove_workflow(
+    client: &OrchestratorClient,
+    project: &str,
+    workflow_id: &str,
+    json: bool,
+) -> Result<()> {
+    let project_id = resolve_project_id(client, project).await?;
+    let workflow_uuid = Uuid::parse_str(workflow_id).context("Invalid workflow UUID")?;
+    client
+        .dissociate_project_workflow(&project_id, &workflow_uuid)
+        .await
+        .context("Failed to remove workflow from project")?;
+
+    if json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(
+                &serde_json::json!({"project_id": project_id, "workflow_id": workflow_uuid})
+            )?
+        );
+        return Ok(());
+    }
+
+    println!(
+        "{} workflow {} from project {}",
+        "Removed".green().bold(),
+        workflow_uuid.to_string().bright_black(),
+        project_id.to_string().bright_black()
+    );
+
+    Ok(())
+}

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -84,7 +84,7 @@ use colored::*;
 use commands::index::IndexClient;
 use commands::{
     AskCommand, AuthCommand, CommunicateCommand, IndexCommand, MemoryCommand, NotifyCommand,
-    OrchestratorCommand, OrgCommand, PromptCommand, WrapCommand,
+    OrchestratorCommand, OrgCommand, ProjectCommand, PromptCommand, WrapCommand,
 };
 use communicate::client::CommunicateClient;
 use memory::client::MemoryClient;
@@ -339,6 +339,27 @@ enum Commands {
         #[command(subcommand)]
         command: OrgCommand,
     },
+
+    /// Manage projects in the orchestrator.
+    ///
+    /// Projects group agents and workflows together for organisational purposes.
+    ///
+    /// # Examples
+    ///
+    /// ```bash
+    /// agent project list
+    /// agent project create my-project --description "Work items"
+    /// agent project show my-project
+    /// agent project add-agent my-project <agent-id>
+    /// agent project remove-agent my-project <agent-id>
+    /// agent project add-workflow my-project <workflow-id>
+    /// agent project remove-workflow my-project <workflow-id>
+    /// agent project delete my-project
+    /// ```
+    Project {
+        #[command(subcommand)]
+        command: ProjectCommand,
+    },
 }
 
 /// Main entry point for the agent CLI.
@@ -469,6 +490,12 @@ async fn main() -> Result<()> {
         }
         Commands::Org { command } => {
             command.execute(cli.json).await?;
+        }
+        Commands::Project { command } => {
+            let url = env::var("AGENTD_ORCHESTRATOR_SERVICE_URL")
+                .unwrap_or_else(|_| "http://localhost:7006".to_string());
+            let client = OrchestratorClient::new(url);
+            command.execute(&client, cli.json).await?;
         }
     }
 

--- a/crates/communicate/src/api.rs
+++ b/crates/communicate/src/api.rs
@@ -98,6 +98,7 @@ struct ListRoomsParams {
     limit: Option<usize>,
     offset: Option<usize>,
     room_type: Option<String>,
+    project_id: Option<String>,
 }
 
 /// Query parameters for paginated list endpoints.
@@ -159,7 +160,7 @@ async fn list_rooms(
         let rt = type_str.parse::<RoomType>().map_err(|e| ApiError::InvalidInput(e.to_string()))?;
         state.storage.list_rooms_by_type(&rt, limit, offset).await?
     } else {
-        state.storage.list_rooms(limit, offset).await?
+        state.storage.list_rooms(limit, offset, params.project_id.as_deref()).await?
     };
 
     let items = rooms.into_iter().map(RoomResponse::from).collect();

--- a/crates/communicate/src/client.rs
+++ b/crates/communicate/src/client.rs
@@ -532,6 +532,7 @@ mod tests {
             description: None,
             room_type: RoomType::Group,
             created_by: "agent-1".to_string(),
+            project_id: None,
         };
 
         let json = serde_json::to_string(&req).unwrap();

--- a/crates/communicate/src/entity/room.rs
+++ b/crates/communicate/src/entity/room.rs
@@ -32,6 +32,9 @@ pub struct Model {
 
     /// RFC3339 last-update timestamp.
     pub updated_at: String,
+    /// Optional project identifier (UUID string).  No FK — rooms and projects
+    /// live in separate databases.  NULL when not assigned to a project.
+    pub project_id: Option<String>,
 }
 
 /// Relations from rooms to participants and messages.

--- a/crates/communicate/src/migration/m20260409_000002_add_project_id_to_rooms.rs
+++ b/crates/communicate/src/migration/m20260409_000002_add_project_id_to_rooms.rs
@@ -1,0 +1,47 @@
+//! Migration 2: add nullable `project_id` column to `rooms`.
+//!
+//! Rooms can be associated with a project by convention — there is no foreign
+//! key since rooms live in a separate database from the projects table.
+//! All existing rows receive `NULL` project_id — this migration is non-breaking.
+
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Rooms::Table)
+                    .add_column(ColumnDef::new(Rooms::ProjectId).string().null())
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx_rooms_project_id")
+                    .table(Rooms::Table)
+                    .col(Rooms::ProjectId)
+                    .to_owned(),
+            )
+            .await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager.drop_index(Index::drop().name("idx_rooms_project_id").to_owned()).await?;
+
+        // SQLite does not support DROP COLUMN.
+        Ok(())
+    }
+}
+
+#[derive(Iden)]
+enum Rooms {
+    Table,
+    ProjectId,
+}

--- a/crates/communicate/src/migration/mod.rs
+++ b/crates/communicate/src/migration/mod.rs
@@ -1,12 +1,16 @@
 pub use sea_orm_migration::prelude::*;
 
 mod m20250319_000001_create_communicate_tables;
+mod m20260409_000002_add_project_id_to_rooms;
 
 pub struct Migrator;
 
 #[async_trait::async_trait]
 impl MigratorTrait for Migrator {
     fn migrations() -> Vec<Box<dyn MigrationTrait>> {
-        vec![Box::new(m20250319_000001_create_communicate_tables::Migration)]
+        vec![
+            Box::new(m20250319_000001_create_communicate_tables::Migration),
+            Box::new(m20260409_000002_add_project_id_to_rooms::Migration),
+        ]
     }
 }

--- a/crates/communicate/src/storage.rs
+++ b/crates/communicate/src/storage.rs
@@ -79,6 +79,7 @@ impl CommunicateStorage {
             created_by: Set(req.created_by.clone()),
             created_at: Set(now.to_rfc3339()),
             updated_at: Set(now.to_rfc3339()),
+            project_id: Set(req.project_id.clone()),
         };
 
         model.insert(&self.db).await.map_err(|e| ApiError::Internal(e.into()))?;
@@ -114,18 +115,23 @@ impl CommunicateStorage {
         row.map(|m| model_to_room(m).map_err(ApiError::Internal)).transpose()
     }
 
-    /// Returns a paginated list of all rooms and the total count.
+    /// Returns a paginated list of all rooms and the total count,
+    /// optionally filtered by project_id.
     pub async fn list_rooms(
         &self,
         limit: usize,
         offset: usize,
+        project_id: Option<&str>,
     ) -> Result<(Vec<Room>, usize), ApiError> {
-        let total = entity::room::Entity::find()
-            .count(&self.db)
-            .await
-            .map_err(|e| ApiError::Internal(e.into()))? as usize;
+        let mut base = entity::room::Entity::find();
+        if let Some(pid) = project_id {
+            base = base.filter(entity::room::Column::ProjectId.eq(pid));
+        }
 
-        let rows = entity::room::Entity::find()
+        let total =
+            base.clone().count(&self.db).await.map_err(|e| ApiError::Internal(e.into()))? as usize;
+
+        let rows = base
             .order_by_asc(entity::room::Column::Name)
             .limit(limit as u64)
             .offset(offset as u64)
@@ -756,6 +762,7 @@ pub fn model_to_room(m: entity::room::Model) -> Result<Room> {
         created_by: m.created_by,
         created_at: m.created_at.parse::<chrono::DateTime<chrono::Utc>>()?,
         updated_at: m.updated_at.parse::<chrono::DateTime<chrono::Utc>>()?,
+        project_id: m.project_id,
     })
 }
 
@@ -810,6 +817,7 @@ mod tests {
             description: Some("Test description".to_string()),
             room_type: RoomType::Group,
             created_by: "agent-test".to_string(),
+            project_id: None,
         }
     }
 
@@ -861,6 +869,7 @@ mod tests {
             description: None,
             room_type: RoomType::Group,
             created_by: "agent-test".to_string(),
+            project_id: None,
         };
         let result = storage.create_room(&req).await;
         assert!(matches!(result, Err(ApiError::InvalidInput(_))));
@@ -875,11 +884,11 @@ mod tests {
             storage.create_room(&req).await.unwrap();
         }
 
-        let (first_page, total) = storage.list_rooms(3, 0).await.unwrap();
+        let (first_page, total) = storage.list_rooms(3, 0, None).await.unwrap();
         assert_eq!(total, 5);
         assert_eq!(first_page.len(), 3);
 
-        let (second_page, total2) = storage.list_rooms(3, 3).await.unwrap();
+        let (second_page, total2) = storage.list_rooms(3, 3, None).await.unwrap();
         assert_eq!(total2, 5);
         assert_eq!(second_page.len(), 2);
     }

--- a/crates/communicate/src/types.rs
+++ b/crates/communicate/src/types.rs
@@ -163,6 +163,10 @@ pub struct Room {
     pub created_by: String,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
+    /// Optional project identifier.  No FK — rooms and projects live in
+    /// separate databases.  `None` when not assigned to a project.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub project_id: Option<String>,
 }
 
 /// An agent or human who is a member of a room.
@@ -211,6 +215,9 @@ pub struct CreateRoomRequest {
     #[serde(default = "default_room_type")]
     pub room_type: RoomType,
     pub created_by: String,
+    /// Optional project identifier to associate this room with a project.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub project_id: Option<String>,
 }
 
 fn default_room_type() -> RoomType {
@@ -432,6 +439,7 @@ mod tests {
             created_by: "agent-abc".to_string(),
             created_at: Utc::now(),
             updated_at: Utc::now(),
+            project_id: None,
         };
         let json = serde_json::to_string(&room).unwrap();
         let back: Room = serde_json::from_str(&json).unwrap();

--- a/crates/communicate/src/websocket.rs
+++ b/crates/communicate/src/websocket.rs
@@ -476,6 +476,7 @@ mod tests {
                 description: None,
                 room_type: RoomType::Group,
                 created_by: "creator".to_string(),
+                project_id: None,
             })
             .await
             .unwrap();
@@ -655,6 +656,7 @@ mod tests {
                 description: None,
                 room_type: RoomType::Group,
                 created_by: "creator".to_string(),
+                project_id: None,
             })
             .await
             .unwrap();
@@ -755,6 +757,7 @@ mod tests {
                 description: None,
                 room_type: RoomType::Group,
                 created_by: "creator".to_string(),
+                project_id: None,
             })
             .await
             .unwrap();

--- a/crates/orchestrator/src/api.rs
+++ b/crates/orchestrator/src/api.rs
@@ -1028,13 +1028,6 @@ struct ProjectListQuery {
     offset: Option<usize>,
 }
 
-#[derive(Serialize)]
-struct ProjectDetails {
-    #[serde(flatten)]
-    project: Project,
-    agent_count: usize,
-    workflow_count: usize,
-}
 
 async fn list_projects(
     State(state): State<ApiState>,
@@ -1081,7 +1074,15 @@ async fn get_project(
     let workflow_count =
         state.scheduler.storage().list_workflows(Some(id)).await.map_err(ApiError::Internal)?.len();
 
-    Ok(Json(ProjectDetails { project, agent_count, workflow_count }))
+    Ok(Json(ProjectResponse {
+        id: project.id,
+        name: project.name,
+        description: project.description,
+        created_at: project.created_at,
+        updated_at: project.updated_at,
+        agent_count,
+        workflow_count,
+    }))
 }
 
 async fn update_project(

--- a/crates/orchestrator/src/api.rs
+++ b/crates/orchestrator/src/api.rs
@@ -785,6 +785,7 @@ async fn join_agent_room(
                         description: None,
                         room_type: RoomType::Group,
                         created_by: agent.name.clone(),
+                        project_id: None,
                     })
                     .await
                     .map_err(|e| communicate_error(e.into()))?,

--- a/crates/orchestrator/src/api.rs
+++ b/crates/orchestrator/src/api.rs
@@ -1,6 +1,7 @@
 use crate::manager::AgentManager;
 use crate::scheduler::api::{queue_routes, webhook_routes, workflow_routes, WorkflowState};
 use crate::scheduler::events::SystemEvent;
+use crate::scheduler::types::WorkflowResponse;
 use crate::scheduler::Scheduler;
 use crate::types::*;
 use crate::websocket::{
@@ -84,6 +85,19 @@ pub fn create_router(state: ApiState) -> Router {
         .route("/approvals/{id}/deny", post(deny_tool))
         .route("/debug/agents", get(debug_agents))
         .route("/events/ask", post(ask_event_handler))
+        // Project management
+        .route("/projects", get(list_projects).post(create_project))
+        .route("/projects/{id}", get(get_project).put(update_project).delete(delete_project))
+        .route("/projects/{id}/agents", get(list_project_agents))
+        .route(
+            "/projects/{id}/agents/{agent_id}",
+            post(associate_project_agent).delete(dissociate_project_agent),
+        )
+        .route("/projects/{id}/workflows", get(list_project_workflows))
+        .route(
+            "/projects/{id}/workflows/{workflow_id}",
+            post(associate_project_workflow).delete(dissociate_project_workflow),
+        )
         .with_state(state);
 
     api_routes
@@ -100,6 +114,7 @@ pub struct ListQuery {
     pub status: Option<String>,
     pub limit: Option<usize>,
     pub offset: Option<usize>,
+    pub project_id: Option<Uuid>,
 }
 
 async fn health_check(State(state): State<ApiState>) -> impl IntoResponse {
@@ -139,7 +154,8 @@ async fn list_agents(
     let limit = clamp_limit(query.limit);
     let offset = query.offset.unwrap_or(0);
 
-    let (agents, total) = state.manager.list_agents_paginated(status_filter, limit, offset).await?;
+    let (agents, total) =
+        state.manager.list_agents_paginated(status_filter, query.project_id, limit, offset).await?;
     let mut items: Vec<AgentResponse> = Vec::with_capacity(agents.len());
     for agent in agents {
         let id = agent.id;
@@ -1000,6 +1016,271 @@ async fn ask_event_handler(
     });
 
     StatusCode::NO_CONTENT
+}
+
+// ---------------------------------------------------------------------------
+// Project management handlers
+// ---------------------------------------------------------------------------
+
+#[derive(Deserialize)]
+struct ProjectListQuery {
+    limit: Option<usize>,
+    offset: Option<usize>,
+}
+
+#[derive(Serialize)]
+struct ProjectDetails {
+    #[serde(flatten)]
+    project: Project,
+    agent_count: usize,
+    workflow_count: usize,
+}
+
+async fn list_projects(
+    State(state): State<ApiState>,
+    Query(query): Query<ProjectListQuery>,
+) -> Result<impl IntoResponse, ApiError> {
+    let ps = state.manager.project_storage();
+    let all = ps.list().await.map_err(ApiError::Internal)?;
+    let total = all.len();
+    let limit = clamp_limit(query.limit);
+    let offset = query.offset.unwrap_or(0);
+    let items: Vec<Project> = all.into_iter().skip(offset).take(limit).collect();
+    Ok(Json(PaginatedResponse { items, total, limit, offset }))
+}
+
+async fn create_project(
+    State(state): State<ApiState>,
+    Json(req): Json<CreateProjectRequest>,
+) -> Result<impl IntoResponse, ApiError> {
+    if req.name.trim().is_empty() {
+        return Err(ApiError::InvalidInput("project name must not be empty".to_string()));
+    }
+    let project = Project::new(req.name, req.description);
+    let ps = state.manager.project_storage();
+    let created = ps.create(&project).await.map_err(|e| {
+        if e.to_string().contains("UNIQUE") {
+            ApiError::Conflict(format!("a project named '{}' already exists", project.name))
+        } else {
+            ApiError::Internal(e)
+        }
+    })?;
+    Ok((StatusCode::CREATED, Json(created)))
+}
+
+async fn get_project(
+    State(state): State<ApiState>,
+    Path(id): Path<Uuid>,
+) -> Result<impl IntoResponse, ApiError> {
+    let ps = state.manager.project_storage();
+    let project = ps.get(&id).await.map_err(ApiError::Internal)?.ok_or(ApiError::NotFound)?;
+
+    let agent_count =
+        state.manager.agent_storage().list(None, Some(id)).await.map_err(ApiError::Internal)?.len();
+
+    let workflow_count =
+        state.scheduler.storage().list_workflows(Some(id)).await.map_err(ApiError::Internal)?.len();
+
+    Ok(Json(ProjectDetails { project, agent_count, workflow_count }))
+}
+
+async fn update_project(
+    State(state): State<ApiState>,
+    Path(id): Path<Uuid>,
+    Json(req): Json<UpdateProjectRequest>,
+) -> Result<impl IntoResponse, ApiError> {
+    let ps = state.manager.project_storage();
+    let updated = ps.update(&id, &req).await.map_err(|e| {
+        let msg = e.to_string();
+        if msg.contains("not found") {
+            ApiError::NotFound
+        } else if msg.contains("UNIQUE") {
+            ApiError::Conflict("a project with that name already exists".to_string())
+        } else {
+            ApiError::Internal(e)
+        }
+    })?;
+    Ok(Json(updated))
+}
+
+async fn delete_project(
+    State(state): State<ApiState>,
+    Path(id): Path<Uuid>,
+) -> Result<impl IntoResponse, ApiError> {
+    let ps = state.manager.project_storage();
+
+    // Verify project exists.
+    ps.get(&id).await.map_err(ApiError::Internal)?.ok_or(ApiError::NotFound)?;
+
+    // Reject if any agents are still associated.
+    let associated_agents =
+        state.manager.agent_storage().list(None, Some(id)).await.map_err(ApiError::Internal)?;
+    if !associated_agents.is_empty() {
+        return Err(ApiError::InvalidInput(format!(
+            "cannot delete project: {} agent(s) still associated",
+            associated_agents.len()
+        )));
+    }
+
+    // Reject if any workflows are still associated.
+    let associated_workflows =
+        state.scheduler.storage().list_workflows(Some(id)).await.map_err(ApiError::Internal)?;
+    if !associated_workflows.is_empty() {
+        return Err(ApiError::InvalidInput(format!(
+            "cannot delete project: {} workflow(s) still associated",
+            associated_workflows.len()
+        )));
+    }
+
+    ps.delete(&id).await.map_err(|e| {
+        if e.to_string().contains("not found") {
+            ApiError::NotFound
+        } else {
+            ApiError::Internal(e)
+        }
+    })?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+async fn list_project_agents(
+    State(state): State<ApiState>,
+    Path(id): Path<Uuid>,
+    Query(query): Query<ProjectListQuery>,
+) -> Result<impl IntoResponse, ApiError> {
+    let ps = state.manager.project_storage();
+    ps.get(&id).await.map_err(ApiError::Internal)?.ok_or(ApiError::NotFound)?;
+
+    let limit = clamp_limit(query.limit);
+    let offset = query.offset.unwrap_or(0);
+
+    let (agents, total) = state
+        .manager
+        .agent_storage()
+        .list_paginated_filtered(None, Some(id), limit, offset)
+        .await
+        .map_err(ApiError::Internal)?;
+
+    let mut items: Vec<AgentResponse> = Vec::with_capacity(agents.len());
+    for agent in agents {
+        let aid = agent.id;
+        let mut response = AgentResponse::from(agent);
+        response.activity = state.registry.get_activity_state(&aid).await;
+        items.push(response);
+    }
+    Ok(Json(PaginatedResponse { items, total, limit, offset }))
+}
+
+async fn associate_project_agent(
+    State(state): State<ApiState>,
+    Path((id, agent_id)): Path<(Uuid, Uuid)>,
+) -> Result<impl IntoResponse, ApiError> {
+    // Verify project and agent exist.
+    let ps = state.manager.project_storage();
+    ps.get(&id).await.map_err(ApiError::Internal)?.ok_or(ApiError::NotFound)?;
+    state
+        .manager
+        .get_agent(&agent_id)
+        .await
+        .map_err(ApiError::Internal)?
+        .ok_or(ApiError::NotFound)?;
+
+    state
+        .manager
+        .agent_storage()
+        .set_agent_project(&agent_id, Some(id))
+        .await
+        .map_err(ApiError::Internal)?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+async fn dissociate_project_agent(
+    State(state): State<ApiState>,
+    Path((id, agent_id)): Path<(Uuid, Uuid)>,
+) -> Result<impl IntoResponse, ApiError> {
+    let ps = state.manager.project_storage();
+    ps.get(&id).await.map_err(ApiError::Internal)?.ok_or(ApiError::NotFound)?;
+    state
+        .manager
+        .get_agent(&agent_id)
+        .await
+        .map_err(ApiError::Internal)?
+        .ok_or(ApiError::NotFound)?;
+
+    state
+        .manager
+        .agent_storage()
+        .set_agent_project(&agent_id, None)
+        .await
+        .map_err(ApiError::Internal)?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+async fn list_project_workflows(
+    State(state): State<ApiState>,
+    Path(id): Path<Uuid>,
+    Query(query): Query<ProjectListQuery>,
+) -> Result<impl IntoResponse, ApiError> {
+    let ps = state.manager.project_storage();
+    ps.get(&id).await.map_err(ApiError::Internal)?.ok_or(ApiError::NotFound)?;
+
+    let limit = clamp_limit(query.limit);
+    let offset = query.offset.unwrap_or(0);
+
+    let (workflows, total) = state
+        .scheduler
+        .storage()
+        .list_workflows_paginated(limit, offset, Some(id))
+        .await
+        .map_err(ApiError::Internal)?;
+
+    let items: Vec<WorkflowResponse> = workflows.into_iter().map(WorkflowResponse::from).collect();
+    Ok(Json(PaginatedResponse { items, total, limit, offset }))
+}
+
+async fn associate_project_workflow(
+    State(state): State<ApiState>,
+    Path((id, workflow_id)): Path<(Uuid, Uuid)>,
+) -> Result<impl IntoResponse, ApiError> {
+    let ps = state.manager.project_storage();
+    ps.get(&id).await.map_err(ApiError::Internal)?.ok_or(ApiError::NotFound)?;
+    state
+        .scheduler
+        .storage()
+        .get_workflow(&workflow_id)
+        .await
+        .map_err(ApiError::Internal)?
+        .ok_or(ApiError::NotFound)?;
+
+    state
+        .scheduler
+        .storage()
+        .set_workflow_project(&workflow_id, Some(id))
+        .await
+        .map_err(ApiError::Internal)?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+async fn dissociate_project_workflow(
+    State(state): State<ApiState>,
+    Path((id, workflow_id)): Path<(Uuid, Uuid)>,
+) -> Result<impl IntoResponse, ApiError> {
+    let ps = state.manager.project_storage();
+    ps.get(&id).await.map_err(ApiError::Internal)?.ok_or(ApiError::NotFound)?;
+    state
+        .scheduler
+        .storage()
+        .get_workflow(&workflow_id)
+        .await
+        .map_err(ApiError::Internal)?
+        .ok_or(ApiError::NotFound)?;
+
+    state
+        .scheduler
+        .storage()
+        .set_workflow_project(&workflow_id, None)
+        .await
+        .map_err(ApiError::Internal)?;
+    Ok(StatusCode::NO_CONTENT)
 }
 
 #[cfg(test)]

--- a/crates/orchestrator/src/client.rs
+++ b/crates/orchestrator/src/client.rs
@@ -35,9 +35,9 @@ use crate::scheduler::types::{
 };
 use crate::types::{
     AddDirRequest, AddDirResponse, AgentResponse, AgentUsageStats, ApprovalActionRequest,
-    ClearContextRequest, ClearContextResponse, CreateAgentRequest, HealthResponse,
-    PaginatedResponse, PendingApproval, SendMessageRequest, SendMessageResponse, SetModelRequest,
-    ToolPolicy,
+    ClearContextRequest, ClearContextResponse, CreateAgentRequest, CreateProjectRequest,
+    HealthResponse, PaginatedResponse, PendingApproval, Project, ProjectResponse,
+    SendMessageRequest, SendMessageResponse, SetModelRequest, ToolPolicy, UpdateProjectRequest,
 };
 
 /// Typed HTTP client for the orchestrator service.
@@ -336,6 +336,113 @@ impl OrchestratorClient {
     /// Purge all tasks from a named queue.
     pub async fn queue_purge(&self, queue_name: &str) -> Result<serde_json::Value> {
         self.delete_with_response(&format!("/queues/{}", queue_name)).await
+    }
+
+    // -- Project management --
+
+    /// List all projects.
+    pub async fn list_projects(&self) -> Result<PaginatedResponse<Project>> {
+        self.get("/projects").await
+    }
+
+    /// Create a new project.
+    pub async fn create_project(&self, req: &CreateProjectRequest) -> Result<Project> {
+        self.post("/projects", req).await
+    }
+
+    /// Get a project by UUID, including agent and workflow counts.
+    pub async fn get_project(&self, id: &Uuid) -> Result<ProjectResponse> {
+        self.get(&format!("/projects/{id}")).await
+    }
+
+    /// Find a project by name (client-side search).
+    pub async fn get_project_by_name(&self, name: &str) -> Result<Option<Project>> {
+        let resp: PaginatedResponse<Project> = self.get("/projects?limit=500").await?;
+        Ok(resp.items.into_iter().find(|p| p.name == name))
+    }
+
+    /// Update a project's name and/or description.
+    pub async fn update_project(&self, id: &Uuid, req: &UpdateProjectRequest) -> Result<Project> {
+        self.put(&format!("/projects/{id}"), req).await
+    }
+
+    /// Delete a project (fails if agents or workflows are still associated).
+    pub async fn delete_project(&self, id: &Uuid) -> Result<()> {
+        self.delete(&format!("/projects/{id}")).await
+    }
+
+    /// List agents associated with a project.
+    pub async fn list_project_agents(
+        &self,
+        id: &Uuid,
+    ) -> Result<PaginatedResponse<AgentResponse>> {
+        self.get(&format!("/projects/{id}/agents")).await
+    }
+
+    /// Associate an agent with a project.
+    pub async fn associate_project_agent(&self, project_id: &Uuid, agent_id: &Uuid) -> Result<()> {
+        let url = format!("{}/projects/{project_id}/agents/{agent_id}", self.base_url);
+        let response = self
+            .client
+            .post(&url)
+            .send()
+            .await
+            .context(format!("Failed to POST {url}"))?;
+        if response.status().is_success() {
+            Ok(())
+        } else {
+            let status = response.status();
+            let text = response.text().await.unwrap_or_default();
+            Err(anyhow::anyhow!("Request failed with status {status}: {text}"))
+        }
+    }
+
+    /// Remove an agent from a project.
+    pub async fn dissociate_project_agent(
+        &self,
+        project_id: &Uuid,
+        agent_id: &Uuid,
+    ) -> Result<()> {
+        self.delete(&format!("/projects/{project_id}/agents/{agent_id}")).await
+    }
+
+    /// List workflows associated with a project.
+    pub async fn list_project_workflows(
+        &self,
+        id: &Uuid,
+    ) -> Result<PaginatedResponse<WorkflowResponse>> {
+        self.get(&format!("/projects/{id}/workflows")).await
+    }
+
+    /// Associate a workflow with a project.
+    pub async fn associate_project_workflow(
+        &self,
+        project_id: &Uuid,
+        workflow_id: &Uuid,
+    ) -> Result<()> {
+        let url = format!("{}/projects/{project_id}/workflows/{workflow_id}", self.base_url);
+        let response = self
+            .client
+            .post(&url)
+            .send()
+            .await
+            .context(format!("Failed to POST {url}"))?;
+        if response.status().is_success() {
+            Ok(())
+        } else {
+            let status = response.status();
+            let text = response.text().await.unwrap_or_default();
+            Err(anyhow::anyhow!("Request failed with status {status}: {text}"))
+        }
+    }
+
+    /// Remove a workflow from a project.
+    pub async fn dissociate_project_workflow(
+        &self,
+        project_id: &Uuid,
+        workflow_id: &Uuid,
+    ) -> Result<()> {
+        self.delete(&format!("/projects/{project_id}/workflows/{workflow_id}")).await
     }
 
     // -- Private HTTP helpers --

--- a/crates/orchestrator/src/entity/agent.rs
+++ b/crates/orchestrator/src/entity/agent.rs
@@ -61,6 +61,9 @@ pub struct Model {
     /// OS process ID of the agent's subprocess. Used during startup
     /// reconciliation to check if the process survived a service restart.
     pub pid: Option<i64>,
+    /// Optional project UUID (stored as TEXT) grouping this agent with related
+    /// workflows and rooms.  NULL when the agent is not assigned to a project.
+    pub project_id: Option<String>,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/crates/orchestrator/src/entity/project.rs
+++ b/crates/orchestrator/src/entity/project.rs
@@ -1,8 +1,5 @@
 //! SeaORM entity for the `projects` table.
 
-// API routes wired in #829; suppress dead_code lint until then.
-#![allow(dead_code)]
-
 use sea_orm::entity::prelude::*;
 
 /// SeaORM model for the `projects` table.

--- a/crates/orchestrator/src/entity/project.rs
+++ b/crates/orchestrator/src/entity/project.rs
@@ -1,5 +1,8 @@
 //! SeaORM entity for the `projects` table.
 
+// API routes wired in #829; suppress dead_code lint until then.
+#![allow(dead_code)]
+
 use sea_orm::entity::prelude::*;
 
 /// SeaORM model for the `projects` table.

--- a/crates/orchestrator/src/entity/workflow.rs
+++ b/crates/orchestrator/src/entity/workflow.rs
@@ -25,6 +25,9 @@ pub struct Model {
     pub tool_policy: String,
     pub created_at: String,
     pub updated_at: String,
+    /// Optional project UUID (stored as TEXT).  NULL when the workflow is not
+    /// assigned to a project.
+    pub project_id: Option<String>,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/crates/orchestrator/src/main.rs
+++ b/crates/orchestrator/src/main.rs
@@ -512,6 +512,7 @@ async fn join_or_create_room(
                     description: None,
                     room_type: RoomType::Group,
                     created_by: agent_name.to_string(),
+                    project_id: None,
                 })
                 .await?
         }

--- a/crates/orchestrator/src/manager.rs
+++ b/crates/orchestrator/src/manager.rs
@@ -243,7 +243,7 @@ impl AgentManager {
     /// (containers/tmux sessions with the correct prefix but no matching
     /// DB record).
     pub async fn reconcile(&self) -> anyhow::Result<()> {
-        let agents = self.storage.list(Some(AgentStatus::Running)).await?;
+        let agents = self.storage.list(Some(AgentStatus::Running), None).await?;
         let mut known_sessions: std::collections::HashSet<String> =
             std::collections::HashSet::new();
 
@@ -449,7 +449,7 @@ impl AgentManager {
     /// List agents with optional status filter.
     #[allow(dead_code)]
     pub async fn list_agents(&self, status: Option<AgentStatus>) -> anyhow::Result<Vec<Agent>> {
-        self.storage.list(status).await
+        self.storage.list(status, None).await
     }
 
     /// List agents with pagination.
@@ -578,7 +578,7 @@ impl AgentManager {
         info!(leave_running, "Shutting down all managed agents");
 
         // Update all running agents to Stopped in the database.
-        let agents = match self.storage.list(Some(AgentStatus::Running)).await {
+        let agents = match self.storage.list(Some(AgentStatus::Running), None).await {
             Ok(a) => a,
             Err(e) => {
                 error!(%e, "Failed to list running agents during shutdown");

--- a/crates/orchestrator/src/manager.rs
+++ b/crates/orchestrator/src/manager.rs
@@ -1,5 +1,5 @@
 use crate::scheduler::events::SystemEvent;
-use crate::storage::AgentStorage;
+use crate::storage::{AgentStorage, ProjectStorage};
 use crate::types::{Agent, AgentConfig, AgentStatus, AgentUsageStats, ClearContextResponse};
 use crate::websocket::ConnectionRegistry;
 use chrono::Utc;
@@ -35,6 +35,16 @@ impl AgentManager {
 
     pub fn registry(&self) -> &ConnectionRegistry {
         &self.registry
+    }
+
+    /// Returns a [`ProjectStorage`] backed by the same database connection.
+    pub fn project_storage(&self) -> ProjectStorage {
+        ProjectStorage::from_db(self.storage.db().clone())
+    }
+
+    /// Returns the underlying [`AgentStorage`] for direct access.
+    pub fn agent_storage(&self) -> &AgentStorage {
+        &self.storage
     }
 
     /// Spawn a new agent: create DB record, backend session, and launch claude.
@@ -452,14 +462,15 @@ impl AgentManager {
         self.storage.list(status, None).await
     }
 
-    /// List agents with pagination.
+    /// List agents with pagination, optionally filtered by project.
     pub async fn list_agents_paginated(
         &self,
         status: Option<AgentStatus>,
+        project_id: Option<Uuid>,
         limit: usize,
         offset: usize,
     ) -> anyhow::Result<(Vec<Agent>, usize)> {
-        self.storage.list_paginated(status, limit, offset).await
+        self.storage.list_paginated_filtered(status, project_id, limit, offset).await
     }
 
     /// Update an agent record in storage.

--- a/crates/orchestrator/src/migration/m20260409_000013_add_project_id_to_agents_workflows.rs
+++ b/crates/orchestrator/src/migration/m20260409_000013_add_project_id_to_agents_workflows.rs
@@ -1,0 +1,75 @@
+//! Migration 13: add nullable `project_id` column to `agents` and `workflows`.
+//!
+//! Projects (#827) group agents and workflows under a named logical boundary.
+//! All existing rows receive `NULL` project_id — this migration is non-breaking.
+
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        // Add project_id to agents
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Agents::Table)
+                    .add_column(ColumnDef::new(Agents::ProjectId).string().null())
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx_agents_project_id")
+                    .table(Agents::Table)
+                    .col(Agents::ProjectId)
+                    .to_owned(),
+            )
+            .await?;
+
+        // Add project_id to workflows
+        manager
+            .alter_table(
+                Table::alter()
+                    .table(Workflows::Table)
+                    .add_column(ColumnDef::new(Workflows::ProjectId).string().null())
+                    .to_owned(),
+            )
+            .await?;
+
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx_workflows_project_id")
+                    .table(Workflows::Table)
+                    .col(Workflows::ProjectId)
+                    .to_owned(),
+            )
+            .await
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager.drop_index(Index::drop().name("idx_agents_project_id").to_owned()).await?;
+
+        manager.drop_index(Index::drop().name("idx_workflows_project_id").to_owned()).await?;
+
+        // SQLite does not support DROP COLUMN — nothing more to do.
+        Ok(())
+    }
+}
+
+#[derive(Iden)]
+enum Agents {
+    Table,
+    ProjectId,
+}
+
+#[derive(Iden)]
+enum Workflows {
+    Table,
+    ProjectId,
+}

--- a/crates/orchestrator/src/migration/mod.rs
+++ b/crates/orchestrator/src/migration/mod.rs
@@ -24,6 +24,7 @@ mod m20260324_000010_add_system_prompt_fields_to_agents;
 mod m20260328_000011_add_task_queue;
 mod m20260411_000012_add_pid_to_agents;
 mod m20260329_000012_create_projects_table;
+mod m20260409_000013_add_project_id_to_agents_workflows;
 
 /// The migration runner — applies all known migrations in order.
 pub struct Migrator;
@@ -45,6 +46,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20260328_000011_add_task_queue::Migration),
             Box::new(m20260411_000012_add_pid_to_agents::Migration),
             Box::new(m20260329_000012_create_projects_table::Migration),
+            Box::new(m20260409_000013_add_project_id_to_agents_workflows::Migration),
         ]
     }
 }

--- a/crates/orchestrator/src/scheduler/api.rs
+++ b/crates/orchestrator/src/scheduler/api.rs
@@ -239,6 +239,7 @@ async fn create_workflow(
         tool_policy: req.tool_policy,
         created_at: now,
         updated_at: now,
+        project_id: None,
     };
 
     state.scheduler.storage().add_workflow(&config).await?;
@@ -259,7 +260,7 @@ async fn list_workflows(
     let offset = params.offset.unwrap_or(0);
 
     let (workflows, total) =
-        state.scheduler.storage().list_workflows_paginated(limit, offset).await?;
+        state.scheduler.storage().list_workflows_paginated(limit, offset, None).await?;
     let items: Vec<WorkflowResponse> = workflows.into_iter().map(WorkflowResponse::from).collect();
     Ok(Json(PaginatedResponse { items, total, limit, offset }))
 }

--- a/crates/orchestrator/src/scheduler/api.rs
+++ b/crates/orchestrator/src/scheduler/api.rs
@@ -24,6 +24,7 @@ use uuid::Uuid;
 struct PaginationParams {
     limit: Option<usize>,
     offset: Option<usize>,
+    project_id: Option<Uuid>,
 }
 
 #[derive(Clone)]
@@ -259,8 +260,11 @@ async fn list_workflows(
     let limit = clamp_limit(params.limit);
     let offset = params.offset.unwrap_or(0);
 
-    let (workflows, total) =
-        state.scheduler.storage().list_workflows_paginated(limit, offset, None).await?;
+    let (workflows, total) = state
+        .scheduler
+        .storage()
+        .list_workflows_paginated(limit, offset, params.project_id)
+        .await?;
     let items: Vec<WorkflowResponse> = workflows.into_iter().map(WorkflowResponse::from).collect();
     Ok(Json(PaginatedResponse { items, total, limit, offset }))
 }

--- a/crates/orchestrator/src/scheduler/mod.rs
+++ b/crates/orchestrator/src/scheduler/mod.rs
@@ -210,7 +210,7 @@ impl Scheduler {
             warn!(count = failed, "Marked in-flight dispatches as failed on startup");
         }
 
-        let workflows = self.storage.list_workflows().await?;
+        let workflows = self.storage.list_workflows(None).await?;
         for workflow in workflows {
             if !workflow.enabled {
                 continue;

--- a/crates/orchestrator/src/scheduler/storage.rs
+++ b/crates/orchestrator/src/scheduler/storage.rs
@@ -56,6 +56,7 @@ impl SchedulerStorage {
             tool_policy: Set(tool_policy_json),
             created_at: Set(workflow.created_at.to_rfc3339()),
             updated_at: Set(workflow.updated_at.to_rfc3339()),
+            project_id: Set(workflow.project_id.map(|id| id.to_string())),
         };
 
         workflow_entity::Entity::insert(model).exec(&self.db).await?;
@@ -71,12 +72,14 @@ impl SchedulerStorage {
         }
     }
 
-    /// Lists all workflows ordered by creation time (newest first).
-    pub async fn list_workflows(&self) -> Result<Vec<WorkflowConfig>> {
-        let models: Vec<workflow_entity::Model> = workflow_entity::Entity::find()
-            .order_by(workflow_entity::Column::CreatedAt, Order::Desc)
-            .all(&self.db)
-            .await?;
+    /// Lists all workflows, optionally filtered by project (newest first).
+    pub async fn list_workflows(&self, project_id: Option<Uuid>) -> Result<Vec<WorkflowConfig>> {
+        let mut query = workflow_entity::Entity::find()
+            .order_by(workflow_entity::Column::CreatedAt, Order::Desc);
+        if let Some(pid) = project_id {
+            query = query.filter(workflow_entity::Column::ProjectId.eq(pid.to_string()));
+        }
+        let models: Vec<workflow_entity::Model> = query.all(&self.db).await?;
         models.into_iter().map(model_to_workflow).collect()
     }
 
@@ -198,15 +201,21 @@ impl SchedulerStorage {
         models.into_iter().map(model_to_dispatch).collect()
     }
 
-    /// Lists workflows with pagination; returns `(items, total_count)`.
+    /// Lists workflows with pagination, optionally filtered by project; returns `(items, total_count)`.
     pub async fn list_workflows_paginated(
         &self,
         limit: usize,
         offset: usize,
+        project_id: Option<Uuid>,
     ) -> Result<(Vec<WorkflowConfig>, usize)> {
-        let total = workflow_entity::Entity::find().count(&self.db).await? as usize;
+        let mut base = workflow_entity::Entity::find();
+        if let Some(pid) = project_id {
+            base = base.filter(workflow_entity::Column::ProjectId.eq(pid.to_string()));
+        }
 
-        let models: Vec<workflow_entity::Model> = workflow_entity::Entity::find()
+        let total = base.clone().count(&self.db).await? as usize;
+
+        let models: Vec<workflow_entity::Model> = base
             .order_by(workflow_entity::Column::CreatedAt, Order::Desc)
             .limit(limit as u64)
             .offset(offset as u64)
@@ -492,6 +501,7 @@ fn model_to_workflow(model: workflow_entity::Model) -> Result<WorkflowConfig> {
         tool_policy: serde_json::from_str::<ToolPolicy>(&model.tool_policy).unwrap_or_default(),
         created_at: DateTime::parse_from_rfc3339(&model.created_at)?.with_timezone(&Utc),
         updated_at: DateTime::parse_from_rfc3339(&model.updated_at)?.with_timezone(&Utc),
+        project_id: model.project_id.map(|s| Uuid::parse_str(&s)).transpose()?,
     })
 }
 
@@ -549,6 +559,7 @@ mod tests {
             tool_policy: Default::default(),
             created_at: now,
             updated_at: now,
+            project_id: None,
         }
     }
 
@@ -567,7 +578,7 @@ mod tests {
         assert_eq!(retrieved.poll_interval_secs, 60);
 
         // List
-        let all = storage.list_workflows().await.unwrap();
+        let all = storage.list_workflows(None).await.unwrap();
         assert_eq!(all.len(), 1);
 
         // Update

--- a/crates/orchestrator/src/scheduler/storage.rs
+++ b/crates/orchestrator/src/scheduler/storage.rs
@@ -118,6 +118,27 @@ impl SchedulerStorage {
         Ok(())
     }
 
+    /// Sets or clears the `project_id` for a single workflow.
+    pub async fn set_workflow_project(&self, id: &Uuid, project_id: Option<Uuid>) -> Result<()> {
+        use sea_orm::sea_query::Expr;
+        let now = chrono::Utc::now().to_rfc3339();
+
+        let result = workflow_entity::Entity::update_many()
+            .col_expr(
+                workflow_entity::Column::ProjectId,
+                Expr::value(project_id.map(|p| p.to_string())),
+            )
+            .col_expr(workflow_entity::Column::UpdatedAt, Expr::value(now))
+            .filter(workflow_entity::Column::Id.eq(id.to_string()))
+            .exec(&self.db)
+            .await?;
+
+        if result.rows_affected == 0 {
+            anyhow::bail!("Workflow not found");
+        }
+        Ok(())
+    }
+
     /// Permanently deletes a workflow by UUID.
     pub async fn delete_workflow(&self, id: &Uuid) -> Result<()> {
         let result = workflow_entity::Entity::delete_many()

--- a/crates/orchestrator/src/scheduler/types.rs
+++ b/crates/orchestrator/src/scheduler/types.rs
@@ -43,6 +43,9 @@ pub struct WorkflowConfig {
     pub tool_policy: ToolPolicy,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
+    /// Optional project this workflow belongs to.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub project_id: Option<Uuid>,
 }
 
 fn default_poll_interval() -> u64 {

--- a/crates/orchestrator/src/storage.rs
+++ b/crates/orchestrator/src/storage.rs
@@ -185,6 +185,27 @@ impl AgentStorage {
         Ok(())
     }
 
+    /// Sets or clears the `project_id` for a single agent.
+    pub async fn set_agent_project(&self, id: &Uuid, project_id: Option<Uuid>) -> Result<()> {
+        use sea_orm::sea_query::Expr;
+        let now = chrono::Utc::now().to_rfc3339();
+
+        let result = agent_entity::Entity::update_many()
+            .col_expr(
+                agent_entity::Column::ProjectId,
+                Expr::value(project_id.map(|p| p.to_string())),
+            )
+            .col_expr(agent_entity::Column::UpdatedAt, Expr::value(now))
+            .filter(agent_entity::Column::Id.eq(id.to_string()))
+            .exec(&self.db)
+            .await?;
+
+        if result.rows_affected == 0 {
+            anyhow::bail!("Agent not found");
+        }
+        Ok(())
+    }
+
     /// Permanently deletes an agent by UUID.
     pub async fn delete(&self, id: &Uuid) -> Result<()> {
         let result = agent_entity::Entity::delete_many()
@@ -497,16 +518,31 @@ impl AgentStorage {
     }
 
     /// Lists agents with pagination; returns `(items, total_count)`.
+    #[allow(dead_code)]
     pub async fn list_paginated(
         &self,
         status_filter: Option<AgentStatus>,
         limit: usize,
         offset: usize,
     ) -> Result<(Vec<Agent>, usize)> {
-        let condition = match &status_filter {
-            Some(s) => Condition::all().add(agent_entity::Column::Status.eq(s.to_string())),
-            None => Condition::all(),
-        };
+        self.list_paginated_filtered(status_filter, None, limit, offset).await
+    }
+
+    /// Lists agents with pagination and optional project_id filter; returns `(items, total_count)`.
+    pub async fn list_paginated_filtered(
+        &self,
+        status_filter: Option<AgentStatus>,
+        project_id: Option<Uuid>,
+        limit: usize,
+        offset: usize,
+    ) -> Result<(Vec<Agent>, usize)> {
+        let mut condition = Condition::all();
+        if let Some(s) = &status_filter {
+            condition = condition.add(agent_entity::Column::Status.eq(s.to_string()));
+        }
+        if let Some(pid) = project_id {
+            condition = condition.add(agent_entity::Column::ProjectId.eq(pid.to_string()));
+        }
 
         let total =
             agent_entity::Entity::find().filter(condition.clone()).count(&self.db).await? as usize;
@@ -533,14 +569,11 @@ impl AgentStorage {
 /// Shares the same [`DatabaseConnection`] as [`AgentStorage`] — construct via
 /// [`ProjectStorage::from_db`] using the connection returned by
 /// [`AgentStorage::db()`].
-// API routes are added in #829; suppress dead_code until then.
-#[allow(dead_code)]
 #[derive(Clone)]
 pub struct ProjectStorage {
     db: DatabaseConnection,
 }
 
-#[allow(dead_code)]
 impl ProjectStorage {
     /// Wrap an existing database connection (shared with `AgentStorage`).
     pub fn from_db(db: DatabaseConnection) -> Self {
@@ -567,6 +600,7 @@ impl ProjectStorage {
     }
 
     /// Retrieve a project by its unique name.  Returns `None` if not found.
+    #[allow(dead_code)]
     pub async fn get_by_name(&self, name: &str) -> Result<Option<Project>> {
         let model = project_entity::Entity::find()
             .filter(project_entity::Column::Name.eq(name))
@@ -706,7 +740,6 @@ fn model_to_session_usage(model: &session_entity::Model) -> Result<SessionUsage>
 }
 
 /// Convert a raw [`project_entity::Model`] into the domain [`Project`] type.
-#[allow(dead_code)]
 fn model_to_project(model: project_entity::Model) -> Result<Project> {
     Ok(Project {
         id: Uuid::parse_str(&model.id)?,

--- a/crates/orchestrator/src/storage.rs
+++ b/crates/orchestrator/src/storage.rs
@@ -107,6 +107,7 @@ impl AgentStorage {
             ),
             launch_command: Set(agent.launch_command.clone()),
             pid: Set(agent.pid.map(|p| p as i64)),
+            project_id: Set(agent.project_id.map(|id| id.to_string())),
         };
 
         agent_entity::Entity::insert(model).exec(&self.db).await?;
@@ -198,13 +199,20 @@ impl AgentStorage {
         Ok(())
     }
 
-    /// Lists all agents, optionally filtered by status (newest first).
-    pub async fn list(&self, status_filter: Option<AgentStatus>) -> Result<Vec<Agent>> {
+    /// Lists all agents, optionally filtered by status and/or project (newest first).
+    pub async fn list(
+        &self,
+        status_filter: Option<AgentStatus>,
+        project_id: Option<Uuid>,
+    ) -> Result<Vec<Agent>> {
         let mut query =
             agent_entity::Entity::find().order_by(agent_entity::Column::CreatedAt, Order::Desc);
 
         if let Some(status) = status_filter {
             query = query.filter(agent_entity::Column::Status.eq(status.to_string()));
+        }
+        if let Some(pid) = project_id {
+            query = query.filter(agent_entity::Column::ProjectId.eq(pid.to_string()));
         }
 
         let models: Vec<agent_entity::Model> = query.all(&self.db).await?;
@@ -525,11 +533,14 @@ impl AgentStorage {
 /// Shares the same [`DatabaseConnection`] as [`AgentStorage`] — construct via
 /// [`ProjectStorage::from_db`] using the connection returned by
 /// [`AgentStorage::db()`].
+// API routes are added in #829; suppress dead_code until then.
+#[allow(dead_code)]
 #[derive(Clone)]
 pub struct ProjectStorage {
     db: DatabaseConnection,
 }
 
+#[allow(dead_code)]
 impl ProjectStorage {
     /// Wrap an existing database connection (shared with `AgentStorage`).
     pub fn from_db(db: DatabaseConnection) -> Self {
@@ -664,6 +675,7 @@ fn model_to_agent(model: agent_entity::Model) -> Result<Agent> {
         backend_type: model.backend_type,
         launch_command: model.launch_command,
         pid: model.pid.and_then(|p| u32::try_from(p).ok()),
+        project_id: model.project_id.map(|s| Uuid::parse_str(&s)).transpose()?,
         created_at: DateTime::parse_from_rfc3339(&model.created_at)?.with_timezone(&Utc),
         updated_at: DateTime::parse_from_rfc3339(&model.updated_at)?.with_timezone(&Utc),
     })
@@ -694,6 +706,7 @@ fn model_to_session_usage(model: &session_entity::Model) -> Result<SessionUsage>
 }
 
 /// Convert a raw [`project_entity::Model`] into the domain [`Project`] type.
+#[allow(dead_code)]
 fn model_to_project(model: project_entity::Model) -> Result<Project> {
     Ok(Project {
         id: Uuid::parse_str(&model.id)?,
@@ -797,11 +810,11 @@ mod tests {
         storage.add(&a1).await.unwrap();
         storage.add(&a2).await.unwrap();
 
-        let running = storage.list(Some(AgentStatus::Running)).await.unwrap();
+        let running = storage.list(Some(AgentStatus::Running), None).await.unwrap();
         assert_eq!(running.len(), 1);
         assert_eq!(running[0].name, "running-agent");
 
-        let all = storage.list(None).await.unwrap();
+        let all = storage.list(None, None).await.unwrap();
         assert_eq!(all.len(), 2);
     }
 

--- a/crates/orchestrator/src/types.rs
+++ b/crates/orchestrator/src/types.rs
@@ -478,8 +478,6 @@ fn default_shell() -> String {
 // ---------------------------------------------------------------------------
 
 /// A project groups agents, workflows, and rooms under a named boundary.
-// API routes are added in #829; suppress dead_code until then.
-#[allow(dead_code)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct Project {
     pub id: Uuid,
@@ -489,7 +487,6 @@ pub struct Project {
     pub updated_at: DateTime<Utc>,
 }
 
-#[allow(dead_code)]
 impl Project {
     pub fn new(name: String, description: Option<String>) -> Self {
         let now = Utc::now();
@@ -498,7 +495,6 @@ impl Project {
 }
 
 /// Request body for POST /projects.
-#[allow(dead_code)]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CreateProjectRequest {
     pub name: String,
@@ -511,7 +507,6 @@ pub struct CreateProjectRequest {
 /// Fields that are `None` are left unchanged in the database.
 /// Pass `description: Some(None)` is not supported via this struct —
 /// to clear a description set it to `Some("")` or omit the field.
-#[allow(dead_code)]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct UpdateProjectRequest {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/orchestrator/src/types.rs
+++ b/crates/orchestrator/src/types.rs
@@ -478,6 +478,8 @@ fn default_shell() -> String {
 // ---------------------------------------------------------------------------
 
 /// A project groups agents, workflows, and rooms under a named boundary.
+// API routes are added in #829; suppress dead_code until then.
+#[allow(dead_code)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct Project {
     pub id: Uuid,
@@ -487,6 +489,7 @@ pub struct Project {
     pub updated_at: DateTime<Utc>,
 }
 
+#[allow(dead_code)]
 impl Project {
     pub fn new(name: String, description: Option<String>) -> Self {
         let now = Utc::now();
@@ -495,6 +498,7 @@ impl Project {
 }
 
 /// Request body for POST /projects.
+#[allow(dead_code)]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CreateProjectRequest {
     pub name: String,
@@ -507,6 +511,7 @@ pub struct CreateProjectRequest {
 /// Fields that are `None` are left unchanged in the database.
 /// Pass `description: Some(None)` is not supported via this struct —
 /// to clear a description set it to `Some("")` or omit the field.
+#[allow(dead_code)]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct UpdateProjectRequest {
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -534,6 +539,9 @@ pub struct Agent {
     /// compatibility.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub backend_type: Option<String>,
+    /// Optional project this agent belongs to.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub project_id: Option<Uuid>,
     /// The exact `claude` command that was generated and sent to the execution
     /// backend when the agent was spawned or restarted.  Useful for debugging
     /// flags, `--sdk-url`, model selection, etc.
@@ -560,6 +568,7 @@ impl Agent {
             backend_type: Some("tmux".to_string()),
             launch_command: None,
             pid: None,
+            project_id: None,
             created_at: now,
             updated_at: now,
         }

--- a/crates/orchestrator/src/types.rs
+++ b/crates/orchestrator/src/types.rs
@@ -494,6 +494,19 @@ impl Project {
     }
 }
 
+/// Detailed project response including associated resource counts.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProjectResponse {
+    pub id: Uuid,
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+    pub agent_count: usize,
+    pub workflow_count: usize,
+}
+
 /// Request body for POST /projects.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CreateProjectRequest {

--- a/crates/orchestrator/tests/composite_triggers.rs
+++ b/crates/orchestrator/tests/composite_triggers.rs
@@ -39,6 +39,7 @@ fn make_workflow(trigger_config: TriggerConfig) -> WorkflowConfig {
         tool_policy: Default::default(),
         created_at: now,
         updated_at: now,
+        project_id: None,
     }
 }
 

--- a/crates/orchestrator/tests/queue_trigger.rs
+++ b/crates/orchestrator/tests/queue_trigger.rs
@@ -53,6 +53,7 @@ fn queue_workflow(agent_id: Uuid, queue_name: &str) -> WorkflowConfig {
         tool_policy: Default::default(),
         created_at: now,
         updated_at: now,
+        project_id: None,
     }
 }
 

--- a/crates/orchestrator/tests/scheduler_integration.rs
+++ b/crates/orchestrator/tests/scheduler_integration.rs
@@ -59,6 +59,7 @@ fn make_workflow(agent_id: Uuid, trigger_config: TriggerConfig) -> WorkflowConfi
         tool_policy: Default::default(),
         created_at: now,
         updated_at: now,
+        project_id: None,
     }
 }
 

--- a/crates/orchestrator/tests/webhook_http.rs
+++ b/crates/orchestrator/tests/webhook_http.rs
@@ -112,6 +112,7 @@ fn make_webhook_workflow(agent_id: Uuid, secret: Option<String>) -> WorkflowConf
         tool_policy: Default::default(),
         created_at: now,
         updated_at: now,
+        project_id: None,
     }
 }
 
@@ -135,6 +136,7 @@ fn make_linear_webhook_workflow(agent_id: Uuid, secret: Option<String>) -> Workf
         tool_policy: Default::default(),
         created_at: now,
         updated_at: now,
+        project_id: None,
     }
 }
 
@@ -386,6 +388,7 @@ async fn test_post_webhook_manual_trigger_workflow_returns_400() {
         tool_policy: Default::default(),
         created_at: now,
         updated_at: now,
+        project_id: None,
     };
     scheduler.storage().add_workflow(&workflow).await.unwrap();
 
@@ -588,6 +591,7 @@ async fn test_post_linear_header_on_github_workflow_returns_400() {
         tool_policy: Default::default(),
         created_at: now,
         updated_at: now,
+        project_id: None,
     };
     scheduler.start_workflow(github_workflow.clone()).await.unwrap();
 


### PR DESCRIPTION
Adds a nullable `project_id` column to the `agents` and `workflows` tables (orchestrator) and the `rooms` table (communicate) via non-breaking migrations. Updates entity models, domain types (`Agent`, `WorkflowConfig`, `Room`), and storage list operations to support optional project_id filtering.

- Migration 13: `ALTER TABLE agents/workflows ADD COLUMN project_id TEXT` + indexes
- Migration 2 (communicate): `ALTER TABLE rooms ADD COLUMN project_id TEXT` + index
- `AgentStorage::list()` gains `project_id: Option<Uuid>` filter param
- `SchedulerStorage::list_workflows()` and `list_workflows_paginated()` gain `project_id` filter
- `CommunicateStorage::list_rooms()` gains `project_id: Option<&str>` filter
- `GET /rooms` API accepts `?project_id=` query param
- All existing records receive `NULL project_id` — non-breaking

Closes #828