### PR TITLE
fix(ui): wire up dashboard Create Agent button to open dialog

### DIFF
--- a/ui/src/hooks/useAgentSummary.ts
+++ b/ui/src/hooks/useAgentSummary.ts
@@ -29,6 +29,7 @@ export interface UseAgentSummaryResult {
 	aggregateUsage: AggregateUsageSummary | null;
 	loading: boolean;
 	error?: string;
+	refetch: () => void;
 }
 
 const EMPTY_COUNTS: AgentStatusCounts = {
@@ -123,5 +124,5 @@ export function useAgentSummary(): UseAgentSummaryResult {
 		void fetch();
 	}, [fetch]);
 
-	return { counts, recentAgents, total, aggregateUsage, loading, error };
+	return { counts, recentAgents, total, aggregateUsage, loading, error, refetch: fetch };
 }

--- a/ui/src/pages/DashboardPage.tsx
+++ b/ui/src/pages/DashboardPage.tsx
@@ -4,7 +4,7 @@
  */
 
 import { BarChart2, RefreshCw, Webhook } from "lucide-react";
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 import type { ActivityEvent } from "@/components/dashboard/ActivityTimeline";
 import { ActivityTimeline } from "@/components/dashboard/ActivityTimeline";
 import { AgentSummary } from "@/components/dashboard/AgentSummary";
