### PR TITLE
feat(orchestrator): add project CRUD API endpoints

### DIFF
--- a/crates/cli/src/commands/apply.rs
+++ b/crates/cli/src/commands/apply.rs
@@ -748,6 +748,7 @@ async fn apply_room(
                 description: tmpl.description.clone(),
                 room_type,
                 created_by: creator,
+                project_id: None,
             };
             // Use create_room_or_conflict to gracefully handle a race (or the
             // get_room_by_name 500-room page cap) where the room already exists

--- a/crates/cli/src/commands/communicate.rs
+++ b/crates/cli/src/commands/communicate.rs
@@ -421,6 +421,7 @@ async fn create_room(
             description: description.map(str::to_string),
             room_type,
             created_by: created_by.to_string(),
+            project_id: None,
         })
         .await
         .context("Failed to create room")?;

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -37,6 +37,7 @@ pub mod memory;
 pub mod notify;
 pub mod orchestrator;
 pub mod org;
+pub mod project;
 pub mod prompt;
 pub mod wrap;
 
@@ -48,5 +49,6 @@ pub use memory::MemoryCommand;
 pub use notify::NotifyCommand;
 pub use orchestrator::OrchestratorCommand;
 pub use org::OrgCommand;
+pub use project::ProjectCommand;
 pub use prompt::PromptCommand;
 pub use wrap::WrapCommand;

