### PR TITLE
feat: migrate subprocess backend from --sdk-url to stdin/stdout NDJSON

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5986,9 +5986,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.12"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8279bb85272c9f10811ae6a6c547ff594d6a7f3c6c6b02ee9726d1d0dcfcdd06"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "ring",
  "rustls-pki-types",

--- a/crates/orchestrator/src/manager.rs
+++ b/crates/orchestrator/src/manager.rs
@@ -134,10 +134,16 @@ impl AgentManager {
             }
         }
 
+        // Subprocess stdio mode takes precedence: agents communicate via
+        // stdin/stdout NDJSON rather than WebSocket.
+        let use_stdio = self.backend.supports_subprocess_stdio();
+
         // Determine whether to use interactive / PTY mode.
         // PTY backend always uses PTY stdin (not WebSocket) so that the session
         // remains interactable. Config-level `interactive` flag is also respected.
-        let effective_interactive = agent.config.interactive || self.backend.supports_pty_input();
+        // Subprocess stdio mode is mutually exclusive with PTY/interactive mode.
+        let effective_interactive =
+            !use_stdio && (agent.config.interactive || self.backend.supports_pty_input());
 
         // Persist the effective interactive state so downstream consumers
         // (API, UI) see the correct mode.  The DB record is the single source
@@ -147,12 +153,13 @@ impl AgentManager {
             agent.config.interactive = true;
         }
 
-        // Build the claude command (never uses -p; prompt sent via WebSocket or PTY stdin).
+        // Build the claude command (prompt sent via WebSocket, PTY stdin, or subprocess stdin).
         let ws_url = self
             .backend
             .agent_ws_url(&session_name, Some(&session_config))
             .unwrap_or_else(|| format!("{}/ws/{}", self.ws_base_url, agent.id));
-        let claude_cmd = build_claude_command(&agent.config, &ws_url, effective_interactive);
+        let claude_cmd =
+            build_claude_command(&agent.config, &ws_url, effective_interactive, use_stdio);
 
         // Persist the launch command so the UI can display it for debugging.
         agent.launch_command = Some(claude_cmd.clone());
