### PR TITLE
feat(ui): auto-scroll to bottom when opening a communication room

### DIFF
--- a/ui/src/components/communicate/ChatMessageView.tsx
+++ b/ui/src/components/communicate/ChatMessageView.tsx
@@ -118,6 +118,8 @@ interface ChatMessageViewProps {
 	loadingOlder: boolean;
 	hasMore: boolean;
 	onLoadOlder: () => void;
+	/** Room identifier — used to reset scroll position when switching rooms. */
+	roomId?: string;
 }
 
 export function ChatMessageView({
@@ -126,10 +128,28 @@ export function ChatMessageView({
 	loadingOlder,
 	hasMore,
 	onLoadOlder,
+	roomId,
 }: ChatMessageViewProps) {
 	const bottomRef = useRef<HTMLDivElement>(null);
 	const containerRef = useRef<HTMLDivElement>(null);
 	const prevScrollHeightRef = useRef<number>(0);
+	const initialScrollDone = useRef(false);
+
+	// Reset the initial-scroll flag whenever the active room changes so that
+	// switching rooms always brings the user to the bottom of the new room.
+	useEffect(() => {
+		initialScrollDone.current = false;
+	}, [roomId]);
+
+	// Scroll to the bottom on initial load or room switch.  The flag prevents
+	// this from re-triggering when the user loads older messages (infinite
+	// scroll upward), because by then initialScrollDone is already true.
+	useEffect(() => {
+		if (messages.length > 0 && !loading && !initialScrollDone.current) {
+			bottomRef.current?.scrollIntoView({ behavior: "instant" });
+			initialScrollDone.current = true;
+		}
+	}, [messages, loading]);
 
 	// Auto-scroll to bottom when new messages arrive
 	useEffect(() => {

--- a/ui/src/pages/communicate/CommunicatePage.tsx
+++ b/ui/src/pages/communicate/CommunicatePage.tsx
@@ -398,6 +398,7 @@ export function CommunicatePage() {
 								loadingOlder={loadingOlder}
 								hasMore={hasMore}
 								onLoadOlder={loadOlder}
+								roomId={selectedRoom?.id}
 							/>
 
 							{/* Message input */}

--- a/ui/src/test/components/communicate/ChatMessageView.test.tsx
+++ b/ui/src/test/components/communicate/ChatMessageView.test.tsx
@@ -8,6 +8,13 @@ import { makeChatMessage, makeChatMessageList } from "@/test/mocks/factories";
 
 const noop = () => {};
 
+// scrollIntoView is not implemented in jsdom — provide a mock.
+const scrollIntoViewMock = vi.fn();
+beforeEach(() => {
+	scrollIntoViewMock.mockClear();
+	window.HTMLElement.prototype.scrollIntoView = scrollIntoViewMock;
+});
+
 describe("ChatMessageView", () => {
 	it("renders messages", () => {
 		const messages = makeChatMessageList(3);
@@ -119,5 +126,129 @@ describe("ChatMessageView", () => {
 		// The parent content appears in the reply indicator
 		expect(screen.getAllByText("Original message")).toHaveLength(2);
 		expect(screen.getByText("Reply message")).toBeInTheDocument();
+	});
+
+	it("scrolls to bottom instantly on initial load", () => {
+		const messages = makeChatMessageList(5);
+		render(
+			<ChatMessageView
+				messages={messages}
+				loading={false}
+				loadingOlder={false}
+				hasMore={false}
+				onLoadOlder={noop}
+				roomId="room-1"
+			/>,
+		);
+
+		expect(scrollIntoViewMock).toHaveBeenCalledWith({ behavior: "instant" });
+	});
+
+	it("does not scroll to bottom while loading", () => {
+		render(
+			<ChatMessageView
+				messages={[]}
+				loading={true}
+				loadingOlder={false}
+				hasMore={false}
+				onLoadOlder={noop}
+				roomId="room-1"
+			/>,
+		);
+
+		// Loading spinner is shown, scrollIntoView should not have been called
+		// with the initial-scroll behavior because messages haven't arrived yet.
+		const instantCalls = scrollIntoViewMock.mock.calls.filter(
+			(call) => call[0]?.behavior === "instant",
+		);
+		expect(instantCalls).toHaveLength(0);
+	});
+
+	it("scrolls to bottom again when switching rooms", () => {
+		const messagesRoom1 = makeChatMessageList(3);
+		const messagesRoom2 = makeChatMessageList(3);
+
+		const { rerender } = render(
+			<ChatMessageView
+				messages={messagesRoom1}
+				loading={false}
+				loadingOlder={false}
+				hasMore={false}
+				onLoadOlder={noop}
+				roomId="room-1"
+			/>,
+		);
+
+		const callsAfterRoom1 = scrollIntoViewMock.mock.calls.filter(
+			(call) => call[0]?.behavior === "instant",
+		).length;
+		expect(callsAfterRoom1).toBe(1);
+
+		// Simulate room switch: loading starts with empty messages, then resolves.
+		rerender(
+			<ChatMessageView
+				messages={[]}
+				loading={true}
+				loadingOlder={false}
+				hasMore={false}
+				onLoadOlder={noop}
+				roomId="room-2"
+			/>,
+		);
+
+		rerender(
+			<ChatMessageView
+				messages={messagesRoom2}
+				loading={false}
+				loadingOlder={false}
+				hasMore={false}
+				onLoadOlder={noop}
+				roomId="room-2"
+			/>,
+		);
+
+		const callsAfterRoom2 = scrollIntoViewMock.mock.calls.filter(
+			(call) => call[0]?.behavior === "instant",
+		).length;
+		expect(callsAfterRoom2).toBe(2);
+	});
+
+	it("does not scroll to bottom when loading older messages", () => {
+		const messages = makeChatMessageList(5);
+		const olderMessages = [...makeChatMessageList(5), ...messages];
+
+		const { rerender } = render(
+			<ChatMessageView
+				messages={messages}
+				loading={false}
+				loadingOlder={false}
+				hasMore={true}
+				onLoadOlder={noop}
+				roomId="room-1"
+			/>,
+		);
+
+		const callsAfterInitial = scrollIntoViewMock.mock.calls.filter(
+			(call) => call[0]?.behavior === "instant",
+		).length;
+		expect(callsAfterInitial).toBe(1);
+
+		// Simulate loading older messages (prepend to list, loadingOlder transitions)
+		rerender(
+			<ChatMessageView
+				messages={olderMessages}
+				loading={false}
+				loadingOlder={false}
+				hasMore={false}
+				onLoadOlder={noop}
+				roomId="room-1"
+			/>,
+		);
+
+		// Still only 1 instant-scroll call — older-message prepend must not jump to bottom
+		const callsAfterOlder = scrollIntoViewMock.mock.calls.filter(
+			(call) => call[0]?.behavior === "instant",
+		).length;
+		expect(callsAfterOlder).toBe(1);
 	});
 });


### PR DESCRIPTION
Add initial scroll-to-bottom effect to `ChatMessageView` so that opening or switching rooms always lands the user at the most recent messages.

**Changes:**
- Added `roomId?: string` prop to `ChatMessageView` — passed down from `CommunicatePage` so the component knows when the room changes
- Added `initialScrollDone` ref to guard the initial scroll — prevents the same effect from jumping to bottom when the user loads older messages via infinite scroll
- Two new `useEffect` hooks: one resets the flag when `roomId` changes, one scrolls to bottom (`behavior: "instant"`) on first load/room switch
- 4 new tests covering: initial scroll, no scroll during loading, scroll on room switch, no scroll on older-message prepend

Closes #1081