### PR TITLE
feat(ui): create agent node and prompt template edge components

### DIFF
--- a/ui/src/components/workflows/canvas/edges/PromptEdge.test.tsx
+++ b/ui/src/components/workflows/canvas/edges/PromptEdge.test.tsx
@@ -1,0 +1,160 @@
+/**
+ * PromptEdge tests.
+ *
+ * Verifies that the prompt edge renders with a truncated template preview,
+ * poll interval badge, and that clicking the label triggers the callback.
+ * Also tests the visual distinction between empty and customised prompts.
+ */
+
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { ReactFlowProvider } from "@xyflow/react";
+import { describe, expect, it, vi } from "vitest";
+import type { PromptEdgeData } from "./PromptEdge";
+import { PromptEdge } from "./PromptEdge";
+
+// EdgeLabelRenderer uses a portal to a React Flow container div that does not
+// exist in jsdom. Stub it to render children inline so tests can find elements.
+vi.mock("@xyflow/react", async (importOriginal) => {
+	const actual = await importOriginal<typeof import("@xyflow/react")>();
+	return {
+		...actual,
+		EdgeLabelRenderer: ({ children }: { children: React.ReactNode }) => (
+			<div data-testid="edge-label-renderer">{children}</div>
+		),
+	};
+});
+
+// React Flow requires ResizeObserver in jsdom
+global.ResizeObserver = class ResizeObserver {
+	observe() {}
+	unobserve() {}
+	disconnect() {}
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function renderPromptEdge(data: Partial<PromptEdgeData> = {}) {
+	const edgeData: PromptEdgeData = {
+		promptTemplate: "",
+		pollIntervalSecs: 300,
+		enabled: true,
+		...data,
+	};
+
+	return render(
+		<ReactFlowProvider>
+			<svg>
+				<PromptEdge
+					id="e1"
+					source="n1"
+					target="n2"
+					sourceX={0}
+					sourceY={0}
+					targetX={200}
+					targetY={0}
+					sourcePosition={"right" as never}
+					targetPosition={"left" as never}
+					data={edgeData}
+					selected={false}
+					animated={false}
+					type="prompt"
+					interactionWidth={20}
+				/>
+			</svg>
+		</ReactFlowProvider>,
+	);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("PromptEdge", () => {
+	describe("rendering", () => {
+		it("renders the edge label", () => {
+			renderPromptEdge({ promptTemplate: "Fix this: {{title}}" });
+			expect(screen.getByTestId("prompt-edge-label")).toBeInTheDocument();
+		});
+
+		it("renders the poll interval badge", () => {
+			renderPromptEdge({ pollIntervalSecs: 300 });
+			expect(screen.getByTestId("prompt-edge-interval")).toBeInTheDocument();
+		});
+	});
+
+	describe("template preview", () => {
+		it("shows 'No prompt set' for empty template", () => {
+			renderPromptEdge({ promptTemplate: "" });
+			expect(screen.getByTestId("prompt-edge-label")).toHaveTextContent(
+				"No prompt set",
+			);
+		});
+
+		it("shows first line of the template truncated to 40 chars", () => {
+			const template = "A".repeat(60);
+			renderPromptEdge({ promptTemplate: template });
+			const label = screen.getByTestId("prompt-edge-label");
+			expect(label.textContent).toContain("…");
+			expect(label.textContent!.length).toBeLessThan(55);
+		});
+
+		it("shows short template fully when under 40 chars", () => {
+			renderPromptEdge({ promptTemplate: "Fix: {{title}}" });
+			expect(screen.getByTestId("prompt-edge-label")).toHaveTextContent(
+				"Fix: {{title}}",
+			);
+		});
+
+		it("shows only first line when template has multiple lines", () => {
+			renderPromptEdge({
+				promptTemplate: "First line\nSecond line\nThird line",
+			});
+			const label = screen.getByTestId("prompt-edge-label");
+			expect(label.textContent).toContain("First line");
+			expect(label.textContent).not.toContain("Second line");
+		});
+	});
+
+	describe("poll interval badge", () => {
+		it("shows seconds for sub-minute intervals", () => {
+			renderPromptEdge({ pollIntervalSecs: 30 });
+			expect(screen.getByTestId("prompt-edge-interval")).toHaveTextContent(
+				"30s",
+			);
+		});
+
+		it("shows minutes for minute-scale intervals", () => {
+			renderPromptEdge({ pollIntervalSecs: 300 });
+			expect(screen.getByTestId("prompt-edge-interval")).toHaveTextContent(
+				"5m",
+			);
+		});
+
+		it("shows hours for hour-scale intervals", () => {
+			renderPromptEdge({ pollIntervalSecs: 3600 });
+			expect(screen.getByTestId("prompt-edge-interval")).toHaveTextContent(
+				"1h",
+			);
+		});
+	});
+
+	describe("click interaction", () => {
+		it("calls onPromptChange when label is clicked", async () => {
+			const user = userEvent.setup();
+			const onPromptChange = vi.fn();
+
+			renderPromptEdge({
+				promptTemplate: "Fix: {{title}}",
+				onPromptChange,
+			});
+
+			const label = screen.getByTestId("prompt-edge-label");
+			await user.click(label.querySelector("button")!);
+			expect(onPromptChange).toHaveBeenCalledOnce();
+			expect(onPromptChange).toHaveBeenCalledWith("Fix: {{title}}");
+		});
+	});
+});

--- a/ui/src/components/workflows/canvas/edges/PromptEdge.tsx
+++ b/ui/src/components/workflows/canvas/edges/PromptEdge.tsx
@@ -1,0 +1,163 @@
+/**
+ * PromptEdge — custom React Flow edge for workflow prompt-template bindings.
+ *
+ * Visual design:
+ * - Bezier curve using React Flow's getBezierPath
+ * - Edge label shows a truncated preview of the prompt template
+ * - Small poll-interval badge on the path
+ * - Click handler to open the prompt template editor
+ * - Visually distinct for empty/default vs. customised prompts
+ */
+
+import {
+	BaseEdge,
+	EdgeLabelRenderer,
+	getBezierPath,
+	type EdgeProps,
+} from "@xyflow/react";
+
+// ---------------------------------------------------------------------------
+// Edge data interface
+// ---------------------------------------------------------------------------
+
+export interface PromptEdgeData extends Record<string, unknown> {
+	promptTemplate: string;
+	pollIntervalSecs: number;
+	enabled: boolean;
+	onPromptChange?: (template: string) => void;
+	onIntervalChange?: (secs: number) => void;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const TRUNCATE_CHARS = 40;
+
+function truncateTemplate(template: string): string {
+	const first = template.split("\n")[0].trim();
+	if (first.length <= TRUNCATE_CHARS) return first;
+	return `${first.slice(0, TRUNCATE_CHARS)}…`;
+}
+
+function formatInterval(secs: number): string {
+	if (secs < 60) return `${secs}s`;
+	const mins = Math.round(secs / 60);
+	if (mins < 60) return `${mins}m`;
+	return `${Math.round(mins / 60)}h`;
+}
+
+/** Returns true when the template is non-empty and not purely the default placeholder */
+function isCustomised(template: string): boolean {
+	return template.trim().length > 0;
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function PromptEdge({
+	id,
+	sourceX,
+	sourceY,
+	targetX,
+	targetY,
+	sourcePosition,
+	targetPosition,
+	data,
+	selected,
+	markerEnd,
+}: EdgeProps<PromptEdgeData>) {
+	const { promptTemplate = "", pollIntervalSecs = 60, enabled = true } =
+		data ?? {};
+
+	const [edgePath, labelX, labelY] = getBezierPath({
+		sourceX,
+		sourceY,
+		sourcePosition,
+		targetX,
+		targetY,
+		targetPosition,
+	});
+
+	const customised = isCustomised(promptTemplate);
+	const preview = customised
+		? truncateTemplate(promptTemplate)
+		: "No prompt set";
+
+	const strokeColour = selected
+		? "var(--th-accent)"
+		: !enabled
+			? "var(--th-border)"
+			: customised
+				? "var(--th-accent)"
+				: "var(--th-text-muted)";
+
+	const strokeWidth = selected ? 2.5 : 1.5;
+	const strokeDasharray = enabled ? undefined : "5 4";
+
+	function handleClick() {
+		data?.onPromptChange?.(promptTemplate);
+	}
+
+	return (
+		<>
+			<BaseEdge
+				id={id}
+				path={edgePath}
+				markerEnd={markerEnd}
+				style={{
+					stroke: strokeColour,
+					strokeWidth,
+					strokeDasharray,
+				}}
+			/>
+
+			<EdgeLabelRenderer>
+				{/* Template preview label */}
+				<div
+					data-testid="prompt-edge-label"
+					style={{
+						position: "absolute",
+						transform: `translate(-50%, -50%) translate(${labelX}px, ${labelY}px)`,
+						pointerEvents: "all",
+					}}
+					className="nodrag nopan"
+				>
+					<button
+						type="button"
+						onClick={handleClick}
+						title={promptTemplate || "Click to edit prompt template"}
+						className={[
+							"max-w-[160px] rounded px-2 py-0.5 text-[11px] leading-tight truncate",
+							"border shadow-sm transition-colors",
+							customised
+								? "bg-th-surface border-th-accent text-th-text"
+								: "bg-th-surface-sunken border-th-border text-th-text-muted",
+							"hover:border-th-accent hover:text-th-text",
+						].join(" ")}
+					>
+						{preview}
+					</button>
+				</div>
+
+				{/* Poll interval badge — offset slightly above mid-point */}
+				<div
+					data-testid="prompt-edge-interval"
+					style={{
+						position: "absolute",
+						transform: `translate(-50%, -220%) translate(${labelX}px, ${labelY}px)`,
+						pointerEvents: "none",
+					}}
+					className="nodrag nopan"
+				>
+					<span className="rounded-full bg-th-surface border border-th-border px-1.5 py-0.5 text-[10px] text-th-text-faint">
+						{formatInterval(pollIntervalSecs)}
+					</span>
+				</div>
+			</EdgeLabelRenderer>
+		</>
+	);
+}
+
+export default PromptEdge;

--- a/ui/src/components/workflows/canvas/edges/index.ts
+++ b/ui/src/components/workflows/canvas/edges/index.ts
@@ -1,0 +1,2 @@
+export type { PromptEdgeData } from "./PromptEdge";
+export { PromptEdge } from "./PromptEdge";

--- a/ui/src/components/workflows/canvas/nodeTypes.ts
+++ b/ui/src/components/workflows/canvas/nodeTypes.ts
@@ -1,18 +1,24 @@
 /**
- * workflowNodeTypes — React Flow node type registry for the workflow canvas.
+ * workflowNodeTypes / workflowEdgeTypes — React Flow type registries
+ * for the workflow canvas.
  *
- * Import this map and pass it as the `nodeTypes` prop to <WorkflowCanvas>
- * (or directly to <ReactFlow>) so React Flow can resolve custom node
- * components by their string type key.
- *
- * New node types (e.g. "agent") will be added here as they are implemented.
+ * Import these maps and pass them as the `nodeTypes` / `edgeTypes` props
+ * to <WorkflowCanvas> (or directly to <ReactFlow>) so React Flow can
+ * resolve custom node/edge components by their string type key.
  */
 
-import type { NodeTypes } from "@xyflow/react";
+import type { EdgeTypes, NodeTypes } from "@xyflow/react";
+import { PromptEdge } from "./edges/PromptEdge";
+import { AgentNode } from "./nodes/AgentNode";
 import { TriggerNode } from "./nodes/TriggerNode";
 
 export const workflowNodeTypes = {
 	trigger: TriggerNode,
+	agent: AgentNode,
 } satisfies NodeTypes;
+
+export const workflowEdgeTypes = {
+	prompt: PromptEdge,
+} satisfies EdgeTypes;
 
 export default workflowNodeTypes;

--- a/ui/src/components/workflows/canvas/nodes/AgentNode.test.tsx
+++ b/ui/src/components/workflows/canvas/nodes/AgentNode.test.tsx
@@ -1,0 +1,170 @@
+/**
+ * AgentNode tests.
+ *
+ * Verifies that the agent node renders name, status badge, model, tool policy
+ * summary, and the input handle. Also verifies selected-state styling and
+ * status-dependent border colours.
+ */
+
+import { render, screen } from "@testing-library/react";
+import { ReactFlowProvider } from "@xyflow/react";
+import { describe, expect, it } from "vitest";
+import type { AgentStatus, ToolPolicy } from "@/types/orchestrator";
+import type { AgentNodeData } from "./AgentNode";
+import { AgentNode } from "./AgentNode";
+
+// React Flow requires ResizeObserver in jsdom
+global.ResizeObserver = class ResizeObserver {
+	observe() {}
+	unobserve() {}
+	disconnect() {}
+};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function renderAgentNode(
+	overrides: Partial<AgentNodeData> = {},
+	selected = false,
+) {
+	const data: AgentNodeData = {
+		agentId: "agent-1",
+		name: "Test Agent",
+		status: "running",
+		toolPolicy: { mode: "allow_all" },
+		...overrides,
+	};
+
+	return render(
+		<ReactFlowProvider>
+			<AgentNode
+				id="n1"
+				type="agent"
+				data={data}
+				selected={selected}
+				dragging={false}
+				zIndex={0}
+				isConnectable={true}
+				positionAbsoluteX={0}
+				positionAbsoluteY={0}
+			/>
+		</ReactFlowProvider>,
+	);
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("AgentNode", () => {
+	describe("rendering", () => {
+		it("renders the node wrapper", () => {
+			renderAgentNode();
+			expect(screen.getByTestId("agent-node")).toBeInTheDocument();
+		});
+
+		it("shows the agent name", () => {
+			renderAgentNode({ name: "My Worker Agent" });
+			expect(screen.getByText("My Worker Agent")).toBeInTheDocument();
+		});
+
+		it("has an input handle on the left", () => {
+			renderAgentNode();
+			expect(screen.getByTestId("agent-node-handle-in")).toBeInTheDocument();
+		});
+	});
+
+	describe("tool policy summary", () => {
+		it("shows 'Allow all tools' for allow_all", () => {
+			renderAgentNode({ toolPolicy: { mode: "allow_all" } });
+			expect(screen.getByText("Allow all tools")).toBeInTheDocument();
+		});
+
+		it("shows 'Deny all tools' for deny_all", () => {
+			renderAgentNode({ toolPolicy: { mode: "deny_all" } });
+			expect(screen.getByText("Deny all tools")).toBeInTheDocument();
+		});
+
+		it("shows tool count for allow_list", () => {
+			const policy: ToolPolicy = {
+				mode: "allow_list",
+				tools: ["Bash", "Read", "Edit"],
+			};
+			renderAgentNode({ toolPolicy: policy });
+			expect(screen.getByText("3 tools allowed")).toBeInTheDocument();
+		});
+
+		it("shows singular 'tool' for single allow_list entry", () => {
+			const policy: ToolPolicy = { mode: "allow_list", tools: ["Bash"] };
+			renderAgentNode({ toolPolicy: policy });
+			expect(screen.getByText("1 tool allowed")).toBeInTheDocument();
+		});
+
+		it("shows tool count for deny_list", () => {
+			const policy: ToolPolicy = {
+				mode: "deny_list",
+				tools: ["Bash", "Write"],
+			};
+			renderAgentNode({ toolPolicy: policy });
+			expect(screen.getByText("2 tools denied")).toBeInTheDocument();
+		});
+
+		it("shows 'Requires approval' for require_approval", () => {
+			renderAgentNode({ toolPolicy: { mode: "require_approval" } });
+			expect(screen.getByText("Requires approval")).toBeInTheDocument();
+		});
+	});
+
+	describe("model display", () => {
+		it("shows model when provided", () => {
+			renderAgentNode({ model: "claude-sonnet-4-20250514" });
+			expect(
+				screen.getByTestId("agent-node-model"),
+			).toHaveTextContent("claude-sonnet-4-20250514");
+		});
+
+		it("does not show model element when not provided", () => {
+			renderAgentNode({ model: undefined });
+			expect(
+				screen.queryByTestId("agent-node-model"),
+			).not.toBeInTheDocument();
+		});
+	});
+
+	describe("status-aware border colouring", () => {
+		const statuses: AgentStatus[] = ["running", "failed", "pending", "stopped"];
+
+		for (const status of statuses) {
+			it(`renders without throwing for status=${status}`, () => {
+				expect(() => renderAgentNode({ status })).not.toThrow();
+			});
+		}
+
+		it("applies green border for running status", () => {
+			renderAgentNode({ status: "running" });
+			const node = screen.getByTestId("agent-node");
+			expect(node.className).toContain("green");
+		});
+
+		it("applies red border for failed status", () => {
+			renderAgentNode({ status: "failed" });
+			const node = screen.getByTestId("agent-node");
+			expect(node.className).toContain("red");
+		});
+	});
+
+	describe("selected state", () => {
+		it("shows ring when selected", () => {
+			renderAgentNode({}, true);
+			const node = screen.getByTestId("agent-node");
+			expect(node.className).toContain("ring-2");
+		});
+
+		it("does not show ring when not selected", () => {
+			renderAgentNode({}, false);
+			const node = screen.getByTestId("agent-node");
+			expect(node.className).not.toContain("ring-2");
+		});
+	});
+});

--- a/ui/src/components/workflows/canvas/nodes/AgentNode.tsx
+++ b/ui/src/components/workflows/canvas/nodes/AgentNode.tsx
@@ -1,0 +1,128 @@
+/**
+ * AgentNode — custom React Flow node for workflow agent targets.
+ *
+ * Displays:
+ * - Agent name (primary text)
+ * - Status badge (running/stopped/pending/failed)
+ * - Model name (if known)
+ * - Tool policy summary
+ * - Input handle on the left for incoming trigger connections
+ *
+ * Styling reflects agent status: green border for running, red for failed,
+ * amber for pending, grey for stopped.
+ */
+
+import { Bot } from "lucide-react";
+import { Handle, Position, type NodeProps } from "@xyflow/react";
+import { AgentStatusBadge } from "@/components/agents/AgentStatusBadge";
+import type { AgentStatus, ToolPolicy } from "@/types/orchestrator";
+
+// ---------------------------------------------------------------------------
+// Node data interface
+// ---------------------------------------------------------------------------
+
+export interface AgentNodeData extends Record<string, unknown> {
+	agentId: string;
+	name: string;
+	status: AgentStatus;
+	model?: string;
+	toolPolicy: ToolPolicy;
+	onAgentChange?: (agentId: string) => void;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function toolPolicySummary(policy: ToolPolicy): string {
+	switch (policy.mode) {
+		case "allow_all":
+			return "Allow all tools";
+		case "deny_all":
+			return "Deny all tools";
+		case "allow_list":
+			return `${policy.tools.length} tool${policy.tools.length !== 1 ? "s" : ""} allowed`;
+		case "deny_list":
+			return `${policy.tools.length} tool${policy.tools.length !== 1 ? "s" : ""} denied`;
+		case "require_approval":
+			return "Requires approval";
+		default:
+			return "Custom policy";
+	}
+}
+
+/** Border colour classes per status */
+const STATUS_BORDER: Record<AgentStatus, string> = {
+	running: "border-green-400 dark:border-green-600",
+	failed: "border-red-400 dark:border-red-600",
+	pending: "border-amber-400 dark:border-amber-600",
+	stopped: "border-slate-300 dark:border-slate-600",
+};
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function AgentNode({ data, selected }: NodeProps<AgentNodeData>) {
+	const { name, status, model, toolPolicy } = data;
+	const borderClass = STATUS_BORDER[status] ?? STATUS_BORDER.stopped;
+
+	return (
+		<div
+			data-testid="agent-node"
+			data-agent-id={data.agentId}
+			className={[
+				"relative min-w-[180px] max-w-[240px] rounded-lg border-2 px-3 py-2.5 shadow-sm transition-all",
+				"bg-th-surface",
+				selected
+					? "border-blue-500 ring-2 ring-blue-300 dark:ring-blue-700"
+					: borderClass,
+			]
+				.filter(Boolean)
+				.join(" ")}
+		>
+			{/* Header: icon + name + status */}
+			<div className="flex items-center gap-1.5">
+				<Bot
+					size={14}
+					className="text-th-text-muted flex-shrink-0"
+					aria-hidden="true"
+				/>
+				<span
+					className="text-xs font-semibold text-th-text truncate flex-1"
+					title={name}
+				>
+					{name}
+				</span>
+				<AgentStatusBadge status={status} variant="dot" />
+			</div>
+
+			{/* Model */}
+			{model && (
+				<p
+					className="mt-1 text-[11px] text-th-text-muted truncate"
+					title={model}
+					data-testid="agent-node-model"
+				>
+					{model}
+				</p>
+			)}
+
+			{/* Tool policy */}
+			<p className="mt-0.5 text-[11px] text-th-text-faint">
+				{toolPolicySummary(toolPolicy)}
+			</p>
+
+			{/* Input handle — left side */}
+			<Handle
+				type="target"
+				position={Position.Left}
+				id="in"
+				className="!w-3 !h-3 !bg-th-accent !border-2 !border-white"
+				data-testid="agent-node-handle-in"
+			/>
+		</div>
+	);
+}
+
+export default AgentNode;

--- a/ui/src/components/workflows/canvas/nodes/index.ts
+++ b/ui/src/components/workflows/canvas/nodes/index.ts
@@ -1,2 +1,4 @@
+export type { AgentNodeData } from "./AgentNode";
+export { AgentNode } from "./AgentNode";
 export type { TriggerNodeData } from "./TriggerNode";
 export { TriggerNode } from "./TriggerNode";


### PR DESCRIPTION
Add AgentNode (status-aware borders, tool policy summary, input handle) and PromptEdge (Bezier curve, truncated template preview, poll interval badge, click callback). Register both in workflowNodeTypes/workflowEdgeTypes. 29 tests.

Closes #1098