### PR TITLE
feat(wrap): make PTY ring-buffer configurable via env vars

### DIFF
--- a/crates/wrap/src/main.rs
+++ b/crates/wrap/src/main.rs
@@ -22,9 +22,11 @@
 //!
 //! # Environment Variables
 //!
-//! - `RUST_LOG`        — Logging level (default: `info`)
-//! - `AGENTD_PORT`     — Listen port (default: `17005`)
-//! - `AGENTD_BACKEND`  — Execution backend: `tmux` | `docker` | `pty` | `subprocess` (default: `tmux`)
+//! - `RUST_LOG`                     — Logging level (default: `info`)
+//! - `AGENTD_PORT`                  — Listen port (default: `17005`)
+//! - `AGENTD_BACKEND`               — Execution backend: `tmux` | `docker` | `pty` | `subprocess` (default: `tmux`)
+//! - `AGENTD_WRAP_HISTORY_BYTES`    — PTY output ring-buffer size in bytes (default: `524288` / 512 KiB); agentd-wrap PTY backend only
+//! - `AGENTD_WRAP_CHANNEL_CAPACITY` — PTY broadcast channel capacity in chunks (default: `256`); must be ≥ 1; agentd-wrap PTY backend only
 
 // Import from the library target — avoids re-declaring modules in the binary and
 // triggering dead-code warnings on items that are only used by the library.
@@ -33,6 +35,7 @@ use wrap::{
     backend::{ExecutionBackend, TmuxBackend},
     docker::{DockerBackend, DEFAULT_IMAGE},
     pty::PtyBackend,
+    pty_stream::{DEFAULT_CHANNEL_CAPACITY, DEFAULT_HISTORY_BYTES},
     subprocess::SubprocessBackend,
     types::BackendType,
 };
