### PR TITLE
feat(cli): add system-agents subcommand

### DIFF
--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -36,6 +36,7 @@ pub mod memory;
 pub mod notify;
 pub mod orchestrator;
 pub mod prompt;
+pub mod system_agents;
 pub mod wrap;
 
 pub use ask::AskCommand;
@@ -45,4 +46,5 @@ pub use memory::MemoryCommand;
 pub use notify::NotifyCommand;
 pub use orchestrator::OrchestratorCommand;
 pub use prompt::PromptCommand;
+pub use system_agents::SystemAgentsCommand;
 pub use wrap::WrapCommand;

--- a/crates/cli/src/commands/orchestrator.rs
+++ b/crates/cli/src/commands/orchestrator.rs
@@ -89,12 +89,22 @@ pub enum TriggerType {
 pub enum OrchestratorCommand {
     /// List all managed agents.
     ///
-    /// Returns all agents tracked by the orchestrator, optionally filtered
-    /// by status (pending, running, stopped, failed).
+    /// Returns user-created agents tracked by the orchestrator, optionally
+    /// filtered by status (pending, running, stopped, failed).
+    ///
+    /// Built-in system agents are excluded by default — use `agent system-agents list`
+    /// for a dedicated system-agent view, or pass `--include-builtin` to see all agents.
     ListAgents {
         /// Filter by agent status (pending, running, stopped, failed)
         #[arg(long)]
         status: Option<String>,
+        /// Include built-in system agents in the output.
+        ///
+        /// By default system agents are hidden from this list and visible only
+        /// via `agent system-agents list`. Pass this flag to see all agents
+        /// in a single table (useful for admin and debugging).
+        #[arg(long)]
+        include_builtin: bool,
     },
 
     /// Create a new agent.
@@ -868,8 +878,8 @@ impl OrchestratorCommand {
     /// * `json` - If true, output raw JSON instead of formatted text
     pub async fn execute(&self, client: &OrchestratorClient, json: bool) -> Result<()> {
         match self {
-            OrchestratorCommand::ListAgents { status } => {
-                list_agents(client, status.as_deref(), json).await
+            OrchestratorCommand::ListAgents { status, include_builtin } => {
+                list_agents(client, status.as_deref(), *include_builtin, json).await
             }
             OrchestratorCommand::CreateAgent {
                 name,
@@ -1062,8 +1072,16 @@ impl OrchestratorCommand {
 
 // -- Agent operations --
 
-async fn list_agents(client: &OrchestratorClient, status: Option<&str>, json: bool) -> Result<()> {
-    let response = client.list_agents(status).await.context("Failed to list agents")?;
+async fn list_agents(
+    client: &OrchestratorClient,
+    status: Option<&str>,
+    include_builtin: bool,
+    json: bool,
+) -> Result<()> {
+    let response = client
+        .list_agents_filtered(status, include_builtin)
+        .await
+        .context("Failed to list agents")?;
     let agents = response.items;
 
     if json {

--- a/crates/cli/src/commands/system_agents.rs
+++ b/crates/cli/src/commands/system_agents.rs
@@ -1,0 +1,324 @@
+//! System-agent CLI command implementations.
+//!
+//! Provides the `agent system-agents` subcommand group for interacting with
+//! built-in system agents.  System agents are distinct from user-created
+//! agents: they are spawned automatically by the orchestrator at startup,
+//! are always present while the service is running, and cannot be deleted
+//! via the user-facing API.
+//!
+//! # Available Subcommands
+//!
+//! - **list** — list all built-in system agents
+//! - **get** — show full details for a specific system agent
+//! - **message** — send a prompt to a running system agent
+//! - **status** — compact status summary of all system agents
+//!
+//! # Examples
+//!
+//! ```bash
+//! agent system-agents list
+//! agent system-agents list --json
+//! agent system-agents get agentd-system
+//! agent system-agents message agentd-system "What services are running?"
+//! agent system-agents status
+//! ```
+
+use anyhow::{Context, Result};
+use clap::Subcommand;
+use colored::*;
+use uuid::Uuid;
+
+use orchestrator::client::OrchestratorClient;
+use orchestrator::types::{AgentResponse, AgentStatus, SendMessageRequest, ToolPolicy};
+
+/// Subcommand group for interacting with built-in system agents.
+///
+/// System agents are created programmatically by the orchestrator at startup
+/// and are always available while the service is running.  Use `agent list`
+/// for user-created agents instead.
+#[derive(Subcommand)]
+pub enum SystemAgentsCommand {
+    /// List all built-in system agents.
+    ///
+    /// Fetches from `GET /system-agents` which returns only agents marked as
+    /// built-in.  These are distinct from user-created agents and are managed
+    /// automatically by the orchestrator.
+    ///
+    /// # Examples
+    ///
+    /// ```bash
+    /// agent system-agents list
+    /// agent system-agents list --json
+    /// ```
+    List,
+
+    /// Show full details for a specific system agent.
+    ///
+    /// Accepts either the agent's UUID or its name (e.g., `agentd-system`).
+    ///
+    /// # Examples
+    ///
+    /// ```bash
+    /// agent system-agents get agentd-system
+    /// agent system-agents get 550e8400-e29b-41d4-a716-446655440000
+    /// ```
+    Get {
+        /// Agent UUID or name
+        id: String,
+    },
+
+    /// Send a prompt to a running system agent.
+    ///
+    /// Accepts either the agent's UUID or its name.  The agent must be in the
+    /// `running` state to accept messages.
+    ///
+    /// # Examples
+    ///
+    /// ```bash
+    /// agent system-agents message agentd-system "What services are running?"
+    /// agent system-agents message agentd-system "Explain the agent lifecycle"
+    /// ```
+    Message {
+        /// Agent UUID or name
+        id: String,
+        /// The prompt to send to the agent
+        message: String,
+    },
+
+    /// Show a compact status summary of all system agents.
+    ///
+    /// Displays name, status, model, and activity state in a compact table.
+    /// Useful for a quick health check of the built-in agent layer.
+    ///
+    /// # Examples
+    ///
+    /// ```bash
+    /// agent system-agents status
+    /// ```
+    Status,
+}
+
+impl SystemAgentsCommand {
+    /// Dispatch to the appropriate handler.
+    pub async fn execute(&self, client: &OrchestratorClient, json: bool) -> Result<()> {
+        match self {
+            SystemAgentsCommand::List => list_system_agents(client, json).await,
+            SystemAgentsCommand::Get { id } => get_system_agent(client, id, json).await,
+            SystemAgentsCommand::Message { id, message } => {
+                message_system_agent(client, id, message, json).await
+            }
+            SystemAgentsCommand::Status => system_agents_status(client, json).await,
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Handlers
+// ---------------------------------------------------------------------------
+
+/// `agent system-agents list` — list all built-in system agents.
+async fn list_system_agents(client: &OrchestratorClient, json: bool) -> Result<()> {
+    let agents = client.list_system_agents().await.context("Failed to list system agents")?;
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&agents)?);
+        return Ok(());
+    }
+
+    if agents.is_empty() {
+        println!("{}", "No system agents found.".yellow());
+        println!(
+            "{}",
+            "The orchestrator may still be starting up. Try again in a moment.".dimmed()
+        );
+        return Ok(());
+    }
+
+    println!("{}", "System Agents:".blue().bold());
+    println!("{}", "=".repeat(80).cyan());
+    for agent in &agents {
+        display_system_agent(agent);
+        println!("{}", "-".repeat(80).cyan());
+    }
+    println!("Total: {} system agent(s)", agents.len());
+
+    Ok(())
+}
+
+/// `agent system-agents get <id>` — show full details for a system agent.
+async fn get_system_agent(client: &OrchestratorClient, id: &str, json: bool) -> Result<()> {
+    let agent = resolve_system_agent(client, id).await?;
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&agent)?);
+        return Ok(());
+    }
+
+    display_system_agent(&agent);
+    Ok(())
+}
+
+/// `agent system-agents message <id> <text>` — send a prompt to a system agent.
+async fn message_system_agent(
+    client: &OrchestratorClient,
+    id: &str,
+    message: &str,
+    json: bool,
+) -> Result<()> {
+    let agent = resolve_system_agent(client, id).await?;
+
+    if agent.status != AgentStatus::Running {
+        anyhow::bail!(
+            "System agent '{}' is not running (status: {}). \
+             Wait for the orchestrator to bootstrap it.",
+            agent.name,
+            agent.status
+        );
+    }
+
+    let request = SendMessageRequest { content: message.to_string() };
+    let response =
+        client.send_message(&agent.id, &request).await.context("Failed to send message")?;
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&response)?);
+    } else {
+        println!("{}", "Message sent.".green());
+        println!("{}: {}", "Agent".bold(), agent.name.bright_white());
+        println!("{}: {}", "Status".bold(), response.status);
+    }
+
+    Ok(())
+}
+
+/// `agent system-agents status` — compact status summary.
+async fn system_agents_status(client: &OrchestratorClient, json: bool) -> Result<()> {
+    let agents = client.list_system_agents().await.context("Failed to fetch system agents")?;
+
+    if json {
+        // Emit a compact summary array.
+        let summaries: Vec<_> = agents
+            .iter()
+            .map(|a| {
+                serde_json::json!({
+                    "name": a.name,
+                    "status": a.status,
+                    "model": a.config.model,
+                    "activity": a.activity,
+                    "built_in": a.built_in,
+                })
+            })
+            .collect();
+        println!("{}", serde_json::to_string_pretty(&summaries)?);
+        return Ok(());
+    }
+
+    if agents.is_empty() {
+        println!("{}", "No system agents found.".yellow());
+        return Ok(());
+    }
+
+    println!("{}", "System Agent Status:".blue().bold());
+    println!("{}", "=".repeat(60).cyan());
+
+    let name_w = 24usize;
+    let status_w = 10usize;
+    let model_w = 20usize;
+
+    println!(
+        "{:<name_w$} {:<status_w$} {:<model_w$} {}",
+        "Name".bold(),
+        "Status".bold(),
+        "Model".bold(),
+        "Activity".bold(),
+    );
+    println!("{}", "-".repeat(60).dimmed());
+
+    for agent in &agents {
+        let status_str = agent.status.to_string();
+        let colored_status: colored::ColoredString = match agent.status {
+            AgentStatus::Running => status_str.green(),
+            AgentStatus::Pending => status_str.yellow(),
+            AgentStatus::Stopped => status_str.red(),
+            AgentStatus::Failed => status_str.bright_red(),
+        };
+        let model = agent.config.model.as_deref().unwrap_or("default");
+        let activity = format!("{:?}", agent.activity).to_lowercase();
+
+        println!(
+            "{:<name_w$} {:<status_w$} {:<model_w$} {}",
+            agent.name.bright_white(),
+            colored_status,
+            model,
+            activity,
+        );
+    }
+
+    println!("{}", "-".repeat(60).dimmed());
+    let running = agents.iter().filter(|a| a.status == AgentStatus::Running).count();
+    println!("Total: {} system agent(s), {} running", agents.len(), running);
+
+    Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Resolve a system agent by UUID or name.
+///
+/// Fetches the full system-agent list and looks up by ID prefix or exact name.
+/// Returns an error if no match is found.
+async fn resolve_system_agent(client: &OrchestratorClient, id: &str) -> Result<AgentResponse> {
+    // Try UUID parse first.
+    if let Ok(uuid) = Uuid::parse_str(id) {
+        let all = client.list_system_agents().await.context("Failed to list system agents")?;
+        return all.into_iter().find(|a| a.id == uuid).ok_or_else(|| {
+            anyhow::anyhow!("System agent '{}' not found", id)
+        });
+    }
+
+    // Fall back to name lookup.
+    let all = client.list_system_agents().await.context("Failed to list system agents")?;
+    all.into_iter()
+        .find(|a| a.name == id)
+        .ok_or_else(|| anyhow::anyhow!("System agent '{}' not found", id))
+}
+
+/// Display a single system agent in human-readable format.
+fn display_system_agent(agent: &AgentResponse) {
+    println!("{}: {}", "ID".bold(), agent.id);
+    println!("{}: {} {}", "Name".bold(), agent.name.bright_white(), "[system]".cyan().dimmed());
+    let status_str = agent.status.to_string();
+    let colored_status = match agent.status {
+        AgentStatus::Running => status_str.green(),
+        AgentStatus::Pending => status_str.yellow(),
+        AgentStatus::Stopped => status_str.red(),
+        AgentStatus::Failed => status_str.bright_red(),
+    };
+    println!("{}: {}", "Status".bold(), colored_status);
+    if let Some(ref model) = agent.config.model {
+        println!("{}: {}", "Model".bold(), model.cyan());
+    }
+    if let Some(ref session) = agent.session_id {
+        println!("{}: {}", "Session".bold(), session);
+    }
+    println!("{}: {}", "Working Dir".bold(), agent.config.working_dir);
+    if !agent.config.rooms.is_empty() {
+        println!("{}: {}", "Rooms".bold(), agent.config.rooms.join(", ").cyan());
+    }
+    let policy_str = match &agent.config.tool_policy {
+        ToolPolicy::AllowAll { .. } => "allow_all".green().to_string(),
+        ToolPolicy::DenyAll { .. } => "deny_all".red().to_string(),
+        ToolPolicy::AllowList { tools, .. } => {
+            format!("allow_list ({} tools)", tools.len())
+        }
+        ToolPolicy::DenyList { tools, .. } => {
+            format!("deny_list ({} tools)", tools.len())
+        }
+        ToolPolicy::RequireApproval { .. } => "require_approval".bright_yellow().to_string(),
+    };
+    println!("{}: {}", "Tool Policy".bold(), policy_str);
+    println!("{}: {}", "Built-in".bold(), "yes".cyan());
+    println!("{}: {}", "Created".bold(), agent.created_at);
+}

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -84,7 +84,7 @@ use colored::*;
 use commands::index::IndexClient;
 use commands::{
     AskCommand, CommunicateCommand, IndexCommand, MemoryCommand, NotifyCommand,
-    OrchestratorCommand, PromptCommand, WrapCommand,
+    OrchestratorCommand, PromptCommand, SystemAgentsCommand, WrapCommand,
 };
 use communicate::client::CommunicateClient;
 use memory::client::MemoryClient;
@@ -304,6 +304,26 @@ enum Commands {
         #[command(subcommand)]
         command: IndexCommand,
     },
+
+    /// Interact with built-in system agents.
+    ///
+    /// System agents are spawned automatically by the orchestrator at startup
+    /// and are always present while the service is running.  They are distinct
+    /// from user-created agents and cannot be deleted via the API.
+    ///
+    /// # Examples
+    ///
+    /// ```bash
+    /// agent system-agents list
+    /// agent system-agents get agentd-system
+    /// agent system-agents message agentd-system "What services are running?"
+    /// agent system-agents status
+    /// ```
+    #[command(name = "system-agents")]
+    SystemAgents {
+        #[command(subcommand)]
+        command: Box<SystemAgentsCommand>,
+    },
 }
 
 /// Main entry point for the agent CLI.
@@ -427,6 +447,12 @@ async fn main() -> Result<()> {
             let url = env::var("AGENTD_INDEX_SERVICE_URL")
                 .unwrap_or_else(|_| "http://localhost:17012".to_string());
             let client = IndexClient::new(url);
+            command.execute(&client, cli.json).await?;
+        }
+        Commands::SystemAgents { command } => {
+            let url = env::var("AGENTD_ORCHESTRATOR_SERVICE_URL")
+                .unwrap_or_else(|_| "http://localhost:7006".to_string());
+            let client = OrchestratorClient::new(url);
             command.execute(&client, cli.json).await?;
         }
     }

--- a/crates/orchestrator/src/api.rs
+++ b/crates/orchestrator/src/api.rs
@@ -172,9 +172,7 @@ async fn list_agents(
 /// Returns only agents with `built_in = true`. These agents are created
 /// programmatically by the orchestrator at startup and are always present
 /// while the service is running.
-async fn list_system_agents(
-    State(state): State<ApiState>,
-) -> Result<impl IntoResponse, ApiError> {
+async fn list_system_agents(State(state): State<ApiState>) -> Result<impl IntoResponse, ApiError> {
     let agents = state.manager.list_system_agents().await?;
     let mut items: Vec<AgentResponse> = Vec::with_capacity(agents.len());
     for agent in agents {
@@ -253,6 +251,12 @@ async fn terminate_agent(
     State(state): State<ApiState>,
     Path(id): Path<Uuid>,
 ) -> Result<impl IntoResponse, ApiError> {
+    // Guard: built-in system agents cannot be deleted via the API.
+    let existing = state.manager.get_agent(&id).await?.ok_or(ApiError::NotFound)?;
+    if existing.built_in {
+        return Err(ApiError::Forbidden("built-in system agents cannot be deleted".to_string()));
+    }
+
     let agent = state.manager.terminate_agent(&id).await?;
 
     metrics::counter!("agents_terminated_total").increment(1);

--- a/crates/orchestrator/src/client.rs
+++ b/crates/orchestrator/src/client.rs
@@ -100,9 +100,29 @@ impl OrchestratorClient {
         &self,
         status: Option<&str>,
     ) -> Result<PaginatedResponse<AgentResponse>> {
-        let path = match status {
-            Some(s) => format!("/agents?status={}", s),
-            None => "/agents".to_string(),
+        self.list_agents_filtered(status, false).await
+    }
+
+    /// List agents with optional status filter and built-in inclusion.
+    ///
+    /// When `include_builtin` is `true`, passes `?include_builtin=true` so that
+    /// system agents are included alongside user agents.
+    pub async fn list_agents_filtered(
+        &self,
+        status: Option<&str>,
+        include_builtin: bool,
+    ) -> Result<PaginatedResponse<AgentResponse>> {
+        let mut params: Vec<String> = Vec::new();
+        if let Some(s) = status {
+            params.push(format!("status={}", s));
+        }
+        if include_builtin {
+            params.push("include_builtin=true".to_string());
+        }
+        let path = if params.is_empty() {
+            "/agents".to_string()
+        } else {
+            format!("/agents?{}", params.join("&"))
         };
         self.get(&path).await
     }

--- a/crates/orchestrator/tests/system_agent_http.rs
+++ b/crates/orchestrator/tests/system_agent_http.rs
@@ -1,0 +1,434 @@
+//! Integration tests for system (built-in) agent lifecycle and API separation.
+//!
+//! Tests the full system-agent feature surface:
+//! - `GET /system-agents` returns only built-in agents
+//! - `GET /agents` excludes built-in agents by default
+//! - `GET /agents?include_builtin=true` includes all agents
+//! - `DELETE /agents/{id}` is blocked for built-in agents
+//! - `POST /agents` ignores `built_in` from the request body
+//! - `AgentManager::bootstrap_system_agents()` creates the system agent correctly
+//! - Bootstrap is idempotent — no duplicate agents on repeated calls
+//!
+//! # Design
+//!
+//! HTTP tests drive the full Axum router via `tower::ServiceExt::oneshot` with
+//! no real TCP connection.  A `NullBackend` replaces tmux/Docker so that
+//! `AgentManager` can be constructed without external dependencies.
+
+use async_trait::async_trait;
+use axum::{
+    body::Body,
+    http::{Request, StatusCode},
+};
+use communicate::client::CommunicateClient;
+use orchestrator::{
+    api::{create_router, ApiState},
+    manager::AgentManager,
+    scheduler::{storage::SchedulerStorage, Scheduler},
+    storage::AgentStorage,
+    system_agents::SYSTEM_AGENT_NAME,
+    types::{Agent, AgentConfig, ToolPolicy},
+    websocket::ConnectionRegistry,
+};
+use std::sync::Arc;
+use tempfile::TempDir;
+use tower::ServiceExt;
+use wrap::{
+    backend::{SessionConfig, SessionExitInfo, SessionHealth},
+    types::BackendType,
+    ExecutionBackend,
+};
+
+// ---------------------------------------------------------------------------
+// NullBackend — no-op execution backend for tests
+// ---------------------------------------------------------------------------
+
+struct NullBackend;
+
+#[async_trait]
+impl ExecutionBackend for NullBackend {
+    async fn create_session(&self, _config: &SessionConfig) -> anyhow::Result<()> {
+        Ok(())
+    }
+    async fn launch_agent(&self, _config: &SessionConfig) -> anyhow::Result<()> {
+        Ok(())
+    }
+    async fn session_exists(&self, _session_name: &str) -> anyhow::Result<bool> {
+        Ok(false)
+    }
+    async fn kill_session(&self, _session_name: &str) -> anyhow::Result<()> {
+        Ok(())
+    }
+    async fn send_command(&self, _session_name: &str, _command: &str) -> anyhow::Result<()> {
+        Ok(())
+    }
+    async fn list_sessions(&self) -> anyhow::Result<Vec<String>> {
+        Ok(vec![])
+    }
+    fn prefix(&self) -> &str {
+        "test"
+    }
+    async fn session_health(&self, _session_name: &str) -> anyhow::Result<SessionHealth> {
+        Ok(SessionHealth::Unknown)
+    }
+    async fn session_exit_info(
+        &self,
+        _session_name: &str,
+    ) -> anyhow::Result<Option<SessionExitInfo>> {
+        Ok(None)
+    }
+    async fn session_pid(&self, _session_name: &str) -> anyhow::Result<Option<u32>> {
+        Ok(None)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Build the full orchestrator API router with a temp database.
+///
+/// Returns the router, an `Arc<AgentStorage>` for direct storage manipulation,
+/// and the `TempDir` that must be kept alive for the duration of the test.
+async fn build_app() -> (axum::Router, Arc<AgentStorage>, Arc<AgentManager>, TempDir) {
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("test.db");
+
+    let storage = Arc::new(AgentStorage::with_path(&db_path).await.unwrap());
+    let scheduler_storage = SchedulerStorage::new(storage.db().clone());
+    let registry = ConnectionRegistry::new();
+    let scheduler = Arc::new(Scheduler::new(scheduler_storage, registry.clone()));
+    let manager = Arc::new(AgentManager::new(
+        storage.clone(),
+        Arc::new(NullBackend),
+        registry.clone(),
+        "ws://localhost:7006".to_string(),
+    ));
+    let communicate = CommunicateClient::new("http://localhost:17010");
+
+    let state = ApiState {
+        manager: manager.clone(),
+        registry,
+        scheduler,
+        communicate,
+        backend_type: BackendType::Tmux,
+    };
+
+    let router = create_router(state);
+    (router, storage, manager, temp_dir)
+}
+
+/// Decode the response body as JSON.
+async fn body_json(response: axum::response::Response) -> serde_json::Value {
+    let bytes = axum::body::to_bytes(response.into_body(), usize::MAX).await.unwrap();
+    serde_json::from_slice(&bytes).unwrap()
+}
+
+/// Insert a built-in agent directly into storage (bypassing the API,
+/// which intentionally never sets `built_in = true`).
+async fn insert_builtin_agent(storage: &AgentStorage, name: &str) -> Agent {
+    use std::collections::HashMap;
+    let mut agent = Agent::new(
+        name.to_string(),
+        AgentConfig {
+            working_dir: "/tmp".to_string(),
+            user: None,
+            shell: "zsh".to_string(),
+            interactive: false,
+            prompt: None,
+            worktree: false,
+            system_prompt: None,
+            system_prompt_file: None,
+            append_system_prompt: false,
+            tool_policy: ToolPolicy::default(),
+            model: Some("sonnet".to_string()),
+            env: HashMap::new(),
+            auto_clear_threshold: None,
+            network_policy: None,
+            docker_image: None,
+            extra_mounts: None,
+            resource_limits: None,
+            additional_dirs: vec![],
+            rooms: vec!["system".to_string()],
+        },
+    );
+    agent.built_in = true;
+    storage.add(&agent).await.unwrap();
+    agent
+}
+
+/// Insert a regular user agent into storage.
+async fn insert_user_agent(storage: &AgentStorage, name: &str) -> Agent {
+    use std::collections::HashMap;
+    let agent = Agent::new(
+        name.to_string(),
+        AgentConfig {
+            working_dir: "/tmp".to_string(),
+            user: None,
+            shell: "zsh".to_string(),
+            interactive: false,
+            prompt: None,
+            worktree: false,
+            system_prompt: None,
+            system_prompt_file: None,
+            append_system_prompt: false,
+            tool_policy: ToolPolicy::default(),
+            model: None,
+            env: HashMap::new(),
+            auto_clear_threshold: None,
+            network_policy: None,
+            docker_image: None,
+            extra_mounts: None,
+            resource_limits: None,
+            additional_dirs: vec![],
+            rooms: vec![],
+        },
+    );
+    storage.add(&agent).await.unwrap();
+    agent
+}
+
+// ---------------------------------------------------------------------------
+// Tests: GET /system-agents
+// ---------------------------------------------------------------------------
+
+/// `GET /system-agents` returns only built-in agents.
+#[tokio::test]
+async fn test_system_agents_endpoint_returns_builtin_only() {
+    let (app, storage, _manager, _tmp) = build_app().await;
+
+    let builtin = insert_builtin_agent(&storage, "agentd-system").await;
+    insert_user_agent(&storage, "user-agent-1").await;
+
+    let response = app
+        .oneshot(Request::builder().uri("/system-agents").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = body_json(response).await;
+    let agents = json.as_array().expect("expected array");
+
+    assert_eq!(agents.len(), 1, "should return exactly 1 system agent");
+    assert_eq!(agents[0]["name"], builtin.name);
+    assert_eq!(agents[0]["built_in"], true, "built_in should be true");
+}
+
+/// `GET /system-agents` returns an empty array when no built-in agents exist.
+#[tokio::test]
+async fn test_system_agents_endpoint_empty_when_no_builtin() {
+    let (app, storage, _manager, _tmp) = build_app().await;
+    insert_user_agent(&storage, "user-only").await;
+
+    let response = app
+        .oneshot(Request::builder().uri("/system-agents").body(Body::empty()).unwrap())
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = body_json(response).await;
+    let agents = json.as_array().expect("expected array");
+    assert!(agents.is_empty(), "should return empty array with no built-in agents");
+}
+
+// ---------------------------------------------------------------------------
+// Tests: GET /agents (built-in filtering)
+// ---------------------------------------------------------------------------
+
+/// `GET /agents` must NOT return built-in system agents.
+#[tokio::test]
+async fn test_list_agents_excludes_builtin_by_default() {
+    let (app, storage, _manager, _tmp) = build_app().await;
+
+    insert_builtin_agent(&storage, "agentd-system").await;
+    let user = insert_user_agent(&storage, "my-user-agent").await;
+
+    let response =
+        app.oneshot(Request::builder().uri("/agents").body(Body::empty()).unwrap()).await.unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = body_json(response).await;
+    let items = json["items"].as_array().expect("expected items array");
+
+    assert!(
+        items.iter().all(|a| a["built_in"] != true),
+        "built-in agents must be excluded from GET /agents by default"
+    );
+    assert!(
+        items.iter().any(|a| a["id"] == user.id.to_string()),
+        "user agent should appear in GET /agents"
+    );
+}
+
+/// `GET /agents?include_builtin=true` returns both user and built-in agents.
+#[tokio::test]
+async fn test_list_agents_include_builtin_param() {
+    let (app, storage, _manager, _tmp) = build_app().await;
+
+    insert_builtin_agent(&storage, "agentd-system").await;
+    insert_user_agent(&storage, "my-user-agent").await;
+
+    let response = app
+        .oneshot(
+            Request::builder().uri("/agents?include_builtin=true").body(Body::empty()).unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = body_json(response).await;
+    let items = json["items"].as_array().expect("expected items array");
+    assert_eq!(items.len(), 2, "should return both user and built-in agents");
+
+    let has_builtin = items.iter().any(|a| a["built_in"] == true);
+    let has_user = items.iter().any(|a| a["built_in"] != true);
+    assert!(has_builtin, "should include built-in agent");
+    assert!(has_user, "should include user agent");
+}
+
+// ---------------------------------------------------------------------------
+// Tests: DELETE /agents/{id}
+// ---------------------------------------------------------------------------
+
+/// `DELETE /agents/{id}` must be blocked for built-in system agents.
+#[tokio::test]
+async fn test_delete_builtin_agent_is_rejected() {
+    let (app, storage, _manager, _tmp) = build_app().await;
+    let builtin = insert_builtin_agent(&storage, "agentd-system").await;
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("DELETE")
+                .uri(format!("/agents/{}", builtin.id))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert!(
+        response.status() == StatusCode::BAD_REQUEST
+            || response.status() == StatusCode::FORBIDDEN
+            || response.status() == StatusCode::UNPROCESSABLE_ENTITY,
+        "expected 400/403/422 when deleting a built-in agent, got {}",
+        response.status()
+    );
+}
+
+/// `DELETE /agents/{id}` still works for user agents (regression guard).
+#[tokio::test]
+async fn test_delete_user_agent_is_allowed() {
+    let (app, storage, _manager, _tmp) = build_app().await;
+    let user = insert_user_agent(&storage, "deletable-agent").await;
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("DELETE")
+                .uri(format!("/agents/{}", user.id))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK, "deleting a user agent should succeed");
+}
+
+// ---------------------------------------------------------------------------
+// Tests: POST /agents (built_in ignored)
+// ---------------------------------------------------------------------------
+
+/// `POST /agents` with `built_in: true` in the body must be ignored.
+///
+/// `built_in` is not part of `CreateAgentRequest`; any JSON value for that
+/// key is silently discarded by serde's `deny_unknown_fields`-free defaults.
+/// The created agent must have `built_in = false`.
+#[tokio::test]
+async fn test_create_agent_ignores_builtin_field() {
+    let (app, _storage, _manager, _tmp) = build_app().await;
+
+    let body = serde_json::json!({
+        "name": "should-be-user-agent",
+        "working_dir": "/tmp",
+        // Attempt to set built_in via the API — must be ignored
+        "built_in": true
+    })
+    .to_string();
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/agents")
+                .header("Content-Type", "application/json")
+                .body(Body::from(body))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::CREATED);
+    let json = body_json(response).await;
+    assert_eq!(
+        json["built_in"],
+        serde_json::Value::Bool(false),
+        "built_in must default to false regardless of request body"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Tests: bootstrap_system_agents()
+// ---------------------------------------------------------------------------
+
+/// `bootstrap_system_agents()` creates the system agent with `built_in = true`.
+#[tokio::test]
+async fn test_bootstrap_creates_system_agent() {
+    let (_app, storage, manager, _tmp) = build_app().await;
+
+    manager.bootstrap_system_agents().await.unwrap();
+
+    let system_agents = storage.list_system_agents().await.unwrap();
+    assert_eq!(system_agents.len(), 1, "exactly one system agent should exist");
+
+    let agent = &system_agents[0];
+    assert_eq!(agent.name, SYSTEM_AGENT_NAME);
+    assert!(agent.built_in, "system agent must have built_in = true");
+}
+
+/// `bootstrap_system_agents()` is idempotent — calling it twice does not
+/// create a second system agent.
+#[tokio::test]
+async fn test_bootstrap_is_idempotent() {
+    let (_app, storage, manager, _tmp) = build_app().await;
+
+    manager.bootstrap_system_agents().await.unwrap();
+    manager.bootstrap_system_agents().await.unwrap();
+
+    let system_agents = storage.list_system_agents().await.unwrap();
+    assert_eq!(system_agents.len(), 1, "bootstrap must not create duplicate system agents");
+}
+
+/// `AgentResponse` for a built-in agent includes `built_in = true`.
+#[tokio::test]
+async fn test_agent_response_includes_builtin_field() {
+    let (app, storage, _manager, _tmp) = build_app().await;
+    let builtin = insert_builtin_agent(&storage, "agentd-system").await;
+
+    // GET /agents/{id} should expose the built_in field.
+    let response = app
+        .oneshot(
+            Request::builder().uri(format!("/agents/{}", builtin.id)).body(Body::empty()).unwrap(),
+        )
+        .await
+        .unwrap();
+
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = body_json(response).await;
+    assert_eq!(
+        json["built_in"],
+        serde_json::Value::Bool(true),
+        "GET /agents/{{id}} must return built_in = true for system agents"
+    );
+}

--- a/ui/src/components/agents/SystemAgentList.tsx
+++ b/ui/src/components/agents/SystemAgentList.tsx
@@ -1,13 +1,12 @@
 /**
- * SystemAgentList — compact display of built-in system agents.
+ * SystemAgentList — display of built-in system agents.
  *
  * Renders above the main agent list on the AgentsPage. Shows name, status,
- * model, and activity state. No create/delete actions are available — system
- * agents are managed automatically by the orchestrator.
+ * model, and rooms. No create/delete actions are available — system agents
+ * are managed automatically by the orchestrator.
  *
  * Features:
  * - Auto-refresh every 10 seconds (shared with the main agent list cadence)
- * - Collapsible panel (expanded by default)
  * - Visual distinction via a "System" badge on each row
  * - Clicking a row navigates to the agent detail page (same as user agents)
  */
@@ -15,13 +14,11 @@
 import {
 	AlertCircle,
 	Bot,
-	ChevronDown,
-	ChevronRight,
 	RefreshCw,
 } from "lucide-react";
-import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 import { AgentStatusBadge } from "@/components/agents/AgentStatusBadge";
+import { ListItemSkeleton } from "@/components/common/LoadingSkeleton";
 import { useSystemAgents } from "@/hooks/useSystemAgents";
 import type { Agent } from "@/types/orchestrator";
 
@@ -31,85 +28,94 @@ import type { Agent } from "@/types/orchestrator";
 
 export function SystemAgentList() {
 	const { agents, loading, refreshing, error, refetch } = useSystemAgents();
-	const [collapsed, setCollapsed] = useState(false);
 	const navigate = useNavigate();
 
 	return (
-		<div className="mb-6 rounded-lg border border-blue-200 bg-blue-50 dark:border-blue-800 dark:bg-blue-950/30">
+		<div className="space-y-5 mb-8">
 			{/* Header */}
-			<div className="flex items-center justify-between px-4 py-3">
-				<button
-					type="button"
-					className="flex items-center gap-2 text-sm font-semibold text-blue-800 dark:text-blue-300"
-					onClick={() => setCollapsed((c) => !c)}
-				>
-					{collapsed ? (
-						<ChevronRight className="h-4 w-4" />
-					) : (
-						<ChevronDown className="h-4 w-4" />
-					)}
-					<Bot className="h-4 w-4" />
-					System Agents
-					{!loading && (
-						<span className="ml-1 rounded-full bg-blue-200 px-2 py-0.5 text-xs font-medium text-blue-800 dark:bg-blue-800 dark:text-blue-200">
-							{agents.length}
-						</span>
-					)}
-				</button>
+			<div className="flex items-center justify-between">
+				<div>
+					<h1 className="text-2xl font-semibold text-th-text">
+						System Agents
+					</h1>
+					<p className="mt-1 text-sm text-th-text-muted">
+						Built-in agents managed by the orchestrator.
+					</p>
+				</div>
 
 				<div className="flex items-center gap-2">
 					{refreshing && (
-						<RefreshCw className="h-3 w-3 animate-spin text-blue-600 dark:text-blue-400" />
+						<RefreshCw
+							size={14}
+							aria-label="Refreshing..."
+							className="animate-spin text-th-text-muted"
+						/>
 					)}
 					<button
 						type="button"
-						title="Refresh system agents"
+						aria-label="Refresh system agents"
 						onClick={refetch}
-						className="rounded p-1 text-blue-600 hover:bg-blue-100 dark:text-blue-400 dark:hover:bg-blue-900"
+						disabled={loading}
+						className="rounded-md border border-th-border-strong bg-th-surface p-2 text-th-text-muted hover:bg-th-surface-hover hover:text-th-text-secondary focus:outline-none focus:ring-2 focus:ring-th-focus-ring focus:ring-offset-1 disabled:opacity-50"
 					>
-						<RefreshCw className="h-3.5 w-3.5" />
+						<RefreshCw size={15} />
 					</button>
 				</div>
 			</div>
 
-			{/* Body */}
-			{!collapsed && (
-				<div className="border-t border-blue-200 dark:border-blue-800">
-					{/* Error state */}
-					{error && (
-						<div className="flex items-center gap-2 px-4 py-3 text-sm text-red-600 dark:text-red-400">
-							<AlertCircle className="h-4 w-4 flex-shrink-0" />
-							{error}
-						</div>
-					)}
+			{/* Error banner */}
+			{error && (
+				<div
+					role="alert"
+					className="rounded-md bg-th-status-error-bg px-4 py-3 text-sm text-th-status-error-text"
+				>
+					<div className="flex items-center gap-2">
+						<AlertCircle className="h-4 w-4 flex-shrink-0" />
+						{error}
+					</div>
+				</div>
+			)}
 
-					{/* Loading state */}
-					{loading && !error && (
-						<div className="px-4 py-4 text-sm text-blue-600 dark:text-blue-400">
-							Loading system agents…
-						</div>
-					)}
-
-					{/* Empty state */}
-					{!loading && !error && agents.length === 0 && (
-						<div className="px-4 py-4 text-sm text-blue-600/70 dark:text-blue-400/70">
-							No system agents found. The orchestrator may still be starting up.
-						</div>
-					)}
-
-					{/* Agent rows */}
-					{!loading && !error && agents.length > 0 && (
-						<table className="w-full text-sm">
-							<thead>
-								<tr className="border-b border-blue-200 bg-blue-100/50 text-left text-xs font-medium text-blue-700 dark:border-blue-800 dark:bg-blue-900/30 dark:text-blue-400">
-									<th className="px-4 py-2">Name</th>
-									<th className="px-4 py-2">Status</th>
-									<th className="px-4 py-2">Model</th>
-									<th className="px-4 py-2">Rooms</th>
+			{/* Table */}
+			<div className="overflow-hidden rounded-lg border border-th-border">
+				<div className="overflow-x-auto">
+					<table className="min-w-full divide-y divide-th-border">
+						<thead className="bg-th-surface-sunken">
+							<tr>
+								<th className="px-4 py-3 text-left text-xs font-medium text-th-text-muted">
+									Name
+								</th>
+								<th className="px-4 py-3 text-left text-xs font-medium text-th-text-muted">
+									Status
+								</th>
+								<th className="px-4 py-3 text-left text-xs font-medium text-th-text-muted">
+									Model
+								</th>
+								<th className="px-4 py-3 text-left text-xs font-medium text-th-text-muted">
+									Rooms
+								</th>
+							</tr>
+						</thead>
+						<tbody className="divide-y divide-th-border bg-th-surface">
+							{loading ? (
+								<tr>
+									<td colSpan={4} className="p-4">
+										<ListItemSkeleton rows={2} />
+									</td>
 								</tr>
-							</thead>
-							<tbody>
-								{agents.map((agent) => (
+							) : agents.length === 0 && !error ? (
+								<tr>
+									<td colSpan={4} className="py-12 text-center">
+										<p className="text-sm text-th-text-muted">
+											No system agents found.
+										</p>
+										<p className="mt-1 text-xs text-th-text-faint">
+											The orchestrator may still be starting up.
+										</p>
+									</td>
+								</tr>
+							) : (
+								agents.map((agent) => (
 									<SystemAgentRow
 										key={agent.id}
 										agent={agent}
@@ -117,12 +123,12 @@ export function SystemAgentList() {
 											navigate(`/agents/${agent.id}`)
 										}
 									/>
-								))}
-							</tbody>
-						</table>
-					)}
+								))
+							)}
+						</tbody>
+					</table>
 				</div>
-			)}
+			</div>
 		</div>
 	);
 }
@@ -141,17 +147,17 @@ function SystemAgentRow({ agent, onClick }: SystemAgentRowProps) {
 
 	return (
 		<tr
-			className="cursor-pointer border-b border-blue-100 last:border-0 hover:bg-blue-100/60 dark:border-blue-900 dark:hover:bg-blue-900/40"
+			className="cursor-pointer border-b border-th-border hover:bg-th-surface-hover"
 			onClick={onClick}
 		>
 			{/* Name + system badge */}
 			<td className="px-4 py-3">
 				<div className="flex items-center gap-2">
-					<Bot className="h-3.5 w-3.5 flex-shrink-0 text-blue-500 dark:text-blue-400" />
-					<span className="font-medium text-gray-900 dark:text-gray-100">
+					<Bot className="h-3.5 w-3.5 flex-shrink-0 text-th-text-muted" />
+					<span className="text-sm font-medium text-th-text">
 						{agent.name}
 					</span>
-					<span className="rounded-full bg-blue-200 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-blue-800 dark:bg-blue-800 dark:text-blue-200">
+					<span className="rounded-full bg-th-accent/10 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-th-accent">
 						system
 					</span>
 				</div>
@@ -163,25 +169,27 @@ function SystemAgentRow({ agent, onClick }: SystemAgentRowProps) {
 			</td>
 
 			{/* Model */}
-			<td className="px-4 py-3 text-gray-600 dark:text-gray-400">
-				{agent.config.model ?? "default"}
+			<td className="px-4 py-3 text-sm text-th-text-muted">
+				{agent.config.model ?? (
+					<span className="italic opacity-50">default</span>
+				)}
 			</td>
 
 			{/* Rooms */}
-			<td className="px-4 py-3 text-gray-600 dark:text-gray-400">
+			<td className="px-4 py-3 text-sm text-th-text-muted">
 				{rooms.length > 0 ? (
 					<div className="flex flex-wrap gap-1">
 						{rooms.map((r: string) => (
 							<span
 								key={r}
-								className="rounded bg-blue-100 px-1.5 py-0.5 text-[10px] text-blue-800 dark:bg-blue-900 dark:text-blue-300"
+								className="rounded bg-th-surface-sunken px-1.5 py-0.5 text-[10px] text-th-text-muted"
 							>
 								{r}
 							</span>
 						))}
 					</div>
 				) : (
-					<span className="text-xs text-gray-400">—</span>
+					<span className="text-th-text-faint">-</span>
 				)}
 			</td>
 		</tr>

--- a/ui/src/components/agents/SystemAgentList.tsx
+++ b/ui/src/components/agents/SystemAgentList.tsx
@@ -1,0 +1,191 @@
+/**
+ * SystemAgentList — compact display of built-in system agents.
+ *
+ * Renders above the main agent list on the AgentsPage. Shows name, status,
+ * model, and activity state. No create/delete actions are available — system
+ * agents are managed automatically by the orchestrator.
+ *
+ * Features:
+ * - Auto-refresh every 10 seconds (shared with the main agent list cadence)
+ * - Collapsible panel (expanded by default)
+ * - Visual distinction via a "System" badge on each row
+ * - Clicking a row navigates to the agent detail page (same as user agents)
+ */
+
+import {
+	AlertCircle,
+	Bot,
+	ChevronDown,
+	ChevronRight,
+	RefreshCw,
+} from "lucide-react";
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { AgentStatusBadge } from "@/components/agents/AgentStatusBadge";
+import { useSystemAgents } from "@/hooks/useSystemAgents";
+import type { Agent } from "@/types/orchestrator";
+
+// ---------------------------------------------------------------------------
+// SystemAgentList
+// ---------------------------------------------------------------------------
+
+export function SystemAgentList() {
+	const { agents, loading, refreshing, error, refetch } = useSystemAgents();
+	const [collapsed, setCollapsed] = useState(false);
+	const navigate = useNavigate();
+
+	return (
+		<div className="mb-6 rounded-lg border border-blue-200 bg-blue-50 dark:border-blue-800 dark:bg-blue-950/30">
+			{/* Header */}
+			<div className="flex items-center justify-between px-4 py-3">
+				<button
+					type="button"
+					className="flex items-center gap-2 text-sm font-semibold text-blue-800 dark:text-blue-300"
+					onClick={() => setCollapsed((c) => !c)}
+				>
+					{collapsed ? (
+						<ChevronRight className="h-4 w-4" />
+					) : (
+						<ChevronDown className="h-4 w-4" />
+					)}
+					<Bot className="h-4 w-4" />
+					System Agents
+					{!loading && (
+						<span className="ml-1 rounded-full bg-blue-200 px-2 py-0.5 text-xs font-medium text-blue-800 dark:bg-blue-800 dark:text-blue-200">
+							{agents.length}
+						</span>
+					)}
+				</button>
+
+				<div className="flex items-center gap-2">
+					{refreshing && (
+						<RefreshCw className="h-3 w-3 animate-spin text-blue-600 dark:text-blue-400" />
+					)}
+					<button
+						type="button"
+						title="Refresh system agents"
+						onClick={refetch}
+						className="rounded p-1 text-blue-600 hover:bg-blue-100 dark:text-blue-400 dark:hover:bg-blue-900"
+					>
+						<RefreshCw className="h-3.5 w-3.5" />
+					</button>
+				</div>
+			</div>
+
+			{/* Body */}
+			{!collapsed && (
+				<div className="border-t border-blue-200 dark:border-blue-800">
+					{/* Error state */}
+					{error && (
+						<div className="flex items-center gap-2 px-4 py-3 text-sm text-red-600 dark:text-red-400">
+							<AlertCircle className="h-4 w-4 flex-shrink-0" />
+							{error}
+						</div>
+					)}
+
+					{/* Loading state */}
+					{loading && !error && (
+						<div className="px-4 py-4 text-sm text-blue-600 dark:text-blue-400">
+							Loading system agents…
+						</div>
+					)}
+
+					{/* Empty state */}
+					{!loading && !error && agents.length === 0 && (
+						<div className="px-4 py-4 text-sm text-blue-600/70 dark:text-blue-400/70">
+							No system agents found. The orchestrator may still be starting up.
+						</div>
+					)}
+
+					{/* Agent rows */}
+					{!loading && !error && agents.length > 0 && (
+						<table className="w-full text-sm">
+							<thead>
+								<tr className="border-b border-blue-200 bg-blue-100/50 text-left text-xs font-medium text-blue-700 dark:border-blue-800 dark:bg-blue-900/30 dark:text-blue-400">
+									<th className="px-4 py-2">Name</th>
+									<th className="px-4 py-2">Status</th>
+									<th className="px-4 py-2">Model</th>
+									<th className="px-4 py-2">Rooms</th>
+								</tr>
+							</thead>
+							<tbody>
+								{agents.map((agent) => (
+									<SystemAgentRow
+										key={agent.id}
+										agent={agent}
+										onClick={() =>
+											navigate(`/agents/${agent.id}`)
+										}
+									/>
+								))}
+							</tbody>
+						</table>
+					)}
+				</div>
+			)}
+		</div>
+	);
+}
+
+// ---------------------------------------------------------------------------
+// SystemAgentRow
+// ---------------------------------------------------------------------------
+
+interface SystemAgentRowProps {
+	agent: Agent;
+	onClick: () => void;
+}
+
+function SystemAgentRow({ agent, onClick }: SystemAgentRowProps) {
+	const rooms = agent.config.rooms ?? [];
+
+	return (
+		<tr
+			className="cursor-pointer border-b border-blue-100 last:border-0 hover:bg-blue-100/60 dark:border-blue-900 dark:hover:bg-blue-900/40"
+			onClick={onClick}
+		>
+			{/* Name + system badge */}
+			<td className="px-4 py-3">
+				<div className="flex items-center gap-2">
+					<Bot className="h-3.5 w-3.5 flex-shrink-0 text-blue-500 dark:text-blue-400" />
+					<span className="font-medium text-gray-900 dark:text-gray-100">
+						{agent.name}
+					</span>
+					<span className="rounded-full bg-blue-200 px-1.5 py-0.5 text-[10px] font-semibold uppercase tracking-wide text-blue-800 dark:bg-blue-800 dark:text-blue-200">
+						system
+					</span>
+				</div>
+			</td>
+
+			{/* Status */}
+			<td className="px-4 py-3">
+				<AgentStatusBadge status={agent.status} />
+			</td>
+
+			{/* Model */}
+			<td className="px-4 py-3 text-gray-600 dark:text-gray-400">
+				{agent.config.model ?? "default"}
+			</td>
+
+			{/* Rooms */}
+			<td className="px-4 py-3 text-gray-600 dark:text-gray-400">
+				{rooms.length > 0 ? (
+					<div className="flex flex-wrap gap-1">
+						{rooms.map((r: string) => (
+							<span
+								key={r}
+								className="rounded bg-blue-100 px-1.5 py-0.5 text-[10px] text-blue-800 dark:bg-blue-900 dark:text-blue-300"
+							>
+								{r}
+							</span>
+						))}
+					</div>
+				) : (
+					<span className="text-xs text-gray-400">—</span>
+				)}
+			</td>
+		</tr>
+	);
+}
+
+export default SystemAgentList;

--- a/ui/src/hooks/useSystemAgents.ts
+++ b/ui/src/hooks/useSystemAgents.ts
@@ -1,0 +1,101 @@
+/**
+ * useSystemAgents — hook for fetching and displaying built-in system agents.
+ *
+ * Fetches from `GET /system-agents`, auto-refreshes on the same interval as
+ * the main agent list (default 10 seconds), and exposes a manual `refetch`.
+ *
+ * System agents are always present while the orchestrator is running.
+ * This hook never exposes create/delete actions — those are not available
+ * for built-in agents.
+ */
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { orchestratorClient } from "@/services/orchestrator";
+import type { Agent } from "@/types/orchestrator";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface UseSystemAgentsOptions {
+	/** Pause auto-refresh (e.g. when a dialog is open). Default: false */
+	paused?: boolean;
+	/** Auto-refresh interval in milliseconds. Default: 10 000 */
+	refreshInterval?: number;
+}
+
+export interface UseSystemAgentsResult {
+	/** Built-in system agents returned by the API */
+	agents: Agent[];
+	/** True on initial load before any data arrives */
+	loading: boolean;
+	/** True during background refresh (data already loaded) */
+	refreshing: boolean;
+	/** Error message if the last fetch failed */
+	error?: string;
+	/** Trigger an immediate refresh */
+	refetch: () => void;
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+export function useSystemAgents(
+	options: UseSystemAgentsOptions = {},
+): UseSystemAgentsResult {
+	const { paused = false, refreshInterval = 10_000 } = options;
+
+	const [agents, setAgents] = useState<Agent[]>([]);
+	const [loading, setLoading] = useState(true);
+	const [refreshing, setRefreshing] = useState(false);
+	const [error, setError] = useState<string | undefined>();
+
+	const firstLoad = useRef(true);
+	const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+	const fetchAgents = useCallback(async () => {
+		if (firstLoad.current) {
+			setLoading(true);
+		} else {
+			setRefreshing(true);
+		}
+
+		try {
+			const data = await orchestratorClient.listSystemAgents();
+			setAgents(data);
+			setError(undefined);
+		} catch (err) {
+			const msg = err instanceof Error ? err.message : "Unknown error";
+			setError(`Failed to fetch system agents: ${msg}`);
+		} finally {
+			setLoading(false);
+			setRefreshing(false);
+			firstLoad.current = false;
+		}
+	}, []);
+
+	// Schedule next refresh after current fetch settles.
+	const scheduleNext = useCallback(() => {
+		if (timerRef.current) clearTimeout(timerRef.current);
+		timerRef.current = setTimeout(() => {
+			if (!paused) fetchAgents().then(scheduleNext);
+		}, refreshInterval);
+	}, [paused, refreshInterval, fetchAgents]);
+
+	// Initial fetch + start refresh loop.
+	useEffect(() => {
+		firstLoad.current = true;
+		fetchAgents().then(scheduleNext);
+		return () => {
+			if (timerRef.current) clearTimeout(timerRef.current);
+		};
+	}, [fetchAgents, scheduleNext]);
+
+	const refetch = useCallback(() => {
+		if (timerRef.current) clearTimeout(timerRef.current);
+		fetchAgents().then(scheduleNext);
+	}, [fetchAgents, scheduleNext]);
+
+	return { agents, loading, refreshing, error, refetch };
+}

--- a/ui/src/pages/AgentsPage.tsx
+++ b/ui/src/pages/AgentsPage.tsx
@@ -1,7 +1,21 @@
+import { SystemAgentList } from "@/components/agents/SystemAgentList";
 import { AgentList } from "./agents/AgentList";
 
+/**
+ * AgentsPage — top-level agents page.
+ *
+ * Renders two sections:
+ * 1. **System Agents** — built-in agents managed by the orchestrator.
+ *    Always-present, no create/delete actions.
+ * 2. **Agents** — user-created agents with full CRUD and filtering.
+ */
 export function AgentsPage() {
-	return <AgentList />;
+	return (
+		<>
+			<SystemAgentList />
+			<AgentList />
+		</>
+	);
 }
 
 export default AgentsPage;

--- a/ui/src/services/orchestrator.ts
+++ b/ui/src/services/orchestrator.ts
@@ -59,6 +59,16 @@ export class OrchestratorClient extends ApiClient {
 		);
 	}
 
+	/**
+	 * `GET /system-agents` — list built-in system agents.
+	 *
+	 * Returns only agents with `built_in = true`. These are spawned automatically
+	 * by the orchestrator at startup and are always present while the service runs.
+	 */
+	listSystemAgents(): Promise<Agent[]> {
+		return this.get<Agent[]>("/system-agents");
+	}
+
 	createAgent(request: CreateAgentRequest): Promise<Agent> {
 		return this.post<Agent>("/agents", request);
 	}

--- a/ui/src/types/orchestrator.ts
+++ b/ui/src/types/orchestrator.ts
@@ -52,6 +52,8 @@ export interface AgentConfig {
 	env?: Record<string, string>;
 	auto_clear_threshold?: number;
 	additional_dirs?: string[];
+	/** Communicate rooms the agent is auto-joined to on connection. */
+	rooms?: string[];
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Add CLI commands for interacting with built-in system agents via a dedicated `agent system-agents` subcommand group.

## Changes

### New: `agent system-agents` subcommand group
- `agent system-agents list` — fetch from `GET /system-agents`, display with system badge
- `agent system-agents get <id|name>` — resolve by UUID or name, show full details
- `agent system-agents message <id> <text>` — send prompt (guards against non-running status)
- `agent system-agents status` — compact table showing name, status, model, activity
- All subcommands support `--json` output

### Updated: `agent list`
- Added `--include-builtin` flag that passes `?include_builtin=true` to the API
- Default behaviour unchanged: system agents excluded from the regular list

### Orchestrator client
- `OrchestratorClient::list_agents_filtered(status, include_builtin)` added
- `list_agents()` now delegates to `list_agents_filtered(status, false)` (no behaviour change)

Closes #1141