### PR TITLE
feat(ui): add read-only workflow visualization with auto-layout

### DIFF
--- a/ui/src/components/workflows/canvas/WorkflowCanvas.test.tsx
+++ b/ui/src/components/workflows/canvas/WorkflowCanvas.test.tsx
@@ -1,8 +1,9 @@
 /**
  * WorkflowCanvas tests.
  *
- * Verifies that the canvas renders without errors and that the React Flow
- * sub-components (controls, minimap, background) are present in the DOM.
+ * Verifies that the canvas renders without errors, that the React Flow
+ * sub-components are present in the DOM, and that readOnly mode shows the
+ * view-mode badge and sets the correct data attribute.
  */
 
 import { render, screen } from "@testing-library/react";
@@ -25,41 +26,76 @@ describe("WorkflowCanvas", () => {
 		onConnect: () => {},
 	};
 
-	it("renders without throwing", () => {
-		expect(() => render(<WorkflowCanvas {...defaultProps} />)).not.toThrow();
-	});
+	describe("basic rendering", () => {
+		it("renders without throwing", () => {
+			expect(() => render(<WorkflowCanvas {...defaultProps} />)).not.toThrow();
+		});
 
-	it("renders the canvas wrapper", () => {
-		render(<WorkflowCanvas {...defaultProps} />);
-		expect(screen.getByTestId("workflow-canvas")).toBeInTheDocument();
-	});
+		it("renders the canvas wrapper", () => {
+			render(<WorkflowCanvas {...defaultProps} />);
+			expect(screen.getByTestId("workflow-canvas")).toBeInTheDocument();
+		});
 
-	it("accepts custom className", () => {
-		render(
-			<WorkflowCanvas {...defaultProps} className="my-custom-class" />,
-		);
-		const wrapper = screen.getByTestId("workflow-canvas");
-		expect(wrapper.className).toContain("my-custom-class");
-	});
-
-	it("renders with nodes and edges without throwing", () => {
-		const nodes = [
-			{
-				id: "n1",
-				type: "default",
-				position: { x: 0, y: 0 },
-				data: { label: "Node 1" },
-			},
-		];
-		const edges = [{ id: "e1", source: "n1", target: "n2" }];
-		expect(() =>
+		it("accepts custom className", () => {
 			render(
-				<WorkflowCanvas
-					{...defaultProps}
-					nodes={nodes}
-					edges={edges}
-				/>,
-			),
-		).not.toThrow();
+				<WorkflowCanvas {...defaultProps} className="my-custom-class" />,
+			);
+			const wrapper = screen.getByTestId("workflow-canvas");
+			expect(wrapper.className).toContain("my-custom-class");
+		});
+
+		it("renders with nodes and edges without throwing", () => {
+			const nodes = [
+				{
+					id: "n1",
+					type: "default",
+					position: { x: 0, y: 0 },
+					data: { label: "Node 1" },
+				},
+			];
+			const edges = [{ id: "e1", source: "n1", target: "n2" }];
+			expect(() =>
+				render(
+					<WorkflowCanvas
+						{...defaultProps}
+						nodes={nodes}
+						edges={edges}
+					/>,
+				),
+			).not.toThrow();
+		});
+	});
+
+	describe("readOnly mode", () => {
+		it("does not show view-mode badge by default", () => {
+			render(<WorkflowCanvas {...defaultProps} />);
+			expect(screen.queryByTestId("readonly-badge")).not.toBeInTheDocument();
+		});
+
+		it("shows view-mode badge when readOnly is true", () => {
+			render(<WorkflowCanvas {...defaultProps} readOnly />);
+			expect(screen.getByTestId("readonly-badge")).toBeInTheDocument();
+		});
+
+		it("displays 'View mode' text in the badge", () => {
+			render(<WorkflowCanvas {...defaultProps} readOnly />);
+			expect(screen.getByText("View mode")).toBeInTheDocument();
+		});
+
+		it("sets data-readonly=false by default", () => {
+			render(<WorkflowCanvas {...defaultProps} />);
+			expect(screen.getByTestId("workflow-canvas")).toHaveAttribute(
+				"data-readonly",
+				"false",
+			);
+		});
+
+		it("sets data-readonly=true when readOnly prop is set", () => {
+			render(<WorkflowCanvas {...defaultProps} readOnly />);
+			expect(screen.getByTestId("workflow-canvas")).toHaveAttribute(
+				"data-readonly",
+				"true",
+			);
+		});
 	});
 });

--- a/ui/src/components/workflows/canvas/WorkflowCanvas.tsx
+++ b/ui/src/components/workflows/canvas/WorkflowCanvas.tsx
@@ -8,6 +8,9 @@
  * Wrap a page-level ancestor in <ReactFlowProvider> when multiple canvas
  * instances need to coexist; for single-canvas pages the provider is
  * included here.
+ *
+ * When `readOnly` is true the canvas disables drag, connect, and delete
+ * interactions while keeping zoom and pan fully functional.
  */
 
 import "@xyflow/react/dist/style.css";
