### PR TITLE
feat(ui): add follow-conversation button when scrolled up in chat rooms

### DIFF
--- a/ui/src/components/communicate/ChatMessageView.tsx
+++ b/ui/src/components/communicate/ChatMessageView.tsx
@@ -10,11 +10,12 @@
  * - Visual distinction between agent and human messages
  * - Thread reply indicator for messages with reply_to
  * - Loading states for initial load and older-page load
+ * - Thinking indicator: animated dots with agent name(s) when agent(s) are busy
  */
 
 import { ArrowDown, Bot, CornerUpLeft, Loader2, User } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import type { ChatMessage, ParticipantKind } from "@/types/communicate";
+import type { ChatMessage, Participant, ParticipantKind } from "@/types/communicate";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -111,6 +112,39 @@ function MessageBubble({ message, replyToMessage }: MessageBubbleProps) {
 }
 
 // ---------------------------------------------------------------------------
+// Thinking indicator
+// ---------------------------------------------------------------------------
+
+function ThinkingIndicator({ agents }: { agents: Participant[] }) {
+	if (agents.length === 0) return null;
+
+	let label: string;
+	if (agents.length === 1) {
+		label = `${agents[0].display_name} is thinking…`;
+	} else if (agents.length === 2) {
+		label = `${agents[0].display_name} and ${agents[1].display_name} are thinking…`;
+	} else {
+		label = `${agents.length} agents are thinking…`;
+	}
+
+	return (
+		<div
+			className="flex items-center gap-2 px-1 text-sm text-th-text-muted"
+			aria-live="polite"
+			aria-label={label}
+		>
+			{/* Three bouncing dots */}
+			<span className="flex items-center gap-0.5" aria-hidden="true">
+				<span className="h-1.5 w-1.5 rounded-full bg-th-text-muted animate-bounce [animation-delay:-0.3s]" />
+				<span className="h-1.5 w-1.5 rounded-full bg-th-text-muted animate-bounce [animation-delay:-0.15s]" />
+				<span className="h-1.5 w-1.5 rounded-full bg-th-text-muted animate-bounce" />
+			</span>
+			<span>{label}</span>
+		</div>
+	);
+}
+
+// ---------------------------------------------------------------------------
 // ChatMessageView
 // ---------------------------------------------------------------------------
 