@@ -16,6 +16,8 @@ import {
 import { useAgentSummary } from "@/hooks/useAgentSummary";
 import { useNotificationSummary } from "@/hooks/useNotificationSummary";
 import { useServiceHealth } from "@/hooks/useServiceHealth";
+import { CreateAgentDialog } from "@/pages/agents/CreateAgentDialog";
+import { orchestratorClient } from "@/services/orchestrator";
 
 // ---------------------------------------------------------------------------
 // Stub "Coming Soon" card
@@ -55,6 +57,7 @@ export function DashboardPage() {
 	} = useServiceHealth();
 	const agentSummary = useAgentSummary();
 	const notifSummary = useNotificationSummary();
+	const [createOpen, setCreateOpen] = useState(false);
 
 	// Build a synthetic activity feed from available data
 	const activityEvents: ActivityEvent[] = useMemo(() => {
@@ -124,7 +127,10 @@ export function DashboardPage() {
 
 			{/* Main grid: agents + notifications */}
 			<div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
-				<AgentSummary {...agentSummary} />
+				<AgentSummary
+					{...agentSummary}
+					onCreateAgent={() => setCreateOpen(true)}
+				/>
 				<NotificationSummary {...notifSummary} />
 			</div>
 
@@ -146,6 +152,16 @@ export function DashboardPage() {
 					icon={<Webhook size={24} className="text-th-text-muted" />}
 				/>
 			</div>
+
+			{/* Create agent dialog */}
+			<CreateAgentDialog
+				open={createOpen}
+				onClose={() => setCreateOpen(false)}
+				onCreate={async (request) => {
+					await orchestratorClient.createAgent(request);
+					agentSummary.refetch();
+				}}
+			/>
 		</div>
 	);
 }

--- a/ui/src/test/components/dashboard/AgentSummaryUsage.test.tsx
+++ b/ui/src/test/components/dashboard/AgentSummaryUsage.test.tsx
@@ -25,6 +25,7 @@ const baseProps: UseAgentSummaryResult = {
 	aggregateUsage: null,
 	loading: false,
 	error: undefined,
+	refetch: vi.fn(),
 };
 
 describe("AgentSummary aggregate usage", () => {

--- a/ui/src/test/pages/DashboardPage.test.tsx
+++ b/ui/src/test/pages/DashboardPage.test.tsx
@@ -1,0 +1,151 @@
+/**
+ * DashboardPage — Create Agent button wiring tests.
+ *
+ * Verifies that clicking the "Create Agent" button opens the dialog,
+ * that submitting calls orchestratorClient.createAgent, and that the
+ * dialog can be closed.
+ */
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+// ---------------------------------------------------------------------------
+// Mock all hooks the page depends on so the test is fast and deterministic
+// ---------------------------------------------------------------------------
+
+const mockRefetch = vi.fn();
+
+vi.mock("@/hooks/useAgentSummary", () => ({
+	useAgentSummary: () => ({
+		counts: { running: 0, pending: 0, stopped: 0, failed: 0 },
+		recentAgents: [],
+		total: 0,
+		aggregateUsage: null,
+		loading: false,
+		error: undefined,
+		refetch: mockRefetch,
+	}),
+}));
+
+vi.mock("@/hooks/useNotificationSummary", () => ({
+	useNotificationSummary: () => ({
+		pending: 0,
+		unread: 0,
+		total: 0,
+		priorityCounts: { low: 0, normal: 0, high: 0, urgent: 0 },
+		loading: false,
+		error: undefined,
+	}),
+}));
+
+vi.mock("@/hooks/useServiceHealth", () => ({
+	useServiceHealth: () => ({
+		services: [],
+		loading: false,
+		initializing: false,
+		refresh: vi.fn(),
+	}),
+}));
+
+// Mock nivo so it doesn't complain about missing ResizeObserver in jsdom
+vi.mock("@nivo/pie", () => ({
+	ResponsivePie: () => <div data-testid="mock-pie" />,
+}));
+
+// ---------------------------------------------------------------------------
+// Mock orchestratorClient.createAgent
+// ---------------------------------------------------------------------------
+
+const mockCreateAgent = vi.fn();
+
+vi.mock("@/services/orchestrator", () => ({
+	orchestratorClient: {
+		createAgent: (...args: unknown[]) => mockCreateAgent(...args),
+	},
+}));
+
+// ---------------------------------------------------------------------------
+// Import the page AFTER all mocks are registered
+// ---------------------------------------------------------------------------
+
+import { DashboardPage } from "@/pages/DashboardPage";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function renderPage() {
+	return render(
+		<MemoryRouter>
+			<DashboardPage />
+		</MemoryRouter>,
+	);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("DashboardPage — Create Agent button", () => {
+	beforeEach(() => {
+		mockCreateAgent.mockResolvedValue({ id: "agent-1", name: "test" });
+		mockRefetch.mockClear();
+	});
+
+	it("renders the Create Agent button inside AgentSummary", () => {
+		renderPage();
+		expect(
+			screen.getByRole("button", { name: /create new agent/i }),
+		).toBeInTheDocument();
+	});
+
+	it("opens the CreateAgentDialog when the button is clicked", () => {
+		renderPage();
+		expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+
+		fireEvent.click(screen.getByRole("button", { name: /create new agent/i }));
+
+		expect(screen.getByRole("dialog")).toBeInTheDocument();
+		expect(screen.getByLabelText("Create Agent")).toBeInTheDocument();
+	});
+
+	it("closes the dialog when Cancel is clicked", () => {
+		renderPage();
+		fireEvent.click(screen.getByRole("button", { name: /create new agent/i }));
+
+		expect(screen.getByRole("dialog")).toBeInTheDocument();
+
+		fireEvent.click(screen.getByRole("button", { name: /cancel/i }));
+
+		expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+	});
+
+	it("calls orchestratorClient.createAgent and refetch on submit", async () => {
+		renderPage();
+		fireEvent.click(screen.getByRole("button", { name: /create new agent/i }));
+
+		// Fill in required fields
+		fireEvent.change(screen.getByLabelText(/^name$/i), {
+			target: { value: "my-agent" },
+		});
+		fireEvent.change(screen.getByLabelText(/working directory/i), {
+			target: { value: "/home/user/project" },
+		});
+
+		fireEvent.click(
+			screen.getByRole("button", { name: /^create agent$/i }),
+		);
+
+		await waitFor(() => {
+			expect(mockCreateAgent).toHaveBeenCalledWith(
+				expect.objectContaining({ name: "my-agent" }),
+			);
+		});
+
+		expect(mockRefetch).toHaveBeenCalled();
+
+		// Dialog should close after successful submit
+		expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+	});
+});


### PR DESCRIPTION
The **Create Agent** button inside the `AgentSummary` card on the dashboard was rendered but had no `onCreateAgent` handler wired from `DashboardPage`. Clicking it did nothing.

**Changes:**
- `useAgentSummary`: expose `refetch` in the hook's return value so the summary can be refreshed after creation
- `DashboardPage`: import and render `CreateAgentDialog`; pass `onCreateAgent={() => setCreateOpen(true)}` to `AgentSummary`; on successful creation call `orchestratorClient.createAgent` then `agentSummary.refetch()`
- `AgentSummaryUsage.test.tsx`: add `refetch: vi.fn()` to satisfy the now-required `UseAgentSummaryResult` interface
- `DashboardPage.test.tsx`: new test file covering button rendering, dialog open/close, and successful agent creation flow

Closes #1077