### PR TITLE
feat(ui): show agent thinking/working indicator in communication rooms

### DIFF
--- a/ui/src/components/communicate/ChatMessageView.tsx
+++ b/ui/src/components/communicate/ChatMessageView.tsx
@@ -10,11 +10,12 @@
  * - Visual distinction between agent and human messages
  * - Thread reply indicator for messages with reply_to
  * - Loading states for initial load and older-page load
+ * - Thinking indicator: animated dots with agent name(s) when agent(s) are busy
  */
 
 import { ArrowDown, Bot, CornerUpLeft, Loader2, User } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import type { ChatMessage, ParticipantKind } from "@/types/communicate";
+import type { ChatMessage, Participant, ParticipantKind } from "@/types/communicate";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -111,6 +112,39 @@ function MessageBubble({ message, replyToMessage }: MessageBubbleProps) {
 }
 
 // ---------------------------------------------------------------------------
+// Thinking indicator
+// ---------------------------------------------------------------------------
+
+function ThinkingIndicator({ agents }: { agents: Participant[] }) {
+	if (agents.length === 0) return null;
+
+	let label: string;
+	if (agents.length === 1) {
+		label = `${agents[0].display_name} is thinking…`;
+	} else if (agents.length === 2) {
+		label = `${agents[0].display_name} and ${agents[1].display_name} are thinking…`;
+	} else {
+		label = `${agents.length} agents are thinking…`;
+	}
+
+	return (
+		<div
+			className="flex items-center gap-2 px-1 text-sm text-th-text-muted"
+			aria-live="polite"
+			aria-label={label}
+		>
+			{/* Three bouncing dots */}
+			<span className="flex items-center gap-0.5" aria-hidden="true">
+				<span className="h-1.5 w-1.5 rounded-full bg-th-text-muted animate-bounce [animation-delay:-0.3s]" />
+				<span className="h-1.5 w-1.5 rounded-full bg-th-text-muted animate-bounce [animation-delay:-0.15s]" />
+				<span className="h-1.5 w-1.5 rounded-full bg-th-text-muted animate-bounce" />
+			</span>
+			<span>{label}</span>
+		</div>
+	);
+}
+
+// ---------------------------------------------------------------------------
 // ChatMessageView
 // ---------------------------------------------------------------------------
 