@@ -40,7 +43,7 @@ use wrap::{
 use axum::{extract::State, response::IntoResponse, routing::get};
 use metrics_exporter_prometheus::PrometheusHandle;
 use std::{env, sync::Arc};
-use tracing::info;
+use tracing::{info, warn};
 
 fn init_metrics() -> PrometheusHandle {
     let builder = metrics_exporter_prometheus::PrometheusBuilder::new();
@@ -67,7 +70,51 @@ async fn main() -> anyhow::Result<()> {
     let exec_backend: Arc<dyn ExecutionBackend> = match &backend_type {
         BackendType::Pty => {
             info!("Initialising PTY backend");
-            Arc::new(PtyBackend::new("agentd"))
+            let history_bytes = env::var("AGENTD_WRAP_HISTORY_BYTES")
+                .ok()
+                .and_then(|raw| {
+                    raw.parse::<usize>()
+                        .map_err(|_| {
+                            warn!(
+                                "AGENTD_WRAP_HISTORY_BYTES={:?} is not a valid usize; \
+                             using default {} bytes",
+                                raw, DEFAULT_HISTORY_BYTES
+                            );
+                        })
+                        .ok()
+                })
+                .unwrap_or(DEFAULT_HISTORY_BYTES);
+            let channel_capacity = {
+                let parsed = env::var("AGENTD_WRAP_CHANNEL_CAPACITY")
+                    .ok()
+                    .and_then(|raw| {
+                        raw.parse::<usize>()
+                            .map_err(|_| {
+                                warn!(
+                                    "AGENTD_WRAP_CHANNEL_CAPACITY={:?} is not a valid usize; \
+                                 using default {}",
+                                    raw, DEFAULT_CHANNEL_CAPACITY
+                                );
+                            })
+                            .ok()
+                    })
+                    .unwrap_or(DEFAULT_CHANNEL_CAPACITY);
+                // broadcast::channel(0) panics — clamp to at least 1.
+                if parsed == 0 {
+                    warn!(
+                        "AGENTD_WRAP_CHANNEL_CAPACITY=0 is invalid \
+                         (tokio broadcast::channel requires capacity ≥ 1); clamped to 1"
+                    );
+                    1
+                } else {
+                    parsed
+                }
+            };
+            info!(
+                "PTY ring-buffer: history_bytes={}, channel_capacity={}",
+                history_bytes, channel_capacity
+            );
+            Arc::new(PtyBackend::new_with_config("agentd", channel_capacity, history_bytes))
         }
         BackendType::Docker => {
             info!("Initialising Docker backend");

--- a/crates/wrap/src/pty.rs
+++ b/crates/wrap/src/pty.rs
@@ -54,16 +54,60 @@ struct PtySession {
 /// No external binary dependencies (unlike [`TmuxBackend`][crate::backend::TmuxBackend]).
 ///
 /// Sessions are stored in-memory; they do not survive process restarts.
+///
+/// Buffer sizing is configurable at construction time via
+/// [`new_with_config`](PtyBackend::new_with_config); the defaults
+/// ([`DEFAULT_CHANNEL_CAPACITY`], [`DEFAULT_HISTORY_BYTES`]) are used by
+/// [`new`](PtyBackend::new) and may be overridden through
+/// `AGENTD_WRAP_CHANNEL_CAPACITY` / `AGENTD_WRAP_HISTORY_BYTES` env vars at
+/// service startup.
 #[derive(Clone)]
 pub struct PtyBackend {
     prefix: String,
     sessions: Arc<RwLock<HashMap<String, PtySession>>>,
+    /// Broadcast channel capacity threaded into every new [`PtyOutputStream`].
+    channel_capacity: usize,
+    /// Ring-buffer byte budget threaded into every new [`PtyOutputStream`].
+    max_history_bytes: usize,
 }
 
 impl PtyBackend {
     /// Create a new `PtyBackend` with the given session name prefix.
+    ///
+    /// Uses [`DEFAULT_CHANNEL_CAPACITY`] and [`DEFAULT_HISTORY_BYTES`] for
+    /// the output ring buffer.  Call [`new_with_config`](Self::new_with_config)
+    /// to supply custom values (e.g. read from env vars at startup).
     pub fn new(prefix: impl Into<String>) -> Self {
-        Self { prefix: prefix.into(), sessions: Arc::new(RwLock::new(HashMap::new())) }
+        Self::new_with_config(prefix, DEFAULT_CHANNEL_CAPACITY, DEFAULT_HISTORY_BYTES)
+    }
+
+    /// Create a new `PtyBackend` with explicit buffer configuration.
+    ///
+    /// # Arguments
+    ///
+    /// * `prefix` - Session name prefix.
+    /// * `channel_capacity` - Broadcast channel capacity
+    ///   (see [`DEFAULT_CHANNEL_CAPACITY`]).  Read from
+    ///   `AGENTD_WRAP_CHANNEL_CAPACITY` at service startup.
+    /// * `max_history_bytes` - Byte budget for the replay ring buffer
+    ///   (see [`DEFAULT_HISTORY_BYTES`]).  Read from
+    ///   `AGENTD_WRAP_HISTORY_BYTES` at service startup.
+    pub fn new_with_config(
+        prefix: impl Into<String>,
+        channel_capacity: usize,
+        max_history_bytes: usize,
+    ) -> Self {
+        assert!(
+            channel_capacity >= 1,
+            "channel_capacity must be ≥ 1 — tokio::sync::broadcast::channel panics on 0 \
+             (got channel_capacity={channel_capacity})"
+        );
+        Self {
+            prefix: prefix.into(),
+            sessions: Arc::new(RwLock::new(HashMap::new())),
+            channel_capacity,
+            max_history_bytes,
+        }
     }
 }
 
@@ -106,7 +150,7 @@ impl ExecutionBackend for PtyBackend {
         .await
         .context("spawn_blocking panicked")??;
 
-        let stream = PtyOutputStream::new(DEFAULT_CHANNEL_CAPACITY, DEFAULT_HISTORY_BYTES, writer);
+        let stream = PtyOutputStream::new(self.channel_capacity, self.max_history_bytes, writer);
         // Spawn the background reader task (moves a clone of the stream)
         stream.clone().spawn_reader(reader);
 
@@ -286,6 +330,30 @@ mod tests {
     fn pty_backend_new_sets_prefix() {
         let backend = PtyBackend::new("test-prefix");
         assert_eq!(backend.prefix(), "test-prefix");
+    }
+
+    #[test]
+    fn pty_backend_new_uses_default_buffer_config() {
+        let backend = PtyBackend::new("test");
+        assert_eq!(backend.channel_capacity, DEFAULT_CHANNEL_CAPACITY);
+        assert_eq!(backend.max_history_bytes, DEFAULT_HISTORY_BYTES);
+    }
+
+    #[test]
+    fn pty_backend_new_with_config_applies_custom_values() {
+        let backend = PtyBackend::new_with_config("custom", 512, 1024 * 1024);
+        assert_eq!(backend.prefix(), "custom");
+        assert_eq!(backend.channel_capacity, 512);
+        assert_eq!(backend.max_history_bytes, 1024 * 1024);
+    }
+
+    /// `broadcast::channel(0)` panics; verify that `new_with_config` enforces
+    /// the capacity ≥ 1 requirement with a clear message rather than silently
+    /// deferring the panic to the first `create_session` call.
+    #[test]
+    #[should_panic(expected = "channel_capacity must be ≥ 1")]
+    fn pty_backend_new_with_config_zero_capacity_panics() {
+        PtyBackend::new_with_config("t", 0, 1024);
     }
 
     #[test]


### PR DESCRIPTION
Add `AGENTD_WRAP_HISTORY_BYTES` and `AGENTD_WRAP_CHANNEL_CAPACITY` environment variables to tune the PTY output ring-buffer size and broadcast channel capacity at service startup, replacing hardcoded defaults.

## Changes

- `PtyBackend::new_with_config(prefix, channel_capacity, max_history_bytes)` constructor stores and threads config into every `PtyOutputStream`
- `PtyBackend::new()` retains default behaviour (`DEFAULT_HISTORY_BYTES` / `DEFAULT_CHANNEL_CAPACITY`)
- `main.rs` reads both env vars at startup (PTY backend only) and logs the resolved values
- Doc comment in `main.rs` updated to list the new env vars
- Two new unit tests: `pty_backend_new_uses_default_buffer_config` and `pty_backend_new_with_config_applies_custom_values`

## Test plan

- [x] `cargo test -p wrap` — 135 tests pass
- [x] `cargo clippy -p wrap -- -D warnings` — clean
- [x] `cargo fmt --check -p wrap` — clean
- [x] `AGENTD_BACKEND=pty AGENTD_WRAP_HISTORY_BYTES=1048576 AGENTD_WRAP_CHANNEL_CAPACITY=512` logs resolved values on startup

Closes #1164

🤖 Generated with [Claude Code](https://claude.com/claude-code)