--- a/crates/cli/src/commands/project.rs
+++ b/crates/cli/src/commands/project.rs
@@ -1,0 +1,480 @@
+//! Project management command implementations.
+//!
+//! This module implements all subcommands for managing projects via the
+//! orchestrator service. Projects group agents and workflows together for
+//! organisational purposes.
+//!
+//! # Available Commands
+//!
+//! - **list**: List all projects
+//! - **create**: Create a new project
+//! - **show**: Show details of a specific project (by name or UUID)
+//! - **update**: Update a project's name or description
+//! - **delete**: Delete a project
+//! - **add-agent**: Associate an agent with a project
+//! - **remove-agent**: Remove an agent from a project
+//! - **add-workflow**: Associate a workflow with a project
+//! - **remove-workflow**: Remove a workflow from a project
+//!
+//! # Examples
+//!
+//! ```bash
+//! agent project list
+//! agent project create my-project --description "Work items"
+//! agent project show my-project
+//! agent project add-agent my-project <agent-id>
+//! agent project remove-agent my-project <agent-id>
+//! ```
+
+use anyhow::{bail, Context, Result};
+use clap::Subcommand;
+use colored::*;
+use uuid::Uuid;
+
+use orchestrator::client::OrchestratorClient;
+use orchestrator::types::{CreateProjectRequest, UpdateProjectRequest};
+
+/// Project management subcommands.
+#[derive(Subcommand)]
+pub enum ProjectCommand {
+    /// List all projects.
+    ///
+    /// # Examples
+    ///
+    /// ```bash
+    /// agent project list
+    /// ```
+    List,
+
+    /// Create a new project.
+    ///
+    /// # Examples
+    ///
+    /// ```bash
+    /// agent project create my-project
+    /// agent project create my-project --description "Description of the project"
+    /// ```
+    Create {
+        /// Project name (must be unique)
+        name: String,
+
+        /// Optional description
+        #[arg(long)]
+        description: Option<String>,
+    },
+
+    /// Show details of a project by name or UUID.
+    ///
+    /// Displays the project details including associated agent and workflow counts.
+    ///
+    /// # Examples
+    ///
+    /// ```bash
+    /// agent project show my-project
+    /// agent project show 550e8400-e29b-41d4-a716-446655440000
+    /// ```
+    Show {
+        /// Project name or UUID
+        id_or_name: String,
+    },
+
+    /// Update a project's name or description.
+    ///
+    /// # Examples
+    ///
+    /// ```bash
+    /// agent project update my-project --name new-name
+    /// agent project update my-project --description "Updated description"
+    /// ```
+    Update {
+        /// Project name or UUID
+        id_or_name: String,
+
+        /// New name for the project
+        #[arg(long)]
+        name: Option<String>,
+
+        /// New description for the project
+        #[arg(long)]
+        description: Option<String>,
+    },
+
+    /// Delete a project.
+    ///
+    /// Fails if agents or workflows are still associated with the project.
+    /// Dissociate them first with `remove-agent` and `remove-workflow`.
+    ///
+    /// # Examples
+    ///
+    /// ```bash
+    /// agent project delete my-project
+    /// ```
+    Delete {
+        /// Project name or UUID
+        id_or_name: String,
+    },
+
+    /// Associate an agent with a project.
+    ///
+    /// # Examples
+    ///
+    /// ```bash
+    /// agent project add-agent my-project 550e8400-e29b-41d4-a716-446655440000
+    /// ```
+    AddAgent {
+        /// Project name or UUID
+        project: String,
+
+        /// Agent UUID
+        agent_id: String,
+    },
+
+    /// Remove an agent from a project.
+    ///
+    /// # Examples
+    ///
+    /// ```bash
+    /// agent project remove-agent my-project 550e8400-e29b-41d4-a716-446655440000
+    /// ```
+    RemoveAgent {
+        /// Project name or UUID
+        project: String,
+
+        /// Agent UUID
+        agent_id: String,
+    },
+
+    /// Associate a workflow with a project.
+    ///
+    /// # Examples
+    ///
+    /// ```bash
+    /// agent project add-workflow my-project 550e8400-e29b-41d4-a716-446655440000
+    /// ```
+    AddWorkflow {
+        /// Project name or UUID
+        project: String,
+
+        /// Workflow UUID
+        workflow_id: String,
+    },
+
+    /// Remove a workflow from a project.
+    ///
+    /// # Examples
+    ///
+    /// ```bash
+    /// agent project remove-workflow my-project 550e8400-e29b-41d4-a716-446655440000
+    /// ```
+    RemoveWorkflow {
+        /// Project name or UUID
+        project: String,
+
+        /// Workflow UUID
+        workflow_id: String,
+    },
+}
+
+impl ProjectCommand {
+    /// Execute the project command.
+    pub async fn execute(&self, client: &OrchestratorClient, json: bool) -> Result<()> {
+        match self {
+            ProjectCommand::List => list_projects(client, json).await,
+            ProjectCommand::Create { name, description } => {
+                create_project(client, name, description.as_deref(), json).await
+            }
+            ProjectCommand::Show { id_or_name } => show_project(client, id_or_name, json).await,
+            ProjectCommand::Update { id_or_name, name, description } => {
+                update_project(client, id_or_name, name.as_deref(), description.as_deref(), json)
+                    .await
+            }
+            ProjectCommand::Delete { id_or_name } => delete_project(client, id_or_name, json).await,
+            ProjectCommand::AddAgent { project, agent_id } => {
+                add_agent(client, project, agent_id, json).await
+            }
+            ProjectCommand::RemoveAgent { project, agent_id } => {
+                remove_agent(client, project, agent_id, json).await
+            }
+            ProjectCommand::AddWorkflow { project, workflow_id } => {
+                add_workflow(client, project, workflow_id, json).await
+            }
+            ProjectCommand::RemoveWorkflow { project, workflow_id } => {
+                remove_workflow(client, project, workflow_id, json).await
+            }
+        }
+    }
+}
+
+/// Resolve a project name or UUID string to a project UUID.
+///
+/// If the string parses as a UUID it is used directly; otherwise a name lookup
+/// is performed against the orchestrator.
+async fn resolve_project_id(client: &OrchestratorClient, id_or_name: &str) -> Result<Uuid> {
+    if let Ok(id) = Uuid::parse_str(id_or_name) {
+        return Ok(id);
+    }
+    match client.get_project_by_name(id_or_name).await? {
+        Some(p) => Ok(p.id),
+        None => bail!("No project found with name {:?}", id_or_name),
+    }
+}
+
+async fn list_projects(client: &OrchestratorClient, json: bool) -> Result<()> {
+    let resp = client.list_projects().await.context("Failed to list projects")?;
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&resp.items)?);
+        return Ok(());
+    }
+
+    if resp.items.is_empty() {
+        println!("{}", "No projects found.".yellow());
+        return Ok(());
+    }
+
+    println!("{}", "Projects".blue().bold());
+    println!("{}", "=".repeat(60).cyan());
+    for project in &resp.items {
+        let desc = project.description.as_deref().unwrap_or("-");
+        println!(
+            "  {} | {} | {}",
+            project.id.to_string().bright_black(),
+            project.name.bold(),
+            desc
+        );
+    }
+    println!();
+    println!("Total: {}", resp.total.to_string().green().bold());
+
+    Ok(())
+}
+
+async fn create_project(
+    client: &OrchestratorClient,
+    name: &str,
+    description: Option<&str>,
+    json: bool,
+) -> Result<()> {
+    let req = CreateProjectRequest {
+        name: name.to_string(),
+        description: description.map(|s| s.to_string()),
+    };
+    let project = client.create_project(&req).await.context("Failed to create project")?;
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&project)?);
+        return Ok(());
+    }
+
+    println!("{}", "Project created".green().bold());
+    println!("  ID:          {}", project.id.to_string().bright_black());
+    println!("  Name:        {}", project.name.bold());
+    if let Some(desc) = &project.description {
+        println!("  Description: {}", desc);
+    }
+
+    Ok(())
+}
+
+async fn show_project(client: &OrchestratorClient, id_or_name: &str, json: bool) -> Result<()> {
+    let id = resolve_project_id(client, id_or_name).await?;
+    let project = client.get_project(&id).await.context("Failed to get project")?;
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&project)?);
+        return Ok(());
+    }
+
+    println!("{}", "Project".blue().bold());
+    println!("{}", "=".repeat(60).cyan());
+    println!("  ID:          {}", project.id.to_string().bright_black());
+    println!("  Name:        {}", project.name.bold());
+    if let Some(desc) = &project.description {
+        println!("  Description: {}", desc);
+    }
+    println!("  Agents:      {}", project.agent_count);
+    println!("  Workflows:   {}", project.workflow_count);
+    println!("  Created:     {}", project.created_at.format("%Y-%m-%d %H:%M:%S UTC"));
+    println!("  Updated:     {}", project.updated_at.format("%Y-%m-%d %H:%M:%S UTC"));
+
+    Ok(())
+}
+
+async fn update_project(
+    client: &OrchestratorClient,
+    id_or_name: &str,
+    name: Option<&str>,
+    description: Option<&str>,
+    json: bool,
+) -> Result<()> {
+    if name.is_none() && description.is_none() {
+        bail!("Provide at least one of --name or --description to update");
+    }
+
+    let id = resolve_project_id(client, id_or_name).await?;
+    let req = UpdateProjectRequest {
+        name: name.map(|s| s.to_string()),
+        description: description.map(|s| s.to_string()),
+    };
+    let project = client.update_project(&id, &req).await.context("Failed to update project")?;
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&project)?);
+        return Ok(());
+    }
+
+    println!("{}", "Project updated".green().bold());
+    println!("  ID:          {}", project.id.to_string().bright_black());
+    println!("  Name:        {}", project.name.bold());
+    if let Some(desc) = &project.description {
+        println!("  Description: {}", desc);
+    }
+
+    Ok(())
+}
+
+async fn delete_project(client: &OrchestratorClient, id_or_name: &str, json: bool) -> Result<()> {
+    let id = resolve_project_id(client, id_or_name).await?;
+    client.delete_project(&id).await.context("Failed to delete project")?;
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&serde_json::json!({"deleted": id}))?);
+        return Ok(());
+    }
+
+    println!("{} {}", "Deleted project".green().bold(), id.to_string().bright_black());
+
+    Ok(())
+}
+
+async fn add_agent(
+    client: &OrchestratorClient,
+    project: &str,
+    agent_id: &str,
+    json: bool,
+) -> Result<()> {
+    let project_id = resolve_project_id(client, project).await?;
+    let agent_uuid = Uuid::parse_str(agent_id).context("Invalid agent UUID")?;
+    client
+        .associate_project_agent(&project_id, &agent_uuid)
+        .await
+        .context("Failed to add agent to project")?;
+
+    if json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(
+                &serde_json::json!({"project_id": project_id, "agent_id": agent_uuid})
+            )?
+        );
+        return Ok(());
+    }
+
+    println!(
+        "{} agent {} to project {}",
+        "Added".green().bold(),
+        agent_uuid.to_string().bright_black(),
+        project_id.to_string().bright_black()
+    );
+
+    Ok(())
+}
+
+async fn remove_agent(
+    client: &OrchestratorClient,
+    project: &str,
+    agent_id: &str,
+    json: bool,
+) -> Result<()> {
+    let project_id = resolve_project_id(client, project).await?;
+    let agent_uuid = Uuid::parse_str(agent_id).context("Invalid agent UUID")?;
+    client
+        .dissociate_project_agent(&project_id, &agent_uuid)
+        .await
+        .context("Failed to remove agent from project")?;
+
+    if json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(
+                &serde_json::json!({"project_id": project_id, "agent_id": agent_uuid})
+            )?
+        );
+        return Ok(());
+    }
+
+    println!(
+        "{} agent {} from project {}",
+        "Removed".green().bold(),
+        agent_uuid.to_string().bright_black(),
+        project_id.to_string().bright_black()
+    );
+
+    Ok(())
+}
+
+async fn add_workflow(
+    client: &OrchestratorClient,
+    project: &str,
+    workflow_id: &str,
+    json: bool,
+) -> Result<()> {
+    let project_id = resolve_project_id(client, project).await?;
+    let workflow_uuid = Uuid::parse_str(workflow_id).context("Invalid workflow UUID")?;
+    client
+        .associate_project_workflow(&project_id, &workflow_uuid)
+        .await
+        .context("Failed to add workflow to project")?;
+
+    if json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(
+                &serde_json::json!({"project_id": project_id, "workflow_id": workflow_uuid})
+            )?
+        );
+        return Ok(());
+    }
+
+    println!(
+        "{} workflow {} to project {}",
+        "Added".green().bold(),
+        workflow_uuid.to_string().bright_black(),
+        project_id.to_string().bright_black()
+    );
+
+    Ok(())
+}
+
+async fn remove_workflow(
+    client: &OrchestratorClient,
+    project: &str,
+    workflow_id: &str,
+    json: bool,
+) -> Result<()> {
+    let project_id = resolve_project_id(client, project).await?;
+    let workflow_uuid = Uuid::parse_str(workflow_id).context("Invalid workflow UUID")?;
+    client
+        .dissociate_project_workflow(&project_id, &workflow_uuid)
+        .await
+        .context("Failed to remove workflow from project")?;
+
+    if json {
+        println!(
+            "{}",
+            serde_json::to_string_pretty(
+                &serde_json::json!({"project_id": project_id, "workflow_id": workflow_uuid})
+            )?
+        );
+        return Ok(());
+    }
+
+    println!(
+        "{} workflow {} from project {}",
+        "Removed".green().bold(),
+        workflow_uuid.to_string().bright_black(),
+        project_id.to_string().bright_black()
+    );
+
+    Ok(())
+}

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -84,7 +84,7 @@ use colored::*;
 use commands::index::IndexClient;
 use commands::{
     AskCommand, AuthCommand, CommunicateCommand, IndexCommand, MemoryCommand, NotifyCommand,
-    OrchestratorCommand, OrgCommand, PromptCommand, WrapCommand,
+    OrchestratorCommand, OrgCommand, ProjectCommand, PromptCommand, WrapCommand,
 };
 use communicate::client::CommunicateClient;
 use memory::client::MemoryClient;