@@ -122,6 +156,8 @@ interface ChatMessageViewProps {
 	onLoadOlder: () => void;
 	/** Room identifier — used to reset scroll position when switching rooms. */
 	roomId?: string;
+	/** Agent participants currently processing (activity_state === "busy"). */
+	busyAgents?: Participant[];
 }
 
 export function ChatMessageView({
@@ -131,6 +167,7 @@ export function ChatMessageView({
 	hasMore,
 	onLoadOlder,
 	roomId,
+	busyAgents = [],
 }: ChatMessageViewProps) {
 	const bottomRef = useRef<HTMLDivElement>(null);
 	const containerRef = useRef<HTMLDivElement>(null);
@@ -304,6 +341,9 @@ export function ChatMessageView({
 						}
 					/>
 				))}
+
+				{/* Thinking indicator — shown when one or more agents are busy */}
+				<ThinkingIndicator agents={busyAgents} />
 
 				<div ref={bottomRef} />
 			</div>

--- a/ui/src/components/communicate/ChatMessageView.tsx
+++ b/ui/src/components/communicate/ChatMessageView.tsx
@@ -4,14 +4,16 @@
  * Features:
  * - Loads and renders message history
  * - Auto-scrolls to the latest message on new arrivals
+ * - Scroll-lock: pauses auto-scroll when user scrolls up; "Jump to latest" button resumes
+ * - New-message counter on the "Jump to latest" button while scroll-locked
  * - Infinite scroll upward (load older messages)
  * - Visual distinction between agent and human messages
  * - Thread reply indicator for messages with reply_to
  * - Loading states for initial load and older-page load
  */
 
-import { Bot, CornerUpLeft, Loader2, User } from "lucide-react";
-import { useCallback, useEffect, useMemo, useRef } from "react";
+import { ArrowDown, Bot, CornerUpLeft, Loader2, User } from "lucide-react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { ChatMessage, ParticipantKind } from "@/types/communicate";
 
 // ---------------------------------------------------------------------------
@@ -135,10 +137,24 @@ export function ChatMessageView({
 	const prevScrollHeightRef = useRef<number>(0);
 	const initialScrollDone = useRef(false);
 
-	// Reset the initial-scroll flag whenever the active room changes so that
-	// switching rooms always brings the user to the bottom of the new room.
+	// Scroll-lock: true when the user has scrolled away from the bottom.
+	const [scrollLocked, setScrollLocked] = useState(false);
+
+	// Count of new messages that arrived while scroll-locked.
+	const [newMessageCount, setNewMessageCount] = useState(0);
+	// Ref used to diff messages.length across renders without stale closures.
+	const prevMessageCountRef = useRef(0);
+	// Detects the loadingOlder true→false transition so prepended historical
+	// messages don't get counted as "new".
+	const prevLoadingOlderRef = useRef(false);
+
+	// Reset all scroll state when the active room changes.
 	useEffect(() => {
 		initialScrollDone.current = false;
+		setScrollLocked(false);
+		setNewMessageCount(0);
+		prevMessageCountRef.current = 0;
+		prevLoadingOlderRef.current = false;
 	}, [roomId]);
 
 	// Scroll to the bottom on initial load or room switch.  The flag prevents
@@ -151,21 +167,45 @@ export function ChatMessageView({
 		}
 	}, [messages, loading]);
 
-	// Auto-scroll to bottom when new messages arrive
+	// Auto-scroll to bottom when new messages arrive (only when not scroll-locked).
 	useEffect(() => {
+		if (scrollLocked) return;
 		const container = containerRef.current;
 		if (!container) return;
 
-		// If the user is near the bottom, keep them there
 		const distanceFromBottom =
 			container.scrollHeight - container.scrollTop - container.clientHeight;
 
 		if (distanceFromBottom < 120) {
 			bottomRef.current?.scrollIntoView({ behavior: "smooth" });
 		}
-	}, [messages]);
+	}, [messages, scrollLocked]);
 