@@ -122,6 +156,8 @@ interface ChatMessageViewProps {
 	onLoadOlder: () => void;
 	/** Room identifier — used to reset scroll position when switching rooms. */
 	roomId?: string;
+	/** Agent participants currently processing (activity_state === "busy"). */
+	busyAgents?: Participant[];
 }
 
 export function ChatMessageView({
@@ -131,6 +167,7 @@ export function ChatMessageView({
 	hasMore,
 	onLoadOlder,
 	roomId,
+	busyAgents = [],
 }: ChatMessageViewProps) {
 	const bottomRef = useRef<HTMLDivElement>(null);
 	const containerRef = useRef<HTMLDivElement>(null);
@@ -304,6 +341,9 @@ export function ChatMessageView({
 						}
 					/>
 				))}
+
+				{/* Thinking indicator — shown when one or more agents are busy */}
+				<ThinkingIndicator agents={busyAgents} />
 
 				<div ref={bottomRef} />
 			</div>

--- a/ui/src/components/communicate/ParticipantPanel.tsx
+++ b/ui/src/components/communicate/ParticipantPanel.tsx
@@ -47,7 +47,9 @@ function ActivityDot({ state }: { state?: "idle" | "busy" }) {
 		<span
 			className={[
 				"h-2 w-2 rounded-full",
-				state === "busy" ? "bg-th-status-warning-dot" : "bg-th-status-success-dot",
+				state === "busy"
+					? "bg-th-status-warning-dot animate-pulse"
+					: "bg-th-status-success-dot",
 			].join(" ")}
 			aria-label={state === "busy" ? "Busy" : "Idle"}
 		/>

--- a/ui/src/components/dashboard/ServiceHealthCard.tsx
+++ b/ui/src/components/dashboard/ServiceHealthCard.tsx
@@ -12,6 +12,9 @@ const SERVICE_ROUTES: Record<string, string> = {
 	orchestrator: "/agents",
 	notify: "/notifications",
 	ask: "/questions",
+	memory: "/memories",
+	index: "/code-index",
+	communicate: "/communicate",
 };
 
 interface ServiceHealthCardProps {

--- a/ui/src/components/workflows/WorkflowForm.tsx
+++ b/ui/src/components/workflows/WorkflowForm.tsx
@@ -97,10 +97,10 @@ export function WorkflowForm({
 			setName(workflow.name);
 			setAgentId(workflow.agent_id);
 			const src = workflow.source_config;
-			if (src.type === "github_issues") {
+			if (src?.type === "github_issues") {
 				setOwner(src.owner);
 				setRepo(src.repo);
-				setLabelsRaw(src.labels.join(", "));
+				setLabelsRaw((src.labels ?? []).join(", "));
 				setIssueState(src.state as "open" | "closed" | "all");
 			}
 			setPromptTemplate(workflow.prompt_template);

--- a/ui/src/hooks/useAgentSummary.ts
+++ b/ui/src/hooks/useAgentSummary.ts
@@ -29,6 +29,7 @@ export interface UseAgentSummaryResult {
 	aggregateUsage: AggregateUsageSummary | null;
 	loading: boolean;
 	error?: string;
+	refetch: () => void;
 }
 
 const EMPTY_COUNTS: AgentStatusCounts = {
@@ -123,5 +124,5 @@ export function useAgentSummary(): UseAgentSummaryResult {
 		void fetch();
 	}, [fetch]);
 
-	return { counts, recentAgents, total, aggregateUsage, loading, error };
+	return { counts, recentAgents, total, aggregateUsage, loading, error, refetch: fetch };
 }

--- a/ui/src/hooks/useCommunicateSocket.ts
+++ b/ui/src/hooks/useCommunicateSocket.ts
@@ -35,6 +35,15 @@ export interface UseCommunicateSocketOptions {
 	onParticipantJoined?: (participant: Participant) => void;
 	/** Called when a participant leaves the selected room. */
 	onParticipantLeft?: (roomId: string, identifier: string) => void;
+	/**
+	 * Called when an agent's activity state changes (idle ↔ busy).
+	 * Fires on `participant_updated` WebSocket events.
+	 */
+	onParticipantUpdated?: (
+		roomId: string,
+		identifier: string,
+		activityState: "idle" | "busy",
+	) => void;
 	/** Whether to suppress the connection entirely. */
 	paused?: boolean;
 }
@@ -59,6 +68,7 @@ export function useCommunicateSocket({
 	onMessage,
 	onParticipantJoined,
 	onParticipantLeft,
+	onParticipantUpdated,
 	paused = false,
 }: UseCommunicateSocketOptions) {
 	// TODO: accept displayName from caller when user profiles are available
@@ -82,6 +92,8 @@ export function useCommunicateSocket({
 	onParticipantJoinedRef.current = onParticipantJoined;
 	const onParticipantLeftRef = useRef(onParticipantLeft);
 	onParticipantLeftRef.current = onParticipantLeft;
+	const onParticipantUpdatedRef = useRef(onParticipantUpdated);
+	onParticipantUpdatedRef.current = onParticipantUpdated;
 	const participantIdRef = useRef(participantId);
 	participantIdRef.current = participantId;
 
@@ -149,6 +161,12 @@ export function useCommunicateSocket({
 			});
 		} else if (event.type === "participant_left") {
 			onParticipantLeftRef.current?.(event.room_id, event.identifier);
+		} else if (event.type === "participant_updated") {
+			onParticipantUpdatedRef.current?.(
+				event.room_id,
+				event.identifier,
+				event.activity_state,
+			);
 		}
 	}, []);
 

--- a/ui/src/hooks/useServiceHealth.ts
+++ b/ui/src/hooks/useServiceHealth.ts
@@ -8,6 +8,8 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { ServiceStatus } from "@/components/common/StatusBadge";
 import { askClient } from "@/services/ask";
+import { communicateClient } from "@/services/communicate";
+import { indexClient } from "@/services/codeindex";
 import { memoryClient } from "@/services/memory";
 import { notifyClient } from "@/services/notify";
 import { orchestratorClient } from "@/services/orchestrator";
@@ -15,7 +17,7 @@ import type { HealthResponse } from "@/types/common";
 
 export interface ServiceHealth {
 	name: string;
-	key: "orchestrator" | "notify" | "ask" | "memory";
+	key: "orchestrator" | "notify" | "ask" | "memory" | "index" | "communicate";
 	port: number;
 	status: ServiceStatus;
 	version?: string;
@@ -77,6 +79,8 @@ export function useServiceHealth(): UseServiceHealthResult {
 			fetchHealth("notify", () => notifyClient.getHealth(), 17004),
 			fetchHealth("ask", () => askClient.getHealth(), 17001),
 			fetchHealth("memory", () => memoryClient.getHealth(), 17008),
+			fetchHealth("index", () => indexClient.getHealth(), 17012),
+			fetchHealth("communicate", () => communicateClient.getHealth(), 17010),
 		]);
 		setServices(results);
 		setLoading(false);

--- a/ui/src/pages/DashboardPage.tsx
+++ b/ui/src/pages/DashboardPage.tsx
@@ -111,9 +111,9 @@ export function DashboardPage() {
 				>
 					Service Health
 				</h2>
-				<div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+				<div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
 					{healthInit
-						? Array.from({ length: 4 }).map((_, i) => (
+						? Array.from({ length: 6 }).map((_, i) => (
 								<ServiceHealthCardSkeleton key={i} />
 							))
 						: services.map((svc) => (

--- a/ui/src/pages/DashboardPage.tsx
+++ b/ui/src/pages/DashboardPage.tsx
@@ -4,7 +4,7 @@
  */
 
 import { BarChart2, RefreshCw, Webhook } from "lucide-react";
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import type { ActivityEvent } from "@/components/dashboard/ActivityTimeline";
 import { ActivityTimeline } from "@/components/dashboard/ActivityTimeline";
 import { AgentSummary } from "@/components/dashboard/AgentSummary";
@@ -16,6 +16,8 @@ import {
 import { useAgentSummary } from "@/hooks/useAgentSummary";
 import { useNotificationSummary } from "@/hooks/useNotificationSummary";
 import { useServiceHealth } from "@/hooks/useServiceHealth";
+import { CreateAgentDialog } from "@/pages/agents/CreateAgentDialog";
+import { orchestratorClient } from "@/services/orchestrator";
 
 // ---------------------------------------------------------------------------
 // Stub "Coming Soon" card
@@ -55,6 +57,7 @@ export function DashboardPage() {
 	} = useServiceHealth();
 	const agentSummary = useAgentSummary();
 	const notifSummary = useNotificationSummary();
+	const [createOpen, setCreateOpen] = useState(false);
 
 	// Build a synthetic activity feed from available data
 	const activityEvents: ActivityEvent[] = useMemo(() => {
@@ -124,7 +127,10 @@ export function DashboardPage() {
 
 			{/* Main grid: agents + notifications */}
 			<div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
-				<AgentSummary {...agentSummary} />
+				<AgentSummary
+					{...agentSummary}
+					onCreateAgent={() => setCreateOpen(true)}
+				/>
 				<NotificationSummary {...notifSummary} />
 			</div>
 
@@ -146,6 +152,16 @@ export function DashboardPage() {
 					icon={<Webhook size={24} className="text-th-text-muted" />}
 				/>
 			</div>
+
+			{/* Create agent dialog */}
+			<CreateAgentDialog
+				open={createOpen}
+				onClose={() => setCreateOpen(false)}
+				onCreate={async (request) => {
+					await orchestratorClient.createAgent(request);
+					agentSummary.refetch();
+				}}
+			/>
 		</div>
 	);
 }

--- a/ui/src/pages/communicate/CommunicatePage.tsx
+++ b/ui/src/pages/communicate/CommunicatePage.tsx
@@ -22,7 +22,7 @@ import {
 	Wifi,
 	WifiOff,
 } from "lucide-react";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
 	ChatMessageView,
 	CreateRoomDialog,
@@ -197,6 +197,29 @@ export function CommunicatePage() {
 		[],
 	);
 
+	// Handle agent activity-state change via WebSocket (participant_updated event)
+	const handleParticipantUpdated = useCallback(
+		(roomId: string, identifier: string, activityState: "idle" | "busy") => {
+			setRealtimeParticipants((prev) =>
+				prev.map((p) =>
+					p.identifier === identifier && p.room_id === roomId
+						? { ...p, activity_state: activityState }
+						: p,
+				),
+			);
+		},
+		[],
+	);
+
+	// Agents currently processing — passed to ChatMessageView for the thinking indicator
+	const busyAgents = useMemo(
+		() =>
+			realtimeParticipants.filter(
+				(p) => p.kind === "agent" && p.activity_state === "busy",
+			),
+		[realtimeParticipants],
+	);
+
 	// WebSocket connection
 	const { connectionState } = useCommunicateSocket({
 		selectedRoomId: selectedRoom?.id,
@@ -204,6 +227,7 @@ export function CommunicatePage() {
 		onMessage: handleMessage,
 		onParticipantJoined: handleParticipantJoined,
 		onParticipantLeft: handleParticipantLeft,
+		onParticipantUpdated: handleParticipantUpdated,
 		paused: !identity,
 	});
 
@@ -399,6 +423,7 @@ export function CommunicatePage() {
 								hasMore={hasMore}
 								onLoadOlder={loadOlder}
 								roomId={selectedRoom?.id}
+								busyAgents={busyAgents}
 							/>
 
 							{/* Message input */}

--- a/ui/src/test/components/ServiceHealthCard.test.tsx
+++ b/ui/src/test/components/ServiceHealthCard.test.tsx
@@ -84,4 +84,54 @@ describe("ServiceHealthCard", () => {
 		fireEvent.keyDown(card, { key: "Enter" });
 		expect(mockNavigate).toHaveBeenCalled();
 	});
+
+	it("navigates to /code-index when index card is clicked", () => {
+		const indexService: ServiceHealth = {
+			name: "Index",
+			key: "index",
+			port: 17012,
+			status: "healthy",
+			lastChecked: new Date(),
+		};
+		renderCard(indexService);
+		fireEvent.click(screen.getByRole("button"));
+		expect(mockNavigate).toHaveBeenCalledWith("/code-index");
+	});
+
+	it("navigates to /communicate when communicate card is clicked", () => {
+		const communicateService: ServiceHealth = {
+			name: "Communicate",
+			key: "communicate",
+			port: 17010,
+			status: "healthy",
+			lastChecked: new Date(),
+		};
+		renderCard(communicateService);
+		fireEvent.click(screen.getByRole("button"));
+		expect(mockNavigate).toHaveBeenCalledWith("/communicate");
+	});
+
+	it("renders correct port for index service", () => {
+		const indexService: ServiceHealth = {
+			name: "Index",
+			key: "index",
+			port: 17012,
+			status: "healthy",
+			lastChecked: new Date(),
+		};
+		renderCard(indexService);
+		expect(screen.getByText(/Port 17012/)).toBeInTheDocument();
+	});
+
+	it("renders correct port for communicate service", () => {
+		const communicateService: ServiceHealth = {
+			name: "Communicate",
+			key: "communicate",
+			port: 17010,
+			status: "healthy",
+			lastChecked: new Date(),
+		};
+		renderCard(communicateService);
+		expect(screen.getByText(/Port 17010/)).toBeInTheDocument();
+	});
 });

--- a/ui/src/test/components/communicate/ChatMessageView.test.tsx
+++ b/ui/src/test/components/communicate/ChatMessageView.test.tsx
@@ -5,7 +5,11 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { ChatMessageView } from "@/components/communicate/ChatMessageView";
-import { makeChatMessage, makeChatMessageList } from "@/test/mocks/factories";
+import {
+	makeChatMessage,
+	makeChatMessageList,
+	makeParticipant,
+} from "@/test/mocks/factories";
 
 // ---------------------------------------------------------------------------
 // Scroll simulation helpers
@@ -499,5 +503,113 @@ describe("ChatMessageView", () => {
 			(call) => call[0]?.behavior === "instant",
 		).length;
 		expect(callsAfterOlder).toBe(1);
+	});
+
+	// -------------------------------------------------------------------------
+	// ThinkingIndicator
+	// -------------------------------------------------------------------------
+
+	it("shows no thinking indicator when busyAgents is empty", () => {
+		const messages = makeChatMessageList(3);
+		render(
+			<ChatMessageView
+				messages={messages}
+				loading={false}
+				loadingOlder={false}
+				hasMore={false}
+				onLoadOlder={noop}
+				busyAgents={[]}
+			/>,
+		);
+
+		expect(screen.queryByText(/is thinking/i)).not.toBeInTheDocument();
+		expect(screen.queryByText(/are thinking/i)).not.toBeInTheDocument();
+	});
+
+	it("shows thinking indicator for a single busy agent", () => {
+		const messages = makeChatMessageList(3);
+		const agent = makeParticipant({ kind: "agent", display_name: "Planner" });
+		render(
+			<ChatMessageView
+				messages={messages}
+				loading={false}
+				loadingOlder={false}
+				hasMore={false}
+				onLoadOlder={noop}
+				busyAgents={[agent]}
+			/>,
+		);
+
+		expect(screen.getByText("Planner is thinking…")).toBeInTheDocument();
+	});
+
+	it("shows combined label for two busy agents", () => {
+		const messages = makeChatMessageList(3);
+		const a1 = makeParticipant({ kind: "agent", display_name: "Alpha" });
+		const a2 = makeParticipant({ kind: "agent", display_name: "Beta" });
+		render(
+			<ChatMessageView
+				messages={messages}
+				loading={false}
+				loadingOlder={false}
+				hasMore={false}
+				onLoadOlder={noop}
+				busyAgents={[a1, a2]}
+			/>,
+		);
+
+		expect(screen.getByText("Alpha and Beta are thinking…")).toBeInTheDocument();
+	});
+
+	it("shows generic label when three or more agents are busy", () => {
+		const messages = makeChatMessageList(3);
+		const agents = [
+			makeParticipant({ kind: "agent", display_name: "A" }),
+			makeParticipant({ kind: "agent", display_name: "B" }),
+			makeParticipant({ kind: "agent", display_name: "C" }),
+		];
+		render(
+			<ChatMessageView
+				messages={messages}
+				loading={false}
+				loadingOlder={false}
+				hasMore={false}
+				onLoadOlder={noop}
+				busyAgents={agents}
+			/>,
+		);
+
+		expect(screen.getByText("3 agents are thinking…")).toBeInTheDocument();
+	});
+
+	it("thinking indicator disappears when busyAgents becomes empty", () => {
+		const messages = makeChatMessageList(3);
+		const agent = makeParticipant({ kind: "agent", display_name: "Planner" });
+
+		const { rerender } = render(
+			<ChatMessageView
+				messages={messages}
+				loading={false}
+				loadingOlder={false}
+				hasMore={false}
+				onLoadOlder={noop}
+				busyAgents={[agent]}
+			/>,
+		);
+
+		expect(screen.getByText("Planner is thinking…")).toBeInTheDocument();
+
+		rerender(
+			<ChatMessageView
+				messages={messages}
+				loading={false}
+				loadingOlder={false}
+				hasMore={false}
+				onLoadOlder={noop}
+				busyAgents={[]}
+			/>,
+		);
+
+		expect(screen.queryByText(/is thinking/i)).not.toBeInTheDocument();
 	});
 });

--- a/ui/src/test/components/communicate/ParticipantPanel.test.tsx
+++ b/ui/src/test/components/communicate/ParticipantPanel.test.tsx
@@ -81,6 +81,48 @@ describe("ParticipantPanel", () => {
 		});
 	});
 
+	it("shows pulsing activity dot when agent is busy", async () => {
+		const agent = makeParticipantList(1, {
+			room_id: ROOM_ID,
+			kind: "agent",
+			activity_state: "busy",
+		});
+
+		server.use(
+			http.get(`http://localhost:17010/rooms/${ROOM_ID}/participants`, () =>
+				HttpResponse.json({ items: agent, total: 1, limit: 100, offset: 0 }),
+			),
+		);
+
+		render(<ParticipantPanel roomId={ROOM_ID} />);
+
+		await waitFor(() => {
+			const dot = screen.getByLabelText("Busy");
+			expect(dot).toHaveClass("animate-pulse");
+		});
+	});
+
+	it("does not pulse the activity dot when agent is idle", async () => {
+		const agent = makeParticipantList(1, {
+			room_id: ROOM_ID,
+			kind: "agent",
+			activity_state: "idle",
+		});
+
+		server.use(
+			http.get(`http://localhost:17010/rooms/${ROOM_ID}/participants`, () =>
+				HttpResponse.json({ items: agent, total: 1, limit: 100, offset: 0 }),
+			),
+		);
+
+		render(<ParticipantPanel roomId={ROOM_ID} />);
+
+		await waitFor(() => {
+			const dot = screen.getByLabelText("Idle");
+			expect(dot).not.toHaveClass("animate-pulse");
+		});
+	});
+
 	it("hides participants who left", async () => {
 		const participants = makeParticipantList(2, {
 			room_id: ROOM_ID,

--- a/ui/src/test/components/dashboard/AgentSummaryUsage.test.tsx
+++ b/ui/src/test/components/dashboard/AgentSummaryUsage.test.tsx
@@ -25,6 +25,7 @@ const baseProps: UseAgentSummaryResult = {
 	aggregateUsage: null,
 	loading: false,
 	error: undefined,
+	refetch: vi.fn(),
 };
 
 describe("AgentSummary aggregate usage", () => {

--- a/ui/src/test/components/workflows/WorkflowForm.test.tsx
+++ b/ui/src/test/components/workflows/WorkflowForm.test.tsx
@@ -1,0 +1,192 @@
+/**
+ * WorkflowForm tests.
+ *
+ * Covers the null-guard fix for source_config: editing a workflow where
+ * source_config is undefined/null must not throw, and editing one with a
+ * valid github_issues source_config must populate the form fields correctly.
+ */
+
+import { render, screen, waitFor } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import { WorkflowForm } from "@/components/workflows/WorkflowForm";
+import type { Agent, Workflow } from "@/types/orchestrator";
+
+// Mock PromptTemplateEditor to keep tests simple (it has its own test suite)
+vi.mock("@/components/workflows/PromptTemplateEditor", () => ({
+	PromptTemplateEditor: ({
+		value,
+		onChange,
+	}: {
+		value: string;
+		onChange: (v: string) => void;
+	}) => (
+		<textarea
+			aria-label="Prompt template"
+			value={value}
+			onChange={(e) => onChange(e.target.value)}
+		/>
+	),
+}));
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const mockAgents: Agent[] = [
+	{
+		id: "agent-1",
+		name: "Test Agent",
+		status: "running",
+		working_dir: "/tmp",
+		shell: "/bin/sh",
+		interactive: false,
+		tool_policy: { mode: "allow_all" },
+		created_at: new Date().toISOString(),
+		updated_at: new Date().toISOString(),
+	},
+];
+
+const validWorkflow: Workflow = {
+	id: "wf-1",
+	name: "My Workflow",
+	agent_id: "agent-1",
+	source_config: {
+		type: "github_issues",
+		owner: "geoffjay",
+		repo: "agentd",
+		labels: ["bug", "enhancement"],
+		state: "open",
+	},
+	prompt_template: "Fix this: {{title}}",
+	poll_interval_secs: 900,
+	enabled: true,
+	tool_policy: { mode: "allow_all" },
+	created_at: new Date().toISOString(),
+	updated_at: new Date().toISOString(),
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function renderForm(workflow?: Workflow) {
+	const onSave = vi.fn().mockResolvedValue(undefined);
+	const onClose = vi.fn();
+
+	render(
+		<WorkflowForm
+			open={true}
+			workflow={workflow}
+			agents={mockAgents}
+			onSave={onSave}
+			onClose={onClose}
+		/>,
+	);
+
+	return { onSave, onClose };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("WorkflowForm", () => {
+	describe("create mode (no workflow)", () => {
+		it("renders with empty fields", () => {
+			renderForm();
+			expect(
+				screen.getByRole("dialog", { name: /create workflow/i }),
+			).toBeInTheDocument();
+			expect(screen.getByPlaceholderText(/dispatch github issues/i)).toHaveValue(
+				"",
+			);
+		});
+	});
+
+	describe("edit mode — valid source_config", () => {
+		it("populates the name field", async () => {
+			renderForm(validWorkflow);
+			await waitFor(() => {
+				expect(screen.getByPlaceholderText(/dispatch github issues/i)).toHaveValue(
+					"My Workflow",
+				);
+			});
+		});
+
+		it("populates the owner field", async () => {
+			renderForm(validWorkflow);
+			await waitFor(() => {
+				expect(screen.getByPlaceholderText(/e\.g\. geoffjay/i)).toHaveValue(
+					"geoffjay",
+				);
+			});
+		});
+
+		it("populates the repo field", async () => {
+			renderForm(validWorkflow);
+			await waitFor(() => {
+				expect(screen.getByPlaceholderText(/e\.g\. agentd/i)).toHaveValue(
+					"agentd",
+				);
+			});
+		});
+
+		it("populates labels as comma-separated string", async () => {
+			renderForm(validWorkflow);
+			await waitFor(() => {
+				expect(
+					screen.getByPlaceholderText(/bug, enhancement/i),
+				).toHaveValue("bug, enhancement");
+			});
+		});
+	});
+
+	describe("edit mode — missing source_config (null guard)", () => {
+		it("does not throw when source_config is undefined", () => {
+			// Cast to bypass TypeScript: simulates an API response with missing field
+			const brokenWorkflow = {
+				...validWorkflow,
+				source_config: undefined,
+			} as unknown as Workflow;
+
+			expect(() => renderForm(brokenWorkflow)).not.toThrow();
+		});
+
+		it("renders the dialog without crashing when source_config is undefined", () => {
+			const brokenWorkflow = {
+				...validWorkflow,
+				source_config: undefined,
+			} as unknown as Workflow;
+
+			renderForm(brokenWorkflow);
+
+			expect(
+				screen.getByRole("dialog", { name: /edit workflow/i }),
+			).toBeInTheDocument();
+		});
+
+		it("leaves GitHub fields at defaults when source_config is undefined", async () => {
+			const brokenWorkflow = {
+				...validWorkflow,
+				source_config: undefined,
+			} as unknown as Workflow;
+
+			renderForm(brokenWorkflow);
+
+			await waitFor(() => {
+				// Owner and repo should be empty (default), not crashed
+				expect(screen.getByPlaceholderText(/e\.g\. geoffjay/i)).toHaveValue("");
+				expect(screen.getByPlaceholderText(/e\.g\. agentd/i)).toHaveValue("");
+			});
+		});
+
+		it("does not throw when source_config is null", () => {
+			const brokenWorkflow = {
+				...validWorkflow,
+				source_config: null,
+			} as unknown as Workflow;
+
+			expect(() => renderForm(brokenWorkflow)).not.toThrow();
+		});
+	});
+});

--- a/ui/src/test/pages/DashboardPage.test.tsx
+++ b/ui/src/test/pages/DashboardPage.test.tsx
@@ -1,0 +1,151 @@
+/**
+ * DashboardPage — Create Agent button wiring tests.
+ *
+ * Verifies that clicking the "Create Agent" button opens the dialog,
+ * that submitting calls orchestratorClient.createAgent, and that the
+ * dialog can be closed.
+ */
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Mock all hooks the page depends on so the test is fast and deterministic
+// ---------------------------------------------------------------------------
+
+const mockRefetch = vi.fn();
+
+vi.mock("@/hooks/useAgentSummary", () => ({
+	useAgentSummary: () => ({
+		counts: { running: 0, pending: 0, stopped: 0, failed: 0 },
+		recentAgents: [],
+		total: 0,
+		aggregateUsage: null,
+		loading: false,
+		error: undefined,
+		refetch: mockRefetch,
+	}),
+}));
+
+vi.mock("@/hooks/useNotificationSummary", () => ({
+	useNotificationSummary: () => ({
+		pending: 0,
+		unread: 0,
+		total: 0,
+		priorityCounts: { low: 0, normal: 0, high: 0, urgent: 0 },
+		loading: false,
+		error: undefined,
+	}),
+}));
+
+vi.mock("@/hooks/useServiceHealth", () => ({
+	useServiceHealth: () => ({
+		services: [],
+		loading: false,
+		initializing: false,
+		refresh: vi.fn(),
+	}),
+}));
+
+// Mock nivo so it doesn't complain about missing ResizeObserver in jsdom
+vi.mock("@nivo/pie", () => ({
+	ResponsivePie: () => <div data-testid="mock-pie" />,
+}));
+
+// ---------------------------------------------------------------------------
+// Mock orchestratorClient.createAgent
+// ---------------------------------------------------------------------------
+
+const mockCreateAgent = vi.fn();
+
+vi.mock("@/services/orchestrator", () => ({
+	orchestratorClient: {
+		createAgent: (...args: unknown[]) => mockCreateAgent(...args),
+	},
+}));
+
+// ---------------------------------------------------------------------------
+// Import the page AFTER all mocks are registered
+// ---------------------------------------------------------------------------
+
+import { DashboardPage } from "@/pages/DashboardPage";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function renderPage() {
+	return render(
+		<MemoryRouter>
+			<DashboardPage />
+		</MemoryRouter>,
+	);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("DashboardPage — Create Agent button", () => {
+	beforeEach(() => {
+		mockCreateAgent.mockResolvedValue({ id: "agent-1", name: "test" });
+		mockRefetch.mockClear();
+	});
+
+	it("renders the Create Agent button inside AgentSummary", () => {
+		renderPage();
+		expect(
+			screen.getByRole("button", { name: /create new agent/i }),
+		).toBeInTheDocument();
+	});
+
+	it("opens the CreateAgentDialog when the button is clicked", () => {
+		renderPage();
+		expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+
+		fireEvent.click(screen.getByRole("button", { name: /create new agent/i }));
+
+		expect(screen.getByRole("dialog")).toBeInTheDocument();
+		expect(screen.getByLabelText("Create Agent")).toBeInTheDocument();
+	});
+
+	it("closes the dialog when Cancel is clicked", () => {
+		renderPage();
+		fireEvent.click(screen.getByRole("button", { name: /create new agent/i }));
+
+		expect(screen.getByRole("dialog")).toBeInTheDocument();
+
+		fireEvent.click(screen.getByRole("button", { name: /cancel/i }));
+
+		expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+	});
+
+	it("calls orchestratorClient.createAgent and refetch on submit", async () => {
+		renderPage();
+		fireEvent.click(screen.getByRole("button", { name: /create new agent/i }));
+
+		// Fill in required fields
+		fireEvent.change(screen.getByLabelText(/^name$/i), {
+			target: { value: "my-agent" },
+		});
+		fireEvent.change(screen.getByLabelText(/working directory/i), {
+			target: { value: "/home/user/project" },
+		});
+
+		fireEvent.click(
+			screen.getByRole("button", { name: /^create agent$/i }),
+		);
+
+		await waitFor(() => {
+			expect(mockCreateAgent).toHaveBeenCalledWith(
+				expect.objectContaining({ name: "my-agent" }),
+			);
+		});
+
+		expect(mockRefetch).toHaveBeenCalled();
+
+		// Dialog should close after successful submit
+		expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+	});
+});

--- a/ui/src/types/communicate.ts
+++ b/ui/src/types/communicate.ts
@@ -99,10 +99,23 @@ export interface WsParticipantLeftEvent {
 	identifier: string;
 }
 
+/**
+ * Emitted by the backend when an agent's activity state changes.
+ * Client-side only until the backend is wired up; the hook already
+ * handles it so the UI will light up as soon as the server emits it.
+ */
+export interface WsParticipantUpdatedEvent {
+	type: "participant_updated";
+	room_id: string;
+	identifier: string;
+	activity_state: "idle" | "busy";
+}
+
 export type WsRoomEvent =
 	| WsMessageEvent
 	| WsParticipantJoinedEvent
-	| WsParticipantLeftEvent;
+	| WsParticipantLeftEvent
+	| WsParticipantUpdatedEvent;
 
 // ---------------------------------------------------------------------------
 // WebSocket client messages


### PR DESCRIPTION
Adds two complementary visual indicators that show when an agent is actively processing a message in a communication room.

## Changes

**`ui/src/types/communicate.ts`**
- Added `WsParticipantUpdatedEvent` (`type: "participant_updated"`, `room_id`, `identifier`, `activity_state`) to the `WsRoomEvent` union. The backend can start emitting this event to activate the indicators in real time.

**`ui/src/hooks/useCommunicateSocket.ts`**
- Added `onParticipantUpdated` callback option
- Added stable ref and handler for `participant_updated` events in `dispatchEvent`

**`ui/src/components/communicate/ParticipantPanel.tsx`**
- `ActivityDot` now adds `animate-pulse` (Tailwind) when `state === "busy"` — provides a pulsing orange dot next to busy agents in the participant list

**`ui/src/components/communicate/ChatMessageView.tsx`**
- Added `ThinkingIndicator` component: three bouncing dots + label ("X is thinking…" / "X and Y are thinking…" / "N agents are thinking…")
- Added `busyAgents?: Participant[]` prop; indicator renders above the bottom sentinel so it's always visible at the bottom of the message stream
- Updated file-level JSDoc to include the new feature

**`ui/src/pages/communicate/CommunicatePage.tsx`**
- Added `handleParticipantUpdated` callback that patches `activity_state` on the matching entry in `realtimeParticipants`
- Derives `busyAgents` via `useMemo` (agents with `activity_state === "busy"`)
- Passes `onParticipantUpdated` to `useCommunicateSocket` and `busyAgents` to `ChatMessageView`

**Tests** (7 new across 2 files)
- `ChatMessageView`: no indicator when empty, single agent label, two-agent label, 3+ generic label, disappears when agents go idle
- `ParticipantPanel`: dot has `animate-pulse` when busy, does not pulse when idle

Stacked on #1085 (scroll-lock / jump-to-latest, issue #1082).

Closes #1080