@@ -18,6 +21,7 @@ import {
 	MiniMap,
 	ReactFlow,
 	ReactFlowProvider,
+	useReactFlow,
 	type Edge,
 	type EdgeTypes,
 	type Node,
@@ -27,6 +31,7 @@ import {
 	type OnNodesChange,
 	type ReactFlowInstance,
 } from "@xyflow/react";
+import { useEffect } from "react";
 
 // ---------------------------------------------------------------------------
 // Props
@@ -49,12 +54,51 @@ export interface WorkflowCanvasProps {
 	edgeTypes?: EdgeTypes;
 	/** Optional CSS class applied to the outer wrapper */
 	className?: string;
-	/** Called with the ReactFlowInstance once the canvas is ready */
+	/**
+	 * When true, disables drag, connect, and delete interactions.
+	 * Zoom and pan remain active.  A "View mode" badge is shown.
+	 */
+	readOnly?: boolean;
+	/**
+	 * Called once after React Flow initialises, exposing the instance
+	 * so callers can use helpers such as screenToFlowPosition.
+	 */
 	onInit?: (instance: ReactFlowInstance) => void;
 }
 
 // ---------------------------------------------------------------------------
-// Component
+// Minimap node colour helper
+// ---------------------------------------------------------------------------
+
+function minimapNodeColor(node: Node): string {
+	switch (node.type) {
+		case "trigger":
+			return "var(--th-accent)";
+		case "agent":
+			return "#22c55e"; // green-500 — matches AgentNode running border
+		default:
+			return "var(--th-text-muted)";
+	}
+}
+
+// ---------------------------------------------------------------------------
+// FitViewOnLoad — triggers fitView after layout data is available
+// ---------------------------------------------------------------------------
+
+function FitViewOnLoad({ readOnly }: { readOnly?: boolean }) {
+	const { fitView } = useReactFlow();
+	useEffect(() => {
+		// Small delay lets React Flow measure node sizes before fitting
+		const id = window.setTimeout(() => fitView({ padding: 0.2 }), 50);
+		return () => window.clearTimeout(id);
+		// We only want this to run once on mount
+		// eslint-disable-next-line react-hooks/exhaustive-deps
+	}, [readOnly]);
+	return null;
+}
+
+// ---------------------------------------------------------------------------
+// Inner canvas (must live inside a ReactFlowProvider)
 // ---------------------------------------------------------------------------
 
 function Canvas({
@@ -66,13 +110,25 @@ function Canvas({
 	nodeTypes,
 	edgeTypes,
 	className = "",
+	readOnly = false,
 	onInit,
 }: WorkflowCanvasProps) {
 	return (
 		<div
-			className={`h-full w-full ${className}`}
+			className={`h-full w-full relative ${className}`}
 			data-testid="workflow-canvas"
+			data-readonly={readOnly}
 		>
+			{readOnly && (
+				<div
+					className="absolute top-2 left-2 z-10 flex items-center gap-1.5 rounded-full border border-th-border bg-th-surface px-2.5 py-1 text-xs font-medium text-th-text-muted shadow-sm pointer-events-none"
+					data-testid="readonly-badge"
+				>
+					<span className="h-1.5 w-1.5 rounded-full bg-th-text-muted" />
+					View mode
+				</div>
+			)}
+
 			<ReactFlow
 				nodes={nodes}
 				edges={edges}
@@ -83,9 +139,16 @@ function Canvas({
 				edgeTypes={edgeTypes}
 				onInit={onInit}
 				fitView
-				snapToGrid
+				snapToGrid={!readOnly}
 				snapGrid={[16, 16]}
 				attributionPosition="bottom-right"
+				// Read-only interaction flags
+				nodesDraggable={!readOnly}
+				nodesConnectable={!readOnly}
+				deleteKeyCode={readOnly ? null : "Delete"}
+				// Always allow viewport navigation
+				panOnDrag
+				zoomOnScroll
 				style={{
 					// Map agentd theme tokens to React Flow CSS variables so the
 					// canvas inherits the active colour scheme automatically.
@@ -104,7 +167,7 @@ function Canvas({
 			>
 				<Controls />
 				<MiniMap
-					nodeColor={() => "var(--th-accent)"}
+					nodeColor={minimapNodeColor}
 					maskColor="rgba(0,0,0,0.12)"
 				/>
 				<Background
@@ -113,10 +176,15 @@ function Canvas({
 					size={1}
 					color="var(--th-border)"
 				/>
+				<FitViewOnLoad readOnly={readOnly} />
 			</ReactFlow>
 		</div>
 	);
 }
+
+// ---------------------------------------------------------------------------
+// Public component
+// ---------------------------------------------------------------------------
 
 /**
  * WorkflowCanvas wraps the inner canvas in a ReactFlowProvider so it can be

--- a/ui/src/components/workflows/canvas/index.ts
+++ b/ui/src/components/workflows/canvas/index.ts
@@ -27,3 +27,5 @@ export {
 	saveLayout,
 	loadLayout,
 } from "./serialization";
+export type { AutoLayoutOptions } from "./layout";
+export { autoLayout } from "./layout";

--- a/ui/src/components/workflows/canvas/layout.test.ts
+++ b/ui/src/components/workflows/canvas/layout.test.ts
@@ -1,0 +1,221 @@
+/**
+ * autoLayout tests.
+ *
+ * Covers: empty graph, single pair, multiple pairs, shared agent,
+ * unconnected nodes, LR vs TB direction, and option overrides.
+ */
+
+import { describe, expect, it } from "vitest";
+import type { Edge, Node } from "@xyflow/react";
+import { autoLayout } from "./layout";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function makeNode(id: string, type: "trigger" | "agent" | "other"): Node {
+	return {
+		id,
+		type,
+		position: { x: 0, y: 0 },
+		data: {},
+	};
+}
+
+function makeEdge(id: string, source: string, target: string): Edge {
+	return { id, source, target };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("autoLayout", () => {
+	describe("empty and trivial cases", () => {
+		it("returns empty array unchanged", () => {
+			expect(autoLayout([], [])).toEqual([]);
+		});
+
+		it("returns single trigger with no edges at origin", () => {
+			const nodes = [makeNode("t1", "trigger")];
+			const result = autoLayout(nodes, []);
+			expect(result[0].position).toEqual({ x: 80, y: 0 });
+		});
+
+		it("returns single agent with no edges at agent column", () => {
+			const nodes = [makeNode("a1", "agent")];
+			const result = autoLayout(nodes, []);
+			// Agent with no triggers: group size = 1, slot = 0
+			expect(result[0].position).toEqual({ x: 380, y: 0 });
+		});
+	});
+
+	describe("LR direction (default)", () => {
+		it("places trigger at TRIGGER_X and agent at AGENT_X for single pair", () => {
+			const nodes = [makeNode("t1", "trigger"), makeNode("a1", "agent")];
+			const edges = [makeEdge("e1", "t1", "a1")];
+			const result = autoLayout(nodes, edges);
+			const t1 = result.find((n) => n.id === "t1")!;
+			const a1 = result.find((n) => n.id === "a1")!;
+			expect(t1.position.x).toBe(80);
+			expect(a1.position.x).toBe(380); // 80 + 300
+		});
+
+		it("centers agent beside its single trigger", () => {
+			const nodes = [makeNode("t1", "trigger"), makeNode("a1", "agent")];
+			const edges = [makeEdge("e1", "t1", "a1")];
+			const result = autoLayout(nodes, edges);
+			const t1 = result.find((n) => n.id === "t1")!;
+			const a1 = result.find((n) => n.id === "a1")!;
+			// Single trigger in group: agent should have same y as trigger
+			expect(a1.position.y).toBe(t1.position.y);
+		});
+
+		it("centers agent when two triggers connect to it", () => {
+			const nodes = [
+				makeNode("t1", "trigger"),
+				makeNode("t2", "trigger"),
+				makeNode("a1", "agent"),
+			];
+			const edges = [
+				makeEdge("e1", "t1", "a1"),
+				makeEdge("e2", "t2", "a1"),
+			];
+			const result = autoLayout(nodes, edges);
+			const t1 = result.find((n) => n.id === "t1")!;
+			const t2 = result.find((n) => n.id === "t2")!;
+			const a1 = result.find((n) => n.id === "a1")!;
+			// Agent y should be midpoint of t1 and t2 y positions
+			const expectedY = (t1.position.y + t2.position.y) / 2;
+			expect(a1.position.y).toBe(expectedY);
+		});
+
+		it("separates two agent groups vertically", () => {
+			const nodes = [
+				makeNode("t1", "trigger"),
+				makeNode("a1", "agent"),
+				makeNode("t2", "trigger"),
+				makeNode("a2", "agent"),
+			];
+			const edges = [
+				makeEdge("e1", "t1", "a1"),
+				makeEdge("e2", "t2", "a2"),
+			];
+			const result = autoLayout(nodes, edges);
+			const a1 = result.find((n) => n.id === "a1")!;
+			const a2 = result.find((n) => n.id === "a2")!;
+			// Groups are separated by a gap slot, so a2 must be below a1
+			expect(a2.position.y).toBeGreaterThan(a1.position.y);
+		});
+
+		it("places unconnected trigger below connected groups", () => {
+			const nodes = [
+				makeNode("t1", "trigger"),
+				makeNode("a1", "agent"),
+				makeNode("t2", "trigger"), // unconnected
+			];
+			const edges = [makeEdge("e1", "t1", "a1")];
+			const result = autoLayout(nodes, edges);
+			const t1 = result.find((n) => n.id === "t1")!;
+			const t2 = result.find((n) => n.id === "t2")!;
+			expect(t2.position.y).toBeGreaterThan(t1.position.y);
+		});
+
+		it("respects nodeSpacing option", () => {
+			const nodes = [
+				makeNode("t1", "trigger"),
+				makeNode("t2", "trigger"),
+				makeNode("a1", "agent"),
+			];
+			const edges = [
+				makeEdge("e1", "t1", "a1"),
+				makeEdge("e2", "t2", "a1"),
+			];
+			const result = autoLayout(nodes, edges, { nodeSpacing: 200 });
+			const t1 = result.find((n) => n.id === "t1")!;
+			const t2 = result.find((n) => n.id === "t2")!;
+			expect(t2.position.y - t1.position.y).toBe(200);
+		});
+
+		it("respects rankSpacing option", () => {
+			const nodes = [makeNode("t1", "trigger"), makeNode("a1", "agent")];
+			const edges = [makeEdge("e1", "t1", "a1")];
+			const result = autoLayout(nodes, edges, { rankSpacing: 500 });
+			const t1 = result.find((n) => n.id === "t1")!;
+			const a1 = result.find((n) => n.id === "a1")!;
+			expect(a1.position.x - t1.position.x).toBe(500);
+		});
+
+		it("passes 'other' typed nodes through unchanged", () => {
+			const other = { ...makeNode("o1", "other"), position: { x: 999, y: 888 } };
+			const nodes = [makeNode("t1", "trigger"), other];
+			const result = autoLayout(nodes, []);
+			const o1 = result.find((n) => n.id === "o1")!;
+			expect(o1.position).toEqual({ x: 999, y: 888 });
+		});
+	});
+
+	describe("TB direction", () => {
+		it("places triggers at top row and agents below", () => {
+			const nodes = [makeNode("t1", "trigger"), makeNode("a1", "agent")];
+			const edges = [makeEdge("e1", "t1", "a1")];
+			const result = autoLayout(nodes, edges, { direction: "TB" });
+			const t1 = result.find((n) => n.id === "t1")!;
+			const a1 = result.find((n) => n.id === "a1")!;
+			expect(t1.position.y).toBeLessThan(a1.position.y);
+		});
+
+		it("centers agent horizontally below its trigger group", () => {
+			const nodes = [
+				makeNode("t1", "trigger"),
+				makeNode("t2", "trigger"),
+				makeNode("a1", "agent"),
+			];
+			const edges = [
+				makeEdge("e1", "t1", "a1"),
+				makeEdge("e2", "t2", "a1"),
+			];
+			const result = autoLayout(nodes, edges, { direction: "TB" });
+			const t1 = result.find((n) => n.id === "t1")!;
+			const t2 = result.find((n) => n.id === "t2")!;
+			const a1 = result.find((n) => n.id === "a1")!;
+			const expectedX = (t1.position.x + t2.position.x) / 2;
+			expect(a1.position.x).toBe(expectedX);
+		});
+	});
+
+	describe("shared agent (multiple triggers, one agent)", () => {
+		it("stacks three triggers vertically for one agent in LR", () => {
+			const nodes = [
+				makeNode("t1", "trigger"),
+				makeNode("t2", "trigger"),
+				makeNode("t3", "trigger"),
+				makeNode("a1", "agent"),
+			];
+			const edges = [
+				makeEdge("e1", "t1", "a1"),
+				makeEdge("e2", "t2", "a1"),
+				makeEdge("e3", "t3", "a1"),
+			];
+			const result = autoLayout(nodes, edges);
+			const triggers = result.filter((n) => n.type === "trigger");
+			const ys = triggers.map((n) => n.position.y).sort((a, b) => a - b);
+			// Triggers should be evenly spaced
+			expect(ys[1] - ys[0]).toBe(ys[2] - ys[1]);
+		});
+	});
+
+	describe("duplicate edge prevention", () => {
+		it("does not double-count a trigger connected by two edges to same agent", () => {
+			const nodes = [makeNode("t1", "trigger"), makeNode("a1", "agent")];
+			// Two edges from t1 to a1 — should not place t1 twice
+			const edges = [
+				makeEdge("e1", "t1", "a1"),
+				makeEdge("e2", "t1", "a1"),
+			];
+			const result = autoLayout(nodes, edges);
+			const triggers = result.filter((n) => n.type === "trigger");
+			expect(triggers).toHaveLength(1);
+		});
+	});
+});

--- a/ui/src/components/workflows/canvas/layout.ts
+++ b/ui/src/components/workflows/canvas/layout.ts
@@ -1,0 +1,227 @@
+/**
+ * autoLayout — deterministic left-to-right layout for workflow graphs.
+ *
+ * Positions trigger nodes on the left (rank 0) and agent nodes on the right
+ * (rank 1), grouping triggers that connect to the same agent so the agent
+ * sits centered beside its triggers.  Unconnected triggers are stacked below
+ * all connected groups.
+ *
+ * No external dependency — the workflow graph is always shallow (rank 0 →
+ * rank 1) so a topological sort is not needed.
+ */
+
+import type { Edge, Node } from "@xyflow/react";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface AutoLayoutOptions {
+	/**
+	 * Layout direction.
+	 * - "LR" (default): triggers left, agents right
+	 * - "TB": triggers top, agents bottom
+	 */
+	direction?: "LR" | "TB";
+	/**
+	 * Center-to-center spacing between nodes in the same rank column.
+	 * Default: 120
+	 */
+	nodeSpacing?: number;
+	/**
+	 * Distance between the trigger column and the agent column.
+	 * Default: 300
+	 */
+	rankSpacing?: number;
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const TRIGGER_ORIGIN_LR = 80; // trigger column x offset in LR mode
+const TRIGGER_ORIGIN_TB = 80; // trigger row y offset in TB mode
+
+// ---------------------------------------------------------------------------
+// autoLayout
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns a new array of nodes with updated `position` values.
+ * Nodes that are neither "trigger" nor "agent" type are passed through
+ * with their existing positions.
+ */
+export function autoLayout(
+	nodes: Node[],
+	edges: Edge[],
+	options?: AutoLayoutOptions,
+): Node[] {
+	const { direction = "LR", nodeSpacing = 120, rankSpacing = 300 } =
+		options ?? {};
+
+	if (nodes.length === 0) return nodes;
+
+	const triggerNodes = nodes.filter((n) => n.type === "trigger");
+	const agentNodes = nodes.filter((n) => n.type === "agent");
+	const otherNodes = nodes.filter(
+		(n) => n.type !== "trigger" && n.type !== "agent",
+	);
+
+	// Build agent → [trigger node ids] map (preserves insertion order for
+	// deterministic layout — the order triggers appear in `nodes` is used)
+	const agentTriggers = new Map<string, string[]>();
+	for (const agent of agentNodes) {
+		agentTriggers.set(agent.id, []);
+	}
+	for (const edge of edges) {
+		const src = nodes.find((n) => n.id === edge.source);
+		const tgt = nodes.find((n) => n.id === edge.target);
+		if (src?.type === "trigger" && tgt?.type === "agent") {
+			const list = agentTriggers.get(edge.target);
+			if (list && !list.includes(edge.source)) {
+				list.push(edge.source);
+			}
+		}
+	}
+
+	const placedTriggerIds = new Set(
+		[...agentTriggers.values()].flat(),
+	);
+
+	const positions = new Map<string, { x: number; y: number }>();
+
+	if (direction === "LR") {
+		_layoutLR(
+			agentNodes,
+			triggerNodes,
+			agentTriggers,
+			placedTriggerIds,
+			positions,
+			nodeSpacing,
+			rankSpacing,
+		);
+	} else {
+		_layoutTB(
+			agentNodes,
+			triggerNodes,
+			agentTriggers,
+			placedTriggerIds,
+			positions,
+			nodeSpacing,
+			rankSpacing,
+		);
+	}
+
+	// Pass other node types through unchanged
+	return nodes.map((node) => {
+		if (otherNodes.includes(node)) return node;
+		const pos = positions.get(node.id);
+		return pos ? { ...node, position: pos } : node;
+	});
+}
+
+// ---------------------------------------------------------------------------
+// LR layout (left-to-right): triggers left, agents right
+// ---------------------------------------------------------------------------
+
+function _layoutLR(
+	agentNodes: Node[],
+	triggerNodes: Node[],
+	agentTriggers: Map<string, string[]>,
+	placedTriggerIds: Set<string>,
+	positions: Map<string, { x: number; y: number }>,
+	nodeSpacing: number,
+	rankSpacing: number,
+): void {
+	const TRIGGER_X = TRIGGER_ORIGIN_LR;
+	const AGENT_X = TRIGGER_X + rankSpacing;
+
+	// "slot" is the unit of vertical space; each slot = nodeSpacing px
+	let nextSlot = 0;
+
+	for (const agent of agentNodes) {
+		const tIds = agentTriggers.get(agent.id) ?? [];
+		const groupSize = Math.max(tIds.length, 1);
+		const groupStart = nextSlot;
+
+		// Position each trigger in this group
+		for (let i = 0; i < tIds.length; i++) {
+			positions.set(tIds[i], {
+				x: TRIGGER_X,
+				y: (groupStart + i) * nodeSpacing,
+			});
+		}
+
+		// Center the agent vertically on its trigger group
+		const agentCenterSlot = groupStart + (groupSize - 1) / 2;
+		positions.set(agent.id, {
+			x: AGENT_X,
+			y: agentCenterSlot * nodeSpacing,
+		});
+
+		// Advance past the group, adding one blank slot as a gap
+		nextSlot = groupStart + groupSize + 1;
+	}
+
+	// Unconnected triggers stacked below everything
+	for (const trigger of triggerNodes) {
+		if (!placedTriggerIds.has(trigger.id)) {
+			positions.set(trigger.id, {
+				x: TRIGGER_X,
+				y: nextSlot * nodeSpacing,
+			});
+			nextSlot++;
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// TB layout (top-to-bottom): triggers top, agents bottom
+// ---------------------------------------------------------------------------
+
+function _layoutTB(
+	agentNodes: Node[],
+	triggerNodes: Node[],
+	agentTriggers: Map<string, string[]>,
+	placedTriggerIds: Set<string>,
+	positions: Map<string, { x: number; y: number }>,
+	nodeSpacing: number,
+	rankSpacing: number,
+): void {
+	const TRIGGER_Y = TRIGGER_ORIGIN_TB;
+	const AGENT_Y = TRIGGER_Y + rankSpacing;
+
+	let nextSlot = 0;
+
+	for (const agent of agentNodes) {
+		const tIds = agentTriggers.get(agent.id) ?? [];
+		const groupSize = Math.max(tIds.length, 1);
+		const groupStart = nextSlot;
+
+		for (let i = 0; i < tIds.length; i++) {
+			positions.set(tIds[i], {
+				x: (groupStart + i) * nodeSpacing,
+				y: TRIGGER_Y,
+			});
+		}
+
+		const agentCenterSlot = groupStart + (groupSize - 1) / 2;
+		positions.set(agent.id, {
+			x: agentCenterSlot * nodeSpacing,
+			y: AGENT_Y,
+		});
+
+		nextSlot = groupStart + groupSize + 1;
+	}
+
+	// Unconnected triggers to the right of everything
+	for (const trigger of triggerNodes) {
+		if (!placedTriggerIds.has(trigger.id)) {
+			positions.set(trigger.id, {
+				x: (nextSlot * nodeSpacing) + TRIGGER_ORIGIN_TB,
+				y: TRIGGER_Y,
+			});
+			nextSlot++;
+		}
+	}
+}

--- a/ui/src/layouts/AppShell.tsx
+++ b/ui/src/layouts/AppShell.tsx
@@ -36,6 +36,7 @@ export function AppShell() {
 		readPersistedSidebarState,
 	);
 	const [searchOpen, setSearchOpen] = useState(false);
+	const [fullBleed, setFullBleed] = useState(false);
 
 	const setSidebarOpen = useCallback((open: boolean) => {
 		setSidebarOpenState(open);
@@ -79,6 +80,8 @@ export function AppShell() {
 					searchOpen,
 					openSearch,
 					closeSearch,
+					fullBleed,
+					setFullBleed,
 				}}
 			>
 				<div className="min-h-screen pt-2 pr-2 pb-2 bg-th-nav transition-colors duration-150">

--- a/ui/src/layouts/ContentArea.tsx
+++ b/ui/src/layouts/ContentArea.tsx
@@ -13,7 +13,19 @@ interface ContentAreaProps {
 }
 
 export function ContentArea({ children }: ContentAreaProps) {
-	const { sidebarOpen: _sidebarOpen } = useLayout();
+	const { fullBleed } = useLayout();
+
+	if (fullBleed) {
+		return (
+			<main
+				id="main-content"
+				className="mt-12 overflow-hidden"
+				style={{ height: "calc(100vh - 4rem)" }}
+			>
+				{children}
+			</main>
+		);
+	}
 
 	return (
 		<main

--- a/ui/src/layouts/context.tsx
+++ b/ui/src/layouts/context.tsx
@@ -17,6 +17,13 @@ export interface LayoutContextValue {
 	openSearch: () => void;
 	/** Close the global search palette */
 	closeSearch: () => void;
+	/**
+	 * When true, ContentArea removes its padding/max-width wrapper and fills
+	 * the full available height. Set by pages that need edge-to-edge layout
+	 * (e.g. WorkflowBuilder). Always reset to false on unmount.
+	 */
+	fullBleed: boolean;
+	setFullBleed: (v: boolean) => void;
 }
 
 export const LayoutContext = createContext<LayoutContextValue | null>(null);

--- a/ui/src/pages/workflows/WorkflowBuilder.tsx
+++ b/ui/src/pages/workflows/WorkflowBuilder.tsx
@@ -25,6 +25,7 @@ import {
 } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useNavigate, useParams } from "react-router-dom";
+import { useLayout } from "@/layouts/context";
 import {
 	useEdgesState,
 	useNodesState,
@@ -80,6 +81,13 @@ export function WorkflowBuilder() {
 	const navigate = useNavigate();
 	const { id: editWorkflowId } = useParams<{ id?: string }>();
 	const isEditing = Boolean(editWorkflowId);
+	const { setFullBleed } = useLayout();
+
+	// Fill the viewport — escape ContentArea's padding wrapper
+	useEffect(() => {
+		setFullBleed(true);
+		return () => setFullBleed(false);
+	}, [setFullBleed]);
 
 	// React Flow state
 	const [nodes, setNodes, onNodesChange] = useNodesState<Node>([]);
@@ -336,7 +344,7 @@ export function WorkflowBuilder() {
 
 	return (
 		<div
-			className="flex flex-col h-full"
+			className="flex flex-col h-full my-4"
 			data-testid="workflow-builder"
 		>
 			{/* ── Header ───────────────────────────────────────────────── */}

--- a/ui/src/pages/workflows/WorkflowDetail.tsx
+++ b/ui/src/pages/workflows/WorkflowDetail.tsx
@@ -3,23 +3,35 @@
  *
  * Layout:
  * - Header: name, enabled status, agent, created/updated timestamps, actions
- * - Configuration card: source config, prompt template, poll interval
- * - Dispatch history table
+ * - View toggle: "Details" (default) or "Graph" (read-only canvas)
+ * - Details view: configuration card + dispatch history
+ * - Graph view: read-only WorkflowCanvas with auto-layout
  */
 
-import { ArrowLeft, Edit2, GitFork, RefreshCw, Trash2, Zap } from "lucide-react";
-import { useState } from "react";
+import { ArrowLeft, Edit2, GitFork, LayoutList, RefreshCw, Trash2, Zap } from "lucide-react";
+import { useEffect, useState } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
+import type { Node, Edge } from "@xyflow/react";
 import { HighlightedCode } from "@/components/common";
 import { ConfirmDialog } from "@/components/common/ConfirmDialog";
 import { CardSkeleton } from "@/components/common/LoadingSkeleton";
 import { StatusBadge } from "@/components/common/StatusBadge";
 import { DispatchHistory } from "@/components/workflows/DispatchHistory";
 import { WorkflowForm } from "@/components/workflows/WorkflowForm";
+import { WorkflowCanvas } from "@/components/workflows/canvas/WorkflowCanvas";
+import { workflowNodeTypes, workflowEdgeTypes } from "@/components/workflows/canvas/nodeTypes";
+import { workflowsToGraph } from "@/components/workflows/canvas/serialization";
+import { autoLayout } from "@/components/workflows/canvas/layout";
 import { useAgents } from "@/hooks/useAgents";
 import { useWorkflowDetail } from "@/hooks/useWorkflows";
 import type { CreateWorkflowRequest, TriggerConfig } from "@/types/orchestrator";
 import { getTriggerLabel } from "@/types/orchestrator";
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const VIEW_PREF_KEY = "wf-detail-view";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -117,6 +129,33 @@ export function WorkflowDetail() {
 	const [confirmDelete, setConfirmDelete] = useState(false);
 	const [deleting, setDeleting] = useState(false);
 
+	// View toggle: "details" (default) | "graph"
+	const [view, setView] = useState<"details" | "graph">(() => {
+		try {
+			return (localStorage.getItem(VIEW_PREF_KEY) as "details" | "graph") ?? "details";
+		} catch {
+			return "details";
+		}
+	});
+
+	// Canvas state for graph view (static — read-only canvas)
+	const [graphNodes, setGraphNodes] = useState<Node[]>([]);
+	const [graphEdges, setGraphEdges] = useState<Edge[]>([]);
+
+	// Populate canvas whenever the graph view becomes active or the workflow changes
+	useEffect(() => {
+		if (view !== "graph" || !workflow) return;
+		const { nodes, edges } = workflowsToGraph([workflow], allAgents, undefined);
+		setGraphNodes(autoLayout(nodes, edges));
+		setGraphEdges(edges);
+	}, [view, workflow, allAgents]);
+
+	function toggleView() {
+		const next: "details" | "graph" = view === "details" ? "graph" : "details";
+		try { localStorage.setItem(VIEW_PREF_KEY, next); } catch { /* ignore */ }
+		setView(next);
+	}
+
 	async function handleSave(request: CreateWorkflowRequest) {
 		await updateWorkflow({
 			name: request.name,
@@ -205,6 +244,21 @@ export function WorkflowDetail() {
 					>
 						<RefreshCw size={18} />
 					</button>
+
+					{/* View toggle */}
+					<button
+						type="button"
+						onClick={toggleView}
+						data-testid="view-toggle-btn"
+						className="inline-flex items-center gap-2 rounded-md border border-th-border-strong bg-th-surface px-3 py-2 text-sm font-medium text-th-text-secondary hover:bg-th-surface-hover transition-colors focus-visible:outline-none focus-visible:ring-2 focus:ring-th-focus-ring"
+					>
+						{view === "details" ? (
+							<><GitFork size={15} /><span>Graph view</span></>
+						) : (
+							<><LayoutList size={15} /><span>Details view</span></>
+						)}
+					</button>
+
 					<Link
 						to={`/workflows/${workflow.id}/edit`}
 						data-testid="edit-in-builder-btn"
@@ -232,54 +286,80 @@ export function WorkflowDetail() {
 				</div>
 			</div>
 
-			{/* Configuration card */}
-			<div className="rounded-lg border border-th-border bg-th-surface p-6">
-				<h2 className="text-base font-semibold text-th-text mb-4">
-					Configuration
-				</h2>
-				<dl>
-					<ConfigRow
-						label="Source"
-						value={sourceDetail(workflow.trigger_config)}
+			{/* ── Graph view ─────────────────────────────────────────────────── */}
+			{view === "graph" && (
+				<div
+					className="rounded-lg border border-th-border overflow-hidden"
+					style={{ height: "480px" }}
+					data-testid="graph-view-canvas"
+				>
+					<WorkflowCanvas
+						nodes={graphNodes}
+						edges={graphEdges}
+						onNodesChange={() => {}}
+						onEdgesChange={() => {}}
+						onConnect={() => {}}
+						nodeTypes={workflowNodeTypes}
+						edgeTypes={workflowEdgeTypes}
+						readOnly
+						className="h-full"
 					/>
-					<ConfigRow
-						label="Poll interval"
-						value={
-							workflow.poll_interval_secs < 60
-								? `${workflow.poll_interval_secs}s`
-								: `${Math.round(workflow.poll_interval_secs / 60)}m`
-						}
-					/>
-					<ConfigRow label="Enabled" value={workflow.enabled ? "Yes" : "No"} />
-					<ConfigRow
-						label="Created"
-						value={formatDateTime(workflow.created_at)}
-					/>
-					<ConfigRow
-						label="Updated"
-						value={formatDateTime(workflow.updated_at)}
-					/>
-					<ConfigRow
-						label="Prompt template"
-						value={
-							<HighlightedCode
-								code={workflow.prompt_template}
-								language="markdown"
-								maxHeight="8rem"
-								className="border border-th-border"
-							/>
-						}
-					/>
-				</dl>
-			</div>
+				</div>
+			)}
 
-			{/* Dispatch history */}
-			<div className="rounded-lg border border-th-border bg-th-surface p-6">
-				<h2 className="text-base font-semibold text-th-text mb-4">
-					Dispatch history
-				</h2>
-				<DispatchHistory workflowId={workflow.id} />
-			</div>
+			{/* ── Details view ───────────────────────────────────────────────── */}
+			{view === "details" && (
+				<>
+					{/* Configuration card */}
+					<div className="rounded-lg border border-th-border bg-th-surface p-6">
+						<h2 className="text-base font-semibold text-th-text mb-4">
+							Configuration
+						</h2>
+						<dl>
+							<ConfigRow
+								label="Source"
+								value={sourceDetail(workflow.trigger_config)}
+							/>
+							<ConfigRow
+								label="Poll interval"
+								value={
+									workflow.poll_interval_secs < 60
+										? `${workflow.poll_interval_secs}s`
+										: `${Math.round(workflow.poll_interval_secs / 60)}m`
+								}
+							/>
+							<ConfigRow label="Enabled" value={workflow.enabled ? "Yes" : "No"} />
+							<ConfigRow
+								label="Created"
+								value={formatDateTime(workflow.created_at)}
+							/>
+							<ConfigRow
+								label="Updated"
+								value={formatDateTime(workflow.updated_at)}
+							/>
+							<ConfigRow
+								label="Prompt template"
+								value={
+									<HighlightedCode
+										code={workflow.prompt_template}
+										language="markdown"
+										maxHeight="8rem"
+										className="border border-th-border"
+									/>
+								}
+							/>
+						</dl>
+					</div>
+
+					{/* Dispatch history */}
+					<div className="rounded-lg border border-th-border bg-th-surface p-6">
+						<h2 className="text-base font-semibold text-th-text mb-4">
+							Dispatch history
+						</h2>
+						<DispatchHistory workflowId={workflow.id} />
+					</div>
+				</>
+			)}
 
 			{/* Edit dialog */}
 			<WorkflowForm

--- a/ui/src/test/pages/WorkflowBuilder.test.tsx
+++ b/ui/src/test/pages/WorkflowBuilder.test.tsx
@@ -38,6 +38,8 @@ vi.mock("@xyflow/react", async (importOriginal) => {
 		MiniMap: () => null,
 		Controls: () => null,
 		Background: () => null,
+		// FitViewOnLoad calls useReactFlow; stub it so tests don't need a real provider
+		useReactFlow: () => ({ fitView: vi.fn() }),
 	};
 });
 

--- a/ui/src/test/pages/WorkflowBuilder.test.tsx
+++ b/ui/src/test/pages/WorkflowBuilder.test.tsx
@@ -44,6 +44,24 @@ vi.mock("@xyflow/react", async (importOriginal) => {
 });
 
 // ---------------------------------------------------------------------------
+// Mock LayoutContext — WorkflowBuilder calls setFullBleed on mount
+// ---------------------------------------------------------------------------
+
+const mockSetFullBleed = vi.fn();
+vi.mock("@/layouts/context", () => ({
+	useLayout: () => ({
+		sidebarOpen: true,
+		toggleSidebar: vi.fn(),
+		setSidebarOpen: vi.fn(),
+		searchOpen: false,
+		openSearch: vi.fn(),
+		closeSearch: vi.fn(),
+		fullBleed: false,
+		setFullBleed: mockSetFullBleed,
+	}),
+}));
+
+// ---------------------------------------------------------------------------
 // Mock hooks and services
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Adds read-only canvas mode to WorkflowCanvas (disables drag/connect/delete, shows 'View mode' badge, color-codes minimap by node type), implements a dependency-free LR/TB auto-layout algorithm, and adds a graph/details toggle to WorkflowDetail with localStorage preference persistence.

Closes #1102