@@ -339,6 +339,27 @@ enum Commands {
         #[command(subcommand)]
         command: OrgCommand,
     },
+
+    /// Manage projects in the orchestrator.
+    ///
+    /// Projects group agents and workflows together for organisational purposes.
+    ///
+    /// # Examples
+    ///
+    /// ```bash
+    /// agent project list
+    /// agent project create my-project --description "Work items"
+    /// agent project show my-project
+    /// agent project add-agent my-project <agent-id>
+    /// agent project remove-agent my-project <agent-id>
+    /// agent project add-workflow my-project <workflow-id>
+    /// agent project remove-workflow my-project <workflow-id>
+    /// agent project delete my-project
+    /// ```
+    Project {
+        #[command(subcommand)]
+        command: ProjectCommand,
+    },
 }
 
 /// Main entry point for the agent CLI.
@@ -469,6 +490,12 @@ async fn main() -> Result<()> {
         }
         Commands::Org { command } => {
             command.execute(cli.json).await?;
+        }
+        Commands::Project { command } => {
+            let url = env::var("AGENTD_ORCHESTRATOR_SERVICE_URL")
+                .unwrap_or_else(|_| "http://localhost:7006".to_string());
+            let client = OrchestratorClient::new(url);
+            command.execute(&client, cli.json).await?;
         }
     }
 

--- a/crates/orchestrator/src/api.rs
+++ b/crates/orchestrator/src/api.rs
@@ -1028,13 +1028,6 @@ struct ProjectListQuery {
     offset: Option<usize>,
 }
 