@@ -176,6 +183,12 @@ impl AgentManager {
         // Register the agent's tool policy with the WebSocket registry.
         self.registry.set_policy(agent.id, agent.config.tool_policy.clone()).await;
 
+        // For subprocess stdio mode, wire stdin/stdout IO immediately after spawn.
+        // The ConnectionRegistry is populated right away (no WebSocket handshake needed).
+        if use_stdio {
+            self.wire_subprocess_io(agent.id, &session_name).await?;
+        }
+
         info!(
             agent_id = %agent.id,
             session = %session_name,
@@ -184,6 +197,8 @@ impl AgentManager {
         );
 
         // If there's an initial prompt, deliver it via the appropriate channel.
+        //
+        // Subprocess stdio mode: registered immediately, send without waiting.
         //
         // Interactive / PTY mode: Claude reads from PTY stdin, not the WebSocket.
         //   Write the prompt directly to PTY stdin. A brief delay lets the
@@ -195,7 +210,14 @@ impl AgentManager {
             let prompt = prompt.clone();
             let agent_id = agent.id;
 
-            if effective_interactive {
+            if use_stdio {
+                // Stdio mode — registered immediately, send without a wait loop.
+                if let Err(e) = self.registry.send_user_message(&agent_id, &prompt).await {
+                    warn!(%agent_id, %e, "Failed to send initial prompt via subprocess stdin");
+                } else {
+                    info!(%agent_id, "Initial prompt sent via subprocess stdin");
+                }
+            } else if effective_interactive {
                 // Interactive mode — inject via PTY stdin.
                 let manager = self.clone();
                 tokio::spawn(async move {
@@ -460,31 +482,38 @@ impl AgentManager {
                 None => {
                     // No exit info means the backend has no record of this
                     // session. For in-memory backends (subprocess, PTY) this
-                    // happens after a service restart. The process may still
-                    // be alive if it was in its own process group (setpgid).
-                    // Check the stored PID before spawning a duplicate.
-                    if let Some(pid) = agent.pid {
-                        if is_process_alive(pid) {
+                    // happens after a service restart.
+                    //
+                    // Subprocess stdio agents cannot reconnect after a service
+                    // restart — the pipe pair is gone. Always restart them.
+                    //
+                    // For other backends the process may still be alive in its
+                    // own process group (setpgid). Check the stored PID before
+                    // spawning a duplicate.
+                    if !self.backend.supports_subprocess_stdio() {
+                        if let Some(pid) = agent.pid {
+                            if is_process_alive(pid) {
+                                info!(
+                                    agent_id = %agent.id,
+                                    session = %session_name,
+                                    pid,
+                                    "Agent process still alive after service restart, skipping restart"
+                                );
+                                return Ok(());
+                            }
                             info!(
                                 agent_id = %agent.id,
                                 session = %session_name,
                                 pid,
-                                "Agent process still alive after service restart, skipping restart"
+                                "Agent process is dead, restarting"
                             );
-                            return Ok(());
+                        } else {
+                            info!(
+                                agent_id = %agent.id,
+                                session = %session_name,
+                                "Agent session lost (no PID recorded), restarting"
+                            );
                         }
-                        info!(
-                            agent_id = %agent.id,
-                            session = %session_name,
-                            pid,
-                            "Agent process is dead, restarting"
-                        );
-                    } else {
-                        info!(
-                            agent_id = %agent.id,
-                            session = %session_name,
-                            "Agent session lost (no PID recorded), restarting"
-                        );
                     }
 
                     if let Err(e) = self.restart_agent(&agent).await {
@@ -869,7 +898,9 @@ impl AgentManager {
         }
 
         // Build and send the claude command with the updated config.
-        let effective_interactive = agent.config.interactive || self.backend.supports_pty_input();
+        let use_stdio = self.backend.supports_subprocess_stdio();
+        let effective_interactive =
+            !use_stdio && (agent.config.interactive || self.backend.supports_pty_input());
 
         // Persist the effective interactive state (mirrors the fix in spawn_agent).
         if effective_interactive && !agent.config.interactive {
@@ -880,7 +911,8 @@ impl AgentManager {
             .backend
             .agent_ws_url(&session_name, Some(&session_config))
             .unwrap_or_else(|| format!("{}/ws/{}", self.ws_base_url, agent.id));
-        let claude_cmd = build_claude_command(&agent.config, &ws_url, effective_interactive);
+        let claude_cmd =
+            build_claude_command(&agent.config, &ws_url, effective_interactive, use_stdio);
 
         // Persist the launch command so the UI can display it for debugging.
         agent.launch_command = Some(claude_cmd.clone());
@@ -903,6 +935,11 @@ impl AgentManager {
         // Re-register tool policy.
         self.registry.set_policy(agent.id, agent.config.tool_policy.clone()).await;
 
+        // Re-wire subprocess IO if needed.
+        if use_stdio {
+            self.wire_subprocess_io(agent.id, &session_name).await?;
+        }
+
         info!(
             agent_id = %agent.id,
             session = %session_name,
@@ -912,6 +949,66 @@ impl AgentManager {
         );
 
         Ok(agent)
+    }
+
+    /// Wire subprocess stdin/stdout IO for an agent running in stdio mode.
+    ///
+    /// - Takes the stdout reader from the backend and spawns a task that reads
+    ///   NDJSON lines and calls `handle_incoming_message`.
+    /// - Creates an mpsc channel, registers it in the ConnectionRegistry, and
+    ///   spawns a relay task that forwards channel messages to subprocess stdin.
+    ///
+    /// Must be called immediately after `send_command` succeeds for subprocess
+    /// backends. The agent is registered in the registry upon return, so
+    /// `send_user_message` works without a wait loop.
+    async fn wire_subprocess_io(
+        &self,
+        agent_id: Uuid,
+        session_name: &str,
+    ) -> anyhow::Result<()> {
+        use crate::websocket::{handle_incoming_message, AgentConnection};
+        use tokio::io::{AsyncBufReadExt, BufReader};
+        use tokio::sync::mpsc;
+
+        let stdout_reader = self.backend.take_subprocess_stdout(session_name).await?;
+
+        // mpsc channel bridges ConnectionRegistry → subprocess stdin relay.
+        let (ws_tx, mut ws_rx) = mpsc::unbounded_channel::<String>();
+        self.registry.register(agent_id, AgentConnection { tx: ws_tx }).await;
+
+        // Stdin relay task: forwards registry messages → subprocess stdin.
+        let backend = self.backend.clone();
+        let session_for_relay = session_name.to_string();
+        tokio::spawn(async move {
+            while let Some(msg) = ws_rx.recv().await {
+                if let Err(e) =
+                    backend.write_subprocess_stdin(&session_for_relay, &msg).await
+                {
+                    warn!(
+                        agent_id = %agent_id,
+                        %e,
+                        "Subprocess stdin relay error"
+                    );
+                    break;
+                }
+            }
+        });
+
+        // Stdout reader task: NDJSON lines → handle_incoming_message.
+        let registry = self.registry.clone();
+        tokio::spawn(async move {
+            let mut lines = BufReader::new(stdout_reader).lines();
+            while let Ok(Some(line)) = lines.next_line().await {
+                if line.trim().is_empty() {
+                    continue;
+                }
+                handle_incoming_message(&agent_id, &line, &registry).await;
+            }
+            registry.unregister(&agent_id).await;
+            info!(agent_id = %agent_id, "Subprocess stdout closed, agent unregistered");
+        });
+
+        Ok(())
     }
 }
 
@@ -968,14 +1065,27 @@ fn build_env_assignments(env: &std::collections::HashMap<String, String>) -> Vec
     assignments
 }
 
-fn build_claude_command(config: &AgentConfig, ws_url: &str, interactive: bool) -> String {
+fn build_claude_command(
+    config: &AgentConfig,
+    ws_url: &str,
+    interactive: bool,
+    use_stdio: bool,
+) -> String {
     let mut args = vec!["claude".to_string()];
 
     if interactive {
         // Interactive / PTY mode: no --sdk-url, no stream-json flags.
         // Prompts are delivered via PTY stdin injection; a human can also
         // type directly in the terminal.
+    } else if use_stdio {
+        // Subprocess stdio mode: communicate via stdin/stdout NDJSON.
+        // --print keeps claude reading stdin until EOF (graceful shutdown).
+        args.push("--print".to_string());
+        args.push("--output-format stream-json".to_string());
+        args.push("--input-format stream-json".to_string());
+        args.push("--dangerously-skip-permissions".to_string());
     } else {
+        // WebSocket / SDK mode (tmux, Docker backends).
         args.push(format!("--sdk-url {}", ws_url));
         args.push("--output-format stream-json".to_string());
         args.push("--input-format stream-json".to_string());
@@ -1010,11 +1120,6 @@ fn build_claude_command(config: &AgentConfig, ws_url: &str, interactive: bool) -
         // Neither prompt nor file set — no flag emitted.
         (_, None, None) => {}
     }
-
-    // NOTE: --print / -p is intentionally NOT used here. It causes claude to
-    // exit after processing a single conversation, making the agent unable to
-    // receive follow-up messages. In SDK mode (--sdk-url), the CLI stays alive
-    // and processes multiple messages without --print.
 
     let base = args.join(" ");
     let env_assignments = build_env_assignments(&config.env);
@@ -1075,7 +1180,7 @@ mod tests {
     #[test]
     fn test_build_claude_command_no_model() {
         let config = base_config();
-        let cmd = build_claude_command(&config, "ws://localhost:7006/ws/abc", false);
+        let cmd = build_claude_command(&config, "ws://localhost:7006/ws/abc", false, false);
         assert!(!cmd.contains("--model"));
         assert!(cmd.contains("claude"));
         assert!(cmd.contains("--sdk-url"));
@@ -1084,14 +1189,14 @@ mod tests {
     #[test]
     fn test_build_claude_command_with_model_alias() {
         let config = AgentConfig { model: Some("opus".to_string()), ..base_config() };
-        let cmd = build_claude_command(&config, "ws://localhost:7006/ws/abc", false);
+        let cmd = build_claude_command(&config, "ws://localhost:7006/ws/abc", false, false);
         assert!(cmd.contains("--model opus"));
     }
 
     #[test]
     fn test_build_claude_command_with_full_model_name() {
         let config = AgentConfig { model: Some("claude-sonnet-4-6".to_string()), ..base_config() };
-        let cmd = build_claude_command(&config, "ws://localhost:7006/ws/abc", false);
+        let cmd = build_claude_command(&config, "ws://localhost:7006/ws/abc", false, false);
         assert!(cmd.contains("--model claude-sonnet-4-6"));
     }
 
@@ -1099,7 +1204,7 @@ mod tests {
     fn test_build_claude_command_model_with_interactive() {
         let config =
             AgentConfig { model: Some("haiku".to_string()), interactive: true, ..base_config() };
-        let cmd = build_claude_command(&config, "ws://localhost:7006/ws/abc", true);
+        let cmd = build_claude_command(&config, "ws://localhost:7006/ws/abc", true, false);
         assert!(cmd.contains("--model haiku"));
         assert!(!cmd.contains("--sdk-url"));
     }
@@ -1111,7 +1216,7 @@ mod tests {
             user: Some("deploy".to_string()),
             ..base_config()
         };
-        let cmd = build_claude_command(&config, "ws://localhost:7006/ws/abc", false);
+        let cmd = build_claude_command(&config, "ws://localhost:7006/ws/abc", false, false);
         assert!(cmd.starts_with("sudo -u deploy"));
         assert!(cmd.contains("--model sonnet"));
     }
@@ -1123,7 +1228,7 @@ mod tests {
         let mut env = HashMap::new();
         env.insert("ANTHROPIC_API_KEY".to_string(), "sk-ant-test123".to_string());
         let config = AgentConfig { env, ..base_config() };
-        let cmd = build_claude_command(&config, "ws://localhost:7006/ws/abc", false);
+        let cmd = build_claude_command(&config, "ws://localhost:7006/ws/abc", false, false);
 
         assert!(cmd.contains("ANTHROPIC_API_KEY='sk-ant-test123'"));
         // Env prefix must come before claude
@@ -1137,7 +1242,7 @@ mod tests {
         let mut env = HashMap::new();
         env.insert("ANTHROPIC_API_KEY".to_string(), "sk-ant-test".to_string());
         let config = AgentConfig { user: Some("deploy".to_string()), env, ..base_config() };
-        let cmd = build_claude_command(&config, "ws://localhost:7006/ws/abc", false);
+        let cmd = build_claude_command(&config, "ws://localhost:7006/ws/abc", false, false);
 
         // For sudo, env vars are injected via `env` to cross the sudo boundary
         assert!(cmd.starts_with("sudo -u deploy env"));
@@ -1151,7 +1256,7 @@ mod tests {
         // Value contains a single quote — must be properly escaped
         env.insert("MY_VAR".to_string(), "it's a value".to_string());
         let config = AgentConfig { env, ..base_config() };
-        let cmd = build_claude_command(&config, "ws://localhost:7006/ws/abc", false);
+        let cmd = build_claude_command(&config, "ws://localhost:7006/ws/abc", false, false);
 
         // Single-quote escaping: ' → '\''
         assert!(cmd.contains("MY_VAR='it'\\''s a value'"));
@@ -1165,7 +1270,7 @@ mod tests {
         env.insert("123STARTS_WITH_DIGIT".to_string(), "v".to_string());
         env.insert("GOOD_KEY".to_string(), "ok".to_string());
         let config = AgentConfig { env, ..base_config() };
-        let cmd = build_claude_command(&config, "ws://localhost:7006/ws/abc", false);
+        let cmd = build_claude_command(&config, "ws://localhost:7006/ws/abc", false, false);
 
         assert!(cmd.contains("GOOD_KEY='ok'"));
         assert!(!cmd.contains("BAD KEY"));
@@ -1176,7 +1281,7 @@ mod tests {
     #[test]
     fn test_build_claude_command_empty_env_no_prefix() {
         let config = base_config(); // env is empty
-        let cmd = build_claude_command(&config, "ws://localhost:7006/ws/abc", false);
+        let cmd = build_claude_command(&config, "ws://localhost:7006/ws/abc", false, false);
 
         // Must start directly with claude (no env prefix)
         assert!(cmd.starts_with("claude"));
@@ -1187,7 +1292,7 @@ mod tests {
         let mut env = HashMap::new();
         env.insert("ANTHROPIC_BASE_URL".to_string(), "https://custom.api.example.com".to_string());
         let config = AgentConfig { interactive: true, env, ..base_config() };
-        let cmd = build_claude_command(&config, "ws://localhost:7006/ws/abc", true);
+        let cmd = build_claude_command(&config, "ws://localhost:7006/ws/abc", true, false);
 
         assert!(cmd.contains("ANTHROPIC_BASE_URL='https://custom.api.example.com'"));
         assert!(!cmd.contains("--sdk-url"));
@@ -1201,8 +1306,8 @@ mod tests {
         env.insert("ANTHROPIC_BASE_URL".to_string(), "https://example.com".to_string());
         env.insert("ANTHROPIC_AUTH_TOKEN".to_string(), "tok-123".to_string());
         let config = AgentConfig { env, ..base_config() };
-        let cmd1 = build_claude_command(&config, "ws://localhost:7006/ws/abc", false);
-        let cmd2 = build_claude_command(&config, "ws://localhost:7006/ws/abc", false);
+        let cmd1 = build_claude_command(&config, "ws://localhost:7006/ws/abc", false, false);
+        let cmd2 = build_claude_command(&config, "ws://localhost:7006/ws/abc", false, false);
 
         // Output must be deterministic (sorted) across calls
         assert_eq!(cmd1, cmd2);
@@ -1240,7 +1345,7 @@ mod tests {
     #[test]
     fn test_build_claude_command_no_system_prompt_flag_when_absent() {
         let config = base_config();
-        let cmd = build_claude_command(&config, "ws://localhost:7006/ws/abc", false);
+        let cmd = build_claude_command(&config, "ws://localhost:7006/ws/abc", false, false);
         assert!(!cmd.contains("--system-prompt"), "no system-prompt flag when none configured");
         assert!(!cmd.contains("--append-system-prompt"), "no append flag when none configured");
     }
@@ -1251,7 +1356,7 @@ mod tests {
             system_prompt: Some("You are a Rust expert".to_string()),
             ..base_config()
         };
-        let cmd = build_claude_command(&config, "ws://localhost:7006/ws/abc", false);
+        let cmd = build_claude_command(&config, "ws://localhost:7006/ws/abc", false, false);
         assert!(cmd.contains("--system-prompt 'You are a Rust expert'"));
         assert!(!cmd.contains("--append-system-prompt"));
         assert!(!cmd.contains("--system-prompt-file"));
@@ -1263,7 +1368,7 @@ mod tests {
             system_prompt_file: Some("./.agentd/agents/expert.md".to_string()),
             ..base_config()
         };
-        let cmd = build_claude_command(&config, "ws://localhost:7006/ws/abc", false);
+        let cmd = build_claude_command(&config, "ws://localhost:7006/ws/abc", false, false);
         assert!(cmd.contains("--system-prompt-file './.agentd/agents/expert.md'"));
         assert!(!cmd.contains("--system-prompt "));
         assert!(!cmd.contains("--append-system-prompt"));
@@ -1276,7 +1381,7 @@ mod tests {
             append_system_prompt: true,
             ..base_config()
         };
-        let cmd = build_claude_command(&config, "ws://localhost:7006/ws/abc", false);
+        let cmd = build_claude_command(&config, "ws://localhost:7006/ws/abc", false, false);
         assert!(cmd.contains("--append-system-prompt 'Always use TypeScript'"));
         assert!(!cmd.contains("--system-prompt "));
         assert!(!cmd.contains("--system-prompt-file"));
@@ -1289,7 +1394,7 @@ mod tests {
             append_system_prompt: true,
             ..base_config()
         };
-        let cmd = build_claude_command(&config, "ws://localhost:7006/ws/abc", false);
+        let cmd = build_claude_command(&config, "ws://localhost:7006/ws/abc", false, false);
         assert!(cmd.contains("--append-system-prompt-file './style-rules.txt'"));
         assert!(!cmd.contains("--system-prompt "));
         assert!(!cmd.contains("--system-prompt-file "));
@@ -1300,7 +1405,7 @@ mod tests {
         // Single quotes in the prompt must be shell-escaped.
         let config =
             AgentConfig { system_prompt: Some("You're an expert".to_string()), ..base_config() };
-        let cmd = build_claude_command(&config, "ws://localhost:7006/ws/abc", false);
+        let cmd = build_claude_command(&config, "ws://localhost:7006/ws/abc", false, false);
         assert!(cmd.contains("--system-prompt 'You'\\''re an expert'"));
     }
 
@@ -1311,7 +1416,7 @@ mod tests {
             append_system_prompt: true,
             ..base_config()
         };
-        let cmd = build_claude_command(&config, "ws://localhost:7006/ws/abc", false);
+        let cmd = build_claude_command(&config, "ws://localhost:7006/ws/abc", false, false);
         assert!(cmd.contains("--append-system-prompt 'Don'\\''t skip tests'"));
     }
 
@@ -1323,7 +1428,7 @@ mod tests {
             system_prompt_file: Some("./file.md".to_string()),
             ..base_config()
         };
-        let cmd = build_claude_command(&config, "ws://localhost:7006/ws/abc", false);
+        let cmd = build_claude_command(&config, "ws://localhost:7006/ws/abc", false, false);
         assert!(cmd.contains("--system-prompt 'inline prompt'"));
         assert!(!cmd.contains("--system-prompt-file"));
     }
@@ -1337,7 +1442,7 @@ mod tests {
             append_system_prompt: true,
             ..base_config()
         };
-        let cmd = build_claude_command(&config, "ws://localhost:7006/ws/abc", false);
+        let cmd = build_claude_command(&config, "ws://localhost:7006/ws/abc", false, false);
         assert!(cmd.contains("--append-system-prompt 'inline append'"));
         assert!(!cmd.contains("--append-system-prompt-file"));
         assert!(!cmd.contains("--system-prompt-file"));
@@ -1349,7 +1454,7 @@ mod tests {
     #[test]
     fn test_build_claude_command_no_add_dir_when_empty() {
         let config = base_config(); // additional_dirs is empty
-        let cmd = build_claude_command(&config, "ws://localhost:7006/ws/abc", false);
+        let cmd = build_claude_command(&config, "ws://localhost:7006/ws/abc", false, false);
         assert!(!cmd.contains("--add-dir"), "no --add-dir flag when additional_dirs is empty");
     }
 
@@ -1359,7 +1464,7 @@ mod tests {
             additional_dirs: vec!["/tmp/project".to_string(), "/home/user/data".to_string()],
             ..base_config()
         };
-        let cmd = build_claude_command(&config, "ws://localhost:7006/ws/abc", false);
+        let cmd = build_claude_command(&config, "ws://localhost:7006/ws/abc", false, false);
         assert!(cmd.contains("--add-dir '/tmp/project'"), "first dir must appear");
         assert!(cmd.contains("--add-dir '/home/user/data'"), "second dir must appear");
     }
@@ -1371,7 +1476,7 @@ mod tests {
             additional_dirs: vec!["/tmp/my project/it's here".to_string()],
             ..base_config()
         };
-        let cmd = build_claude_command(&config, "ws://localhost:7006/ws/abc", false);
+        let cmd = build_claude_command(&config, "ws://localhost:7006/ws/abc", false, false);
         // Single-quote escaping: ' → '\''
         assert!(
             cmd.contains("--add-dir '/tmp/my project/it'\\''s here'"),
@@ -1383,7 +1488,7 @@ mod tests {
     fn test_build_claude_command_pty_backend_no_sdk_url() {
         // Simulates PTY backend: effective_interactive = true
         let config = base_config();
-        let cmd = build_claude_command(&config, "ws://localhost:7006/ws/abc", true);
+        let cmd = build_claude_command(&config, "ws://localhost:7006/ws/abc", true, false);
         assert!(!cmd.contains("--sdk-url"), "PTY mode must not include --sdk-url");
         assert!(!cmd.contains("--input-format"), "PTY mode must not include --input-format");
         assert!(!cmd.contains("--output-format"), "PTY mode must not include --output-format");
@@ -1394,7 +1499,7 @@ mod tests {
     fn test_build_claude_command_sdk_mode_has_sdk_url() {
         // Non-PTY backend: effective_interactive = false
         let config = base_config(); // interactive = false
-        let cmd = build_claude_command(&config, "ws://localhost:7006/ws/abc", false);
+        let cmd = build_claude_command(&config, "ws://localhost:7006/ws/abc", false, false);
         assert!(cmd.contains("--sdk-url"));
         assert!(cmd.contains("--input-format stream-json"));
         assert!(cmd.contains("--output-format stream-json"));

--- a/crates/orchestrator/src/manager.rs
+++ b/crates/orchestrator/src/manager.rs
@@ -1080,7 +1080,9 @@ fn build_claude_command(
     } else if use_stdio {
         // Subprocess stdio mode: communicate via stdin/stdout NDJSON.
         // --print keeps claude reading stdin until EOF (graceful shutdown).
+        // --verbose is required by --output-format=stream-json with --print.
         args.push("--print".to_string());
+        args.push("--verbose".to_string());
         args.push("--output-format stream-json".to_string());
         args.push("--input-format stream-json".to_string());
         args.push("--dangerously-skip-permissions".to_string());

--- a/crates/orchestrator/src/manager.rs
+++ b/crates/orchestrator/src/manager.rs
@@ -961,11 +961,7 @@ impl AgentManager {
     /// Must be called immediately after `send_command` succeeds for subprocess
     /// backends. The agent is registered in the registry upon return, so
     /// `send_user_message` works without a wait loop.
-    async fn wire_subprocess_io(
-        &self,
-        agent_id: Uuid,
-        session_name: &str,
-    ) -> anyhow::Result<()> {
+    async fn wire_subprocess_io(&self, agent_id: Uuid, session_name: &str) -> anyhow::Result<()> {
         use crate::websocket::{handle_incoming_message, AgentConnection};
         use tokio::io::{AsyncBufReadExt, BufReader};
         use tokio::sync::mpsc;
@@ -981,9 +977,7 @@ impl AgentManager {
         let session_for_relay = session_name.to_string();
         tokio::spawn(async move {
             while let Some(msg) = ws_rx.recv().await {
-                if let Err(e) =
-                    backend.write_subprocess_stdin(&session_for_relay, &msg).await
-                {
+                if let Err(e) = backend.write_subprocess_stdin(&session_for_relay, &msg).await {
                     warn!(
                         agent_id = %agent_id,
                         %e,

--- a/crates/orchestrator/src/websocket.rs
+++ b/crates/orchestrator/src/websocket.rs
@@ -597,7 +597,11 @@ fn broadcast_output(agent_id: &Uuid, text: &str, registry: &ConnectionRegistry) 
 }
 
 /// Process an incoming NDJSON message from a claude code instance.
-async fn handle_incoming_message(agent_id: &Uuid, text: &str, registry: &ConnectionRegistry) {
+pub(crate) async fn handle_incoming_message(
+    agent_id: &Uuid,
+    text: &str,
+    registry: &ConnectionRegistry,
+) {
     // Claude sends NDJSON — each line is a separate JSON message.
     for line in text.lines() {
         let line = line.trim();

--- a/crates/wrap/src/backend.rs
+++ b/crates/wrap/src/backend.rs
@@ -262,11 +262,7 @@ pub trait ExecutionBackend: Send + Sync {
     ///
     /// Only meaningful when [`supports_subprocess_stdio`](Self::supports_subprocess_stdio)
     /// returns `true`. The default returns an error.
-    async fn write_subprocess_stdin(
-        &self,
-        _session_name: &str,
-        _line: &str,
-    ) -> anyhow::Result<()> {
+    async fn write_subprocess_stdin(&self, _session_name: &str, _line: &str) -> anyhow::Result<()> {
         Err(anyhow::anyhow!("This backend does not support subprocess stdin"))
     }
 

--- a/crates/wrap/src/backend.rs
+++ b/crates/wrap/src/backend.rs
@@ -246,6 +246,42 @@ pub trait ExecutionBackend: Send + Sync {
         Ok(None)
     }
 
+    /// Returns `true` when this backend communicates with agents via subprocess
+    /// stdin/stdout (NDJSON stream-json) rather than WebSocket (`--sdk-url`).
+    ///
+    /// When `true`, the orchestrator skips the WebSocket connection wait loop
+    /// and instead wires stdin/stdout IO directly after `send_command`.
+    ///
+    /// [`SubprocessBackend`](crate::subprocess::SubprocessBackend) overrides
+    /// this to return `true`; all other backends use the default of `false`.
+    fn supports_subprocess_stdio(&self) -> bool {
+        false
+    }
+
+    /// Write one NDJSON line to the subprocess stdin relay.
+    ///
+    /// Only meaningful when [`supports_subprocess_stdio`](Self::supports_subprocess_stdio)
+    /// returns `true`. The default returns an error.
+    async fn write_subprocess_stdin(
+        &self,
+        _session_name: &str,
+        _line: &str,
+    ) -> anyhow::Result<()> {
+        Err(anyhow::anyhow!("This backend does not support subprocess stdin"))
+    }
+
+    /// Take the stdout reader for a subprocess session (callable only once).
+    ///
+    /// Returns a boxed [`AsyncRead`](tokio::io::AsyncRead) for object-safety.
+    /// Only meaningful when [`supports_subprocess_stdio`](Self::supports_subprocess_stdio)
+    /// returns `true`. The default returns an error.
+    async fn take_subprocess_stdout(
+        &self,
+        _session_name: &str,
+    ) -> anyhow::Result<Box<dyn tokio::io::AsyncRead + Send + Unpin>> {
+        Err(anyhow::anyhow!("This backend does not support subprocess stdout"))
+    }
+
     /// Stops all sessions managed by this backend.
     ///
     /// Used during graceful shutdown to clean up all running sessions.

--- a/crates/wrap/src/subprocess.rs
+++ b/crates/wrap/src/subprocess.rs
@@ -231,38 +231,22 @@ fn is_valid_env_name(s: &str) -> bool {
     chars.all(|c| c.is_ascii_alphanumeric() || c == '_')
 }
 
-/// Log level for a drain task.
-#[derive(Clone, Copy)]
-enum DrainLevel {
-    Debug,
-    Warn,
-}
-
-/// Spawn a task that drains a piped stream to tracing logs.
+/// Spawn a task that drains a piped stream to tracing logs at WARN level.
 fn spawn_drain_task(
     stream: impl tokio::io::AsyncRead + Unpin + Send + 'static,
     session_name: String,
     stream_name: &'static str,
-    level: DrainLevel,
 ) -> JoinHandle<()> {
     tokio::spawn(async move {
         let reader = BufReader::new(stream);
         let mut lines = reader.lines();
         while let Ok(Some(line)) = lines.next_line().await {
-            match level {
-                DrainLevel::Debug => debug!(
-                    session = %session_name,
-                    stream = stream_name,
-                    "{}",
-                    line,
-                ),
-                DrainLevel::Warn => warn!(
-                    session = %session_name,
-                    stream = stream_name,
-                    "{}",
-                    line,
-                ),
-            }
+            warn!(
+                session = %session_name,
+                stream = stream_name,
+                "{}",
+                line,
+            );
         }
     })
 }
@@ -400,8 +384,7 @@ impl ExecutionBackend for SubprocessBackend {
         });
 
         // stderr is drained to tracing; stdout is held for the orchestrator to take.
-        let stderr_task =
-            spawn_drain_task(stderr, session_name.to_string(), "stderr", DrainLevel::Warn);
+        let stderr_task = spawn_drain_task(stderr, session_name.to_string(), "stderr");
 
         info!(
             session = %session_name,

--- a/crates/wrap/src/subprocess.rs
+++ b/crates/wrap/src/subprocess.rs
@@ -44,6 +44,7 @@ const KILL_GRACE_SECS: u64 = 5;
 
 /// Internal state of a subprocess session.
 #[allow(dead_code)]
+#[allow(clippy::large_enum_variant)]
 enum SessionState {
     /// Reserved by `create_session` -- no process spawned yet.
     Pending { config: SessionConfig },

--- a/crates/wrap/src/subprocess.rs
+++ b/crates/wrap/src/subprocess.rs
@@ -719,10 +719,9 @@ impl SubprocessBackend {
     pub async fn write_stdin(&self, session_name: &str, line: &str) -> Result<()> {
         let sessions = self.sessions.read().await;
         match sessions.get(session_name) {
-            Some(SessionState::Running { stdin_tx: Some(tx), .. }) => {
-                tx.send(line.to_string())
-                    .map_err(|_| anyhow!("Stdin relay closed for session '{}'", session_name))
-            }
+            Some(SessionState::Running { stdin_tx: Some(tx), .. }) => tx
+                .send(line.to_string())
+                .map_err(|_| anyhow!("Stdin relay closed for session '{}'", session_name)),
             Some(SessionState::Running { stdin_tx: None, .. }) => {
                 Err(anyhow!("Stdin already closed for session '{}'", session_name))
             }
@@ -799,10 +798,9 @@ mod tests {
 
     #[test]
     fn parse_simple_command() {
-        let (env, binary, args) = parse_command(
-            "claude --print --output-format stream-json --input-format stream-json",
-        )
-        .unwrap();
+        let (env, binary, args) =
+            parse_command("claude --print --output-format stream-json --input-format stream-json")
+                .unwrap();
         assert!(env.is_empty());
         assert_binary(&binary, "claude");
         assert_eq!(

--- a/crates/wrap/src/subprocess.rs
+++ b/crates/wrap/src/subprocess.rs
@@ -5,10 +5,10 @@
 //! multiplexer, no PTY, no intermediate shell -- the agent binary is exec'd
 //! with its full argv and environment.
 //!
-//! This backend is designed for SDK-mode agents that communicate via
-//! `--sdk-url` WebSocket. It eliminates the shell readiness races inherent
-//! in tmux/PTY backends where a shell must initialise before a command can
-//! be injected.
+//! This backend communicates with agents via subprocess stdin/stdout using
+//! NDJSON (the Claude Agent SDK protocol). stdin is kept open for the lifetime
+//! of the session; the orchestrator writes messages to it via an mpsc channel
+//! relay. stdout is exposed once to the orchestrator for NDJSON parsing.
 //!
 //! Sessions are tracked in-memory and do not survive process restarts.
 //!
@@ -33,9 +33,9 @@ use std::path::Path;
 use std::process::ExitStatus;
 use std::sync::Arc;
 use std::time::{Duration, Instant};
-use tokio::io::{AsyncBufReadExt, BufReader};
-use tokio::process::Child;
-use tokio::sync::RwLock;
+use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader, BufWriter};
+use tokio::process::{Child, ChildStdout};
+use tokio::sync::{mpsc, RwLock};
 use tokio::task::JoinHandle;
 use tracing::{debug, info, warn};
 
@@ -51,7 +51,12 @@ enum SessionState {
     Running {
         child: Child,
         pid: u32,
-        _stdout_task: JoinHandle<()>,
+        /// Stdout reader, available once via [`SubprocessBackend::take_stdout`].
+        stdout: Option<ChildStdout>,
+        /// Channel sender for the stdin relay task. Dropping this closes
+        /// the child's stdin (EOF), signalling a clean exit.
+        stdin_tx: Option<mpsc::UnboundedSender<String>>,
+        _stdin_task: JoinHandle<()>,
         _stderr_task: JoinHandle<()>,
         config: SessionConfig,
         created_at: Instant,
@@ -342,7 +347,7 @@ impl ExecutionBackend for SubprocessBackend {
         cmd.args(&args)
             .current_dir(&working_dir)
             .envs(&env_vars)
-            .stdin(std::process::Stdio::null())
+            .stdin(std::process::Stdio::piped())
             .stdout(std::process::Stdio::piped())
             .stderr(std::process::Stdio::piped())
             .kill_on_drop(true);
@@ -373,11 +378,28 @@ impl ExecutionBackend for SubprocessBackend {
         let pid =
             child.id().ok_or_else(|| anyhow!("Child process has no PID (already exited?)"))?;
 
-        // Drain stdout/stderr to tracing to prevent pipe deadlock.
+        // Extract pipes before storing the child.
+        let stdin_pipe = child.stdin.take().expect("stdin was piped");
         let stdout = child.stdout.take().expect("stdout was piped");
         let stderr = child.stderr.take().expect("stderr was piped");
-        let stdout_task =
-            spawn_drain_task(stdout, session_name.to_string(), "stdout", DrainLevel::Debug);
+
+        // Stdin relay: orchestrator writes to tx, this task forwards to child stdin.
+        // Dropping all tx handles closes the channel, causing the task to exit and
+        // the child's stdin to receive EOF (clean shutdown signal).
+        let (stdin_tx, mut stdin_rx) = mpsc::unbounded_channel::<String>();
+        let stdin_task = tokio::spawn(async move {
+            let mut writer = BufWriter::new(stdin_pipe);
+            while let Some(line) = stdin_rx.recv().await {
+                if writer.write_all(line.as_bytes()).await.is_err() {
+                    break;
+                }
+                if writer.flush().await.is_err() {
+                    break;
+                }
+            }
+        });
+
+        // stderr is drained to tracing; stdout is held for the orchestrator to take.
         let stderr_task =
             spawn_drain_task(stderr, session_name.to_string(), "stderr", DrainLevel::Warn);
 
@@ -407,7 +429,9 @@ impl ExecutionBackend for SubprocessBackend {
             SessionState::Running {
                 child,
                 pid,
-                _stdout_task: stdout_task,
+                stdout: Some(stdout),
+                stdin_tx: Some(stdin_tx),
+                _stdin_task: stdin_task,
                 _stderr_task: stderr_task,
                 config,
                 created_at: Instant::now(),
@@ -473,6 +497,16 @@ impl ExecutionBackend for SubprocessBackend {
         };
 
         if let Some(pid) = pid {
+            // Drop stdin_tx so the relay task exits and stdin EOF reaches claude.
+            // This gives claude a chance to shut down cleanly before SIGTERM.
+            {
+                let mut sessions = self.sessions.write().await;
+                if let Some(SessionState::Running { stdin_tx, .. }) = sessions.get_mut(session_name)
+                {
+                    let _ = stdin_tx.take();
+                }
+            }
+
             // Phase 1: SIGTERM to process group.
             #[cfg(unix)]
             {
@@ -659,6 +693,69 @@ impl ExecutionBackend for SubprocessBackend {
         }
         Ok(())
     }
+
+    fn supports_subprocess_stdio(&self) -> bool {
+        true
+    }
+
+    async fn write_subprocess_stdin(&self, session_name: &str, line: &str) -> Result<()> {
+        self.write_stdin(session_name, line).await
+    }
+
+    async fn take_subprocess_stdout(
+        &self,
+        session_name: &str,
+    ) -> Result<Box<dyn tokio::io::AsyncRead + Send + Unpin>> {
+        let stdout = self.take_stdout(session_name).await?;
+        Ok(Box::new(stdout))
+    }
+}
+
+impl SubprocessBackend {
+    /// Write one NDJSON line to the subprocess stdin relay channel.
+    ///
+    /// The line is forwarded to the child's stdin by a background relay task.
+    /// Returns an error if the session is not running or the relay has exited.
+    pub async fn write_stdin(&self, session_name: &str, line: &str) -> Result<()> {
+        let sessions = self.sessions.read().await;
+        match sessions.get(session_name) {
+            Some(SessionState::Running { stdin_tx: Some(tx), .. }) => {
+                tx.send(line.to_string())
+                    .map_err(|_| anyhow!("Stdin relay closed for session '{}'", session_name))
+            }
+            Some(SessionState::Running { stdin_tx: None, .. }) => {
+                Err(anyhow!("Stdin already closed for session '{}'", session_name))
+            }
+            Some(SessionState::Pending { .. }) => {
+                Err(anyhow!("Session '{}' not yet running", session_name))
+            }
+            Some(SessionState::Exited { .. }) => {
+                Err(anyhow!("Session '{}' has exited", session_name))
+            }
+            None => Err(anyhow!("Session '{}' not found", session_name)),
+        }
+    }
+
+    /// Take the stdout reader for a session. Callable only once per session.
+    ///
+    /// Returns an error if the session is not running or stdout has already
+    /// been taken. The caller is responsible for reading NDJSON from the
+    /// returned handle.
+    pub async fn take_stdout(&self, session_name: &str) -> Result<ChildStdout> {
+        let mut sessions = self.sessions.write().await;
+        match sessions.get_mut(session_name) {
+            Some(SessionState::Running { stdout, .. }) => {
+                stdout.take().ok_or_else(|| anyhow!("Stdout already taken for '{}'", session_name))
+            }
+            Some(SessionState::Pending { .. }) => {
+                Err(anyhow!("Session '{}' not yet running", session_name))
+            }
+            Some(SessionState::Exited { .. }) => {
+                Err(anyhow!("Session '{}' has exited", session_name))
+            }
+            None => Err(anyhow!("Session '{}' not found", session_name)),
+        }
+    }
 }
 
 /// Convert an [`ExitStatus`] to a [`SessionExitInfo`].
@@ -703,14 +800,14 @@ mod tests {
     #[test]
     fn parse_simple_command() {
         let (env, binary, args) = parse_command(
-            "claude --sdk-url ws://localhost:7006/ws/abc --output-format stream-json",
+            "claude --print --output-format stream-json --input-format stream-json",
         )
         .unwrap();
         assert!(env.is_empty());
         assert_binary(&binary, "claude");
         assert_eq!(
             args,
-            vec!["--sdk-url", "ws://localhost:7006/ws/abc", "--output-format", "stream-json"]
+            vec!["--print", "--output-format", "stream-json", "--input-format", "stream-json"]
         );
     }
 

--- a/crates/xtask/src/platform/linux.rs
+++ b/crates/xtask/src/platform/linux.rs
@@ -135,8 +135,7 @@ impl Platform for LinuxPlatform {
                 let unit_name = format!("agentd-{}.service", service.name);
                 let unit_path = unit_dir.join(&unit_name);
                 if unit_path.exists() {
-                    fs::remove_file(&unit_path)
-                        .context(format!("Failed to remove {unit_name}"))?;
+                    fs::remove_file(&unit_path).context(format!("Failed to remove {unit_name}"))?;
                     println!("  {} Removed {}", "✓".green(), unit_name);
                 }
             }
@@ -315,8 +314,7 @@ impl LinuxPlatform {
             let unit_name = format!("agentd-{}.service", service.name);
             let unit_path = unit_dir.join(&unit_name);
 
-            fs::write(&unit_path, &unit_content)
-                .context(format!("Failed to write {unit_name}"))?;
+            fs::write(&unit_path, &unit_content).context(format!("Failed to write {unit_name}"))?;
             println!("  {} {}", "✓".green(), unit_name);
         }
 


### PR DESCRIPTION
## Summary

- Claude Code v2.1.121+ restricted `--sdk-url` to Anthropic-controlled endpoints only, causing all subprocess-backed agents to exit with code 1 immediately after spawn
- Migrates the subprocess backend to the Claude Agent SDK protocol: `--print --verbose --input-format stream-json --output-format stream-json`
- Communication now happens via subprocess stdin/stdout NDJSON instead of WebSocket

## Changes

**`crates/wrap/src/subprocess.rs`**
- Open stdin pipe instead of null; spawn mpsc relay task forwarding channel messages to child stdin
- Store `ChildStdout` for one-time take by the orchestrator
- Add `write_stdin()` and `take_stdout()` methods
- Drop `stdin_tx` in `kill_session` to send EOF before SIGTERM (graceful shutdown)

**`crates/wrap/src/backend.rs`**
- Add `supports_subprocess_stdio()`, `write_subprocess_stdin()`, `take_subprocess_stdout()` trait methods with no-op defaults
- `SubprocessBackend` overrides all three

**`crates/orchestrator/src/manager.rs`**
- New `use_stdio` branch in `build_claude_command`: emits `--print --verbose` instead of `--sdk-url`
- `wire_subprocess_io()`: registers agent in `ConnectionRegistry` immediately, spawns stdin relay and stdout reader tasks that route NDJSON to `handle_incoming_message`
- `reconcile_agent`: subprocess stdio agents always restart after service restart (pipe pair is gone, no reconnect possible)

**`crates/orchestrator/src/websocket.rs`**
- `handle_incoming_message` made `pub(crate)` for use from manager

## Test plan

- [x] `cargo build` clean
- [x] `cargo clippy` clean
- [x] `cargo test -p wrap -p orchestrator` all pass
- [x] All 4 agents (triage, worker, planner, reviewer) confirmed running stably for 2+ minutes via live log monitoring after restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)