-	// Maintain scroll position when older messages are prepended
+	// Count new messages that arrive while scroll-locked, without counting
+	// historical messages prepended by infinite scroll.
+	useEffect(() => {
+		const wasLoadingOlder = prevLoadingOlderRef.current;
+		prevLoadingOlderRef.current = loadingOlder;
+
+		if (loadingOlder) return; // still fetching older page
+
+		const currentCount = messages.length;
+
+		if (wasLoadingOlder) {
+			// Older messages just finished loading — absorb the prepended count
+			// without incrementing the new-message indicator.
+			prevMessageCountRef.current = currentCount;
+			return;
+		}
+
+		const delta = currentCount - prevMessageCountRef.current;
+		if (scrollLocked && delta > 0 && !loading) {
+			setNewMessageCount((c) => c + delta);
+		}
+		prevMessageCountRef.current = currentCount;
+	}, [messages.length, loading, loadingOlder, scrollLocked]);
+
+	// Maintain scroll position when older messages are prepended.
 	useEffect(() => {
 		const container = containerRef.current;
 		if (!container || !loadingOlder) return;
@@ -182,16 +222,33 @@ export function ChatMessageView({
 		prevScrollHeightRef.current = 0;
 	}, [messages, loadingOlder]);
 
-	// Infinite scroll: fire when user scrolls near the top
+	// Jump to the bottom and release the scroll lock.
+	const resumeScroll = useCallback(() => {
+		setScrollLocked(false);
+		setNewMessageCount(0);
+		const container = containerRef.current;
+		if (container) {
+			container.scrollTop = container.scrollHeight;
+		}
+	}, []);
+
+	// Infinite scroll upward + scroll-lock detection.
 	const handleScroll = useCallback(() => {
 		const container = containerRef.current;
-		if (!container || loadingOlder || !hasMore) return;
-		if (container.scrollTop < 80) {
+		if (!container) return;
+
+		// Detect whether the user has scrolled away from the bottom.
+		const atBottom =
+			container.scrollHeight - container.scrollTop - container.clientHeight < 120;
+		setScrollLocked(!atBottom);
+
+		// Trigger infinite scroll when near the top.
+		if (!loadingOlder && hasMore && container.scrollTop < 80) {
 			onLoadOlder();
 		}
 	}, [loadingOlder, hasMore, onLoadOlder]);
 
-	// Build lookup map for reply references — memoised to avoid re-allocating on every render
+	// Build lookup map for reply references — memoised to avoid re-allocating on every render.
 	const messageMap = useMemo(
 		() => new Map(messages.map((m) => [m.id, m])),
 		[messages],
@@ -216,37 +273,61 @@ export function ChatMessageView({
 	}
 
 	return (
-		<div
-			ref={containerRef}
-			onScroll={handleScroll}
-			className="flex-1 overflow-y-auto px-4 py-4 space-y-4"
-			aria-label="Chat messages"
-			aria-live="polite"
-			aria-relevant="additions"
-		>
-			{/* Load older indicator */}
-			{loadingOlder && (
-				<div className="flex justify-center py-2">
-					<Loader2 size={16} className="animate-spin text-th-text-muted" />
+		<div className="relative flex-1 overflow-hidden">
+			{/* Scrollable message list */}
+			<div
+				ref={containerRef}
+				onScroll={handleScroll}
+				className="h-full overflow-y-auto px-4 py-4 space-y-4"
+				aria-label="Chat messages"
+				aria-live="polite"
+				aria-relevant="additions"
+			>
+				{/* Load older indicator */}
+				{loadingOlder && (
+					<div className="flex justify-center py-2">
+						<Loader2 size={16} className="animate-spin text-th-text-muted" />
+					</div>
+				)}
+				{!hasMore && messages.length > 0 && (
+					<p className="text-center text-xs text-th-text-muted py-1">
+						Beginning of conversation
+					</p>
+				)}
+
+				{messages.map((msg) => (
+					<MessageBubble
+						key={msg.id}
+						message={msg}
+						replyToMessage={
+							msg.reply_to ? messageMap.get(msg.reply_to) : undefined
+						}
+					/>
+				))}
+
+				<div ref={bottomRef} />
+			</div>
+
+			{/* Jump-to-latest button — appears when scroll-locked */}
+			{scrollLocked && (
+				<div className="pointer-events-none absolute inset-x-0 bottom-4 flex justify-center">
+					<button
+						type="button"
+						onClick={resumeScroll}
+						aria-label={
+							newMessageCount > 0
+								? `${newMessageCount} new message${newMessageCount === 1 ? "" : "s"} — jump to latest`
+								: "Jump to latest messages"
+						}
+						className="pointer-events-auto flex items-center gap-1.5 rounded-full bg-th-accent px-4 py-2 text-sm font-medium text-th-accent-text shadow-lg transition-colors hover:bg-th-accent/90"
+					>
+						<ArrowDown size={14} aria-hidden="true" />
+						{newMessageCount > 0
+							? `${newMessageCount} new message${newMessageCount === 1 ? "" : "s"}`
+							: "Jump to latest"}
+					</button>
 				</div>
 			)}
-			{!hasMore && messages.length > 0 && (
-				<p className="text-center text-xs text-th-text-muted py-1">
-					Beginning of conversation
-				</p>
-			)}
-
-			{messages.map((msg) => (
-				<MessageBubble
-					key={msg.id}
-					message={msg}
-					replyToMessage={
-						msg.reply_to ? messageMap.get(msg.reply_to) : undefined
-					}
-				/>
-			))}
-
-			<div ref={bottomRef} />
 		</div>
 	);
 }

--- a/ui/src/components/communicate/ParticipantPanel.tsx
+++ b/ui/src/components/communicate/ParticipantPanel.tsx
@@ -47,7 +47,9 @@ function ActivityDot({ state }: { state?: "idle" | "busy" }) {
 		<span
 			className={[
 				"h-2 w-2 rounded-full",
-				state === "busy" ? "bg-th-status-warning-dot" : "bg-th-status-success-dot",
+				state === "busy"
+					? "bg-th-status-warning-dot animate-pulse"
+					: "bg-th-status-success-dot",
 			].join(" ")}
 			aria-label={state === "busy" ? "Busy" : "Idle"}
 		/>

--- a/ui/src/hooks/useCommunicateSocket.ts
+++ b/ui/src/hooks/useCommunicateSocket.ts
@@ -35,6 +35,15 @@ export interface UseCommunicateSocketOptions {
 	onParticipantJoined?: (participant: Participant) => void;
 	/** Called when a participant leaves the selected room. */
 	onParticipantLeft?: (roomId: string, identifier: string) => void;
+	/**
+	 * Called when an agent's activity state changes (idle ↔ busy).
+	 * Fires on `participant_updated` WebSocket events.
+	 */
+	onParticipantUpdated?: (
+		roomId: string,
+		identifier: string,
+		activityState: "idle" | "busy",
+	) => void;
 	/** Whether to suppress the connection entirely. */
 	paused?: boolean;
 }
@@ -59,6 +68,7 @@ export function useCommunicateSocket({
 	onMessage,
 	onParticipantJoined,
 	onParticipantLeft,
+	onParticipantUpdated,
 	paused = false,
 }: UseCommunicateSocketOptions) {
 	// TODO: accept displayName from caller when user profiles are available
@@ -82,6 +92,8 @@ export function useCommunicateSocket({
 	onParticipantJoinedRef.current = onParticipantJoined;
 	const onParticipantLeftRef = useRef(onParticipantLeft);
 	onParticipantLeftRef.current = onParticipantLeft;
+	const onParticipantUpdatedRef = useRef(onParticipantUpdated);
+	onParticipantUpdatedRef.current = onParticipantUpdated;
 	const participantIdRef = useRef(participantId);
 	participantIdRef.current = participantId;
 
@@ -149,6 +161,12 @@ export function useCommunicateSocket({
 			});
 		} else if (event.type === "participant_left") {
 			onParticipantLeftRef.current?.(event.room_id, event.identifier);
+		} else if (event.type === "participant_updated") {
+			onParticipantUpdatedRef.current?.(
+				event.room_id,
+				event.identifier,
+				event.activity_state,
+			);
 		}
 	}, []);
 

--- a/ui/src/pages/communicate/CommunicatePage.tsx
+++ b/ui/src/pages/communicate/CommunicatePage.tsx
@@ -22,7 +22,7 @@ import {
 	Wifi,
 	WifiOff,
 } from "lucide-react";
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
 	ChatMessageView,
 	CreateRoomDialog,
@@ -197,6 +197,29 @@ export function CommunicatePage() {
 		[],
 	);
 
+	// Handle agent activity-state change via WebSocket (participant_updated event)
+	const handleParticipantUpdated = useCallback(
+		(roomId: string, identifier: string, activityState: "idle" | "busy") => {
+			setRealtimeParticipants((prev) =>
+				prev.map((p) =>
+					p.identifier === identifier && p.room_id === roomId
+						? { ...p, activity_state: activityState }
+						: p,
+				),
+			);
+		},
+		[],
+	);
+
+	// Agents currently processing — passed to ChatMessageView for the thinking indicator
+	const busyAgents = useMemo(
+		() =>
+			realtimeParticipants.filter(
+				(p) => p.kind === "agent" && p.activity_state === "busy",
+			),
+		[realtimeParticipants],
+	);
+
 	// WebSocket connection
 	const { connectionState } = useCommunicateSocket({
 		selectedRoomId: selectedRoom?.id,
@@ -204,6 +227,7 @@ export function CommunicatePage() {
 		onMessage: handleMessage,
 		onParticipantJoined: handleParticipantJoined,
 		onParticipantLeft: handleParticipantLeft,
+		onParticipantUpdated: handleParticipantUpdated,
 		paused: !identity,
 	});
 
@@ -399,6 +423,7 @@ export function CommunicatePage() {
 								hasMore={hasMore}
 								onLoadOlder={loadOlder}
 								roomId={selectedRoom?.id}
+								busyAgents={busyAgents}
 							/>
 
 							{/* Message input */}

--- a/ui/src/test/components/communicate/ChatMessageView.test.tsx
+++ b/ui/src/test/components/communicate/ChatMessageView.test.tsx
@@ -5,7 +5,11 @@
 import { fireEvent, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { ChatMessageView } from "@/components/communicate/ChatMessageView";
-import { makeChatMessage, makeChatMessageList } from "@/test/mocks/factories";
+import {
+	makeChatMessage,
+	makeChatMessageList,
+	makeParticipant,
+} from "@/test/mocks/factories";
 
 // ---------------------------------------------------------------------------
 // Scroll simulation helpers
@@ -499,5 +503,113 @@ describe("ChatMessageView", () => {
 			(call) => call[0]?.behavior === "instant",
 		).length;
 		expect(callsAfterOlder).toBe(1);
+	});
+
+	// -------------------------------------------------------------------------
+	// ThinkingIndicator
+	// -------------------------------------------------------------------------
+
+	it("shows no thinking indicator when busyAgents is empty", () => {
+		const messages = makeChatMessageList(3);
+		render(
+			<ChatMessageView
+				messages={messages}
+				loading={false}
+				loadingOlder={false}
+				hasMore={false}
+				onLoadOlder={noop}
+				busyAgents={[]}
+			/>,
+		);
+
+		expect(screen.queryByText(/is thinking/i)).not.toBeInTheDocument();
+		expect(screen.queryByText(/are thinking/i)).not.toBeInTheDocument();
+	});
+
+	it("shows thinking indicator for a single busy agent", () => {
+		const messages = makeChatMessageList(3);
+		const agent = makeParticipant({ kind: "agent", display_name: "Planner" });
+		render(
+			<ChatMessageView
+				messages={messages}
+				loading={false}
+				loadingOlder={false}
+				hasMore={false}
+				onLoadOlder={noop}
+				busyAgents={[agent]}
+			/>,
+		);
+
+		expect(screen.getByText("Planner is thinking…")).toBeInTheDocument();
+	});
+
+	it("shows combined label for two busy agents", () => {
+		const messages = makeChatMessageList(3);
+		const a1 = makeParticipant({ kind: "agent", display_name: "Alpha" });
+		const a2 = makeParticipant({ kind: "agent", display_name: "Beta" });
+		render(
+			<ChatMessageView
+				messages={messages}
+				loading={false}
+				loadingOlder={false}
+				hasMore={false}
+				onLoadOlder={noop}
+				busyAgents={[a1, a2]}
+			/>,
+		);
+
+		expect(screen.getByText("Alpha and Beta are thinking…")).toBeInTheDocument();
+	});
+
+	it("shows generic label when three or more agents are busy", () => {
+		const messages = makeChatMessageList(3);
+		const agents = [
+			makeParticipant({ kind: "agent", display_name: "A" }),
+			makeParticipant({ kind: "agent", display_name: "B" }),
+			makeParticipant({ kind: "agent", display_name: "C" }),
+		];
+		render(
+			<ChatMessageView
+				messages={messages}
+				loading={false}
+				loadingOlder={false}
+				hasMore={false}
+				onLoadOlder={noop}
+				busyAgents={agents}
+			/>,
+		);
+
+		expect(screen.getByText("3 agents are thinking…")).toBeInTheDocument();
+	});
+
+	it("thinking indicator disappears when busyAgents becomes empty", () => {
+		const messages = makeChatMessageList(3);
+		const agent = makeParticipant({ kind: "agent", display_name: "Planner" });
+
+		const { rerender } = render(
+			<ChatMessageView
+				messages={messages}
+				loading={false}
+				loadingOlder={false}
+				hasMore={false}
+				onLoadOlder={noop}
+				busyAgents={[agent]}
+			/>,
+		);
+
+		expect(screen.getByText("Planner is thinking…")).toBeInTheDocument();
+
+		rerender(
+			<ChatMessageView
+				messages={messages}
+				loading={false}
+				loadingOlder={false}
+				hasMore={false}
+				onLoadOlder={noop}
+				busyAgents={[]}
+			/>,
+		);
+
+		expect(screen.queryByText(/is thinking/i)).not.toBeInTheDocument();
 	});
 });

--- a/ui/src/test/components/communicate/ChatMessageView.test.tsx
+++ b/ui/src/test/components/communicate/ChatMessageView.test.tsx
@@ -2,9 +2,35 @@
  * Tests for ChatMessageView component.
  */
 
-import { render, screen } from "@testing-library/react";
+import { fireEvent, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { ChatMessageView } from "@/components/communicate/ChatMessageView";
 import { makeChatMessage, makeChatMessageList } from "@/test/mocks/factories";
+
+// ---------------------------------------------------------------------------
+// Scroll simulation helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Mock scroll geometry on a container so handleScroll can compute distances.
+ * distanceFromBottom = scrollHeight - scrollTop - clientHeight
+ */
+function mockScrollGeometry(
+	el: HTMLElement,
+	{
+		scrollHeight,
+		scrollTop,
+		clientHeight,
+	}: { scrollHeight: number; scrollTop: number; clientHeight: number },
+) {
+	Object.defineProperty(el, "scrollHeight", { value: scrollHeight, configurable: true });
+	Object.defineProperty(el, "scrollTop", {
+		value: scrollTop,
+		writable: true,
+		configurable: true,
+	});
+	Object.defineProperty(el, "clientHeight", { value: clientHeight, configurable: true });
+}
 
 const noop = () => {};
 
@@ -211,6 +237,229 @@ describe("ChatMessageView", () => {
 			(call) => call[0]?.behavior === "instant",
 		).length;
 		expect(callsAfterRoom2).toBe(2);
+	});
+
+	// -------------------------------------------------------------------------
+	// Scroll-lock / jump-to-latest button
+	// -------------------------------------------------------------------------
+
+	it("does not show jump-to-latest button when at bottom", () => {
+		const messages = makeChatMessageList(5);
+		render(
+			<ChatMessageView
+				messages={messages}
+				loading={false}
+				loadingOlder={false}
+				hasMore={false}
+				onLoadOlder={noop}
+				roomId="room-1"
+			/>,
+		);
+
+		expect(
+			screen.queryByRole("button", { name: /jump to latest/i }),
+		).not.toBeInTheDocument();
+	});
+
+	it("shows jump-to-latest button when scrolled away from bottom", () => {
+		const messages = makeChatMessageList(5);
+		render(
+			<ChatMessageView
+				messages={messages}
+				loading={false}
+				loadingOlder={false}
+				hasMore={false}
+				onLoadOlder={noop}
+				roomId="room-1"
+			/>,
+		);
+
+		const container = screen.getByLabelText("Chat messages");
+
+		// Simulate scrolling well above the bottom (distanceFromBottom = 700 > 120)
+		mockScrollGeometry(container, {
+			scrollHeight: 1000,
+			scrollTop: 0,
+			clientHeight: 300,
+		});
+		fireEvent.scroll(container);
+
+		expect(
+			screen.getByRole("button", { name: /jump to latest/i }),
+		).toBeInTheDocument();
+	});
+
+	it("hides jump-to-latest button when scrolled back to bottom", () => {
+		const messages = makeChatMessageList(5);
+		render(
+			<ChatMessageView
+				messages={messages}
+				loading={false}
+				loadingOlder={false}
+				hasMore={false}
+				onLoadOlder={noop}
+				roomId="room-1"
+			/>,
+		);
+
+		const container = screen.getByLabelText("Chat messages");
+
+		// Scroll up — lock engages
+		mockScrollGeometry(container, {
+			scrollHeight: 1000,
+			scrollTop: 0,
+			clientHeight: 300,
+		});
+		fireEvent.scroll(container);
+		expect(
+			screen.getByRole("button", { name: /jump to latest/i }),
+		).toBeInTheDocument();
+
+		// Scroll back to bottom — lock releases (distanceFromBottom = 10 < 120)
+		mockScrollGeometry(container, {
+			scrollHeight: 1000,
+			scrollTop: 690,
+			clientHeight: 300,
+		});
+		fireEvent.scroll(container);
+		expect(
+			screen.queryByRole("button", { name: /jump to latest/i }),
+		).not.toBeInTheDocument();
+	});
+
+	it("clicking jump-to-latest scrolls to bottom and hides the button", async () => {
+		const user = userEvent.setup();
+		const messages = makeChatMessageList(5);
+		render(
+			<ChatMessageView
+				messages={messages}
+				loading={false}
+				loadingOlder={false}
+				hasMore={false}
+				onLoadOlder={noop}
+				roomId="room-1"
+			/>,
+		);
+
+		const container = screen.getByLabelText("Chat messages");
+
+		// Scroll up to show the button
+		mockScrollGeometry(container, {
+			scrollHeight: 1000,
+			scrollTop: 0,
+			clientHeight: 300,
+		});
+		fireEvent.scroll(container);
+
+		const btn = screen.getByRole("button", { name: /jump to latest/i });
+		await user.click(btn);
+
+		// Button should be gone after clicking
+		expect(
+			screen.queryByRole("button", { name: /jump to latest/i }),
+		).not.toBeInTheDocument();
+	});
+
+	it("shows new message count on jump-to-latest button when messages arrive while locked", async () => {
+		const messages = makeChatMessageList(3);
+		const { rerender } = render(
+			<ChatMessageView
+				messages={messages}
+				loading={false}
+				loadingOlder={false}
+				hasMore={false}
+				onLoadOlder={noop}
+				roomId="room-1"
+			/>,
+		);
+
+		// Scroll up to engage lock
+		const container = screen.getByLabelText("Chat messages");
+		mockScrollGeometry(container, {
+			scrollHeight: 1000,
+			scrollTop: 0,
+			clientHeight: 300,
+		});
+		fireEvent.scroll(container);
+
+		expect(
+			screen.getByRole("button", { name: /jump to latest/i }),
+		).toBeInTheDocument();
+
+		// Two new messages arrive
+		const newMsg1 = makeChatMessage({});
+		const newMsg2 = makeChatMessage({});
+		rerender(
+			<ChatMessageView
+				messages={[...messages, newMsg1, newMsg2]}
+				loading={false}
+				loadingOlder={false}
+				hasMore={false}
+				onLoadOlder={noop}
+				roomId="room-1"
+			/>,
+		);
+
+		expect(
+			screen.getByRole("button", { name: /2 new messages/i }),
+		).toBeInTheDocument();
+	});
+
+	it("resets scroll lock and new message count when switching rooms", async () => {
+		const user = userEvent.setup();
+		const messages = makeChatMessageList(3);
+		const { rerender } = render(
+			<ChatMessageView
+				messages={messages}
+				loading={false}
+				loadingOlder={false}
+				hasMore={false}
+				onLoadOlder={noop}
+				roomId="room-1"
+			/>,
+		);
+
+		// Scroll up and accumulate new messages in room-1
+		const container = screen.getByLabelText("Chat messages");
+		mockScrollGeometry(container, {
+			scrollHeight: 1000,
+			scrollTop: 0,
+			clientHeight: 300,
+		});
+		fireEvent.scroll(container);
+		rerender(
+			<ChatMessageView
+				messages={[...messages, makeChatMessage({})]}
+				loading={false}
+				loadingOlder={false}
+				hasMore={false}
+				onLoadOlder={noop}
+				roomId="room-1"
+			/>,
+		);
+		expect(screen.getByRole("button", { name: /new message/i })).toBeInTheDocument();
+
+		// Switch to room-2 — all scroll state should reset
+		rerender(
+			<ChatMessageView
+				messages={makeChatMessageList(2)}
+				loading={false}
+				loadingOlder={false}
+				hasMore={false}
+				onLoadOlder={noop}
+				roomId="room-2"
+			/>,
+		);
+
+		expect(
+			screen.queryByRole("button", { name: /jump to latest/i }),
+		).not.toBeInTheDocument();
+		expect(
+			screen.queryByRole("button", { name: /new message/i }),
+		).not.toBeInTheDocument();
+
+		// Suppress unused variable warning
+		void user;
 	});
 
 	it("does not scroll to bottom when loading older messages", () => {

--- a/ui/src/test/components/communicate/ParticipantPanel.test.tsx
+++ b/ui/src/test/components/communicate/ParticipantPanel.test.tsx
@@ -81,6 +81,48 @@ describe("ParticipantPanel", () => {
 		});
 	});
 
+	it("shows pulsing activity dot when agent is busy", async () => {
+		const agent = makeParticipantList(1, {
+			room_id: ROOM_ID,
+			kind: "agent",
+			activity_state: "busy",
+		});
+
+		server.use(
+			http.get(`http://localhost:17010/rooms/${ROOM_ID}/participants`, () =>
+				HttpResponse.json({ items: agent, total: 1, limit: 100, offset: 0 }),
+			),
+		);
+
+		render(<ParticipantPanel roomId={ROOM_ID} />);
+
+		await waitFor(() => {
+			const dot = screen.getByLabelText("Busy");
+			expect(dot).toHaveClass("animate-pulse");
+		});
+	});
+
+	it("does not pulse the activity dot when agent is idle", async () => {
+		const agent = makeParticipantList(1, {
+			room_id: ROOM_ID,
+			kind: "agent",
+			activity_state: "idle",
+		});
+
+		server.use(
+			http.get(`http://localhost:17010/rooms/${ROOM_ID}/participants`, () =>
+				HttpResponse.json({ items: agent, total: 1, limit: 100, offset: 0 }),
+			),
+		);
+
+		render(<ParticipantPanel roomId={ROOM_ID} />);
+
+		await waitFor(() => {
+			const dot = screen.getByLabelText("Idle");
+			expect(dot).not.toHaveClass("animate-pulse");
+		});
+	});
+
 	it("hides participants who left", async () => {
 		const participants = makeParticipantList(2, {
 			room_id: ROOM_ID,

--- a/ui/src/types/communicate.ts
+++ b/ui/src/types/communicate.ts
@@ -99,10 +99,23 @@ export interface WsParticipantLeftEvent {
 	identifier: string;
 }
 
+/**
+ * Emitted by the backend when an agent's activity state changes.
+ * Client-side only until the backend is wired up; the hook already
+ * handles it so the UI will light up as soon as the server emits it.
+ */
+export interface WsParticipantUpdatedEvent {
+	type: "participant_updated";
+	room_id: string;
+	identifier: string;
+	activity_state: "idle" | "busy";
+}
+
 export type WsRoomEvent =
 	| WsMessageEvent
 	| WsParticipantJoinedEvent
-	| WsParticipantLeftEvent;
+	| WsParticipantLeftEvent
+	| WsParticipantUpdatedEvent;
 
 // ---------------------------------------------------------------------------
 // WebSocket client messages


### PR DESCRIPTION
## Summary

- Adds a "Jump to latest" sticky button when user scrolls up in communication room chat
- Button appears as overlay at bottom of chat area, matching existing "Resume scroll" pattern from AgentLogView
- Includes agent thinking/working indicator in communication rooms

Closes #1082

## Test plan

- [ ] Scroll up in a chat room - "Jump to latest" button appears
- [ ] Click button - scrolls to bottom and resumes auto-follow
- [ ] Button disappears when near bottom
- [ ] Visual style matches agent log "Resume scroll" button
- [ ] Existing auto-scroll behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)