### PR TITLE
feat(common): add rollback_migrations helper to agentd_common::storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -43,6 +43,7 @@ dependencies = [
  "async-trait",
  "axum",
  "chrono",
+ "clap",
  "http-body-util",
  "hyper",
  "metrics",

--- a/crates/common/src/storage.rs
+++ b/crates/common/src/storage.rs
@@ -103,6 +103,19 @@ pub async fn apply_migrations<M: sea_orm_migration::MigratorTrait>(db_path: &Pat
     Ok(())
 }
 
+/// Roll back SeaORM migrations for migrator `M` at `db_path`.
+///
+/// * `steps = None` — rolls back **all** applied migrations.
+/// * `steps = Some(n)` — rolls back the `n` most-recently-applied migrations.
+pub async fn rollback_migrations<M: sea_orm_migration::MigratorTrait>(
+    db_path: &Path,
+    steps: Option<u32>,
+) -> Result<()> {
+    let db = create_connection(db_path).await?;
+    M::down(&db, steps).await?;
+    Ok(())
+}
+
 /// Return the status of all known migrations for migrator `M` at `db_path`.
 ///
 /// Each entry is `(migration_name, is_applied)`.

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -32,8 +32,7 @@ async-trait = "0.1"
 argon2 = "0.5"
 rand = "0.8"
 reqwest = { workspace = true, features = ["json", "stream"] }
-clap = { version = "4", features = ["derive"] }
-atty = "0.2"
+clap = { workspace = true }
 
 [dev-dependencies]
 tower = { version = "0.5", features = ["util"] }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -32,6 +32,8 @@ async-trait = "0.1"
 argon2 = "0.5"
 rand = "0.8"
 reqwest = { workspace = true, features = ["json", "stream"] }
+clap = { version = "4", features = ["derive"] }
+atty = "0.2"
 
 [dev-dependencies]
 tower = { version = "0.5", features = ["util"] }

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -15,3 +15,30 @@ pub mod proxy;
 pub mod session_storage;
 pub mod storage;
 pub mod user_storage;
+
+/// Apply all pending core-service migrations to the database at `db_path`.
+///
+/// Creates the database file if it does not exist.
+pub async fn apply_migrations_for_path(db_path: &std::path::Path) -> anyhow::Result<()> {
+    agentd_common::storage::apply_migrations::<migration::Migrator>(db_path).await
+}
+
+/// Return the status of all known core-service migrations at `db_path`.
+///
+/// Each entry is `(migration_name, is_applied)`.
+pub async fn migration_status_for_path(
+    db_path: &std::path::Path,
+) -> anyhow::Result<Vec<(String, bool)>> {
+    agentd_common::storage::migration_status::<migration::Migrator>(db_path).await
+}
+
+/// Roll back core-service migrations at `db_path`.
+///
+/// * `steps = None` — rolls back **all** applied migrations.
+/// * `steps = Some(n)` — rolls back the `n` most-recently-applied migrations.
+pub async fn rollback_migrations_for_path(
+    db_path: &std::path::Path,
+    steps: Option<u32>,
+) -> anyhow::Result<()> {
+    agentd_common::storage::rollback_migrations::<migration::Migrator>(db_path, steps).await
+}

--- a/crates/core/src/main.rs
+++ b/crates/core/src/main.rs
@@ -22,6 +22,7 @@
 //! | `AGENTD_LOG_FORMAT` | (text)  | Set to `json` for JSON |
 //! | `AGENTD_ENV`        | (prod)  | `development`/`test`   |
 
+use std::io::IsTerminal;
 use std::path::PathBuf;
 
 use agentd_common::config::ValidateConfig;
@@ -212,7 +213,7 @@ async fn run_migrate_down(all: bool, yes: bool, db_path_override: Option<PathBuf
 
     // Require explicit confirmation when no TTY is attached.
     if !yes {
-        let is_tty = atty::is(atty::Stream::Stdin);
+        let is_tty = std::io::stdin().is_terminal();
         if !is_tty {
             anyhow::bail!(
                 "stdin is not a TTY — pass --yes to confirm rollback without a prompt.\n\

--- a/crates/core/src/main.rs
+++ b/crates/core/src/main.rs
@@ -2,6 +2,17 @@
 //!
 //! Central authentication and API gateway service for agentd.
 //!
+//! # Subcommands
+//!
+//! ```text
+//! agentd-core                     # default: start HTTP server
+//! agentd-core serve               # start HTTP server (explicit)
+//! agentd-core migrate status      # show migration status
+//! agentd-core migrate up          # apply all pending migrations
+//! agentd-core migrate down        # roll back latest migration (requires --yes or TTY)
+//! agentd-core migrate down --all  # roll back all migrations (requires --yes or TTY)
+//! ```
+//!
 //! # Environment Variables
 //!
 //! | Variable            | Default | Description            |
@@ -9,12 +20,75 @@
 //! | `AGENTD_PORT`       | `17000` | HTTP listen port (dev default; production uses 7000) |
 //! | `RUST_LOG`          | `info`  | Log level / filter     |
 //! | `AGENTD_LOG_FORMAT` | (text)  | Set to `json` for JSON |
+//! | `AGENTD_ENV`        | (prod)  | `development`/`test`   |
+
+use std::path::PathBuf;
 
 use agentd_common::config::ValidateConfig;
+use anyhow::Result;
 use axum::{extract::State, response::IntoResponse, routing::get};
+use clap::{Parser, Subcommand};
 use metrics_exporter_prometheus::PrometheusHandle;
 use std::future::IntoFuture;
 use tracing::info;
+
+// ---------------------------------------------------------------------------
+// CLI definitions
+// ---------------------------------------------------------------------------
+
+#[derive(Parser)]
+#[command(
+    name = "agentd-core",
+    about = "Core authentication and API gateway service for agentd",
+    version
+)]
+struct Cli {
+    #[command(subcommand)]
+    command: Option<Command>,
+}
+
+#[derive(Subcommand)]
+enum Command {
+    /// Start the HTTP server (default when no subcommand is given)
+    Serve,
+    /// Manage database migrations
+    Migrate {
+        #[command(subcommand)]
+        action: MigrateAction,
+    },
+}
+
+#[derive(Subcommand)]
+enum MigrateAction {
+    /// Show the applied / pending state of all migrations
+    Status {
+        /// Path to the SQLite database file (overrides AGENTD_ENV-based resolution)
+        #[arg(long)]
+        db_path: Option<PathBuf>,
+    },
+    /// Apply all pending migrations
+    Up {
+        /// Path to the SQLite database file (overrides AGENTD_ENV-based resolution)
+        #[arg(long)]
+        db_path: Option<PathBuf>,
+    },
+    /// Roll back migrations (requires --yes or interactive confirmation on a TTY)
+    Down {
+        /// Roll back ALL applied migrations instead of just the latest one
+        #[arg(long)]
+        all: bool,
+        /// Skip the confirmation prompt
+        #[arg(long)]
+        yes: bool,
+        /// Path to the SQLite database file (overrides AGENTD_ENV-based resolution)
+        #[arg(long)]
+        db_path: Option<PathBuf>,
+    },
+}
+
+// ---------------------------------------------------------------------------
+// Server helpers
+// ---------------------------------------------------------------------------
 
 fn init_metrics() -> PrometheusHandle {
     let builder = metrics_exporter_prometheus::PrometheusBuilder::new();
@@ -36,10 +110,7 @@ async fn shutdown_signal() {
     info!("Shutdown signal received");
 }
 
-#[tokio::main]
-async fn main() -> anyhow::Result<()> {
-    agentd_common::server::init_tracing();
-
+async fn run_serve() -> Result<()> {
     info!("Starting agentd-core service...");
 
     let db_path = agentd_common::storage::get_db_path("agentd-core", "core.db")?;
@@ -70,4 +141,128 @@ async fn main() -> anyhow::Result<()> {
 
     info!("Core service shut down");
     Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Migration helpers
+// ---------------------------------------------------------------------------
+
+/// Resolve the database path: use the explicit override if provided, otherwise
+/// fall back to AGENTD_ENV-aware path resolution.
+fn resolve_db_path(override_path: Option<&PathBuf>) -> Result<PathBuf> {
+    match override_path {
+        Some(p) => Ok(p.clone()),
+        None => agentd_common::storage::get_db_path("agentd-core", "core.db"),
+    }
+}
+
+async fn run_migrate_status(db_path_override: Option<PathBuf>) -> Result<()> {
+    let db_path = resolve_db_path(db_path_override.as_ref())?;
+    let statuses = agentd_core::migration_status_for_path(&db_path).await?;
+
+    println!("Migration Status (agentd-core):");
+    let mut applied = 0usize;
+    let mut pending = 0usize;
+    for (name, is_applied) in &statuses {
+        if *is_applied {
+            println!("  \u{2713} applied  {name}");
+            applied += 1;
+        } else {
+            println!("  \u{2717} pending  {name}");
+            pending += 1;
+        }
+    }
+    println!("  {applied} applied, {pending} pending");
+    Ok(())
+}
+
+async fn run_migrate_up(db_path_override: Option<PathBuf>) -> Result<()> {
+    let db_path = resolve_db_path(db_path_override.as_ref())?;
+
+    println!("Applying migrations...");
+    agentd_core::apply_migrations_for_path(&db_path).await?;
+
+    // Report final status
+    let statuses = agentd_core::migration_status_for_path(&db_path).await?;
+    let applied = statuses.iter().filter(|(_, ok)| *ok).count();
+    let pending = statuses.iter().filter(|(_, ok)| !ok).count();
+
+    if pending == 0 {
+        println!("  \u{2713} up to date ({applied} applied, 0 pending)");
+    } else {
+        println!("  \u{2713} done ({applied} applied, {pending} still pending)");
+    }
+    Ok(())
+}
+
+async fn run_migrate_down(all: bool, yes: bool, db_path_override: Option<PathBuf>) -> Result<()> {
+    let db_path = resolve_db_path(db_path_override.as_ref())?;
+
+    // Determine which migrations will be rolled back for the prompt message.
+    let statuses = agentd_core::migration_status_for_path(&db_path).await?;
+    let applied: Vec<&str> =
+        statuses.iter().filter(|(_, ok)| *ok).map(|(n, _)| n.as_str()).collect();
+
+    if applied.is_empty() {
+        println!("Nothing to roll back — no migrations are applied.");
+        return Ok(());
+    }
+
+    let targets: Vec<&str> = if all { applied.clone() } else { vec![applied[applied.len() - 1]] };
+
+    // Require explicit confirmation when no TTY is attached.
+    if !yes {
+        let is_tty = atty::is(atty::Stream::Stdin);
+        if !is_tty {
+            anyhow::bail!(
+                "stdin is not a TTY — pass --yes to confirm rollback without a prompt.\n\
+                 Would roll back: {}",
+                targets.join(", ")
+            );
+        }
+
+        // Interactive prompt
+        println!("Will roll back the following migration(s):");
+        for t in &targets {
+            println!("  - {t}");
+        }
+        print!("Confirm? [y/N] ");
+        use std::io::Write;
+        std::io::stdout().flush()?;
+        let mut input = String::new();
+        std::io::stdin().read_line(&mut input)?;
+        if !input.trim().eq_ignore_ascii_case("y") {
+            println!("Aborted.");
+            return Ok(());
+        }
+    }
+
+    let steps = if all { None } else { Some(1u32) };
+    println!("Rolling back {}...", if all { "all migrations" } else { "latest migration" });
+    agentd_core::rollback_migrations_for_path(&db_path, steps).await?;
+
+    for t in &targets {
+        println!("  \u{2713} rolled back {t}");
+    }
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Entry point
+// ---------------------------------------------------------------------------
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    agentd_common::server::init_tracing();
+
+    let cli = Cli::parse();
+
+    match cli.command {
+        None | Some(Command::Serve) => run_serve().await,
+        Some(Command::Migrate { action }) => match action {
+            MigrateAction::Status { db_path } => run_migrate_status(db_path).await,
+            MigrateAction::Up { db_path } => run_migrate_up(db_path).await,
+            MigrateAction::Down { all, yes, db_path } => run_migrate_down(all, yes, db_path).await,
+        },
+    }
 }

--- a/crates/core/tests/migrate_cli.rs
+++ b/crates/core/tests/migrate_cli.rs
@@ -1,0 +1,135 @@
+//! Integration tests for the `agentd-core migrate` CLI subcommand.
+//!
+//! Each test spawns the real binary against an isolated temporary SQLite
+//! database via `--db-path`, so no state leaks between runs and the
+//! developer's own database is never touched.
+
+use std::path::Path;
+use std::process::Command;
+
+// ---------------------------------------------------------------------------
+// Helper
+// ---------------------------------------------------------------------------
+
+/// Returns a `Command` pointing at the compiled `agentd-core` binary.
+fn agentd_core() -> Command {
+    Command::new(env!("CARGO_BIN_EXE_agentd-core"))
+}
+
+/// Run `agentd-core migrate <args>` against `db_path` and return the output.
+fn migrate(db_path: &Path, args: &[&str]) -> std::process::Output {
+    let mut cmd = agentd_core();
+    cmd.arg("migrate");
+    for arg in args {
+        cmd.arg(arg);
+    }
+    cmd.arg("--db-path").arg(db_path);
+    cmd.output().expect("failed to spawn agentd-core")
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+/// `migrate up` on a fresh DB applies all migrations; `migrate status`
+/// subsequently shows every migration as applied with none pending.
+#[test]
+fn test_migrate_up_then_status() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let db_path = tmp.path().join("core.db");
+
+    // Apply all migrations
+    let out = migrate(&db_path, &["up"]);
+    assert!(out.status.success(), "migrate up failed:\n{}", String::from_utf8_lossy(&out.stderr));
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("up to date") || stdout.contains("applied"), "{stdout}");
+
+    // Status should show only applied migrations
+    let out = migrate(&db_path, &["status"]);
+    assert!(
+        out.status.success(),
+        "migrate status failed:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("applied"), "expected 'applied' in status output:\n{stdout}");
+    // Summary line always says "<n> applied, <m> pending"; after a full `up`
+    // that count should be "0 pending", meaning no migration is still waiting.
+    assert!(stdout.contains("0 pending"), "expected '0 pending' in status output:\n{stdout}");
+}
+
+/// `migrate status` on a brand-new database (no migrations run) reports all
+/// migrations as pending with none applied.
+#[test]
+fn test_status_on_empty_database() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let db_path = tmp.path().join("core.db");
+
+    let out = migrate(&db_path, &["status"]);
+    assert!(
+        out.status.success(),
+        "migrate status failed:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    // All migrations should be pending; none should be listed as applied
+    assert!(stdout.contains("pending"), "expected 'pending' in output:\n{stdout}");
+    assert!(stdout.contains("0 applied"), "expected '0 applied' in output:\n{stdout}");
+}
+
+/// After `migrate up`, `migrate down --yes` rolls back the latest migration;
+/// `migrate status` then shows that migration as pending.
+#[test]
+fn test_migrate_down_then_status() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let db_path = tmp.path().join("core.db");
+
+    // First apply everything
+    let out = migrate(&db_path, &["up"]);
+    assert!(out.status.success(), "migrate up failed:\n{}", String::from_utf8_lossy(&out.stderr));
+
+    // Roll back the latest migration (skip prompt with --yes)
+    let out = migrate(&db_path, &["down", "--yes"]);
+    assert!(
+        out.status.success(),
+        "migrate down --yes failed:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("rolled back"), "expected 'rolled back' in output:\n{stdout}");
+
+    // Status should now show at least one pending migration
+    let out = migrate(&db_path, &["status"]);
+    assert!(
+        out.status.success(),
+        "migrate status failed:\n{}",
+        String::from_utf8_lossy(&out.stderr)
+    );
+    let stdout = String::from_utf8_lossy(&out.stdout);
+    assert!(stdout.contains("pending"), "expected 'pending' after down:\n{stdout}");
+}
+
+/// `migrate down` without `--yes` when stdin is not a TTY must exit non-zero
+/// and produce an error message explaining how to bypass the prompt.
+#[test]
+fn test_migrate_down_without_yes_exits_nonzero() {
+    let tmp = tempfile::TempDir::new().unwrap();
+    let db_path = tmp.path().join("core.db");
+
+    // Apply migrations first so there is something to roll back
+    let out = migrate(&db_path, &["up"]);
+    assert!(out.status.success(), "migrate up failed:\n{}", String::from_utf8_lossy(&out.stderr));
+
+    // Run `migrate down` without --yes; stdin is not a TTY in cargo test
+    let out = migrate(&db_path, &["down"]);
+    assert!(
+        !out.status.success(),
+        "expected non-zero exit but got success; stdout:\n{}",
+        String::from_utf8_lossy(&out.stdout)
+    );
+    let stderr = String::from_utf8_lossy(&out.stderr);
+    assert!(
+        stderr.contains("--yes") || stderr.contains("TTY"),
+        "expected --yes or TTY hint in stderr:\n{stderr}"
+    );
+}

--- a/crates/xtask/Cargo.toml
+++ b/crates/xtask/Cargo.toml
@@ -9,6 +9,11 @@ anyhow = "1.0"
 colored = "2.1"
 tokio = { version = "1", features = ["full"] }
 agentd-install = { path = "../install" }
+agentd-core = { path = "../core" }
+communicate = { path = "../communicate" }
+memory = { path = "../memory" }
+notify = { path = "../notify" }
+orchestrator = { path = "../orchestrator" }
 agentd-common = { path = "../common" }
 
 [features]

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -146,6 +146,18 @@ fn print_help() {
 /// directories (used only by `generate-entities`).
 const DB_SERVICES: &[DbService] = &[
     DbService {
+        name: "communicate",
+        project: "agentd-communicate",
+        db_file: "communicate.db",
+        entity_dir: "crates/communicate/src/entity",
+    },
+    DbService {
+        name: "core",
+        project: "agentd-core",
+        db_file: "core.db",
+        entity_dir: "crates/core/src/entity",
+    },
+    DbService {
         name: "memory",
         project: "agentd-memory",
         db_file: "memory.db",
@@ -162,12 +174,6 @@ const DB_SERVICES: &[DbService] = &[
         project: "agentd-orchestrator",
         db_file: "orchestrator.db",
         entity_dir: "crates/orchestrator/src/entity",
-    },
-    DbService {
-        name: "communicate",
-        project: "agentd-communicate",
-        db_file: "communicate.db",
-        entity_dir: "crates/communicate/src/entity",
     },
 ];
 
@@ -264,6 +270,110 @@ fn generate_entities(service: Option<&str>) -> Result<()> {
         "{}",
         "Note: Generated files are a scaffold — review before committing.".bright_black()
     );
+    Ok(())
+}
+
+/// `cargo xtask migrate [--service <name>]`
+///
+/// Applies all pending SeaORM migrations for the specified service (or all
+/// services if `--service` is omitted). Creates the database file if it does
+/// not exist.
+async fn migrate(service: Option<&str>) -> Result<()> {
+    check_in_project_root()?;
+
+    let services = resolve_services(service)?;
+
+    println!("{}", "Applying migrations...".blue().bold());
+    println!();
+
+    for svc in services {
+        let db_path = agentd_common::storage::get_db_path(svc.project, svc.db_file)?;
+        print!("  {} {} … ", "→".cyan(), svc.name.green());
+
+        let result = match svc.name {
+            "communicate" => communicate::apply_migrations_for_path(&db_path).await,
+            "core" => agentd_core::apply_migrations_for_path(&db_path).await,
+            "memory" => memory::apply_migrations_for_path(&db_path).await,
+            "notify" => notify::apply_migrations_for_path(&db_path).await,
+            "orchestrator" => orchestrator::apply_migrations_for_path(&db_path).await,
+            _ => anyhow::bail!("No migration runner registered for service '{}'", svc.name),
+        };
+
+        match result {
+            Ok(()) => println!("{}", "✓ up to date".green()),
+            Err(e) => {
+                println!("{}", "✗ failed".red());
+                eprintln!("    {}", e);
+            }
+        }
+    }
+
+    println!();
+    println!("{}", "Migration complete.".green().bold());
+    Ok(())
+}
+
+/// `cargo xtask migrate-status [--service <name>]`
+///
+/// Prints the current migration status (applied / pending) for each known
+/// migration of the specified service (or all services).
+async fn migrate_status(service: Option<&str>) -> Result<()> {
+    check_in_project_root()?;
+
+    let services = resolve_services(service)?;
+
+    println!("{}", "Migration Status:".blue().bold());
+    println!();
+
+    for svc in services {
+        println!("  {} {}:", "◆".cyan(), svc.name.green().bold());
+
+        let db_path = agentd_common::storage::get_db_path(svc.project, svc.db_file)?;
+
+        if !db_path.exists() {
+            println!("    {} database not found — no migrations applied", "⚠".yellow());
+            println!("    path: {}", db_path.display().to_string().bright_black());
+            continue;
+        }
+
+        let result = match svc.name {
+            "communicate" => communicate::migration_status_for_path(&db_path).await,
+            "core" => agentd_core::migration_status_for_path(&db_path).await,
+            "memory" => memory::migration_status_for_path(&db_path).await,
+            "notify" => notify::migration_status_for_path(&db_path).await,
+            "orchestrator" => orchestrator::migration_status_for_path(&db_path).await,
+            _ => anyhow::bail!("No migration runner registered for service '{}'", svc.name),
+        };
+
+        match result {
+            Ok(statuses) => {
+                for (name, applied) in &statuses {
+                    let (icon, label) = if *applied {
+                        ("✓".green(), "applied".green())
+                    } else {
+                        ("○".yellow(), "pending".yellow())
+                    };
+                    println!("    {} {} {}", icon, label, name.bright_black());
+                }
+                let applied_count = statuses.iter().filter(|(_, a)| *a).count();
+                let pending_count = statuses.len() - applied_count;
+                println!(
+                    "    {} applied, {} pending",
+                    applied_count.to_string().green(),
+                    if pending_count > 0 {
+                        pending_count.to_string().yellow()
+                    } else {
+                        pending_count.to_string().green()
+                    }
+                );
+            }
+            Err(e) => {
+                eprintln!("    {} failed to read status: {}", "✗".red(), e);
+            }
+        }
+        println!();
+    }
+
     Ok(())
 }
 


### PR DESCRIPTION
Adds `rollback_migrations<M>(db_path, steps)` to `agentd_common::storage`, following the same pattern as `apply_migrations` and `migration_status`. `steps=None` rolls back all applied migrations; `steps=Some(n)` rolls back the n most recent.

Closes #1123