-#[derive(Serialize)]
-struct ProjectDetails {
-    #[serde(flatten)]
-    project: Project,
-    agent_count: usize,
-    workflow_count: usize,
-}
 
 async fn list_projects(
     State(state): State<ApiState>,
@@ -1081,7 +1074,15 @@ async fn get_project(
     let workflow_count =
         state.scheduler.storage().list_workflows(Some(id)).await.map_err(ApiError::Internal)?.len();
 
-    Ok(Json(ProjectDetails { project, agent_count, workflow_count }))
+    Ok(Json(ProjectResponse {
+        id: project.id,
+        name: project.name,
+        description: project.description,
+        created_at: project.created_at,
+        updated_at: project.updated_at,
+        agent_count,
+        workflow_count,
+    }))
 }
 
 async fn update_project(

--- a/crates/orchestrator/src/api.rs
+++ b/crates/orchestrator/src/api.rs
@@ -1,6 +1,7 @@
 use crate::manager::AgentManager;
 use crate::scheduler::api::{queue_routes, webhook_routes, workflow_routes, WorkflowState};
 use crate::scheduler::events::SystemEvent;
+use crate::scheduler::types::WorkflowResponse;
 use crate::scheduler::Scheduler;
 use crate::types::*;
 use crate::websocket::{
@@ -84,6 +85,19 @@ pub fn create_router(state: ApiState) -> Router {
         .route("/approvals/{id}/deny", post(deny_tool))
         .route("/debug/agents", get(debug_agents))
         .route("/events/ask", post(ask_event_handler))
+        // Project management
+        .route("/projects", get(list_projects).post(create_project))
+        .route("/projects/{id}", get(get_project).put(update_project).delete(delete_project))
+        .route("/projects/{id}/agents", get(list_project_agents))
+        .route(
+            "/projects/{id}/agents/{agent_id}",
+            post(associate_project_agent).delete(dissociate_project_agent),
+        )
+        .route("/projects/{id}/workflows", get(list_project_workflows))
+        .route(
+            "/projects/{id}/workflows/{workflow_id}",
+            post(associate_project_workflow).delete(dissociate_project_workflow),
+        )
         .with_state(state);
 
     api_routes
@@ -100,6 +114,7 @@ pub struct ListQuery {
     pub status: Option<String>,
     pub limit: Option<usize>,
     pub offset: Option<usize>,
+    pub project_id: Option<Uuid>,
 }
 
 async fn health_check(State(state): State<ApiState>) -> impl IntoResponse {
@@ -139,7 +154,8 @@ async fn list_agents(
     let limit = clamp_limit(query.limit);
     let offset = query.offset.unwrap_or(0);
 
-    let (agents, total) = state.manager.list_agents_paginated(status_filter, limit, offset).await?;
+    let (agents, total) =
+        state.manager.list_agents_paginated(status_filter, query.project_id, limit, offset).await?;
     let mut items: Vec<AgentResponse> = Vec::with_capacity(agents.len());
     for agent in agents {
         let id = agent.id;
@@ -1000,6 +1016,271 @@ async fn ask_event_handler(
     });
 
     StatusCode::NO_CONTENT
+}
+
+// ---------------------------------------------------------------------------
+// Project management handlers
+// ---------------------------------------------------------------------------
+
+#[derive(Deserialize)]
+struct ProjectListQuery {
+    limit: Option<usize>,
+    offset: Option<usize>,
+}
+
+#[derive(Serialize)]
+struct ProjectDetails {
+    #[serde(flatten)]
+    project: Project,
+    agent_count: usize,
+    workflow_count: usize,
+}
+
+async fn list_projects(
+    State(state): State<ApiState>,
+    Query(query): Query<ProjectListQuery>,
+) -> Result<impl IntoResponse, ApiError> {
+    let ps = state.manager.project_storage();
+    let all = ps.list().await.map_err(ApiError::Internal)?;
+    let total = all.len();
+    let limit = clamp_limit(query.limit);
+    let offset = query.offset.unwrap_or(0);
+    let items: Vec<Project> = all.into_iter().skip(offset).take(limit).collect();
+    Ok(Json(PaginatedResponse { items, total, limit, offset }))
+}
+
+async fn create_project(
+    State(state): State<ApiState>,
+    Json(req): Json<CreateProjectRequest>,
+) -> Result<impl IntoResponse, ApiError> {
+    if req.name.trim().is_empty() {
+        return Err(ApiError::InvalidInput("project name must not be empty".to_string()));
+    }
+    let project = Project::new(req.name, req.description);
+    let ps = state.manager.project_storage();
+    let created = ps.create(&project).await.map_err(|e| {
+        if e.to_string().contains("UNIQUE") {
+            ApiError::Conflict(format!("a project named '{}' already exists", project.name))
+        } else {
+            ApiError::Internal(e)
+        }
+    })?;
+    Ok((StatusCode::CREATED, Json(created)))
+}
+
+async fn get_project(
+    State(state): State<ApiState>,
+    Path(id): Path<Uuid>,
+) -> Result<impl IntoResponse, ApiError> {
+    let ps = state.manager.project_storage();
+    let project = ps.get(&id).await.map_err(ApiError::Internal)?.ok_or(ApiError::NotFound)?;
+
+    let agent_count =
+        state.manager.agent_storage().list(None, Some(id)).await.map_err(ApiError::Internal)?.len();
+
+    let workflow_count =
+        state.scheduler.storage().list_workflows(Some(id)).await.map_err(ApiError::Internal)?.len();
+
+    Ok(Json(ProjectDetails { project, agent_count, workflow_count }))
+}
+
+async fn update_project(
+    State(state): State<ApiState>,
+    Path(id): Path<Uuid>,
+    Json(req): Json<UpdateProjectRequest>,
+) -> Result<impl IntoResponse, ApiError> {
+    let ps = state.manager.project_storage();
+    let updated = ps.update(&id, &req).await.map_err(|e| {
+        let msg = e.to_string();
+        if msg.contains("not found") {
+            ApiError::NotFound
+        } else if msg.contains("UNIQUE") {
+            ApiError::Conflict("a project with that name already exists".to_string())
+        } else {
+            ApiError::Internal(e)
+        }
+    })?;
+    Ok(Json(updated))
+}
+
+async fn delete_project(
+    State(state): State<ApiState>,
+    Path(id): Path<Uuid>,
+) -> Result<impl IntoResponse, ApiError> {
+    let ps = state.manager.project_storage();
+
+    // Verify project exists.
+    ps.get(&id).await.map_err(ApiError::Internal)?.ok_or(ApiError::NotFound)?;
+
+    // Reject if any agents are still associated.
+    let associated_agents =
+        state.manager.agent_storage().list(None, Some(id)).await.map_err(ApiError::Internal)?;
+    if !associated_agents.is_empty() {
+        return Err(ApiError::InvalidInput(format!(
+            "cannot delete project: {} agent(s) still associated",
+            associated_agents.len()
+        )));
+    }
+
+    // Reject if any workflows are still associated.
+    let associated_workflows =
+        state.scheduler.storage().list_workflows(Some(id)).await.map_err(ApiError::Internal)?;
+    if !associated_workflows.is_empty() {
+        return Err(ApiError::InvalidInput(format!(
+            "cannot delete project: {} workflow(s) still associated",
+            associated_workflows.len()
+        )));
+    }
+
+    ps.delete(&id).await.map_err(|e| {
+        if e.to_string().contains("not found") {
+            ApiError::NotFound
+        } else {
+            ApiError::Internal(e)
+        }
+    })?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+async fn list_project_agents(
+    State(state): State<ApiState>,
+    Path(id): Path<Uuid>,
+    Query(query): Query<ProjectListQuery>,
+) -> Result<impl IntoResponse, ApiError> {
+    let ps = state.manager.project_storage();
+    ps.get(&id).await.map_err(ApiError::Internal)?.ok_or(ApiError::NotFound)?;
+
+    let limit = clamp_limit(query.limit);
+    let offset = query.offset.unwrap_or(0);
+
+    let (agents, total) = state
+        .manager
+        .agent_storage()
+        .list_paginated_filtered(None, Some(id), limit, offset)
+        .await
+        .map_err(ApiError::Internal)?;
+
+    let mut items: Vec<AgentResponse> = Vec::with_capacity(agents.len());
+    for agent in agents {
+        let aid = agent.id;
+        let mut response = AgentResponse::from(agent);
+        response.activity = state.registry.get_activity_state(&aid).await;
+        items.push(response);
+    }
+    Ok(Json(PaginatedResponse { items, total, limit, offset }))
+}
+
+async fn associate_project_agent(
+    State(state): State<ApiState>,
+    Path((id, agent_id)): Path<(Uuid, Uuid)>,
+) -> Result<impl IntoResponse, ApiError> {
+    // Verify project and agent exist.
+    let ps = state.manager.project_storage();
+    ps.get(&id).await.map_err(ApiError::Internal)?.ok_or(ApiError::NotFound)?;
+    state
+        .manager
+        .get_agent(&agent_id)
+        .await
+        .map_err(ApiError::Internal)?
+        .ok_or(ApiError::NotFound)?;
+
+    state
+        .manager
+        .agent_storage()
+        .set_agent_project(&agent_id, Some(id))
+        .await
+        .map_err(ApiError::Internal)?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+async fn dissociate_project_agent(
+    State(state): State<ApiState>,
+    Path((id, agent_id)): Path<(Uuid, Uuid)>,
+) -> Result<impl IntoResponse, ApiError> {
+    let ps = state.manager.project_storage();
+    ps.get(&id).await.map_err(ApiError::Internal)?.ok_or(ApiError::NotFound)?;
+    state
+        .manager
+        .get_agent(&agent_id)
+        .await
+        .map_err(ApiError::Internal)?
+        .ok_or(ApiError::NotFound)?;
+
+    state
+        .manager
+        .agent_storage()
+        .set_agent_project(&agent_id, None)
+        .await
+        .map_err(ApiError::Internal)?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+async fn list_project_workflows(
+    State(state): State<ApiState>,
+    Path(id): Path<Uuid>,
+    Query(query): Query<ProjectListQuery>,
+) -> Result<impl IntoResponse, ApiError> {
+    let ps = state.manager.project_storage();
+    ps.get(&id).await.map_err(ApiError::Internal)?.ok_or(ApiError::NotFound)?;
+
+    let limit = clamp_limit(query.limit);
+    let offset = query.offset.unwrap_or(0);
+
+    let (workflows, total) = state
+        .scheduler
+        .storage()
+        .list_workflows_paginated(limit, offset, Some(id))
+        .await
+        .map_err(ApiError::Internal)?;
+
+    let items: Vec<WorkflowResponse> = workflows.into_iter().map(WorkflowResponse::from).collect();
+    Ok(Json(PaginatedResponse { items, total, limit, offset }))
+}
+
+async fn associate_project_workflow(
+    State(state): State<ApiState>,
+    Path((id, workflow_id)): Path<(Uuid, Uuid)>,
+) -> Result<impl IntoResponse, ApiError> {
+    let ps = state.manager.project_storage();
+    ps.get(&id).await.map_err(ApiError::Internal)?.ok_or(ApiError::NotFound)?;
+    state
+        .scheduler
+        .storage()
+        .get_workflow(&workflow_id)
+        .await
+        .map_err(ApiError::Internal)?
+        .ok_or(ApiError::NotFound)?;
+
+    state
+        .scheduler
+        .storage()
+        .set_workflow_project(&workflow_id, Some(id))
+        .await
+        .map_err(ApiError::Internal)?;
+    Ok(StatusCode::NO_CONTENT)
+}
+
+async fn dissociate_project_workflow(
+    State(state): State<ApiState>,
+    Path((id, workflow_id)): Path<(Uuid, Uuid)>,
+) -> Result<impl IntoResponse, ApiError> {
+    let ps = state.manager.project_storage();
+    ps.get(&id).await.map_err(ApiError::Internal)?.ok_or(ApiError::NotFound)?;
+    state
+        .scheduler
+        .storage()
+        .get_workflow(&workflow_id)
+        .await
+        .map_err(ApiError::Internal)?
+        .ok_or(ApiError::NotFound)?;
+
+    state
+        .scheduler
+        .storage()
+        .set_workflow_project(&workflow_id, None)
+        .await
+        .map_err(ApiError::Internal)?;
+    Ok(StatusCode::NO_CONTENT)
 }
 
 #[cfg(test)]

--- a/crates/orchestrator/src/client.rs
+++ b/crates/orchestrator/src/client.rs
@@ -35,9 +35,9 @@ use crate::scheduler::types::{
 };
 use crate::types::{
     AddDirRequest, AddDirResponse, AgentResponse, AgentUsageStats, ApprovalActionRequest,
-    ClearContextRequest, ClearContextResponse, CreateAgentRequest, HealthResponse,
-    PaginatedResponse, PendingApproval, SendMessageRequest, SendMessageResponse, SetModelRequest,
-    ToolPolicy,
+    ClearContextRequest, ClearContextResponse, CreateAgentRequest, CreateProjectRequest,
+    HealthResponse, PaginatedResponse, PendingApproval, Project, ProjectResponse,
+    SendMessageRequest, SendMessageResponse, SetModelRequest, ToolPolicy, UpdateProjectRequest,
 };
 
 /// Typed HTTP client for the orchestrator service.
@@ -336,6 +336,113 @@ impl OrchestratorClient {
     /// Purge all tasks from a named queue.
     pub async fn queue_purge(&self, queue_name: &str) -> Result<serde_json::Value> {
         self.delete_with_response(&format!("/queues/{}", queue_name)).await
+    }
+
+    // -- Project management --
+
+    /// List all projects.
+    pub async fn list_projects(&self) -> Result<PaginatedResponse<Project>> {
+        self.get("/projects").await
+    }
+
+    /// Create a new project.
+    pub async fn create_project(&self, req: &CreateProjectRequest) -> Result<Project> {
+        self.post("/projects", req).await
+    }
+
+    /// Get a project by UUID, including agent and workflow counts.
+    pub async fn get_project(&self, id: &Uuid) -> Result<ProjectResponse> {
+        self.get(&format!("/projects/{id}")).await
+    }
+
+    /// Find a project by name (client-side search).
+    pub async fn get_project_by_name(&self, name: &str) -> Result<Option<Project>> {
+        let resp: PaginatedResponse<Project> = self.get("/projects?limit=500").await?;
+        Ok(resp.items.into_iter().find(|p| p.name == name))
+    }
+
+    /// Update a project's name and/or description.
+    pub async fn update_project(&self, id: &Uuid, req: &UpdateProjectRequest) -> Result<Project> {
+        self.put(&format!("/projects/{id}"), req).await
+    }
+
+    /// Delete a project (fails if agents or workflows are still associated).
+    pub async fn delete_project(&self, id: &Uuid) -> Result<()> {
+        self.delete(&format!("/projects/{id}")).await
+    }
+
+    /// List agents associated with a project.
+    pub async fn list_project_agents(
+        &self,
+        id: &Uuid,
+    ) -> Result<PaginatedResponse<AgentResponse>> {
+        self.get(&format!("/projects/{id}/agents")).await
+    }
+
+    /// Associate an agent with a project.
+    pub async fn associate_project_agent(&self, project_id: &Uuid, agent_id: &Uuid) -> Result<()> {
+        let url = format!("{}/projects/{project_id}/agents/{agent_id}", self.base_url);
+        let response = self
+            .client
+            .post(&url)
+            .send()
+            .await
+            .context(format!("Failed to POST {url}"))?;
+        if response.status().is_success() {
+            Ok(())
+        } else {
+            let status = response.status();
+            let text = response.text().await.unwrap_or_default();
+            Err(anyhow::anyhow!("Request failed with status {status}: {text}"))
+        }
+    }
+
+    /// Remove an agent from a project.
+    pub async fn dissociate_project_agent(
+        &self,
+        project_id: &Uuid,
+        agent_id: &Uuid,
+    ) -> Result<()> {
+        self.delete(&format!("/projects/{project_id}/agents/{agent_id}")).await
+    }
+
+    /// List workflows associated with a project.
+    pub async fn list_project_workflows(
+        &self,
+        id: &Uuid,
+    ) -> Result<PaginatedResponse<WorkflowResponse>> {
+        self.get(&format!("/projects/{id}/workflows")).await
+    }
+
+    /// Associate a workflow with a project.
+    pub async fn associate_project_workflow(
+        &self,
+        project_id: &Uuid,
+        workflow_id: &Uuid,
+    ) -> Result<()> {
+        let url = format!("{}/projects/{project_id}/workflows/{workflow_id}", self.base_url);
+        let response = self
+            .client
+            .post(&url)
+            .send()
+            .await
+            .context(format!("Failed to POST {url}"))?;
+        if response.status().is_success() {
+            Ok(())
+        } else {
+            let status = response.status();
+            let text = response.text().await.unwrap_or_default();
+            Err(anyhow::anyhow!("Request failed with status {status}: {text}"))
+        }
+    }
+
+    /// Remove a workflow from a project.
+    pub async fn dissociate_project_workflow(
+        &self,
+        project_id: &Uuid,
+        workflow_id: &Uuid,
+    ) -> Result<()> {
+        self.delete(&format!("/projects/{project_id}/workflows/{workflow_id}")).await
     }
 
     // -- Private HTTP helpers --

--- a/crates/orchestrator/src/entity/project.rs
+++ b/crates/orchestrator/src/entity/project.rs
@@ -1,8 +1,5 @@
 //! SeaORM entity for the `projects` table.
 
-// API routes wired in #829; suppress dead_code lint until then.
-#![allow(dead_code)]
-
 use sea_orm::entity::prelude::*;
 
 /// SeaORM model for the `projects` table.

--- a/crates/orchestrator/src/manager.rs
+++ b/crates/orchestrator/src/manager.rs
@@ -1,5 +1,5 @@
 use crate::scheduler::events::SystemEvent;
-use crate::storage::AgentStorage;
+use crate::storage::{AgentStorage, ProjectStorage};
 use crate::types::{Agent, AgentConfig, AgentStatus, AgentUsageStats, ClearContextResponse};
 use crate::websocket::ConnectionRegistry;
 use chrono::Utc;
@@ -35,6 +35,16 @@ impl AgentManager {
 
     pub fn registry(&self) -> &ConnectionRegistry {
         &self.registry
+    }
+
+    /// Returns a [`ProjectStorage`] backed by the same database connection.
+    pub fn project_storage(&self) -> ProjectStorage {
+        ProjectStorage::from_db(self.storage.db().clone())
+    }
+
+    /// Returns the underlying [`AgentStorage`] for direct access.
+    pub fn agent_storage(&self) -> &AgentStorage {
+        &self.storage
     }
 
     /// Spawn a new agent: create DB record, backend session, and launch claude.
@@ -452,14 +462,15 @@ impl AgentManager {
         self.storage.list(status, None).await
     }
 
-    /// List agents with pagination.
+    /// List agents with pagination, optionally filtered by project.
     pub async fn list_agents_paginated(
         &self,
         status: Option<AgentStatus>,
+        project_id: Option<Uuid>,
         limit: usize,
         offset: usize,
     ) -> anyhow::Result<(Vec<Agent>, usize)> {
-        self.storage.list_paginated(status, limit, offset).await
+        self.storage.list_paginated_filtered(status, project_id, limit, offset).await
     }
 
     /// Update an agent record in storage.

--- a/crates/orchestrator/src/scheduler/api.rs
+++ b/crates/orchestrator/src/scheduler/api.rs
@@ -24,6 +24,7 @@ use uuid::Uuid;
 struct PaginationParams {
     limit: Option<usize>,
     offset: Option<usize>,
+    project_id: Option<Uuid>,
 }
 
 #[derive(Clone)]
@@ -259,8 +260,11 @@ async fn list_workflows(
     let limit = clamp_limit(params.limit);
     let offset = params.offset.unwrap_or(0);
 
-    let (workflows, total) =
-        state.scheduler.storage().list_workflows_paginated(limit, offset, None).await?;
+    let (workflows, total) = state
+        .scheduler
+        .storage()
+        .list_workflows_paginated(limit, offset, params.project_id)
+        .await?;
     let items: Vec<WorkflowResponse> = workflows.into_iter().map(WorkflowResponse::from).collect();
     Ok(Json(PaginatedResponse { items, total, limit, offset }))
 }

--- a/crates/orchestrator/src/scheduler/mod.rs
+++ b/crates/orchestrator/src/scheduler/mod.rs
@@ -210,7 +210,7 @@ impl Scheduler {
             warn!(count = failed, "Marked in-flight dispatches as failed on startup");
         }
 
-        let workflows = self.storage.list_workflows().await?;
+        let workflows = self.storage.list_workflows(None).await?;
         for workflow in workflows {
             if !workflow.enabled {
                 continue;

--- a/crates/orchestrator/src/scheduler/storage.rs
+++ b/crates/orchestrator/src/scheduler/storage.rs
@@ -118,6 +118,27 @@ impl SchedulerStorage {
         Ok(())
     }
 
+    /// Sets or clears the `project_id` for a single workflow.
+    pub async fn set_workflow_project(&self, id: &Uuid, project_id: Option<Uuid>) -> Result<()> {
+        use sea_orm::sea_query::Expr;
+        let now = chrono::Utc::now().to_rfc3339();
+
+        let result = workflow_entity::Entity::update_many()
+            .col_expr(
+                workflow_entity::Column::ProjectId,
+                Expr::value(project_id.map(|p| p.to_string())),
+            )
+            .col_expr(workflow_entity::Column::UpdatedAt, Expr::value(now))
+            .filter(workflow_entity::Column::Id.eq(id.to_string()))
+            .exec(&self.db)
+            .await?;
+
+        if result.rows_affected == 0 {
+            anyhow::bail!("Workflow not found");
+        }
+        Ok(())
+    }
+
     /// Permanently deletes a workflow by UUID.
     pub async fn delete_workflow(&self, id: &Uuid) -> Result<()> {
         let result = workflow_entity::Entity::delete_many()

--- a/crates/orchestrator/src/storage.rs
+++ b/crates/orchestrator/src/storage.rs
@@ -185,6 +185,27 @@ impl AgentStorage {
         Ok(())
     }
 
+    /// Sets or clears the `project_id` for a single agent.
+    pub async fn set_agent_project(&self, id: &Uuid, project_id: Option<Uuid>) -> Result<()> {
+        use sea_orm::sea_query::Expr;
+        let now = chrono::Utc::now().to_rfc3339();
+
+        let result = agent_entity::Entity::update_many()
+            .col_expr(
+                agent_entity::Column::ProjectId,
+                Expr::value(project_id.map(|p| p.to_string())),
+            )
+            .col_expr(agent_entity::Column::UpdatedAt, Expr::value(now))
+            .filter(agent_entity::Column::Id.eq(id.to_string()))
+            .exec(&self.db)
+            .await?;
+
+        if result.rows_affected == 0 {
+            anyhow::bail!("Agent not found");
+        }
+        Ok(())
+    }
+
     /// Permanently deletes an agent by UUID.
     pub async fn delete(&self, id: &Uuid) -> Result<()> {
         let result = agent_entity::Entity::delete_many()
@@ -497,16 +518,31 @@ impl AgentStorage {
     }
 
     /// Lists agents with pagination; returns `(items, total_count)`.
+    #[allow(dead_code)]
     pub async fn list_paginated(
         &self,
         status_filter: Option<AgentStatus>,
         limit: usize,
         offset: usize,
     ) -> Result<(Vec<Agent>, usize)> {
-        let condition = match &status_filter {
-            Some(s) => Condition::all().add(agent_entity::Column::Status.eq(s.to_string())),
-            None => Condition::all(),
-        };
+        self.list_paginated_filtered(status_filter, None, limit, offset).await
+    }
+
+    /// Lists agents with pagination and optional project_id filter; returns `(items, total_count)`.
+    pub async fn list_paginated_filtered(
+        &self,
+        status_filter: Option<AgentStatus>,
+        project_id: Option<Uuid>,
+        limit: usize,
+        offset: usize,
+    ) -> Result<(Vec<Agent>, usize)> {
+        let mut condition = Condition::all();
+        if let Some(s) = &status_filter {
+            condition = condition.add(agent_entity::Column::Status.eq(s.to_string()));
+        }
+        if let Some(pid) = project_id {
+            condition = condition.add(agent_entity::Column::ProjectId.eq(pid.to_string()));
+        }
 
         let total =
             agent_entity::Entity::find().filter(condition.clone()).count(&self.db).await? as usize;
@@ -533,14 +569,11 @@ impl AgentStorage {
 /// Shares the same [`DatabaseConnection`] as [`AgentStorage`] — construct via
 /// [`ProjectStorage::from_db`] using the connection returned by
 /// [`AgentStorage::db()`].
-// API routes are added in #829; suppress dead_code until then.
-#[allow(dead_code)]
 #[derive(Clone)]
 pub struct ProjectStorage {
     db: DatabaseConnection,
 }
 
-#[allow(dead_code)]
 impl ProjectStorage {
     /// Wrap an existing database connection (shared with `AgentStorage`).
     pub fn from_db(db: DatabaseConnection) -> Self {
@@ -567,6 +600,7 @@ impl ProjectStorage {
     }
 
     /// Retrieve a project by its unique name.  Returns `None` if not found.
+    #[allow(dead_code)]
     pub async fn get_by_name(&self, name: &str) -> Result<Option<Project>> {
         let model = project_entity::Entity::find()
             .filter(project_entity::Column::Name.eq(name))
@@ -706,7 +740,6 @@ fn model_to_session_usage(model: &session_entity::Model) -> Result<SessionUsage>
 }
 
 /// Convert a raw [`project_entity::Model`] into the domain [`Project`] type.
-#[allow(dead_code)]
 fn model_to_project(model: project_entity::Model) -> Result<Project> {
     Ok(Project {
         id: Uuid::parse_str(&model.id)?,

--- a/crates/orchestrator/src/types.rs
+++ b/crates/orchestrator/src/types.rs
@@ -478,8 +478,6 @@ fn default_shell() -> String {
 // ---------------------------------------------------------------------------
 
 /// A project groups agents, workflows, and rooms under a named boundary.
-// API routes are added in #829; suppress dead_code until then.
-#[allow(dead_code)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct Project {
     pub id: Uuid,
@@ -489,7 +487,6 @@ pub struct Project {
     pub updated_at: DateTime<Utc>,
 }
 
-#[allow(dead_code)]
 impl Project {
     pub fn new(name: String, description: Option<String>) -> Self {
         let now = Utc::now();
@@ -498,7 +495,6 @@ impl Project {
 }
 
 /// Request body for POST /projects.
-#[allow(dead_code)]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CreateProjectRequest {
     pub name: String,
@@ -511,7 +507,6 @@ pub struct CreateProjectRequest {
 /// Fields that are `None` are left unchanged in the database.
 /// Pass `description: Some(None)` is not supported via this struct —
 /// to clear a description set it to `Some("")` or omit the field.
-#[allow(dead_code)]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct UpdateProjectRequest {
     #[serde(skip_serializing_if = "Option::is_none")]

--- a/crates/orchestrator/src/types.rs
+++ b/crates/orchestrator/src/types.rs
@@ -494,6 +494,19 @@ impl Project {
     }
 }
 
+/// Detailed project response including associated resource counts.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ProjectResponse {
+    pub id: Uuid,
+    pub name: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub description: Option<String>,
+    pub created_at: DateTime<Utc>,
+    pub updated_at: DateTime<Utc>,
+    pub agent_count: usize,
+    pub workflow_count: usize,
+}
+
 /// Request body for POST /projects.
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CreateProjectRequest {


### PR DESCRIPTION
Adds REST API endpoints for project management to the orchestrator service, building on the project storage from #827 and the project_id FK columns from #828.

**New endpoints:**
- `GET /projects` — list all projects (paginated)
- `POST /projects` — create a project
- `GET /projects/{id}` — get project details with agent/workflow counts
- `PUT /projects/{id}` — update project name/description
- `DELETE /projects/{id}` — delete project (rejected if agents/workflows still associated)
- `GET /projects/{id}/agents` — list agents in project (paginated)
- `POST /projects/{id}/agents/{agent_id}` — associate agent with project
- `DELETE /projects/{id}/agents/{agent_id}` — remove agent from project
- `GET /projects/{id}/workflows` — list workflows in project (paginated)
- `POST /projects/{id}/workflows/{workflow_id}` — associate workflow
- `DELETE /projects/{id}/workflows/{workflow_id}` — remove workflow from project

**Updated endpoints:**
- `GET /agents?project_id=X` — filter agents by project
- `GET /workflows?project_id=X` — filter workflows by project

Closes #829