### PR TITLE
feat(ui): add Index and Communicate service health cards to dashboard

### DIFF
--- a/ui/src/components/dashboard/ServiceHealthCard.tsx
+++ b/ui/src/components/dashboard/ServiceHealthCard.tsx
@@ -12,6 +12,9 @@ const SERVICE_ROUTES: Record<string, string> = {
 	orchestrator: "/agents",
 	notify: "/notifications",
 	ask: "/questions",
+	memory: "/memories",
+	index: "/code-index",
+	communicate: "/communicate",
 };
 
 interface ServiceHealthCardProps {

--- a/ui/src/hooks/useServiceHealth.ts
+++ b/ui/src/hooks/useServiceHealth.ts
@@ -8,6 +8,8 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import type { ServiceStatus } from "@/components/common/StatusBadge";
 import { askClient } from "@/services/ask";
+import { communicateClient } from "@/services/communicate";
+import { indexClient } from "@/services/codeindex";
 import { memoryClient } from "@/services/memory";
 import { notifyClient } from "@/services/notify";
 import { orchestratorClient } from "@/services/orchestrator";
@@ -15,7 +17,7 @@ import type { HealthResponse } from "@/types/common";
 
 export interface ServiceHealth {
 	name: string;
-	key: "orchestrator" | "notify" | "ask" | "memory";
+	key: "orchestrator" | "notify" | "ask" | "memory" | "index" | "communicate";
 	port: number;
 	status: ServiceStatus;
 	version?: string;
@@ -77,6 +79,8 @@ export function useServiceHealth(): UseServiceHealthResult {
 			fetchHealth("notify", () => notifyClient.getHealth(), 17004),
 			fetchHealth("ask", () => askClient.getHealth(), 17001),
 			fetchHealth("memory", () => memoryClient.getHealth(), 17008),
+			fetchHealth("index", () => indexClient.getHealth(), 17012),
+			fetchHealth("communicate", () => communicateClient.getHealth(), 17010),
 		]);
 		setServices(results);
 		setLoading(false);

--- a/ui/src/pages/DashboardPage.tsx
+++ b/ui/src/pages/DashboardPage.tsx
@@ -111,9 +111,9 @@ export function DashboardPage() {
 				>
 					Service Health
 				</h2>
-				<div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+				<div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3">
 					{healthInit
-						? Array.from({ length: 4 }).map((_, i) => (
+						? Array.from({ length: 6 }).map((_, i) => (
 								<ServiceHealthCardSkeleton key={i} />
 							))
 						: services.map((svc) => (

--- a/ui/src/test/components/ServiceHealthCard.test.tsx
+++ b/ui/src/test/components/ServiceHealthCard.test.tsx
@@ -84,4 +84,54 @@ describe("ServiceHealthCard", () => {
 		fireEvent.keyDown(card, { key: "Enter" });
 		expect(mockNavigate).toHaveBeenCalled();
 	});
+
+	it("navigates to /code-index when index card is clicked", () => {
+		const indexService: ServiceHealth = {
+			name: "Index",
+			key: "index",
+			port: 17012,
+			status: "healthy",
+			lastChecked: new Date(),
+		};
+		renderCard(indexService);
+		fireEvent.click(screen.getByRole("button"));
+		expect(mockNavigate).toHaveBeenCalledWith("/code-index");
+	});
+
+	it("navigates to /communicate when communicate card is clicked", () => {
+		const communicateService: ServiceHealth = {
+			name: "Communicate",
+			key: "communicate",
+			port: 17010,
+			status: "healthy",
+			lastChecked: new Date(),
+		};
+		renderCard(communicateService);
+		fireEvent.click(screen.getByRole("button"));
+		expect(mockNavigate).toHaveBeenCalledWith("/communicate");
+	});
+
+	it("renders correct port for index service", () => {
+		const indexService: ServiceHealth = {
+			name: "Index",
+			key: "index",
+			port: 17012,
+			status: "healthy",
+			lastChecked: new Date(),
+		};
+		renderCard(indexService);
+		expect(screen.getByText(/Port 17012/)).toBeInTheDocument();
+	});
+
+	it("renders correct port for communicate service", () => {
+		const communicateService: ServiceHealth = {
+			name: "Communicate",
+			key: "communicate",
+			port: 17010,
+			status: "healthy",
+			lastChecked: new Date(),
+		};
+		renderCard(communicateService);
+		expect(screen.getByText(/Port 17010/)).toBeInTheDocument();
+	});
 });


### PR DESCRIPTION
Adds Index and Communicate service health cards to the dashboard Service Health section, bringing the total from 4 to 6 cards.

## Changes

**`ui/src/hooks/useServiceHealth.ts`**
- Extended `ServiceHealth["key"]` union to include `"index"` and `"communicate"`
- Added `indexClient` and `communicateClient` imports
- Added `fetchHealth` calls for both in the `Promise.all` with ports 17012 and 17010

**`ui/src/components/dashboard/ServiceHealthCard.tsx`**
- Added `memory`, `index`, and `communicate` entries to `SERVICE_ROUTES` (memory was previously missing too)

**`ui/src/pages/DashboardPage.tsx`**
- Grid changed from `lg:grid-cols-4` to `lg:grid-cols-3` to fit 6 cards in two rows
- Skeleton placeholder count bumped from 4 to 6

**`ui/src/test/components/ServiceHealthCard.test.tsx`**
- 4 new tests: navigation to `/code-index` and `/communicate`, correct port rendering for both new cards

Closes #1079