### PR TITLE
feat(orchestrator): add conversation retention policy and periodic cleanup

### DIFF
--- a/crates/orchestrator/src/main.rs
+++ b/crates/orchestrator/src/main.rs
@@ -117,9 +117,24 @@ async fn main() -> anyhow::Result<()> {
         .with_event_bus(event_bus.clone())
         .with_storage((*storage).clone());
 
+    // Conversation event retention policy (read once at startup).
+    let retention_config = Arc::new(types::RetentionConfig::from_env());
+    info!(
+        retention_days = retention_config.retention_days,
+        max_events_per_agent = retention_config.max_events_per_agent,
+        cleanup_on_terminate = retention_config.cleanup_on_terminate,
+        cleanup_interval_secs = retention_config.cleanup_interval_secs,
+        "Conversation retention config loaded",
+    );
+
     // Agent manager (Arc'd immediately so it can be shared with callbacks and API state).
-    let manager =
-        Arc::new(AgentManager::new(storage.clone(), backend, registry.clone(), ws_base_url));
+    let manager = Arc::new(AgentManager::with_retention(
+        storage.clone(),
+        backend,
+        registry.clone(),
+        ws_base_url,
+        retention_config.clone(),
+    ));
 
     // Scheduler for autonomous workflows (shares the same SeaORM connection).
     // Schema is already applied by AgentStorage::with_path() via Migrator::up().
@@ -407,6 +422,71 @@ async fn main() -> anyhow::Result<()> {
                 interval.tick().await;
                 if let Err(e) = manager_reconcile.reconcile().await {
                     error!(%e, "Periodic reconciliation failed");
+                }
+            }
+        });
+    }
+
+    // Periodic conversation event cleanup: prune old events and enforce the
+    // per-agent cap on a configurable interval (default 6 h).
+    {
+        let storage_cleanup = storage.clone();
+        let retention = retention_config.clone();
+        let cleanup_interval = retention.cleanup_interval_secs;
+        info!(
+            cleanup_interval_secs = cleanup_interval,
+            "Starting periodic conversation cleanup loop"
+        );
+        tokio::spawn(async move {
+            let mut interval =
+                tokio::time::interval(tokio::time::Duration::from_secs(cleanup_interval));
+            interval.tick().await; // skip immediate tick on startup
+            loop {
+                interval.tick().await;
+
+                // Age-based pruning: remove events older than retention_days.
+                match storage_cleanup.prune_old_conversation_events(retention.retention_days).await
+                {
+                    Ok(n) if n > 0 => {
+                        info!(pruned = n, "Pruned old conversation events");
+                        metrics::counter!("agentd_conversation_events_pruned_total").increment(n);
+                    }
+                    Ok(_) => {}
+                    Err(e) => error!(%e, "Conversation event age-prune failed"),
+                }
+
+                // Per-agent cap: enforce max_events_per_agent for every known agent.
+                match storage_cleanup.list(None, None).await {
+                    Ok(agents) => {
+                        for agent in &agents {
+                            match storage_cleanup
+                                .prune_excess_conversation_events(
+                                    agent.id,
+                                    retention.max_events_per_agent,
+                                )
+                                .await
+                            {
+                                Ok(n) if n > 0 => {
+                                    info!(
+                                        agent_id = %agent.id,
+                                        pruned = n,
+                                        "Pruned excess conversation events for agent",
+                                    );
+                                    metrics::counter!("agentd_conversation_events_pruned_total")
+                                        .increment(n);
+                                }
+                                Ok(_) => {}
+                                Err(e) => {
+                                    error!(
+                                        agent_id = %agent.id,
+                                        %e,
+                                        "Conversation event cap-prune failed for agent",
+                                    );
+                                }
+                            }
+                        }
+                    }
+                    Err(e) => error!(%e, "Failed to list agents for per-agent cap pruning"),
                 }
             }
         });

--- a/crates/orchestrator/src/manager.rs
+++ b/crates/orchestrator/src/manager.rs
@@ -1,6 +1,8 @@
 use crate::scheduler::events::SystemEvent;
 use crate::storage::{AgentStorage, ProjectStorage};
-use crate::types::{Agent, AgentConfig, AgentStatus, AgentUsageStats, ClearContextResponse};
+use crate::types::{
+    Agent, AgentConfig, AgentStatus, AgentUsageStats, ClearContextResponse, RetentionConfig,
+};
 use crate::websocket::ConnectionRegistry;
 use chrono::Utc;
 use std::sync::Arc;
@@ -21,6 +23,8 @@ pub struct AgentManager {
     registry: ConnectionRegistry,
     /// The base URL agents will use to connect back via WebSocket.
     ws_base_url: String,
+    /// Conversation event retention policy applied at terminate and on schedule.
+    retention_config: Arc<RetentionConfig>,
 }
 
 impl AgentManager {
@@ -30,7 +34,25 @@ impl AgentManager {
         registry: ConnectionRegistry,
         ws_base_url: String,
     ) -> Self {
-        Self { storage, backend, registry, ws_base_url }
+        Self::with_retention(
+            storage,
+            backend,
+            registry,
+            ws_base_url,
+            Arc::new(RetentionConfig::from_env()),
+        )
+    }
+
+    /// Construct with an explicit [`RetentionConfig`] (useful for testing and
+    /// for wiring up the config read from env vars in `main`).
+    pub fn with_retention(
+        storage: Arc<AgentStorage>,
+        backend: Arc<dyn ExecutionBackend>,
+        registry: ConnectionRegistry,
+        ws_base_url: String,
+        retention_config: Arc<RetentionConfig>,
+    ) -> Self {
+        Self { storage, backend, registry, ws_base_url, retention_config }
     }
 
     pub fn registry(&self) -> &ConnectionRegistry {
@@ -237,6 +259,18 @@ impl AgentManager {
         if let Some(ref session) = agent.session_id {
             if let Err(e) = self.backend.kill_session(session).await {
                 warn!(agent_id = %id, %e, "Failed to kill session");
+            }
+        }
+
+        // Optionally delete all conversation events before removing the record.
+        if self.retention_config.cleanup_on_terminate {
+            match self.storage.delete_conversation_events_for_agent(*id).await {
+                Ok(n) => {
+                    info!(agent_id = %id, deleted = n, "Conversation events deleted on terminate")
+                }
+                Err(e) => {
+                    warn!(agent_id = %id, %e, "Failed to clean up conversation events on terminate")
+                }
             }
         }
 

--- a/crates/orchestrator/src/storage.rs
+++ b/crates/orchestrator/src/storage.rs
@@ -797,6 +797,60 @@ impl AgentStorage {
             last_event_at,
         })
     }
+
+    // -----------------------------------------------------------------------
+    // Retention / pruning
+    // -----------------------------------------------------------------------
+
+    /// Deletes conversation events whose `created_at` is older than
+    /// `retention_days` days.  Returns the number of rows deleted.
+    pub async fn prune_old_conversation_events(&self, retention_days: u64) -> Result<u64> {
+        use chrono::Duration;
+        let cutoff = (Utc::now() - Duration::days(retention_days as i64)).to_rfc3339();
+        let result = conv_entity::Entity::delete_many()
+            .filter(conv_entity::Column::CreatedAt.lt(cutoff))
+            .exec(&self.db)
+            .await?;
+        Ok(result.rows_affected)
+    }
+
+    /// For the given agent, deletes the oldest events that exceed `max_events`.
+    ///
+    /// If the current count is at or below `max_events`, nothing is deleted and
+    /// `0` is returned.  Otherwise the `(count - max_events)` oldest rows are
+    /// removed.
+    pub async fn prune_excess_conversation_events(
+        &self,
+        agent_id: Uuid,
+        max_events: u64,
+    ) -> Result<u64> {
+        let count = self.count_conversation_events(agent_id).await?;
+        if count <= max_events {
+            return Ok(0);
+        }
+        let to_delete = count - max_events;
+
+        // Fetch the IDs of the oldest `to_delete` events for this agent.
+        let oldest: Vec<String> = conv_entity::Entity::find()
+            .filter(conv_entity::Column::AgentId.eq(agent_id.to_string()))
+            .order_by(conv_entity::Column::CreatedAt, Order::Asc)
+            .limit(to_delete)
+            .all(&self.db)
+            .await?
+            .into_iter()
+            .map(|m| m.id)
+            .collect();
+
+        if oldest.is_empty() {
+            return Ok(0);
+        }
+
+        let result = conv_entity::Entity::delete_many()
+            .filter(conv_entity::Column::Id.is_in(oldest))
+            .exec(&self.db)
+            .await?;
+        Ok(result.rows_affected)
+    }
 }
 
 // ---------------------------------------------------------------------------
@@ -1901,12 +1955,12 @@ mod tests {
             .await
             .unwrap();
 
-        // `since` — only events on or after boundary.
+        // `since` -- only events on or after boundary.
         let opts = ConversationQuery { since: Some(boundary), ..Default::default() };
         let events = storage.list_conversation_events(agent_id, &opts).await.unwrap();
         assert_eq!(events.len(), 2, "since filter: expected 2 events after boundary");
 
-        // `until` — only events strictly before boundary.
+        // `until` -- only events strictly before boundary.
         let opts = ConversationQuery { until: Some(boundary), ..Default::default() };
         let events = storage.list_conversation_events(agent_id, &opts).await.unwrap();
         assert_eq!(events.len(), 1, "until filter: expected 1 event before boundary");
@@ -2038,5 +2092,110 @@ mod tests {
         assert!(summary.first_event_at.is_some());
         assert!(summary.last_event_at.is_some());
         assert!(summary.first_event_at <= summary.last_event_at);
+    }
+
+    // -----------------------------------------------------------------------
+    // Pruning tests
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_prune_old_events_removes_old_rows() {
+        let (storage, _tmp) = create_test_storage().await;
+        let agent_id = Uuid::new_v4();
+
+        // Insert an event with a timestamp 40 days in the past.
+        let old_event = ConversationEvent {
+            id: Uuid::new_v4(),
+            agent_id,
+            event_type: ConversationEventType::Output,
+            session_number: 0,
+            content: Some("old".to_string()),
+            metadata: None,
+            created_at: Utc::now() - chrono::Duration::days(40),
+        };
+        storage.insert_conversation_event(&old_event).await.unwrap();
+
+        // Insert a recent event.
+        storage
+            .insert_conversation_event(&make_event(agent_id, ConversationEventType::Output))
+            .await
+            .unwrap();
+
+        assert_eq!(storage.count_conversation_events(agent_id).await.unwrap(), 2);
+
+        // Prune events older than 30 days -- only the old one should be removed.
+        let pruned = storage.prune_old_conversation_events(30).await.unwrap();
+        assert_eq!(pruned, 1);
+        assert_eq!(storage.count_conversation_events(agent_id).await.unwrap(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_prune_old_events_no_op_when_nothing_old() {
+        let (storage, _tmp) = create_test_storage().await;
+        let agent_id = Uuid::new_v4();
+
+        for _ in 0..3 {
+            storage
+                .insert_conversation_event(&make_event(agent_id, ConversationEventType::Output))
+                .await
+                .unwrap();
+        }
+
+        let pruned = storage.prune_old_conversation_events(30).await.unwrap();
+        assert_eq!(pruned, 0);
+        assert_eq!(storage.count_conversation_events(agent_id).await.unwrap(), 3);
+    }
+
+    #[tokio::test]
+    async fn test_prune_excess_removes_oldest_first() {
+        let (storage, _tmp) = create_test_storage().await;
+        let agent_id = Uuid::new_v4();
+
+        // Insert 5 events with *explicit* timestamps spaced 1 second apart so
+        // that `ORDER BY created_at ASC` is deterministic even on fast machines
+        // where multiple `Utc::now()` calls may return the same millisecond.
+        let base = Utc::now() - chrono::Duration::seconds(10);
+        for i in 0..5i64 {
+            let mut ev = ConversationEvent::new(
+                agent_id,
+                ConversationEventType::Output,
+                i,
+                Some(format!("line {i}")),
+                None,
+            );
+            ev.created_at = base + chrono::Duration::seconds(i);
+            storage.insert_conversation_event(&ev).await.unwrap();
+        }
+
+        // Cap at 3 -- 2 oldest events (session_numbers 0 and 1) should be deleted.
+        let pruned = storage.prune_excess_conversation_events(agent_id, 3).await.unwrap();
+        assert_eq!(pruned, 2);
+
+        let remaining = storage
+            .list_conversation_events(agent_id, &ConversationQuery::default())
+            .await
+            .unwrap();
+        assert_eq!(remaining.len(), 3);
+        // The 3 newest events (session_numbers 2, 3, 4) should remain.
+        let sessions: Vec<i64> = remaining.iter().map(|e| e.session_number).collect();
+        assert!(sessions.iter().all(|&s| s >= 2), "only recent events should remain: {sessions:?}");
+    }
+
+    #[tokio::test]
+    async fn test_prune_excess_no_op_under_cap() {
+        let (storage, _tmp) = create_test_storage().await;
+        let agent_id = Uuid::new_v4();
+
+        for _ in 0..3 {
+            storage
+                .insert_conversation_event(&make_event(agent_id, ConversationEventType::Output))
+                .await
+                .unwrap();
+        }
+
+        // Cap is 5 -- nothing should be pruned.
+        let pruned = storage.prune_excess_conversation_events(agent_id, 5).await.unwrap();
+        assert_eq!(pruned, 0);
+        assert_eq!(storage.count_conversation_events(agent_id).await.unwrap(), 3);
     }
 }

--- a/crates/orchestrator/src/types.rs
+++ b/crates/orchestrator/src/types.rs
@@ -2132,6 +2132,72 @@ impl From<ConversationEvent> for ConversationEventResponse {
     }
 }
 
+// ─── Retention / cleanup configuration ──────────────────────────────────────
+
+/// Configuration for conversation event retention and periodic pruning.
+///
+/// All values are read from environment variables at service startup via
+/// [`RetentionConfig::from_env`].  The defaults are conservative — 30-day
+/// history, 50 k events per agent, no on-terminate delete, 6-hour cleanup cycle.
+#[derive(Debug, Clone)]
+pub struct RetentionConfig {
+    /// Delete events older than this many days
+    /// (env: `AGENTD_CONVERSATION_RETENTION_DAYS`, default: 30).
+    /// Must be ≥ 1; `0` would delete all events and is rejected (falls back to default).
+    pub retention_days: u64,
+    /// Hard cap per agent; oldest events are evicted first.
+    /// Enforced both by the periodic cleanup task (for all known agents) and
+    /// on agent termination when `cleanup_on_terminate = true`.
+    /// (env: `AGENTD_CONVERSATION_MAX_EVENTS_PER_AGENT`, default: 50000).
+    /// Must be ≥ 1; `0` would delete all events and is rejected (falls back to default).
+    pub max_events_per_agent: u64,
+    /// If `true`, all events for an agent are deleted when it is terminated
+    /// (env: `AGENTD_CONVERSATION_CLEANUP_ON_TERMINATE`, default: false).
+    pub cleanup_on_terminate: bool,
+    /// How often the periodic cleanup task runs, in seconds
+    /// (env: `AGENTD_CONVERSATION_CLEANUP_INTERVAL_SECS`, default: 21600 = 6 h).
+    /// Must be ≥ 1; `0` panics `tokio::time::interval` and is rejected (falls back to default).
+    pub cleanup_interval_secs: u64,
+}
+
+impl RetentionConfig {
+    /// Safe, hardcoded fallback values used when env vars are absent or invalid.
+    pub const DEFAULT_RETENTION_DAYS: u64 = 30;
+    pub const DEFAULT_MAX_EVENTS_PER_AGENT: u64 = 50_000;
+    pub const DEFAULT_CLEANUP_INTERVAL_SECS: u64 = 21_600; // 6 h
+
+    /// Build a `RetentionConfig` from environment variables, falling back to
+    /// safe defaults when a variable is absent, unparseable, or out of range.
+    ///
+    /// Zero values for `retention_days`, `max_events_per_agent`, and
+    /// `cleanup_interval_secs` are rejected and replaced with defaults:
+    /// `0` retention days would wipe all events, `0` max events would delete
+    /// everything for every agent, and `0` interval panics `tokio::time::interval`.
+    pub fn from_env() -> Self {
+        Self {
+            retention_days: std::env::var("AGENTD_CONVERSATION_RETENTION_DAYS")
+                .ok()
+                .and_then(|v| v.parse().ok())
+                .filter(|&v: &u64| v > 0)
+                .unwrap_or(Self::DEFAULT_RETENTION_DAYS),
+            max_events_per_agent: std::env::var("AGENTD_CONVERSATION_MAX_EVENTS_PER_AGENT")
+                .ok()
+                .and_then(|v| v.parse().ok())
+                .filter(|&v: &u64| v > 0)
+                .unwrap_or(Self::DEFAULT_MAX_EVENTS_PER_AGENT),
+            cleanup_on_terminate: std::env::var("AGENTD_CONVERSATION_CLEANUP_ON_TERMINATE")
+                .ok()
+                .map(|v| v == "true" || v == "1")
+                .unwrap_or(false),
+            cleanup_interval_secs: std::env::var("AGENTD_CONVERSATION_CLEANUP_INTERVAL_SECS")
+                .ok()
+                .and_then(|v| v.parse().ok())
+                .filter(|&v: &u64| v > 0)
+                .unwrap_or(Self::DEFAULT_CLEANUP_INTERVAL_SECS),
+        }
+    }
+}
+
 /// Query parameters for `GET /agents/{id}/conversation`.
 #[derive(Debug, Default, Deserialize)]
 pub struct ConversationHistoryQuery {
@@ -2165,4 +2231,17 @@ pub struct ConversationSummary {
     pub session_count: u64,
     pub first_event_at: Option<DateTime<Utc>>,
     pub last_event_at: Option<DateTime<Utc>>,
+}
+
+impl Default for RetentionConfig {
+    /// Returns hardcoded safe defaults.  Does **not** read environment variables.
+    /// Use [`RetentionConfig::from_env`] explicitly when env-var overrides are needed.
+    fn default() -> Self {
+        Self {
+            retention_days: Self::DEFAULT_RETENTION_DAYS,
+            max_events_per_agent: Self::DEFAULT_MAX_EVENTS_PER_AGENT,
+            cleanup_on_terminate: false,
+            cleanup_interval_secs: Self::DEFAULT_CLEANUP_INTERVAL_SECS,
+        }
+    }
 }


### PR DESCRIPTION
Adds configurable retention policy for conversation events to prevent unbounded database growth. Stacked on #1167 (issue #1159).

## Changes

**`types.rs`** — `RetentionConfig` struct with `from_env()` constructor reading four env vars:
- `AGENTD_CONVERSATION_RETENTION_DAYS` (default: 30)
- `AGENTD_CONVERSATION_MAX_EVENTS_PER_AGENT` (default: 50000)
- `AGENTD_CONVERSATION_CLEANUP_ON_TERMINATE` (default: false)
- `AGENTD_CONVERSATION_CLEANUP_INTERVAL_SECS` (default: 21600 / 6 h)

**`storage.rs`** — Two new pruning methods on `AgentStorage`:
- `prune_old_conversation_events(retention_days)` — deletes rows older than the cutoff timestamp
- `prune_excess_conversation_events(agent_id, max_events)` — fetches oldest IDs beyond the cap and deletes them

**`manager.rs`** — `AgentManager` gains a `retention_config: Arc<RetentionConfig>` field. `with_retention()` constructor for explicit config (testing/main). `terminate_agent()` calls `delete_conversation_events_for_agent()` when `cleanup_on_terminate = true`.

**`main.rs`** — Reads `RetentionConfig::from_env()` at startup, passes it to `AgentManager::with_retention()`, logs resolved values, and spawns a periodic cleanup task (alongside the reconciliation loop) that runs `prune_old_conversation_events` on the configured interval and increments the `agentd_conversation_events_pruned_total` Prometheus counter.

## Test plan

- [x] 4 new unit tests: `test_prune_old_events_removes_old_rows`, `test_prune_old_events_no_op_when_nothing_old`, `test_prune_excess_removes_oldest_first`, `test_prune_excess_no_op_under_cap`
- [x] `cargo test -p orchestrator` — 417 tests pass
- [x] `cargo fmt --check -p orchestrator` — clean
- [x] `cargo clippy -p orchestrator` — no errors

Closes #1163

🤖 Generated with [Claude Code](https://claude.com/claude-code)