### PR TITLE
epic: add built-in agent support

### DIFF
--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -36,6 +36,7 @@ pub mod memory;
 pub mod notify;
 pub mod orchestrator;
 pub mod prompt;
+pub mod system_agents;
 pub mod wrap;
 
 pub use ask::AskCommand;
@@ -45,4 +46,5 @@ pub use memory::MemoryCommand;
 pub use notify::NotifyCommand;
 pub use orchestrator::OrchestratorCommand;
 pub use prompt::PromptCommand;
+pub use system_agents::SystemAgentsCommand;
 pub use wrap::WrapCommand;

--- a/crates/cli/src/commands/orchestrator.rs
+++ b/crates/cli/src/commands/orchestrator.rs
@@ -89,12 +89,22 @@ pub enum TriggerType {
 pub enum OrchestratorCommand {
     /// List all managed agents.
     ///
-    /// Returns all agents tracked by the orchestrator, optionally filtered
-    /// by status (pending, running, stopped, failed).
+    /// Returns user-created agents tracked by the orchestrator, optionally
+    /// filtered by status (pending, running, stopped, failed).
+    ///
+    /// Built-in system agents are excluded by default — use `agent system-agents list`
+    /// for a dedicated system-agent view, or pass `--include-builtin` to see all agents.
     ListAgents {
         /// Filter by agent status (pending, running, stopped, failed)
         #[arg(long)]
         status: Option<String>,
+        /// Include built-in system agents in the output.
+        ///
+        /// By default system agents are hidden from this list and visible only
+        /// via `agent system-agents list`. Pass this flag to see all agents
+        /// in a single table (useful for admin and debugging).
+        #[arg(long)]
+        include_builtin: bool,
     },
 
     /// Create a new agent.
@@ -868,8 +878,8 @@ impl OrchestratorCommand {
     /// * `json` - If true, output raw JSON instead of formatted text
     pub async fn execute(&self, client: &OrchestratorClient, json: bool) -> Result<()> {
         match self {
-            OrchestratorCommand::ListAgents { status } => {
-                list_agents(client, status.as_deref(), json).await
+            OrchestratorCommand::ListAgents { status, include_builtin } => {
+                list_agents(client, status.as_deref(), *include_builtin, json).await
             }
             OrchestratorCommand::CreateAgent {
                 name,
@@ -1062,8 +1072,16 @@ impl OrchestratorCommand {
 
 // -- Agent operations --
 
-async fn list_agents(client: &OrchestratorClient, status: Option<&str>, json: bool) -> Result<()> {
-    let response = client.list_agents(status).await.context("Failed to list agents")?;
+async fn list_agents(
+    client: &OrchestratorClient,
+    status: Option<&str>,
+    include_builtin: bool,
+    json: bool,
+) -> Result<()> {
+    let response = client
+        .list_agents_filtered(status, include_builtin)
+        .await
+        .context("Failed to list agents")?;
     let agents = response.items;
 
     if json {

--- a/crates/cli/src/commands/system_agents.rs
+++ b/crates/cli/src/commands/system_agents.rs
@@ -1,0 +1,324 @@
+//! System-agent CLI command implementations.
+//!
+//! Provides the `agent system-agents` subcommand group for interacting with
+//! built-in system agents.  System agents are distinct from user-created
+//! agents: they are spawned automatically by the orchestrator at startup,
+//! are always present while the service is running, and cannot be deleted
+//! via the user-facing API.
+//!
+//! # Available Subcommands
+//!
+//! - **list** — list all built-in system agents
+//! - **get** — show full details for a specific system agent
+//! - **message** — send a prompt to a running system agent
+//! - **status** — compact status summary of all system agents
+//!
+//! # Examples
+//!
+//! ```bash
+//! agent system-agents list
+//! agent system-agents list --json
+//! agent system-agents get agentd-system
+//! agent system-agents message agentd-system "What services are running?"
+//! agent system-agents status
+//! ```
+
+use anyhow::{Context, Result};
+use clap::Subcommand;
+use colored::*;
+use uuid::Uuid;
+
+use orchestrator::client::OrchestratorClient;
+use orchestrator::types::{AgentResponse, AgentStatus, SendMessageRequest, ToolPolicy};
+
+/// Subcommand group for interacting with built-in system agents.
+///
+/// System agents are created programmatically by the orchestrator at startup
+/// and are always available while the service is running.  Use `agent list`
+/// for user-created agents instead.
+#[derive(Subcommand)]
+pub enum SystemAgentsCommand {
+    /// List all built-in system agents.
+    ///
+    /// Fetches from `GET /system-agents` which returns only agents marked as
+    /// built-in.  These are distinct from user-created agents and are managed
+    /// automatically by the orchestrator.
+    ///
+    /// # Examples
+    ///
+    /// ```bash
+    /// agent system-agents list
+    /// agent system-agents list --json
+    /// ```
+    List,
+
+    /// Show full details for a specific system agent.
+    ///
+    /// Accepts either the agent's UUID or its name (e.g., `agentd-system`).
+    ///
+    /// # Examples
+    ///
+    /// ```bash
+    /// agent system-agents get agentd-system
+    /// agent system-agents get 550e8400-e29b-41d4-a716-446655440000
+    /// ```
+    Get {
+        /// Agent UUID or name
+        id: String,
+    },
+
+    /// Send a prompt to a running system agent.
+    ///
+    /// Accepts either the agent's UUID or its name.  The agent must be in the
+    /// `running` state to accept messages.
+    ///
+    /// # Examples
+    ///
+    /// ```bash
+    /// agent system-agents message agentd-system "What services are running?"
+    /// agent system-agents message agentd-system "Explain the agent lifecycle"
+    /// ```
+    Message {
+        /// Agent UUID or name
+        id: String,
+        /// The prompt to send to the agent
+        message: String,
+    },
+
+    /// Show a compact status summary of all system agents.
+    ///
+    /// Displays name, status, model, and activity state in a compact table.
+    /// Useful for a quick health check of the built-in agent layer.
+    ///
+    /// # Examples
+    ///
+    /// ```bash
+    /// agent system-agents status
+    /// ```
+    Status,
+}
+
+impl SystemAgentsCommand {
+    /// Dispatch to the appropriate handler.
+    pub async fn execute(&self, client: &OrchestratorClient, json: bool) -> Result<()> {
+        match self {
+            SystemAgentsCommand::List => list_system_agents(client, json).await,
+            SystemAgentsCommand::Get { id } => get_system_agent(client, id, json).await,
+            SystemAgentsCommand::Message { id, message } => {
+                message_system_agent(client, id, message, json).await
+            }
+            SystemAgentsCommand::Status => system_agents_status(client, json).await,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Handlers
+// ---------------------------------------------------------------------------
+
+/// `agent system-agents list` — list all built-in system agents.
+async fn list_system_agents(client: &OrchestratorClient, json: bool) -> Result<()> {
+    let agents = client.list_system_agents().await.context("Failed to list system agents")?;
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&agents)?);
+        return Ok(());
+    }
+
+    if agents.is_empty() {
+        println!("{}", "No system agents found.".yellow());
+        println!(
+            "{}",
+            "The orchestrator may still be starting up. Try again in a moment.".dimmed()
+        );
+        return Ok(());
+    }
+
+    println!("{}", "System Agents:".blue().bold());
+    println!("{}", "=".repeat(80).cyan());
+    for agent in &agents {
+        display_system_agent(agent);
+        println!("{}", "-".repeat(80).cyan());
+    }
+    println!("Total: {} system agent(s)", agents.len());
+
+    Ok(())
+}
+
+/// `agent system-agents get <id>` — show full details for a system agent.
+async fn get_system_agent(client: &OrchestratorClient, id: &str, json: bool) -> Result<()> {
+    let agent = resolve_system_agent(client, id).await?;
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&agent)?);
+        return Ok(());
+    }
+
+    display_system_agent(&agent);
+    Ok(())
+}
+
+/// `agent system-agents message <id> <text>` — send a prompt to a system agent.
+async fn message_system_agent(
+    client: &OrchestratorClient,
+    id: &str,
+    message: &str,
+    json: bool,
+) -> Result<()> {
+    let agent = resolve_system_agent(client, id).await?;
+
+    if agent.status != AgentStatus::Running {
+        anyhow::bail!(
+            "System agent '{}' is not running (status: {}). \
+             Wait for the orchestrator to bootstrap it.",
+            agent.name,
+            agent.status
+        );
+    }
+
+    let request = SendMessageRequest { content: message.to_string() };
+    let response =
+        client.send_message(&agent.id, &request).await.context("Failed to send message")?;
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&response)?);
+    } else {
+        println!("{}", "Message sent.".green());
+        println!("{}: {}", "Agent".bold(), agent.name.bright_white());
+        println!("{}: {}", "Status".bold(), response.status);
+    }
+
+    Ok(())
+}
+
+/// `agent system-agents status` — compact status summary.
+async fn system_agents_status(client: &OrchestratorClient, json: bool) -> Result<()> {
+    let agents = client.list_system_agents().await.context("Failed to fetch system agents")?;
+
+    if json {
+        // Emit a compact summary array.
+        let summaries: Vec<_> = agents
+            .iter()
+            .map(|a| {
+                serde_json::json!({
+                    "name": a.name,
+                    "status": a.status,
+                    "model": a.config.model,
+                    "activity": a.activity,
+                    "built_in": a.built_in,
+                })
+            })
+            .collect();
+        println!("{}", serde_json::to_string_pretty(&summaries)?);
+        return Ok(());
+    }
+
+    if agents.is_empty() {
+        println!("{}", "No system agents found.".yellow());
+        return Ok(());
+    }
+
+    println!("{}", "System Agent Status:".blue().bold());
+    println!("{}", "=".repeat(60).cyan());
+
+    let name_w = 24usize;
+    let status_w = 10usize;
+    let model_w = 20usize;
+
+    println!(
+        "{:<name_w$} {:<status_w$} {:<model_w$} {}",
+        "Name".bold(),
+        "Status".bold(),
+        "Model".bold(),
+        "Activity".bold(),
+    );
+    println!("{}", "-".repeat(60).dimmed());
+
+    for agent in &agents {
+        let status_str = agent.status.to_string();
+        let colored_status: colored::ColoredString = match agent.status {
+            AgentStatus::Running => status_str.green(),
+            AgentStatus::Pending => status_str.yellow(),
+            AgentStatus::Stopped => status_str.red(),
+            AgentStatus::Failed => status_str.bright_red(),
+        };
+        let model = agent.config.model.as_deref().unwrap_or("default");
+        let activity = format!("{:?}", agent.activity).to_lowercase();
+
+        println!(
+            "{:<name_w$} {:<status_w$} {:<model_w$} {}",
+            agent.name.bright_white(),
+            colored_status,
+            model,
+            activity,
+        );
+    }
+
+    println!("{}", "-".repeat(60).dimmed());
+    let running = agents.iter().filter(|a| a.status == AgentStatus::Running).count();
+    println!("Total: {} system agent(s), {} running", agents.len(), running);
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Resolve a system agent by UUID or name.
+///
+/// Fetches the full system-agent list and looks up by ID prefix or exact name.
+/// Returns an error if no match is found.
+async fn resolve_system_agent(client: &OrchestratorClient, id: &str) -> Result<AgentResponse> {
+    // Try UUID parse first.
+    if let Ok(uuid) = Uuid::parse_str(id) {
+        let all = client.list_system_agents().await.context("Failed to list system agents")?;
+        return all.into_iter().find(|a| a.id == uuid).ok_or_else(|| {
+            anyhow::anyhow!("System agent '{}' not found", id)
+        });
+    }
+
+    // Fall back to name lookup.
+    let all = client.list_system_agents().await.context("Failed to list system agents")?;
+    all.into_iter()
+        .find(|a| a.name == id)
+        .ok_or_else(|| anyhow::anyhow!("System agent '{}' not found", id))
+}
+
+/// Display a single system agent in human-readable format.
+fn display_system_agent(agent: &AgentResponse) {
+    println!("{}: {}", "ID".bold(), agent.id);
+    println!("{}: {} {}", "Name".bold(), agent.name.bright_white(), "[system]".cyan().dimmed());
+    let status_str = agent.status.to_string();
+    let colored_status = match agent.status {
+        AgentStatus::Running => status_str.green(),
+        AgentStatus::Pending => status_str.yellow(),
+        AgentStatus::Stopped => status_str.red(),
+        AgentStatus::Failed => status_str.bright_red(),
+    };
+    println!("{}: {}", "Status".bold(), colored_status);
+    if let Some(ref model) = agent.config.model {
+        println!("{}: {}", "Model".bold(), model.cyan());
+    }
+    if let Some(ref session) = agent.session_id {
+        println!("{}: {}", "Session".bold(), session);
+    }
+    println!("{}: {}", "Working Dir".bold(), agent.config.working_dir);
+    if !agent.config.rooms.is_empty() {
+        println!("{}: {}", "Rooms".bold(), agent.config.rooms.join(", ").cyan());
+    }
+    let policy_str = match &agent.config.tool_policy {
+        ToolPolicy::AllowAll { .. } => "allow_all".green().to_string(),
+        ToolPolicy::DenyAll { .. } => "deny_all".red().to_string(),
+        ToolPolicy::AllowList { tools, .. } => {
+            format!("allow_list ({} tools)", tools.len())
+        }
+        ToolPolicy::DenyList { tools, .. } => {
+            format!("deny_list ({} tools)", tools.len())
+        }
+        ToolPolicy::RequireApproval { .. } => "require_approval".bright_yellow().to_string(),
+    };
+    println!("{}: {}", "Tool Policy".bold(), policy_str);
+    println!("{}: {}", "Built-in".bold(), "yes".cyan());
+    println!("{}: {}", "Created".bold(), agent.created_at);
+}

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -84,7 +84,7 @@ use colored::*;
 use commands::index::IndexClient;
 use commands::{
     AskCommand, CommunicateCommand, IndexCommand, MemoryCommand, NotifyCommand,
-    OrchestratorCommand, PromptCommand, WrapCommand,
+    OrchestratorCommand, PromptCommand, SystemAgentsCommand, WrapCommand,
 };
 use communicate::client::CommunicateClient;
 use memory::client::MemoryClient;
@@ -304,6 +304,26 @@ enum Commands {
         #[command(subcommand)]
         command: IndexCommand,
     },
+
+    /// Interact with built-in system agents.
+    ///
+    /// System agents are spawned automatically by the orchestrator at startup
+    /// and are always present while the service is running.  They are distinct
+    /// from user-created agents and cannot be deleted via the API.
+    ///
+    /// # Examples
+    ///
+    /// ```bash
+    /// agent system-agents list
+    /// agent system-agents get agentd-system
+    /// agent system-agents message agentd-system "What services are running?"
+    /// agent system-agents status
+    /// ```
+    #[command(name = "system-agents")]
+    SystemAgents {
+        #[command(subcommand)]
+        command: Box<SystemAgentsCommand>,
+    },
 }
 
 /// Main entry point for the agent CLI.
@@ -427,6 +447,12 @@ async fn main() -> Result<()> {
             let url = env::var("AGENTD_INDEX_SERVICE_URL")
                 .unwrap_or_else(|_| "http://localhost:17012".to_string());
             let client = IndexClient::new(url);
+            command.execute(&client, cli.json).await?;
+        }
+        Commands::SystemAgents { command } => {
+            let url = env::var("AGENTD_ORCHESTRATOR_SERVICE_URL")
+                .unwrap_or_else(|_| "http://localhost:7006".to_string());
+            let client = OrchestratorClient::new(url);
             command.execute(&client, cli.json).await?;
         }
     }

--- a/crates/orchestrator/src/api.rs
+++ b/crates/orchestrator/src/api.rs
@@ -231,7 +231,7 @@ async fn create_agent(
         rooms: req.rooms,
     };
 
-    let agent = state.manager.spawn_agent(req.name, config).await?;
+    let agent = state.manager.spawn_agent(req.name, config, false).await?;
 
     metrics::counter!("agents_created_total").increment(1);
 

--- a/crates/orchestrator/src/api.rs
+++ b/crates/orchestrator/src/api.rs
@@ -172,9 +172,7 @@ async fn list_agents(
 /// Returns only agents with `built_in = true`. These agents are created
 /// programmatically by the orchestrator at startup and are always present
 /// while the service is running.
-async fn list_system_agents(
-    State(state): State<ApiState>,
-) -> Result<impl IntoResponse, ApiError> {
+async fn list_system_agents(State(state): State<ApiState>) -> Result<impl IntoResponse, ApiError> {
     let agents = state.manager.list_system_agents().await?;
     let mut items: Vec<AgentResponse> = Vec::with_capacity(agents.len());
     for agent in agents {
@@ -253,6 +251,12 @@ async fn terminate_agent(
     State(state): State<ApiState>,
     Path(id): Path<Uuid>,
 ) -> Result<impl IntoResponse, ApiError> {
+    // Guard: built-in system agents cannot be deleted via the API.
+    let existing = state.manager.get_agent(&id).await?.ok_or(ApiError::NotFound)?;
+    if existing.built_in {
+        return Err(ApiError::Forbidden("built-in system agents cannot be deleted".to_string()));
+    }
+
     let agent = state.manager.terminate_agent(&id).await?;
 
     metrics::counter!("agents_terminated_total").increment(1);

--- a/crates/orchestrator/src/api.rs
+++ b/crates/orchestrator/src/api.rs
@@ -63,6 +63,7 @@ pub fn create_router(state: ApiState) -> Router {
         .route("/health", get(health_check))
         .route("/info", get(backend_info))
         .route("/agents", get(list_agents).post(create_agent))
+        .route("/system-agents", get(list_system_agents))
         .route("/agents/{id}", get(get_agent).delete(terminate_agent))
         .route("/agents/{id}/message", post(send_message))
         .route("/agents/{id}/restart", post(restart_agent))
@@ -100,6 +101,12 @@ pub struct ListQuery {
     pub status: Option<String>,
     pub limit: Option<usize>,
     pub offset: Option<usize>,
+    /// When `true`, include built-in system agents in the response.
+    ///
+    /// By default `GET /agents` excludes system agents — they are listed
+    /// separately via `GET /system-agents`.  Pass `?include_builtin=true`
+    /// to include them (e.g., for admin or debug tooling).
+    pub include_builtin: Option<bool>,
 }
 
 async fn health_check(State(state): State<ApiState>) -> impl IntoResponse {
@@ -139,7 +146,16 @@ async fn list_agents(
     let limit = clamp_limit(query.limit);
     let offset = query.offset.unwrap_or(0);
 
-    let (agents, total) = state.manager.list_agents_paginated(status_filter, limit, offset).await?;
+    // By default exclude built-in system agents from the user-facing list.
+    // Pass ?include_builtin=true to see all agents regardless of the flag.
+    let built_in_filter = if query.include_builtin.unwrap_or(false) {
+        None // no filter — return everything
+    } else {
+        Some(false) // exclude system agents
+    };
+
+    let (agents, total) =
+        state.manager.list_agents_paginated(status_filter, built_in_filter, limit, offset).await?;
     let mut items: Vec<AgentResponse> = Vec::with_capacity(agents.len());
     for agent in agents {
         let id = agent.id;
@@ -149,6 +165,25 @@ async fn list_agents(
     }
 
     Ok(Json(PaginatedResponse { items, total, limit, offset }))
+}
+
+/// `GET /system-agents` — list all built-in system agents.
+///
+/// Returns only agents with `built_in = true`. These agents are created
+/// programmatically by the orchestrator at startup and are always present
+/// while the service is running.
+async fn list_system_agents(
+    State(state): State<ApiState>,
+) -> Result<impl IntoResponse, ApiError> {
+    let agents = state.manager.list_system_agents().await?;
+    let mut items: Vec<AgentResponse> = Vec::with_capacity(agents.len());
+    for agent in agents {
+        let id = agent.id;
+        let mut response = AgentResponse::from(agent);
+        response.activity = state.registry.get_activity_state(&id).await;
+        items.push(response);
+    }
+    Ok(Json(items))
 }
 
 async fn create_agent(

--- a/crates/orchestrator/src/client.rs
+++ b/crates/orchestrator/src/client.rs
@@ -100,9 +100,29 @@ impl OrchestratorClient {
         &self,
         status: Option<&str>,
     ) -> Result<PaginatedResponse<AgentResponse>> {
-        let path = match status {
-            Some(s) => format!("/agents?status={}", s),
-            None => "/agents".to_string(),
+        self.list_agents_filtered(status, false).await
+    }
+
+    /// List agents with optional status filter and built-in inclusion.
+    ///
+    /// When `include_builtin` is `true`, passes `?include_builtin=true` so that
+    /// system agents are included alongside user agents.
+    pub async fn list_agents_filtered(
+        &self,
+        status: Option<&str>,
+        include_builtin: bool,
+    ) -> Result<PaginatedResponse<AgentResponse>> {
+        let mut params: Vec<String> = Vec::new();
+        if let Some(s) = status {
+            params.push(format!("status={}", s));
+        }
+        if include_builtin {
+            params.push("include_builtin=true".to_string());
+        }
+        let path = if params.is_empty() {
+            "/agents".to_string()
+        } else {
+            format!("/agents?{}", params.join("&"))
         };
         self.get(&path).await
     }

--- a/crates/orchestrator/src/client.rs
+++ b/crates/orchestrator/src/client.rs
@@ -107,6 +107,15 @@ impl OrchestratorClient {
         self.get(&path).await
     }
 
+    /// List built-in system agents.
+    ///
+    /// Fetches from `GET /system-agents` which returns only agents with
+    /// `built_in = true`. These are the programmatically-managed agents
+    /// always present during orchestrator operation.
+    pub async fn list_system_agents(&self) -> Result<Vec<AgentResponse>> {
+        self.get("/system-agents").await
+    }
+
     /// Create a new agent.
     pub async fn create_agent(&self, request: &CreateAgentRequest) -> Result<AgentResponse> {
         self.post("/agents", request).await

--- a/crates/orchestrator/src/entity/agent.rs
+++ b/crates/orchestrator/src/entity/agent.rs
@@ -61,6 +61,10 @@ pub struct Model {
     /// OS process ID of the agent's subprocess. Used during startup
     /// reconciliation to check if the process survived a service restart.
     pub pid: Option<i64>,
+    /// Whether this agent is a built-in system agent. Stored as INTEGER (0/1).
+    /// System agents are created programmatically and managed by the orchestrator;
+    /// user-created agents always have this set to 0.
+    pub built_in: i32,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/crates/orchestrator/src/lib.rs
+++ b/crates/orchestrator/src/lib.rs
@@ -30,6 +30,7 @@ pub mod message_bridge;
 pub(crate) mod migration;
 pub mod scheduler;
 pub mod storage;
+pub mod system_agents;
 pub mod types;
 pub mod websocket;
 

--- a/crates/orchestrator/src/main.rs
+++ b/crates/orchestrator/src/main.rs
@@ -6,6 +6,7 @@ mod message_bridge;
 mod migration;
 mod scheduler;
 mod storage;
+mod system_agents;
 mod types;
 mod websocket;
 
@@ -379,6 +380,12 @@ async fn main() -> anyhow::Result<()> {
     // endpoint instead of failing because the port isn't bound yet.
     if let Err(e) = manager.reconcile().await {
         error!(%e, "Agent reconciliation failed");
+    }
+
+    // Bootstrap built-in system agents after reconciliation so that surviving
+    // user agents are handled first, and the system agent session URL is valid.
+    if let Err(e) = manager.bootstrap_system_agents().await {
+        error!(%e, "System agent bootstrap failed");
     }
 
     // Periodic reconciliation: detect agents whose processes died after startup.

--- a/crates/orchestrator/src/manager.rs
+++ b/crates/orchestrator/src/manager.rs
@@ -44,8 +44,18 @@ impl AgentManager {
     /// started in long-running SDK mode and the initial prompt is sent via the
     /// WebSocket once the agent connects. This keeps the agent alive for
     /// follow-up messages.
-    pub async fn spawn_agent(&self, name: String, config: AgentConfig) -> anyhow::Result<Agent> {
+    /// Spawn a new agent.
+    ///
+    /// `built_in` — when `true`, marks the agent as a programmatically-managed
+    /// system agent that cannot be deleted via the user-facing API.
+    pub async fn spawn_agent(
+        &self,
+        name: String,
+        config: AgentConfig,
+        built_in: bool,
+    ) -> anyhow::Result<Agent> {
         let mut agent = Agent::new(name, config);
+        agent.built_in = built_in;
         let session_name = format!("{}-{}", self.backend.prefix(), agent.id);
 
         // Persist agent record.
@@ -204,6 +214,16 @@ impl AgentManager {
         let mut agent =
             self.storage.get(id).await?.ok_or_else(|| anyhow::anyhow!("Agent not found"))?;
 
+        // System agents are managed by the orchestrator and must not be
+        // deleted via the user-facing API.
+        if agent.built_in {
+            anyhow::bail!(
+                "Cannot terminate built-in system agent '{}'. \
+                 System agents are managed by the orchestrator.",
+                agent.name
+            );
+        }
+
         if let Some(ref session) = agent.session_id {
             if let Err(e) = self.backend.kill_session(session).await {
                 warn!(agent_id = %id, %e, "Failed to kill session");
@@ -220,6 +240,67 @@ impl AgentManager {
         info!(agent_id = %id, "Agent terminated and record deleted");
 
         Ok(agent)
+    }
+
+    /// Bootstrap built-in system agents at orchestrator startup.
+    ///
+    /// Called once after [`reconcile`] so that reconciliation has already
+    /// handled any surviving user agents before we insert/restart system agents.
+    ///
+    /// Behaviour:
+    /// 1. Query storage for existing built-in agents.
+    /// 2. If the system agent exists and is `Running` → skip (reconcile handled it).
+    /// 3. If it exists but is `Stopped` or `Failed` → restart it.
+    /// 4. If it doesn't exist → create it via `spawn_agent()` with `built_in: true`.
+    pub async fn bootstrap_system_agents(&self) -> anyhow::Result<()> {
+        use crate::system_agents::build_system_agent_config;
+        use crate::system_agents::SYSTEM_AGENT_NAME;
+
+        let existing = self.storage.list_system_agents().await?;
+        let system_agent = existing.into_iter().find(|a| a.name == SYSTEM_AGENT_NAME);
+
+        match system_agent {
+            Some(agent) if agent.status == AgentStatus::Running => {
+                // Reconciliation already handled it — nothing to do.
+                info!(
+                    agent_id = %agent.id,
+                    "System agent '{}' is already running, skipping bootstrap",
+                    SYSTEM_AGENT_NAME
+                );
+            }
+            Some(agent) => {
+                // Exists but stopped/failed — restart it.
+                info!(
+                    agent_id = %agent.id,
+                    status = %agent.status,
+                    "Restarting system agent '{}'",
+                    SYSTEM_AGENT_NAME
+                );
+                if let Err(e) = self.restart_agent(&agent).await {
+                    error!(
+                        agent_id = %agent.id,
+                        %e,
+                        "Failed to restart system agent '{}'",
+                        SYSTEM_AGENT_NAME
+                    );
+                }
+            }
+            None => {
+                // First run — create the system agent.
+                info!("Bootstrapping system agent '{}'", SYSTEM_AGENT_NAME);
+                let config = build_system_agent_config();
+                match self.spawn_agent(SYSTEM_AGENT_NAME.to_string(), config, true).await {
+                    Ok(agent) => {
+                        info!(agent_id = %agent.id, "System agent '{}' spawned", SYSTEM_AGENT_NAME)
+                    }
+                    Err(e) => {
+                        error!(%e, "Failed to spawn system agent '{}'", SYSTEM_AGENT_NAME)
+                    }
+                }
+            }
+        }
+
+        Ok(())
     }
 
     /// Reconcile DB state with actual backend sessions and WebSocket connections on startup.

--- a/crates/orchestrator/src/manager.rs
+++ b/crates/orchestrator/src/manager.rs
@@ -453,13 +453,27 @@ impl AgentManager {
     }
 
     /// List agents with pagination.
+    ///
+    /// `built_in_filter`:
+    /// - `Some(false)` — exclude system agents (use for `GET /agents`)
+    /// - `Some(true)` — only system agents (use for `GET /system-agents`)
+    /// - `None` — all agents regardless of flag (use for debug/admin views)
     pub async fn list_agents_paginated(
         &self,
         status: Option<AgentStatus>,
+        built_in_filter: Option<bool>,
         limit: usize,
         offset: usize,
     ) -> anyhow::Result<(Vec<Agent>, usize)> {
-        self.storage.list_paginated(status, limit, offset).await
+        self.storage.list_paginated(status, built_in_filter, limit, offset).await
+    }
+
+    /// List all built-in system agents (newest first).
+    ///
+    /// Returns agents created programmatically by the orchestrator at startup.
+    /// Used by `GET /system-agents`.
+    pub async fn list_system_agents(&self) -> anyhow::Result<Vec<Agent>> {
+        self.storage.list_system_agents().await
     }
 
     /// Update an agent record in storage.

--- a/crates/orchestrator/src/migration/m20260415_000013_add_builtin_to_agents.rs
+++ b/crates/orchestrator/src/migration/m20260415_000013_add_builtin_to_agents.rs
@@ -1,0 +1,33 @@
+//! Migration: add `built_in` column to the `agents` table.
+//!
+//! Adds one column:
+//! - `built_in` (INTEGER NOT NULL DEFAULT 0): distinguishes programmatically-created
+//!   system agents (`1`) from user-created agents (`0`).  All existing rows receive
+//!   the default value of `0` so that no data migration is needed.
+
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let db = manager.get_connection();
+
+        let stmt = "ALTER TABLE agents ADD COLUMN built_in INTEGER NOT NULL DEFAULT 0";
+        if let Err(e) = db.execute_unprepared(stmt).await {
+            // Idempotent: ignore if column already exists (e.g., re-run).
+            if !e.to_string().contains("duplicate column name") {
+                return Err(e);
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn down(&self, _manager: &SchemaManager) -> Result<(), DbErr> {
+        // SQLite < 3.35.0 does not support DROP COLUMN.
+        Ok(())
+    }
+}

--- a/crates/orchestrator/src/migration/mod.rs
+++ b/crates/orchestrator/src/migration/mod.rs
@@ -23,6 +23,7 @@ mod m20260323_000009_add_launch_command_to_agents;
 mod m20260324_000010_add_system_prompt_fields_to_agents;
 mod m20260328_000011_add_task_queue;
 mod m20260411_000012_add_pid_to_agents;
+mod m20260415_000013_add_builtin_to_agents;
 
 /// The migration runner — applies all known migrations in order.
 pub struct Migrator;
@@ -43,6 +44,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20260324_000010_add_system_prompt_fields_to_agents::Migration),
             Box::new(m20260328_000011_add_task_queue::Migration),
             Box::new(m20260411_000012_add_pid_to_agents::Migration),
+            Box::new(m20260415_000013_add_builtin_to_agents::Migration),
         ]
     }
 }

--- a/crates/orchestrator/src/storage.rs
+++ b/crates/orchestrator/src/storage.rs
@@ -198,6 +198,11 @@ impl AgentStorage {
     }
 
     /// Lists all agents, optionally filtered by status (newest first).
+    ///
+    /// This method returns **all** agents regardless of the `built_in` flag.
+    /// It is used internally by reconciliation and debug endpoints that need
+    /// the complete picture. Use [`list_paginated`] with a `built_in_filter`
+    /// for user-facing listing where system agents should be excluded.
     pub async fn list(&self, status_filter: Option<AgentStatus>) -> Result<Vec<Agent>> {
         let mut query =
             agent_entity::Entity::find().order_by(agent_entity::Column::CreatedAt, Order::Desc);
@@ -207,6 +212,19 @@ impl AgentStorage {
         }
 
         let models: Vec<agent_entity::Model> = query.all(&self.db).await?;
+        models.into_iter().map(model_to_agent).collect()
+    }
+
+    /// Lists only system agents (`built_in = true`), newest first.
+    ///
+    /// Used by the `GET /system-agents` endpoint and the system-agent bootstrap
+    /// to check whether the built-in agent already exists.
+    pub async fn list_system_agents(&self) -> Result<Vec<Agent>> {
+        let models: Vec<agent_entity::Model> = agent_entity::Entity::find()
+            .filter(agent_entity::Column::BuiltIn.eq(1i32))
+            .order_by(agent_entity::Column::CreatedAt, Order::Desc)
+            .all(&self.db)
+            .await?;
         models.into_iter().map(model_to_agent).collect()
     }
 
@@ -488,16 +506,29 @@ impl AgentStorage {
     }
 
     /// Lists agents with pagination; returns `(items, total_count)`.
+    /// Lists agents with pagination, optional status filter, and optional `built_in` filter.
+    ///
+    /// * `status_filter` — when `Some`, restricts to agents with that status.
+    /// * `built_in_filter` — when `Some(false)`, excludes system agents (default for
+    ///   `GET /agents`); when `Some(true)`, returns only system agents; when `None`,
+    ///   returns all agents regardless of the flag.
     pub async fn list_paginated(
         &self,
         status_filter: Option<AgentStatus>,
+        built_in_filter: Option<bool>,
         limit: usize,
         offset: usize,
     ) -> Result<(Vec<Agent>, usize)> {
-        let condition = match &status_filter {
-            Some(s) => Condition::all().add(agent_entity::Column::Status.eq(s.to_string())),
-            None => Condition::all(),
-        };
+        let mut condition = Condition::all();
+
+        if let Some(s) = &status_filter {
+            condition = condition.add(agent_entity::Column::Status.eq(s.to_string()));
+        }
+
+        if let Some(built_in) = built_in_filter {
+            condition =
+                condition.add(agent_entity::Column::BuiltIn.eq(if built_in { 1i32 } else { 0i32 }));
+        }
 
         let total =
             agent_entity::Entity::find().filter(condition.clone()).count(&self.db).await? as usize;

--- a/crates/orchestrator/src/storage.rs
+++ b/crates/orchestrator/src/storage.rs
@@ -105,6 +105,7 @@ impl AgentStorage {
             ),
             launch_command: Set(agent.launch_command.clone()),
             pid: Set(agent.pid.map(|p| p as i64)),
+            built_in: Set(if agent.built_in { 1 } else { 0 }),
         };
 
         agent_entity::Entity::insert(model).exec(&self.db).await?;
@@ -560,6 +561,7 @@ fn model_to_agent(model: agent_entity::Model) -> Result<Agent> {
         backend_type: model.backend_type,
         launch_command: model.launch_command,
         pid: model.pid.and_then(|p| u32::try_from(p).ok()),
+        built_in: model.built_in != 0,
         created_at: DateTime::parse_from_rfc3339(&model.created_at)?.with_timezone(&Utc),
         updated_at: DateTime::parse_from_rfc3339(&model.updated_at)?.with_timezone(&Utc),
     })

--- a/crates/orchestrator/src/system_agents.rs
+++ b/crates/orchestrator/src/system_agents.rs
@@ -26,11 +26,39 @@ pub const SYSTEM_AGENT_NAME: &str = "agentd-system";
 /// Build the [`AgentConfig`] for the agentd system agent.
 ///
 /// The configuration sets:
-/// - An inline system prompt covering the agentd architecture.
+/// - An inline system prompt covering the agentd architecture and services.
+///   Version/build info is interpolated at call time from `CARGO_PKG_VERSION`.
 /// - A restrictive `AllowList` tool policy (read-only tooling only).
 /// - Automatic membership in the `system` communicate room.
 /// - The `sonnet` model alias.
+///
+/// # Prompt authorship
+///
+/// The prompt is authored to cover:
+/// - Service inventory with ports and responsibilities
+/// - Agent lifecycle (create → spawn → connect → message → terminate)
+/// - Common CLI operations (`agent list`, `agent send-message`, etc.)
+/// - Communicate room system (rooms, members, broadcasting)
+/// - Diagnostics (health checks, log locations, debug endpoints)
+/// - Tool policy rationale (why certain operations are blocked)
+///
+/// # Tool policy rationale
+///
+/// The system agent uses an `AllowList` with read-only tools:
+/// - `Read`, `Grep`, `Glob`, `LS` — file and code inspection
+/// - `Bash(curl *)` — HTTP health checks
+/// - `Bash(git log/status/diff *)` — read-only VCS state inspection
+/// - `Bash(cargo clippy/test/build *)` — compile-time checks
+/// - `Bash(agent *)` — CLI interactions with agentd services
+///
+/// Notably absent: `Write`, `Edit`, `NotebookEdit`, unrestricted `Bash`.
+/// This prevents the system agent from modifying source code, configuration
+/// files, or agent state — it can explain and diagnose but not act.
 pub fn build_system_agent_config() -> AgentConfig {
+    // Include version/build metadata in the prompt so the agent can report it.
+    let version = env!("CARGO_PKG_VERSION");
+    let prompt = format!("agentd version: {version}\n\n{SYSTEM_AGENT_PROMPT}");
+
     AgentConfig {
         working_dir: std::env::current_dir()
             .map(|p| p.to_string_lossy().to_string())
@@ -40,7 +68,7 @@ pub fn build_system_agent_config() -> AgentConfig {
         interactive: false,
         prompt: None,
         worktree: false,
-        system_prompt: Some(SYSTEM_AGENT_PROMPT.to_string()),
+        system_prompt: Some(prompt),
         system_prompt_file: None,
         append_system_prompt: false,
         tool_policy: system_agent_tool_policy(),
@@ -58,29 +86,39 @@ pub fn build_system_agent_config() -> AgentConfig {
 
 /// Restrictive tool policy for the system agent.
 ///
-/// Uses an allowlist of read-only tools.  No `Write`, `Edit`, `NotebookEdit`,
-/// or unconstrained `Bash` is permitted — the agent can read the codebase and
-/// check service health but cannot modify anything.
+/// Uses an `AllowList` of read-only tools.  Absent tools are denied automatically:
+/// - `Write`, `Edit`, `NotebookEdit` — no file modifications
+/// - Unrestricted `Bash` — only specific safe subcommands are permitted
+/// - `TodoWrite` — no task-list manipulation
+///
+/// The allowlist entries map directly to the documented policy in
+/// [`SYSTEM_AGENT_PROMPT`].  Update both in tandem if the policy changes.
 fn system_agent_tool_policy() -> ToolPolicy {
     ToolPolicy::AllowList {
         tools: vec![
-            // Navigation and search
+            // ── File and code navigation ──────────────────────────────────
             "Read".to_string(),
             "Grep".to_string(),
             "Glob".to_string(),
             "LS".to_string(),
-            // Restricted bash: only safe read-only commands
+            // ── Safe bash subcommands (read-only) ─────────────────────────
+            // HTTP health checks and API reads
             "Bash(curl *)".to_string(),
+            // Basic filesystem inspection
             "Bash(cat *)".to_string(),
             "Bash(ls *)".to_string(),
+            // Process inspection
             "Bash(ps *)".to_string(),
             "Bash(echo *)".to_string(),
+            // Read-only VCS state
             "Bash(git log *)".to_string(),
             "Bash(git status*)".to_string(),
             "Bash(git diff *)".to_string(),
+            // Rust build and analysis (read-only; no publish/install)
             "Bash(cargo clippy *)".to_string(),
             "Bash(cargo test *)".to_string(),
             "Bash(cargo build *)".to_string(),
+            // agentd CLI — list, get, search, message (no destructive ops)
             "Bash(agent *)".to_string(),
         ],
         sandbox_bypass: vec![],
@@ -89,96 +127,229 @@ fn system_agent_tool_policy() -> ToolPolicy {
 
 /// System prompt for the agentd-system agent.
 ///
-/// This prompt is embedded as a compile-time constant so it is version-controlled
-/// with the code.  Keep it under 8 000 tokens (≈ 30 000 characters).
+/// Embedded as a compile-time constant so it is version-controlled with the
+/// code and requires no files on disk.  The version line is prepended
+/// dynamically in [`build_system_agent_config`].
 ///
-/// The full authoring of this prompt is tracked in issue #1142.
+/// # Content coverage
+///
+/// - Service inventory: names, ports, responsibilities
+/// - Agent lifecycle: create → spawn → connect → message → terminate
+/// - Status and activity states
+/// - Common CLI operations (agent, agent communicate, agent memory)
+/// - Communicate room system: rooms, members, broadcasting
+/// - Diagnostics: health checks, log locations, debug endpoints
+/// - Metrics interpretation (Prometheus)
+/// - Tool policy rationale: what the agent can and cannot do
+///
+/// # Token budget
+///
+/// Target: under 6 000 tokens (≈ 24 000 characters). The version prefix
+/// adds ~20 tokens.  Review periodically and trim if this grows.
 const SYSTEM_AGENT_PROMPT: &str = "\
-You are the agentd system agent — a domain expert on the agentd platform.
+You are the agentd system agent — a built-in, always-present domain expert
+on the agentd platform.
 
-# Your Role
+─────────────────────────────────────────────────────────────────────────────
+YOUR ROLE
+─────────────────────────────────────────────────────────────────────────────
 
-You assist users and other agents by answering questions about the agentd
-architecture, diagnosing issues, explaining how services interact, and
-providing guidance on common operations.  You do NOT modify code or
-configuration files.
+You assist users and other agents by:
+- Answering questions about agentd architecture, configuration, and operation
+- Diagnosing issues with agents, workflows, and services
+- Explaining how services interact and what each is responsible for
+- Providing CLI commands and API calls the user should run
+- Reading and interpreting logs, metrics, and database state
 
-# Architecture Overview
+You do NOT modify code, configuration files, or agent state.  If asked to
+perform a destructive or state-changing operation, explain why you cannot do
+it and give the exact command the user should run instead.
 
-agentd is a Rust workspace of microservices that together provide an
-AI-agent orchestration platform:
+─────────────────────────────────────────────────────────────────────────────
+SERVICE INVENTORY
+─────────────────────────────────────────────────────────────────────────────
 
-| Service         | Port  | Description                                      |
-|-----------------|-------|--------------------------------------------------|
-| orchestrator    | 7006  | Manages agent lifecycle, WebSocket connections   |
-| communicate     | 17010 | Room-based messaging between agents and users    |
-| memory          | 17008 | Semantic memory store (vector search)            |
-| index           | 17012 | Code-search index (semantic + keyword)           |
-| notify          | 17005 | Notification delivery and routing                |
-| core            | 7010  | Authentication gateway and API proxy             |
-| wrap            | 7007  | Docker/tmux execution backend                    |
+agentd is a Rust workspace of microservices.  All expose `/health` (GET).
 
-All services expose REST APIs and health endpoints at `/health`.
+| Service       | Dev Port | Prod Port | Description                              |
+|---------------|----------|-----------|------------------------------------------|
+| orchestrator  | 17006    | 7006      | Agent lifecycle, WebSocket SDK, policies |
+| core          | 17010    | 7010      | Auth gateway, API proxy                  |
+| communicate   | 17010    | 7010      | Room-based messaging (WebSocket + REST)  |
+| memory        | 17008    | 17008     | Semantic vector memory store             |
+| index         | 17012    | 17012     | Code search (semantic + keyword)         |
+| notify        | 17005    | 17005     | Notification routing and delivery        |
+| wrap          | 17007    | 7007      | Docker/tmux execution backend            |
 
-# Agent Lifecycle
+Note: `AGENTD_ENV=development` or `dev` routes to dev ports.
 
-1. A user or agent sends `POST /agents` to the orchestrator with an `AgentConfig`.
-2. The orchestrator spawns a Claude Code process via the configured backend
-   (tmux or Docker).
-3. Claude Code connects back via WebSocket at `ws://localhost:7006/ws/{agent_id}`.
-4. The orchestrator routes messages, tool approvals, and events over this
-   WebSocket connection.
-5. When an agent completes or is terminated, its record remains in the SQLite
-   database (status = stopped/failed) for auditing.
+─────────────────────────────────────────────────────────────────────────────
+AGENT LIFECYCLE
+─────────────────────────────────────────────────────────────────────────────
 
-# Common Operations
+1. POST /agents          Create agent record and spawn Claude Code process.
+                         Backend: tmux session (default) or Docker container.
+2. WebSocket connect     Claude Code connects back to ws://host:port/ws/{id}.
+3. Tool approval         Orchestrator evaluates tool policy on each tool call.
+4. Messaging             Users/agents send prompts via POST /agents/{id}/message.
+5. Reconciliation        On restart, orchestrator reconciles DB state with
+                         actual backend sessions (restart/mark failed as needed).
+6. Termination           DELETE /agents/{id} kills session, removes DB record.
 
-## Check which agents are running
-```
-agent list
-agent list --status running
-```
+AGENT STATUS VALUES
+  pending  — record created, process not yet spawned
+  running  — Claude process is live and connected
+  stopped  — process exited cleanly (exit code 0)
+  failed   — process crashed or was killed unexpectedly
 
-## Send a message to an agent
-```
-agent send-message <agent-id> \"Your prompt here\"
-```
+ACTIVITY STATE (in-memory, not persisted)
+  idle     — agent waiting for input
+  busy     — agent currently processing a prompt
 
-## Check service health
-```
-curl http://localhost:7006/health
-curl http://localhost:17010/health
-curl http://localhost:17008/health
-```
+BUILT-IN AGENTS
+  Agents with built_in=true are managed by the orchestrator itself.
+  They cannot be deleted via the API. You are one of these agents.
 
-## View agent logs (tmux backend)
-```
-tmux attach -t <session-name>
-```
+─────────────────────────────────────────────────────────────────────────────
+COMMON CLI OPERATIONS
+─────────────────────────────────────────────────────────────────────────────
 
-# Communicate Rooms
+## Agents
+  agent list                              # list user agents (built-in excluded)
+  agent list --status running             # filter by status
+  agent system-agents list                # list system/built-in agents
+  agent system-agents status              # summarise system agent health
+  agent get <id>                          # show full agent details
+  agent send-message <id> \"prompt\"      # send a prompt to a running agent
+  agent restart <id>                      # restart a stopped/failed agent
+  agent delete <id>                       # terminate and remove agent
 
-Agents can join named rooms in the communicate service.  Messages posted to a
-room are broadcast to all members (agents and users).  You are auto-joined to
-the `system` room.  Use `agent communicate` to interact with rooms.
+## Workflows
+  agent workflow list                     # list scheduled workflows
+  agent workflow get <id>                 # show workflow details
 
-# Tool Policy
+## Memory
+  agent memory search \"query\"           # semantic search stored memories
+  agent memory remember \"content\"       # store a memory
+  agent memory list                       # list recent memories
 
-Your tool policy is restrictive by design — you may read files, search code,
-and run safe read-only commands.  You may NOT write or edit files, run
-destructive git commands, restart services, or perform operations that modify
-state.
+## Communication
+  agent communicate room list             # list rooms
+  agent communicate message send <room> \"text\"  # post to a room
+  agent communicate message list <room>   # read room messages
 
-When asked to perform an action you cannot do, explain what you cannot do and
-suggest the appropriate CLI command or API call the user should run instead.
+## Health checks (curl)
+  curl http://localhost:7006/health
+  curl http://localhost:7006/info         # backend type and capabilities
+  curl http://localhost:7006/debug/agents # all agents including built-in
 
-# Diagnostics
+─────────────────────────────────────────────────────────────────────────────
+COMMUNICATE ROOM SYSTEM
+─────────────────────────────────────────────────────────────────────────────
 
-When diagnosing issues, check:
-1. Service health endpoints
-2. Agent status via `agent list`
-3. Recent logs in `tmp/` (development) or the platform log aggregator
-4. Database state via the orchestrator debug endpoint at `GET /debug/agents`
+The communicate service provides persistent, named rooms for agent-to-agent
+and agent-to-user messaging.
 
-Always prefer explaining how to fix an issue over attempting to fix it yourself.
+- Rooms are created on first join (or explicitly via POST /rooms).
+- Messages are broadcast to all current room members in real time.
+- Agents can be members of multiple rooms simultaneously.
+- You are auto-joined to the `system` room at startup.
+
+Room operations (REST):
+  GET    /rooms                 list all rooms
+  POST   /rooms                 create a room
+  GET    /rooms/{id}/messages   fetch message history
+  POST   /rooms/{id}/messages   post a message
+
+─────────────────────────────────────────────────────────────────────────────
+MEMORY SERVICE
+─────────────────────────────────────────────────────────────────────────────
+
+The memory service stores agent knowledge as vector embeddings for semantic
+search.  Memories have a type (information, question, request), visibility
+(public, shared, private), and optional tags.
+
+All agents can search public memories.  Use `agent memory` CLI to interact.
+
+─────────────────────────────────────────────────────────────────────────────
+DIAGNOSING COMMON ISSUES
+─────────────────────────────────────────────────────────────────────────────
+
+## Agent stuck in 'running' but not responding
+1. Check whether the Claude process is still alive:
+     agent get <id>              # check pid field
+     ps -p <pid>
+2. Check the tmux session:
+     tmux ls
+     tmux attach -t <session-name>
+3. Restart the agent:
+     agent restart <id>
+
+## Agent immediately fails on spawn
+1. Check the launch_command field: agent get <id>
+2. Verify working_dir exists and is accessible.
+3. Ensure ANTHROPIC_API_KEY / ANTHROPIC_AUTH_TOKEN is set in agent env.
+4. Check wrap service health: curl http://localhost:7007/health
+
+## WebSocket never connects (agent stays 'pending' or flips to 'failed')
+1. Verify orchestrator is listening: curl http://localhost:7006/health
+2. Check that the SDK URL in launch_command matches the listening address.
+3. Review orchestrator logs for WebSocket handshake errors.
+
+## Workflow not firing
+1. List workflows: agent workflow list
+2. Check trigger configuration (cron, polling interval, event type).
+3. Verify the scheduler loop is running (orchestrator logs at startup).
+
+## Service not reachable
+1. Check if process is running: ps aux | grep agentd
+2. Verify port binding: lsof -i :<port>
+3. Check AGENTD_ENV — dev ports differ from production ports (see table above).
+
+─────────────────────────────────────────────────────────────────────────────
+METRICS AND OBSERVABILITY
+─────────────────────────────────────────────────────────────────────────────
+
+Each service exports Prometheus metrics at `GET /metrics` (when enabled).
+Key orchestrator metrics:
+
+  websocket_connections_active   — currently connected Claude processes
+  agent_spawns_total             — total agent spawn attempts
+  agent_failures_total           — total spawn/runtime failures
+  tool_approvals_total           — tool calls evaluated by policy
+
+To check metrics:
+  curl http://localhost:7006/metrics
+
+Logs are written to stderr in structured JSON (production) or human-readable
+format (development, when AGENTD_LOG_FORMAT=pretty).
+
+─────────────────────────────────────────────────────────────────────────────
+YOUR TOOL POLICY
+─────────────────────────────────────────────────────────────────────────────
+
+Your tool policy is an AllowList — only the following tool patterns are
+permitted.  Everything else is denied automatically.
+
+ALLOWED:
+  Read, Grep, Glob, LS               File and directory inspection
+  Bash(curl *)                       HTTP requests (health checks, API reads)
+  Bash(cat *), Bash(ls *)            Basic file/directory listing
+  Bash(ps *), Bash(echo *)           Process inspection and output
+  Bash(git log *), Bash(git status*) Read-only VCS state
+  Bash(git diff *)                   Diff inspection
+  Bash(cargo clippy *)               Static analysis (read-only)
+  Bash(cargo test *)                 Test execution
+  Bash(cargo build *)                Build verification
+  Bash(agent *)                      agentd CLI (list, get, search, message)
+
+DENIED (everything else, including):
+  Write, Edit, NotebookEdit          No file modifications
+  Bash(git commit *)                 No commits
+  Bash(git push *)                   No pushes
+  Bash(rm *), Bash(mv *)             No destructive filesystem ops
+  Bash(cargo publish *)              No package publishing
+
+When you cannot complete a request due to your tool policy, say so clearly
+and provide the exact command the user should run themselves.
 ";

--- a/crates/orchestrator/src/system_agents.rs
+++ b/crates/orchestrator/src/system_agents.rs
@@ -1,0 +1,184 @@
+//! Built-in system agent definitions.
+//!
+//! This module defines the programmatically-managed system agents that the
+//! orchestrator spawns automatically at startup.  System agents are always
+//! present while the service is running and cannot be deleted via the
+//! user-facing API.
+//!
+//! # Design
+//!
+//! A single omniscient agent named `agentd-system` acts as a domain expert on
+//! the full agentd platform.  It auto-joins a `system` communicate room and
+//! uses a restrictive tool policy that prevents destructive operations while
+//! still allowing read-oriented tooling for diagnostics and information
+//! gathering.
+//!
+//! The system prompt and tool policy constants defined here are embedded
+//! directly as Rust string literals so that they are version-controlled with
+//! the code and require no files on disk.
+
+use crate::types::{AgentConfig, ToolPolicy};
+use std::collections::HashMap;
+
+/// Name of the primary built-in system agent.
+pub const SYSTEM_AGENT_NAME: &str = "agentd-system";
+
+/// Build the [`AgentConfig`] for the agentd system agent.
+///
+/// The configuration sets:
+/// - An inline system prompt covering the agentd architecture.
+/// - A restrictive `AllowList` tool policy (read-only tooling only).
+/// - Automatic membership in the `system` communicate room.
+/// - The `sonnet` model alias.
+pub fn build_system_agent_config() -> AgentConfig {
+    AgentConfig {
+        working_dir: std::env::current_dir()
+            .map(|p| p.to_string_lossy().to_string())
+            .unwrap_or_else(|_| "/".to_string()),
+        user: None,
+        shell: "zsh".to_string(),
+        interactive: false,
+        prompt: None,
+        worktree: false,
+        system_prompt: Some(SYSTEM_AGENT_PROMPT.to_string()),
+        system_prompt_file: None,
+        append_system_prompt: false,
+        tool_policy: system_agent_tool_policy(),
+        model: Some("sonnet".to_string()),
+        env: HashMap::new(),
+        auto_clear_threshold: None,
+        network_policy: None,
+        docker_image: None,
+        extra_mounts: None,
+        resource_limits: None,
+        additional_dirs: vec![],
+        rooms: vec!["system".to_string()],
+    }
+}
+
+/// Restrictive tool policy for the system agent.
+///
+/// Uses an allowlist of read-only tools.  No `Write`, `Edit`, `NotebookEdit`,
+/// or unconstrained `Bash` is permitted — the agent can read the codebase and
+/// check service health but cannot modify anything.
+fn system_agent_tool_policy() -> ToolPolicy {
+    ToolPolicy::AllowList {
+        tools: vec![
+            // Navigation and search
+            "Read".to_string(),
+            "Grep".to_string(),
+            "Glob".to_string(),
+            "LS".to_string(),
+            // Restricted bash: only safe read-only commands
+            "Bash(curl *)".to_string(),
+            "Bash(cat *)".to_string(),
+            "Bash(ls *)".to_string(),
+            "Bash(ps *)".to_string(),
+            "Bash(echo *)".to_string(),
+            "Bash(git log *)".to_string(),
+            "Bash(git status*)".to_string(),
+            "Bash(git diff *)".to_string(),
+            "Bash(cargo clippy *)".to_string(),
+            "Bash(cargo test *)".to_string(),
+            "Bash(cargo build *)".to_string(),
+            "Bash(agent *)".to_string(),
+        ],
+        sandbox_bypass: vec![],
+    }
+}
+
+/// System prompt for the agentd-system agent.
+///
+/// This prompt is embedded as a compile-time constant so it is version-controlled
+/// with the code.  Keep it under 8 000 tokens (≈ 30 000 characters).
+///
+/// The full authoring of this prompt is tracked in issue #1142.
+const SYSTEM_AGENT_PROMPT: &str = "\
+You are the agentd system agent — a domain expert on the agentd platform.
+
+# Your Role
+
+You assist users and other agents by answering questions about the agentd
+architecture, diagnosing issues, explaining how services interact, and
+providing guidance on common operations.  You do NOT modify code or
+configuration files.
+
+# Architecture Overview
+
+agentd is a Rust workspace of microservices that together provide an
+AI-agent orchestration platform:
+
+| Service         | Port  | Description                                      |
+|-----------------|-------|--------------------------------------------------|
+| orchestrator    | 7006  | Manages agent lifecycle, WebSocket connections   |
+| communicate     | 17010 | Room-based messaging between agents and users    |
+| memory          | 17008 | Semantic memory store (vector search)            |
+| index           | 17012 | Code-search index (semantic + keyword)           |
+| notify          | 17005 | Notification delivery and routing                |
+| core            | 7010  | Authentication gateway and API proxy             |
+| wrap            | 7007  | Docker/tmux execution backend                    |
+
+All services expose REST APIs and health endpoints at `/health`.
+
+# Agent Lifecycle
+
+1. A user or agent sends `POST /agents` to the orchestrator with an `AgentConfig`.
+2. The orchestrator spawns a Claude Code process via the configured backend
+   (tmux or Docker).
+3. Claude Code connects back via WebSocket at `ws://localhost:7006/ws/{agent_id}`.
+4. The orchestrator routes messages, tool approvals, and events over this
+   WebSocket connection.
+5. When an agent completes or is terminated, its record remains in the SQLite
+   database (status = stopped/failed) for auditing.
+
+# Common Operations
+
+## Check which agents are running
+```
+agent list
+agent list --status running
+```
+
+## Send a message to an agent
+```
+agent send-message <agent-id> \"Your prompt here\"
+```
+
+## Check service health
+```
+curl http://localhost:7006/health
+curl http://localhost:17010/health
+curl http://localhost:17008/health
+```
+
+## View agent logs (tmux backend)
+```
+tmux attach -t <session-name>
+```
+
+# Communicate Rooms
+
+Agents can join named rooms in the communicate service.  Messages posted to a
+room are broadcast to all members (agents and users).  You are auto-joined to
+the `system` room.  Use `agent communicate` to interact with rooms.
+
+# Tool Policy
+
+Your tool policy is restrictive by design — you may read files, search code,
+and run safe read-only commands.  You may NOT write or edit files, run
+destructive git commands, restart services, or perform operations that modify
+state.
+
+When asked to perform an action you cannot do, explain what you cannot do and
+suggest the appropriate CLI command or API call the user should run instead.
+
+# Diagnostics
+
+When diagnosing issues, check:
+1. Service health endpoints
+2. Agent status via `agent list`
+3. Recent logs in `tmp/` (development) or the platform log aggregator
+4. Database state via the orchestrator debug endpoint at `GET /debug/agents`
+
+Always prefer explaining how to fix an issue over attempting to fix it yourself.
+";

--- a/crates/orchestrator/src/types.rs
+++ b/crates/orchestrator/src/types.rs
@@ -502,6 +502,14 @@ pub struct Agent {
     /// orchestrator run is still alive, avoiding duplicate spawns.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub pid: Option<u32>,
+    /// Whether this is a built-in system agent.
+    ///
+    /// System agents are created programmatically by the orchestrator at startup
+    /// and are always present while the service is running. User-created agents
+    /// always have this set to `false`. The field is intentionally absent from
+    /// [`CreateAgentRequest`] — only the orchestrator itself may set it.
+    #[serde(default)]
+    pub built_in: bool,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
 }
@@ -518,6 +526,7 @@ impl Agent {
             backend_type: Some("tmux".to_string()),
             launch_command: None,
             pid: None,
+            built_in: false,
             created_at: now,
             updated_at: now,
         }
@@ -614,6 +623,13 @@ pub struct AgentResponse {
     pub launch_command: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub pid: Option<u32>,
+    /// Whether this is a built-in system agent.
+    ///
+    /// System agents are created programmatically at orchestrator startup.
+    /// Clients should use this field to distinguish system agents from
+    /// user-created agents and suppress destructive actions (e.g., delete).
+    #[serde(default)]
+    pub built_in: bool,
     pub created_at: DateTime<Utc>,
     pub updated_at: DateTime<Utc>,
 }
@@ -634,6 +650,7 @@ impl From<Agent> for AgentResponse {
             backend_type: agent.backend_type,
             launch_command: agent.launch_command,
             pid: agent.pid,
+            built_in: agent.built_in,
             created_at: agent.created_at,
             updated_at: agent.updated_at,
         }

--- a/crates/orchestrator/tests/system_agent_http.rs
+++ b/crates/orchestrator/tests/system_agent_http.rs
@@ -1,0 +1,434 @@
+//! Integration tests for system (built-in) agent lifecycle and API separation.
+//!
+//! Tests the full system-agent feature surface:
+//! - `GET /system-agents` returns only built-in agents
+//! - `GET /agents` excludes built-in agents by default
+//! - `GET /agents?include_builtin=true` includes all agents
+//! - `DELETE /agents/{id}` is blocked for built-in agents
+//! - `POST /agents` ignores `built_in` from the request body
+//! - `AgentManager::bootstrap_system_agents()` creates the system agent correctly
+//! - Bootstrap is idempotent — no duplicate agents on repeated calls
+//!
+//! # Design
+//!
+//! HTTP tests drive the full Axum router via `tower::ServiceExt::oneshot` with
+//! no real TCP connection.  A `NullBackend` replaces tmux/Docker so that
+//! `AgentManager` can be constructed without external dependencies.
+
+use async_trait::async_trait;
+use axum::{
+    body::Body,
+    http::{Request, StatusCode},
+};
+use communicate::client::CommunicateClient;
+use orchestrator::{
+    api::{create_router, ApiState},
+    manager::AgentManager,
+    scheduler::{storage::SchedulerStorage, Scheduler},
+    storage::AgentStorage,
+    system_agents::SYSTEM_AGENT_NAME,
+    types::{Agent, AgentConfig, ToolPolicy},
+    websocket::ConnectionRegistry,
+};
+use std::sync::Arc;
+use tempfile::TempDir;
+use tower::ServiceExt;
+use wrap::{
+    backend::{SessionConfig, SessionExitInfo, SessionHealth},
+    types::BackendType,
+    ExecutionBackend,
+};
+
+// ---------------------------------------------------------------------------
+// NullBackend — no-op execution backend for tests
+// ---------------------------------------------------------------------------
+
+struct NullBackend;
+
+#[async_trait]
+impl ExecutionBackend for NullBackend {
+    async fn create_session(&self, _config: &SessionConfig) -> anyhow::Result<()> {
+        Ok(())
+    }
+    async fn launch_agent(&self, _config: &SessionConfig) -> anyhow::Result<()> {
+        Ok(())
+    }
+    async fn session_exists(&self, _session_name: &str) -> anyhow::Result<bool> {
+        Ok(false)
+    }
+    async fn kill_session(&self, _session_name: &str) -> anyhow::Result<()> {
+        Ok(())
+    }
+    async fn send_command(&self, _session_name: &str, _command: &str) -> anyhow::Result<()> {
+        Ok(())
+    }
+    async fn list_sessions(&self) -> anyhow::Result<Vec<String>> {
+        Ok(vec![])
+    }
+    fn prefix(&self) -> &str {
+        "test"
+    }
+    async fn session_health(&self, _session_name: &str) -> anyhow::Result<SessionHealth> {
+        Ok(SessionHealth::Unknown)
+    }
+    async fn session_exit_info(
+        &self,
+        _session_name: &str,
+    ) -> anyhow::Result<Option<SessionExitInfo>> {
+        Ok(None)
+    }
+    async fn session_pid(&self, _session_name: &str) -> anyhow::Result<Option<u32>> {
+        Ok(None)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Build the full orchestrator API router with a temp database.
+///
+/// Returns the router, an `Arc<AgentStorage>` for direct storage manipulation,
+/// and the `TempDir` that must be kept alive for the duration of the test.
+async fn build_app() -> (axum::Router, Arc<AgentStorage>, Arc<AgentManager>, TempDir) {
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("test.db");
+
+    let storage = Arc::new(AgentStorage::with_path(&db_path).await.unwrap());
+    let scheduler_storage = SchedulerStorage::new(storage.db().clone());
+    let registry = ConnectionRegistry::new();
+    let scheduler = Arc::new(Scheduler::new(scheduler_storage, registry.clone()));
+    let manager = Arc::new(AgentManager::new(
+        storage.clone(),
+        Arc::new(NullBackend),
+        registry.clone(),
+        "ws://localhost:7006".to_string(),
+    ));
+    let communicate = CommunicateClient::new("http://localhost:17010");
+
+    let state = ApiState {
+        manager: manager.clone(),
+        registry,
+        scheduler,
+        communicate,
+        backend_type: BackendType::Tmux,
+    };
+
+    let router = create_router(state);
+    (router, storage, manager, temp_dir)
+}
+
+/// Decode the response body as JSON.
+async fn body_json(response: axum::response::Response) -> serde_json::Value {
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    serde_json::from_slice(&bytes).unwrap()
+}
+
+/// Insert a built-in agent directly into storage (bypassing the API,
+/// which intentionally never sets `built_in = true`).
+async fn insert_builtin_agent(storage: &AgentStorage, name: &str) -> Agent {
+    use std::collections::HashMap;
+    let mut agent = Agent::new(
+        name.to_string(),
+        AgentConfig {
+            working_dir: "/tmp".to_string(),
+            user: None,
+            shell: "zsh".to_string(),
+            interactive: false,
+            prompt: None,
+            worktree: false,
+            system_prompt: None,
+            system_prompt_file: None,
+            append_system_prompt: false,
+            tool_policy: ToolPolicy::default(),
+            model: Some("sonnet".to_string()),
+            env: HashMap::new(),
+            auto_clear_threshold: None,
+            network_policy: None,
+            docker_image: None,
+            extra_mounts: None,
+            resource_limits: None,
+            additional_dirs: vec![],
+            rooms: vec!["system".to_string()],
+        },
+    );
+    agent.built_in = true;
+    storage.add(&agent).await.unwrap();
+    agent
+}
+
+/// Insert a regular user agent into storage.
+async fn insert_user_agent(storage: &AgentStorage, name: &str) -> Agent {
+    use std::collections::HashMap;
+    let agent = Agent::new(
+        name.to_string(),
+        AgentConfig {
+            working_dir: "/tmp".to_string(),
+            user: None,
+            shell: "zsh".to_string(),
+            interactive: false,
+            prompt: None,
+            worktree: false,
+            system_prompt: None,
+            system_prompt_file: None,
+            append_system_prompt: false,
+            tool_policy: ToolPolicy::default(),
+            model: None,
+            env: HashMap::new(),
+            auto_clear_threshold: None,
+            network_policy: None,
+            docker_image: None,
+            extra_mounts: None,
+            resource_limits: None,
+            additional_dirs: vec![],
+            rooms: vec![],
+        },
+    );
+    storage.add(&agent).await.unwrap();
+    agent
+}
+
+// ---------------------------------------------------------------------------
+// Tests: GET /system-agents
+// ---------------------------------------------------------------------------
+
+/// `GET /system-agents` returns only built-in agents.
+#[tokio::test]
+async fn test_system_agents_endpoint_returns_builtin_only() {
+    let (app, storage, _manager, _tmp) = build_app().await;
+
+    let builtin = insert_builtin_agent(&storage, "agentd-system").await;
+    insert_user_agent(&storage, "user-agent-1").await;
+
+    let response = app
+        .oneshot(Request::builder().uri("/system-agents").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = body_json(response).await;
+    let agents = json.as_array().expect("expected array");
+
+    assert_eq!(agents.len(), 1, "should return exactly 1 system agent");
+    assert_eq!(agents[0]["name"], builtin.name);
+    assert_eq!(agents[0]["built_in"], true, "built_in should be true");
+}
+
+/// `GET /system-agents` returns an empty array when no built-in agents exist.
+#[tokio::test]
+async fn test_system_agents_endpoint_empty_when_no_builtin() {
+    let (app, storage, _manager, _tmp) = build_app().await;
+    insert_user_agent(&storage, "user-only").await;
+
+    let response = app
+        .oneshot(Request::builder().uri("/system-agents").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = body_json(response).await;
+    let agents = json.as_array().expect("expected array");
+    assert!(agents.is_empty(), "should return empty array with no built-in agents");
+}
+
+// ---------------------------------------------------------------------------
+// Tests: GET /agents (built-in filtering)
+// ---------------------------------------------------------------------------
+
+/// `GET /agents` must NOT return built-in system agents.
+#[tokio::test]
+async fn test_list_agents_excludes_builtin_by_default() {
+    let (app, storage, _manager, _tmp) = build_app().await;
+
+    insert_builtin_agent(&storage, "agentd-system").await;
+    let user = insert_user_agent(&storage, "my-user-agent").await;
+
+    let response =
+        app.oneshot(Request::builder().uri("/agents").body(Body::empty()).unwrap()).await.unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = body_json(response).await;
+    let items = json["items"].as_array().expect("expected items array");
+
+    assert!(
+        items.iter().all(|a| a["built_in"] != true),
+        "built-in agents must be excluded from GET /agents by default"
+    );
+    assert!(
+        items.iter().any(|a| a["id"] == user.id.to_string()),
+        "user agent should appear in GET /agents"
+    );
+}
+
+/// `GET /agents?include_builtin=true` returns both user and built-in agents.
+#[tokio::test]
+async fn test_list_agents_include_builtin_param() {
+    let (app, storage, _manager, _tmp) = build_app().await;
+
+    insert_builtin_agent(&storage, "agentd-system").await;
+    insert_user_agent(&storage, "my-user-agent").await;
+
+    let response = app
+        .oneshot(
+            Request::builder().uri("/agents?include_builtin=true").body(Body::empty()).unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = body_json(response).await;
+    let items = json["items"].as_array().expect("expected items array");
+    assert_eq!(items.len(), 2, "should return both user and built-in agents");
+
+    let has_builtin = items.iter().any(|a| a["built_in"] == true);
+    let has_user = items.iter().any(|a| a["built_in"] != true);
+    assert!(has_builtin, "should include built-in agent");
+    assert!(has_user, "should include user agent");
+}
+
+// ---------------------------------------------------------------------------
+// Tests: DELETE /agents/{id}
+// ---------------------------------------------------------------------------
+
+/// `DELETE /agents/{id}` must be blocked for built-in system agents.
+#[tokio::test]
+async fn test_delete_builtin_agent_is_rejected() {
+    let (app, storage, _manager, _tmp) = build_app().await;
+    let builtin = insert_builtin_agent(&storage, "agentd-system").await;
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("DELETE")
+                .uri(format!("/agents/{}", builtin.id))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert!(
+        response.status() == StatusCode::BAD_REQUEST
+            || response.status() == StatusCode::FORBIDDEN
+            || response.status() == StatusCode::UNPROCESSABLE_ENTITY,
+        "expected 400/403/422 when deleting a built-in agent, got {}",
+        response.status()
+    );
+}
+
+/// `DELETE /agents/{id}` still works for user agents (regression guard).
+#[tokio::test]
+async fn test_delete_user_agent_is_allowed() {
+    let (app, storage, _manager, _tmp) = build_app().await;
+    let user = insert_user_agent(&storage, "deletable-agent").await;
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("DELETE")
+                .uri(format!("/agents/{}", user.id))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK, "deleting a user agent should succeed");
+}
+
+// ---------------------------------------------------------------------------
+// Tests: POST /agents (built_in ignored)
+// ---------------------------------------------------------------------------
+
+/// `POST /agents` with `built_in: true` in the body must be ignored.
+///
+/// `built_in` is not part of `CreateAgentRequest`; any JSON value for that
+/// key is silently discarded by serde's `deny_unknown_fields`-free defaults.
+/// The created agent must have `built_in = false`.
+#[tokio::test]
+async fn test_create_agent_ignores_builtin_field() {
+    let (app, _storage, _manager, _tmp) = build_app().await;
+
+    let body = serde_json::json!({
+        "name": "should-be-user-agent",
+        "working_dir": "/tmp",
+        // Attempt to set built_in via the API — must be ignored
+        "built_in": true
+    })
+    .to_string();
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/agents")
+                .header("Content-Type", "application/json")
+                .body(Body::from(body))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::CREATED);
+    let json = body_json(response).await;
+    assert_eq!(
+        json["built_in"],
+        serde_json::Value::Bool(false),
+        "built_in must default to false regardless of request body"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Tests: bootstrap_system_agents()
+// ---------------------------------------------------------------------------
+
+/// `bootstrap_system_agents()` creates the system agent with `built_in = true`.
+#[tokio::test]
+async fn test_bootstrap_creates_system_agent() {
+    let (_app, storage, manager, _tmp) = build_app().await;
+
+    manager.bootstrap_system_agents().await.unwrap();
+
+    let system_agents = storage.list_system_agents().await.unwrap();
+    assert_eq!(system_agents.len(), 1, "exactly one system agent should exist");
+
+    let agent = &system_agents[0];
+    assert_eq!(agent.name, SYSTEM_AGENT_NAME);
+    assert!(agent.built_in, "system agent must have built_in = true");
+}
+
+/// `bootstrap_system_agents()` is idempotent — calling it twice does not
+/// create a second system agent.
+#[tokio::test]
+async fn test_bootstrap_is_idempotent() {
+    let (_app, storage, manager, _tmp) = build_app().await;
+
+    manager.bootstrap_system_agents().await.unwrap();
+    manager.bootstrap_system_agents().await.unwrap();
+
+    let system_agents = storage.list_system_agents().await.unwrap();
+    assert_eq!(system_agents.len(), 1, "bootstrap must not create duplicate system agents");
+}
+
+/// `AgentResponse` for a built-in agent includes `built_in = true`.
+#[tokio::test]
+async fn test_agent_response_includes_builtin_field() {
+    let (app, storage, _manager, _tmp) = build_app().await;
+    let builtin = insert_builtin_agent(&storage, "agentd-system").await;
+
+    // GET /agents/{id} should expose the built_in field.
+    let response = app
+        .oneshot(
+            Request::builder().uri(format!("/agents/{}", builtin.id)).body(Body::empty()).unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = body_json(response).await;
+    assert_eq!(
+        json["built_in"],
+        serde_json::Value::Bool(true),
+        "GET /agents/{{id}} must return built_in = true for system agents"
+    );
+}

--- a/ui/src/components/agents/SystemAgentList.tsx
+++ b/ui/src/components/agents/SystemAgentList.tsx
@@ -1,13 +1,12 @@
 /**
- * SystemAgentList — compact display of built-in system agents.
+ * SystemAgentList — display of built-in system agents.
  *
  * Renders above the main agent list on the AgentsPage. Shows name, status,
- * model, and activity state. No create/delete actions are available — system
- * agents are managed automatically by the orchestrator.
+ * model, and rooms. No create/delete actions are available — system agents
+ * are managed automatically by the orchestrator.
  *
  * Features:
  * - Auto-refresh every 10 seconds (shared with the main agent list cadence)
- * - Collapsible panel (expanded by default)
  * - Visual distinction via a "System" badge on each row
  * - Clicking a row navigates to the agent detail page (same as user agents)
  */
@@ -15,13 +14,11 @@
 import {
 	AlertCircle,
 	Bot,
-	ChevronDown,
-	ChevronRight,
 	RefreshCw,
 } from "lucide-react";
-import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { AgentStatusBadge } from "@/components/agents/AgentStatusBadge";
+import { ListItemSkeleton } from "@/components/common/LoadingSkeleton";
 import { useSystemAgents } from "@/hooks/useSystemAgents";
 import type { Agent } from "@/types/orchestrator";
 
@@ -31,85 +28,94 @@ import type { Agent } from "@/types/orchestrator";
 
 export function SystemAgentList() {
 	const { agents, loading, refreshing, error, refetch } = useSystemAgents();
-	const [collapsed, setCollapsed] = useState(false);
 	const navigate = useNavigate();
 
 	return (
-		<div className="mb-6 rounded-lg border border-blue-200 bg-blue-50 dark:border-blue-800 dark:bg-blue-950/30">
+		<div className="space-y-5 mb-8">
 			{/* Header */}
-			<div className="flex items-center justify-between px-4 py-3">
-				<button
-					type="button"
-					className="flex items-center gap-2 text-sm font-semibold text-blue-800 dark:text-blue-300"
-					onClick={() => setCollapsed((c) => !c)}
-				>
-					{collapsed ? (
-						<ChevronRight className="h-4 w-4" />
-					) : (
-						<ChevronDown className="h-4 w-4" />
-					)}
-					<Bot className="h-4 w-4" />
-					System Agents
-					{!loading && (
-						<span className="ml-1 rounded-full bg-blue-200 px-2 py-0.5 text-xs font-medium text-blue-800 dark:bg-blue-800 dark:text-blue-200">
-							{agents.length}
-						</span>
-					)}
-				</button>
+			<div className="flex items-center justify-between">
+				<div>
+					<h1 className="text-2xl font-semibold text-th-text">
+						System Agents
+					</h1>
+					<p className="mt-1 text-sm text-th-text-muted">
+						Built-in agents managed by the orchestrator.
+					</p>
+				</div>
 
 				<div className="flex items-center gap-2">
 					{refreshing && (
-						<RefreshCw className="h-3 w-3 animate-spin text-blue-600 dark:text-blue-400" />
+						<RefreshCw
+							size={14}
+							aria-label="Refreshing..."
+							className="animate-spin text-th-text-muted"
+						/>
 					)}
 					<button
 						type="button"
-						title="Refresh system agents"
+						aria-label="Refresh system agents"
 						onClick={refetch}
-						className="rounded p-1 text-blue-600 hover:bg-blue-100 dark:text-blue-400 dark:hover:bg-blue-900"
+						disabled={loading}
+						className="rounded-md border border-th-border-strong bg-th-surface p-2 text-th-text-muted hover:bg-th-surface-hover hover:text-th-text-secondary focus:outline-none focus:ring-2 focus:ring-th-focus-ring focus:ring-offset-1 disabled:opacity-50"
 					>
-						<RefreshCw className="h-3.5 w-3.5" />
+						<RefreshCw size={15} />
 					</button>
 				</div>
 			</div>
 
-			{/* Body */}
-			{!collapsed && (
-				<div className="border-t border-blue-200 dark:border-blue-800">
-					{/* Error state */}
-					{error && (
-						<div className="flex items-center gap-2 px-4 py-3 text-sm text-red-600 dark:text-red-400">
-							<AlertCircle className="h-4 w-4 flex-shrink-0" />
-							{error}
-						</div>
-					)}
+			{/* Error banner */}
+			{error && (
+				<div
+					role="alert"
+					className="rounded-md bg-th-status-error-bg px-4 py-3 text-sm text-th-status-error-text"
+				>
+					<div className="flex items-center gap-2">
+						<AlertCircle className="h-4 w-4 flex-shrink-0" />
+						{error}
+					</div>
+				</div>
+			)}
 
-					{/* Loading state */}
-					{loading && !error && (
-						<div className="px-4 py-4 text-sm text-blue-600 dark:text-blue-400">
-							Loading system agents…
-						</div>
-					)}
-
-					{/* Empty state */}
-					{!loading && !error && agents.length === 0 && (
-						<div className="px-4 py-4 text-sm text-blue-600/70 dark:text-blue-400/70">
-							No system agents found. The orchestrator may still be starting up.
-						</div>
-					)}
-
-					{/* Agent rows */}
-					{!loading && !error && agents.length > 0 && (
-						<table className="w-full text-sm">
-							<thead>
-								<tr className="border-b border-blue-200 bg-blue-100/50 text-left text-xs font-medium text-blue-700 dark:border-blue-800 dark:bg-blue-900/30 dark:text-blue-400">
-									<th className="px-4 py-2">Name</th>
-									<th className="px-4 py-2">Status</th>
-									<th className="px-4 py-2">Model</th>
-									<th className="px-4 py-2">Rooms</th>
+			{/* Table */}
+			<div className="overflow-hidden rounded-lg border border-th-border">
+				<div className="overflow-x-auto">
+					<table className="min-w-full divide-y divide-th-border">
+						<thead className="bg-th-surface-sunken">
+							<tr>
+								<th className="px-4 py-3 text-left text-xs font-medium text-th-text-muted">
+									Name
+								</th>
+								<th className="px-4 py-3 text-left text-xs font-medium text-th-text-muted">
+									Status
+								</th>
+								<th className="px-4 py-3 text-left text-xs font-medium text-th-text-muted">
+									Model
+								</th>
+								<th className="px-4 py-3 text-left text-xs font-medium text-th-text-muted">
+									Rooms
+								</th>
+							</tr>
+						</thead>
+						<tbody className="divide-y divide-th-border bg-th-surface">
+							{loading ? (
+								<tr>
+									<td colSpan={4} className="p-4">
+										<ListItemSkeleton rows={2} />
+									</td>
 								</tr>
-							</thead>
-							<tbody>
-								{agents.map((agent) => (
+							) : agents.length === 0 && !error ? (
+								<tr>
+									<td colSpan={4} className="py-12 text-center">
+										<p className="text-sm text-th-text-muted">
+											No system agents found.
+										</p>
+										<p className="mt-1 text-xs text-th-text-faint">
+											The orchestrator may still be starting up.
+										</p>
+									</td>
+								</tr>
+							) : (
+								agents.map((agent) => (
 									<SystemAgentRow
 										key={agent.id}
 										agent={agent}
@@ -117,12 +123,12 @@ export function SystemAgentList() {
 											navigate(`/agents/${agent.id}`)
 										}
 									/>
-								))}
-							</tbody>
-						</table>
-					)}
+								))
+							)}
+						</tbody>
+					</table>
 				</div>
-			)}
+			</div>
 		</div>
 	);
 }
@@ -141,17 +147,17 @@ function SystemAgentRow({ agent, onClick }: SystemAgentRowProps) {
 
 	return (
 		<tr
-			className="cursor-pointer border-b border-blue-100 last:border-0 hover:bg-blue-100/60 dark:border-blue-900 dark:hover:bg-blue-900/40"
+			className="cursor-pointer border-b border-th-border hover:bg-th-surface-hover"
 			onClick={onClick}
 		>
 			{/* Name + system badge */}
 			<td className="px-4 py-3">
 				<div className="flex items-center gap-2">
-					<Bot className="h-3.5 w-3.5 flex-shrink-0 text-blue-500 dark:text-blue-400" />
-					<span className="font-medium text-gray-900 dark:text-gray-100">
+					<Bot className="h-3.5 w-3.5 flex-shrink-0 text-th-text-muted" />
+					<span className="text-sm font-medium text-th-text">
 						{agent.name}
 					</span>
-					<span className="rounded-full bg-blue-200 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-blue-800 dark:bg-blue-800 dark:text-blue-200">
+					<span className="rounded-full bg-th-accent/10 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-th-accent">
 						system
 					</span>
 				</div>
@@ -163,25 +169,27 @@ function SystemAgentRow({ agent, onClick }: SystemAgentRowProps) {
 			</td>
 
 			{/* Model */}
-			<td className="px-4 py-3 text-gray-600 dark:text-gray-400">
-				{agent.config.model ?? "default"}
+			<td className="px-4 py-3 text-sm text-th-text-muted">
+				{agent.config.model ?? (
+					<span className="italic opacity-50">default</span>
+				)}
 			</td>
 
 			{/* Rooms */}
-			<td className="px-4 py-3 text-gray-600 dark:text-gray-400">
+			<td className="px-4 py-3 text-sm text-th-text-muted">
 				{rooms.length > 0 ? (
 					<div className="flex flex-wrap gap-1">
 						{rooms.map((r: string) => (
 							<span
 								key={r}
-								className="rounded bg-blue-100 px-1.5 py-0.5 text-[10px] text-blue-800 dark:bg-blue-900 dark:text-blue-300"
+								className="rounded bg-th-surface-sunken px-1.5 py-0.5 text-[10px] text-th-text-muted"
 							>
 								{r}
 							</span>
 						))}
 					</div>
 				) : (
-					<span className="text-xs text-gray-400">—</span>
+					<span className="text-th-text-faint">-</span>
 				)}
 			</td>
 		</tr>

--- a/ui/src/components/agents/SystemAgentList.tsx
+++ b/ui/src/components/agents/SystemAgentList.tsx
@@ -1,0 +1,191 @@
+/**
+ * SystemAgentList — compact display of built-in system agents.
+ *
+ * Renders above the main agent list on the AgentsPage. Shows name, status,
+ * model, and activity state. No create/delete actions are available — system
+ * agents are managed automatically by the orchestrator.
+ *
+ * Features:
+ * - Auto-refresh every 10 seconds (shared with the main agent list cadence)
+ * - Collapsible panel (expanded by default)
+ * - Visual distinction via a "System" badge on each row
+ * - Clicking a row navigates to the agent detail page (same as user agents)
+ */
+
+import {
+	AlertCircle,
+	Bot,
+	ChevronDown,
+	ChevronRight,
+	RefreshCw,
+} from "lucide-react";
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { AgentStatusBadge } from "@/components/agents/AgentStatusBadge";
+import { useSystemAgents } from "@/hooks/useSystemAgents";
+import type { Agent } from "@/types/orchestrator";
+
+// ---------------------------------------------------------------------------
+// SystemAgentList
+// ---------------------------------------------------------------------------
+
+export function SystemAgentList() {
+	const { agents, loading, refreshing, error, refetch } = useSystemAgents();
+	const [collapsed, setCollapsed] = useState(false);
+	const navigate = useNavigate();
+
+	return (
+		<div className="mb-6 rounded-lg border border-blue-200 bg-blue-50 dark:border-blue-800 dark:bg-blue-950/30">
+			{/* Header */}
+			<div className="flex items-center justify-between px-4 py-3">
+				<button
+					type="button"
+					className="flex items-center gap-2 text-sm font-semibold text-blue-800 dark:text-blue-300"
+					onClick={() => setCollapsed((c) => !c)}
+				>
+					{collapsed ? (
+						<ChevronRight className="h-4 w-4" />
+					) : (
+						<ChevronDown className="h-4 w-4" />
+					)}
+					<Bot className="h-4 w-4" />
+					System Agents
+					{!loading && (
+						<span className="ml-1 rounded-full bg-blue-200 px-2 py-0.5 text-xs font-medium text-blue-800 dark:bg-blue-800 dark:text-blue-200">
+							{agents.length}
+						</span>
+					)}
+				</button>
+
+				<div className="flex items-center gap-2">
+					{refreshing && (
+						<RefreshCw className="h-3 w-3 animate-spin text-blue-600 dark:text-blue-400" />
+					)}
+					<button
+						type="button"
+						title="Refresh system agents"
+						onClick={refetch}
+						className="rounded p-1 text-blue-600 hover:bg-blue-100 dark:text-blue-400 dark:hover:bg-blue-900"
+					>
+						<RefreshCw className="h-3.5 w-3.5" />
+					</button>
+				</div>
+			</div>
+
+			{/* Body */}
+			{!collapsed && (
+				<div className="border-t border-blue-200 dark:border-blue-800">
+					{/* Error state */}
+					{error && (
+						<div className="flex items-center gap-2 px-4 py-3 text-sm text-red-600 dark:text-red-400">
+							<AlertCircle className="h-4 w-4 flex-shrink-0" />
+							{error}
+						</div>
+					)}
+
+					{/* Loading state */}
+					{loading && !error && (
+						<div className="px-4 py-4 text-sm text-blue-600 dark:text-blue-400">
+							Loading system agents…
+						</div>
+					)}
+
+					{/* Empty state */}
+					{!loading && !error && agents.length === 0 && (
+						<div className="px-4 py-4 text-sm text-blue-600/70 dark:text-blue-400/70">
+							No system agents found. The orchestrator may still be starting up.
+						</div>
+					)}
+
+					{/* Agent rows */}
+					{!loading && !error && agents.length > 0 && (
+						<table className="w-full text-sm">
+							<thead>
+								<tr className="border-b border-blue-200 bg-blue-100/50 text-left text-xs font-medium text-blue-700 dark:border-blue-800 dark:bg-blue-900/30 dark:text-blue-400">
+									<th className="px-4 py-2">Name</th>
+									<th className="px-4 py-2">Status</th>
+									<th className="px-4 py-2">Model</th>
+									<th className="px-4 py-2">Rooms</th>
+								</tr>
+							</thead>
+							<tbody>
+								{agents.map((agent) => (
+									<SystemAgentRow
+										key={agent.id}
+										agent={agent}
+										onClick={() =>
+											navigate(`/agents/${agent.id}`)
+										}
+									/>
+								))}
+							</tbody>
+						</table>
+					)}
+				</div>
+			)}
+		</div>
+	);
+}
+
+// ---------------------------------------------------------------------------
+// SystemAgentRow
+// ---------------------------------------------------------------------------
+
+interface SystemAgentRowProps {
+	agent: Agent;
+	onClick: () => void;
+}
+
+function SystemAgentRow({ agent, onClick }: SystemAgentRowProps) {
+	const rooms = agent.config.rooms ?? [];
+
+	return (
+		<tr
+			className="cursor-pointer border-b border-blue-100 last:border-0 hover:bg-blue-100/60 dark:border-blue-900 dark:hover:bg-blue-900/40"
+			onClick={onClick}
+		>
+			{/* Name + system badge */}
+			<td className="px-4 py-3">
+				<div className="flex items-center gap-2">
+					<Bot className="h-3.5 w-3.5 flex-shrink-0 text-blue-500 dark:text-blue-400" />
+					<span className="font-medium text-gray-900 dark:text-gray-100">
+						{agent.name}
+					</span>
+					<span className="rounded-full bg-blue-200 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-blue-800 dark:bg-blue-800 dark:text-blue-200">
+						system
+					</span>
+				</div>
+			</td>
+
+			{/* Status */}
+			<td className="px-4 py-3">
+				<AgentStatusBadge status={agent.status} />
+			</td>
+
+			{/* Model */}
+			<td className="px-4 py-3 text-gray-600 dark:text-gray-400">
+				{agent.config.model ?? "default"}
+			</td>
+
+			{/* Rooms */}
+			<td className="px-4 py-3 text-gray-600 dark:text-gray-400">
+				{rooms.length > 0 ? (
+					<div className="flex flex-wrap gap-1">
+						{rooms.map((r: string) => (
+							<span
+								key={r}
+								className="rounded bg-blue-100 px-1.5 py-0.5 text-[10px] text-blue-800 dark:bg-blue-900 dark:text-blue-300"
+							>
+								{r}
+							</span>
+						))}
+					</div>
+				) : (
+					<span className="text-xs text-gray-400">—</span>
+				)}
+			</td>
+		</tr>
+	);
+}
+
+export default SystemAgentList;

--- a/ui/src/hooks/useSystemAgents.ts
+++ b/ui/src/hooks/useSystemAgents.ts
@@ -1,0 +1,101 @@
+/**
+ * useSystemAgents — hook for fetching and displaying built-in system agents.
+ *
+ * Fetches from `GET /system-agents`, auto-refreshes on the same interval as
+ * the main agent list (default 10 seconds), and exposes a manual `refetch`.
+ *
+ * System agents are always present while the orchestrator is running.
+ * This hook never exposes create/delete actions — those are not available
+ * for built-in agents.
+ */
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { orchestratorClient } from "@/services/orchestrator";
+import type { Agent } from "@/types/orchestrator";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface UseSystemAgentsOptions {
+	/** Pause auto-refresh (e.g. when a dialog is open). Default: false */
+	paused?: boolean;
+	/** Auto-refresh interval in milliseconds. Default: 10 000 */
+	refreshInterval?: number;
+}
+
+export interface UseSystemAgentsResult {
+	/** Built-in system agents returned by the API */
+	agents: Agent[];
+	/** True on initial load before any data arrives */
+	loading: boolean;
+	/** True during background refresh (data already loaded) */
+	refreshing: boolean;
+	/** Error message if the last fetch failed */
+	error?: string;
+	/** Trigger an immediate refresh */
+	refetch: () => void;
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+export function useSystemAgents(
+	options: UseSystemAgentsOptions = {},
+): UseSystemAgentsResult {
+	const { paused = false, refreshInterval = 10_000 } = options;
+
+	const [agents, setAgents] = useState<Agent[]>([]);
+	const [loading, setLoading] = useState(true);
+	const [refreshing, setRefreshing] = useState(false);
+	const [error, setError] = useState<string | undefined>();
+
+	const firstLoad = useRef(true);
+	const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+	const fetchAgents = useCallback(async () => {
+		if (firstLoad.current) {
+			setLoading(true);
+		} else {
+			setRefreshing(true);
+		}
+
+		try {
+			const data = await orchestratorClient.listSystemAgents();
+			setAgents(data);
+			setError(undefined);
+		} catch (err) {
+			const msg = err instanceof Error ? err.message : "Unknown error";
+			setError(`Failed to fetch system agents: ${msg}`);
+		} finally {
+			setLoading(false);
+			setRefreshing(false);
+			firstLoad.current = false;
+		}
+	}, []);
+
+	// Schedule next refresh after current fetch settles.
+	const scheduleNext = useCallback(() => {
+		if (timerRef.current) clearTimeout(timerRef.current);
+		timerRef.current = setTimeout(() => {
+			if (!paused) fetchAgents().then(scheduleNext);
+		}, refreshInterval);
+	}, [paused, refreshInterval, fetchAgents]);
+
+	// Initial fetch + start refresh loop.
+	useEffect(() => {
+		firstLoad.current = true;
+		fetchAgents().then(scheduleNext);
+		return () => {
+			if (timerRef.current) clearTimeout(timerRef.current);
+		};
+	}, [fetchAgents, scheduleNext]);
+
+	const refetch = useCallback(() => {
+		if (timerRef.current) clearTimeout(timerRef.current);
+		fetchAgents().then(scheduleNext);
+	}, [fetchAgents, scheduleNext]);
+
+	return { agents, loading, refreshing, error, refetch };
+}

--- a/ui/src/pages/AgentsPage.tsx
+++ b/ui/src/pages/AgentsPage.tsx
@@ -1,7 +1,21 @@
+import { SystemAgentList } from "@/components/agents/SystemAgentList";
 import { AgentList } from "./agents/AgentList";
 
+/**
+ * AgentsPage — top-level agents page.
+ *
+ * Renders two sections:
+ * 1. **System Agents** — built-in agents managed by the orchestrator.
+ *    Always-present, no create/delete actions.
+ * 2. **Agents** — user-created agents with full CRUD and filtering.
+ */
 export function AgentsPage() {
-	return <AgentList />;
+	return (
+		<>
+			<SystemAgentList />
+			<AgentList />
+		</>
+	);
 }
 
 export default AgentsPage;

--- a/ui/src/services/orchestrator.ts
+++ b/ui/src/services/orchestrator.ts
@@ -59,6 +59,16 @@ export class OrchestratorClient extends ApiClient {
 		);
 	}
 
+	/**
+	 * `GET /system-agents` — list built-in system agents.
+	 *
+	 * Returns only agents with `built_in = true`. These are spawned automatically
+	 * by the orchestrator at startup and are always present while the service runs.
+	 */
+	listSystemAgents(): Promise<Agent[]> {
+		return this.get<Agent[]>("/system-agents");
+	}
+
 	createAgent(request: CreateAgentRequest): Promise<Agent> {
 		return this.post<Agent>("/agents", request);
 	}

--- a/ui/src/types/orchestrator.ts
+++ b/ui/src/types/orchestrator.ts
@@ -52,6 +52,8 @@ export interface AgentConfig {
 	env?: Record<string, string>;
 	auto_clear_threshold?: number;
 	additional_dirs?: string[];
+	/** Communicate rooms the agent is auto-joined to on connection. */
+	rooms?: string[];
 }
 
 // ---------------------------------------------------------------------------

--- a/ui/src/types/orchestrator.ts
+++ b/ui/src/types/orchestrator.ts
@@ -70,6 +70,14 @@ export interface Agent {
 	launch_command?: string;
 	/** OS process ID of the agent's subprocess. */
 	pid?: number;
+	/**
+	 * Whether this is a built-in system agent.
+	 *
+	 * System agents are created programmatically at orchestrator startup and
+	 * are always present. UI should hide destructive actions (delete, bulk-delete)
+	 * for agents where this is `true`.
+	 */
+	built_in?: boolean;
 	created_at: string;
 	updated_at: string;
 }


### PR DESCRIPTION
Rollup PR tracking all sub-issues for the built-in agent epic.

Sub-issues (implemented as stacked branches on top of this):
- #1137 — Add built_in flag to Agent schema and storage layer
- #1138 — Filter built-in agents from list API and add /system-agents endpoint
- #1139 — Define system agent config and spawn at orchestrator startup
- #1142 — Write system prompt and tool policy for agentd-system agent
- #1141 — Add CLI support for system agents
- #1140 — Add system agents section to UI agents page
- #1143 — Integration tests for system agent lifecycle

Closes #1144