### PR TITLE
feat(gitlab): add GitLab trigger source scaffolding and TriggerConfig variants

### DIFF
--- a/crates/cli/src/commands/apply.rs
+++ b/crates/cli/src/commands/apply.rs
@@ -249,7 +249,7 @@ pub enum SourceTemplate {
         #[serde(default = "default_state")]
         state: String,
         #[serde(default)]
-        assignees: Option<Vec<String>>,
+        assignee: Option<String>,
     },
     Cron {
         expression: String,
@@ -316,7 +316,7 @@ pub enum SourceTemplate {
         #[serde(default = "default_gitlab_state")]
         state: String,
         #[serde(default)]
-        assignees: Option<Vec<String>>,
+        assignee: Option<String>,
     },
 }
 
@@ -682,8 +682,8 @@ pub async fn apply_workflow_file(
         SourceTemplate::GithubIssues { owner, repo, labels, state, assignee } => {
             TriggerConfig::GithubIssues { owner, repo, labels, state, assignee }
         }
-        SourceTemplate::GithubPullRequests { owner, repo, labels, state, assignees } => {
-            TriggerConfig::GithubPullRequests { owner, repo, labels, state, assignees }
+        SourceTemplate::GithubPullRequests { owner, repo, labels, state, assignee } => {
+            TriggerConfig::GithubPullRequests { owner, repo, labels, state, assignee }
         }
         SourceTemplate::Cron { expression } => TriggerConfig::Cron { expression },
         SourceTemplate::Delay { run_at } => TriggerConfig::Delay { run_at },
@@ -701,8 +701,8 @@ pub async fn apply_workflow_file(
         SourceTemplate::GitlabIssues { owner, repo, labels, state, assignee } => {
             TriggerConfig::GitlabIssues { owner, repo, labels, state, assignee }
         }
-        SourceTemplate::GitlabMergeRequests { owner, repo, labels, state, assignees } => {
-            TriggerConfig::GitlabMergeRequests { owner, repo, labels, state, assignees }
+        SourceTemplate::GitlabMergeRequests { owner, repo, labels, state, assignee } => {
+            TriggerConfig::GitlabMergeRequests { owner, repo, labels, state, assignee }
         }
     };
 
@@ -1912,5 +1912,94 @@ tool_policy:
         assert_eq!(tmpl.env.get("API_KEY"), Some(&"abc123".to_string()));
         assert_eq!(tmpl.env.get("BASE_URL"), Some(&"https://api.example.com".to_string()));
         assert_eq!(tmpl.tool_policy, ToolPolicy::AllowAll { sandbox_bypass: vec![] });
+    }
+
+    // -------------------------------------------------------------------------
+    // GitLab SourceTemplate parsing tests
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn test_parse_gitlab_issues_source_template_full() {
+        let yaml = r#"
+type: gitlab_issues
+owner: mygroup
+repo: myproject
+labels: [bug, agent]
+state: opened
+assignee: alice
+"#;
+        let src: SourceTemplate = serde_yaml::from_str(yaml).unwrap();
+        match src {
+            SourceTemplate::GitlabIssues { owner, repo, labels, state, assignee } => {
+                assert_eq!(owner, "mygroup");
+                assert_eq!(repo, "myproject");
+                assert_eq!(labels, vec!["bug", "agent"]);
+                assert_eq!(state, "opened");
+                assert_eq!(assignee.as_deref(), Some("alice"));
+            }
+            other => panic!("Expected GitlabIssues, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_parse_gitlab_issues_source_template_defaults() {
+        let yaml = r#"
+type: gitlab_issues
+owner: mygroup
+repo: myproject
+"#;
+        let src: SourceTemplate = serde_yaml::from_str(yaml).unwrap();
+        match src {
+            SourceTemplate::GitlabIssues { labels, state, assignee, .. } => {
+                assert!(labels.is_empty());
+                assert_eq!(state, "opened");
+                assert!(assignee.is_none());
+            }
+            other => panic!("Expected GitlabIssues, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_parse_gitlab_merge_requests_source_template_full() {
+        let yaml = r#"
+type: gitlab_merge_requests
+owner: mygroup
+repo: myproject
+labels: [needs-review]
+state: opened
+assignees: [alice, bob]
+"#;
+        let src: SourceTemplate = serde_yaml::from_str(yaml).unwrap();
+        match src {
+            SourceTemplate::GitlabMergeRequests { owner, repo, labels, state, assignees } => {
+                assert_eq!(owner, "mygroup");
+                assert_eq!(repo, "myproject");
+                assert_eq!(labels, vec!["needs-review"]);
+                assert_eq!(state, "opened");
+                assert_eq!(
+                    assignees.as_deref(),
+                    Some(&["alice".to_string(), "bob".to_string()][..])
+                );
+            }
+            other => panic!("Expected GitlabMergeRequests, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_parse_gitlab_merge_requests_source_template_defaults() {
+        let yaml = r#"
+type: gitlab_merge_requests
+owner: mygroup
+repo: myproject
+"#;
+        let src: SourceTemplate = serde_yaml::from_str(yaml).unwrap();
+        match src {
+            SourceTemplate::GitlabMergeRequests { labels, state, assignees, .. } => {
+                assert!(labels.is_empty());
+                assert_eq!(state, "opened");
+                assert!(assignees.is_none());
+            }
+            other => panic!("Expected GitlabMergeRequests, got {:?}", other),
+        }
     }
 }

--- a/crates/cli/src/commands/apply.rs
+++ b/crates/cli/src/commands/apply.rs
@@ -288,10 +288,40 @@ pub enum SourceTemplate {
         #[serde(default)]
         assignee: Option<String>,
     },
+    /// GitLab issues trigger — polls GitLab for issues matching the given filters.
+    ///
+    /// Requires `AGENTD_GITLAB_TOKEN` to be set in the environment.
+    GitlabIssues {
+        owner: String,
+        repo: String,
+        #[serde(default)]
+        labels: Vec<String>,
+        #[serde(default = "default_gitlab_state")]
+        state: String,
+        #[serde(default)]
+        assignee: Option<String>,
+    },
+    /// GitLab merge requests trigger — polls GitLab for MRs matching the given filters.
+    ///
+    /// Requires `AGENTD_GITLAB_TOKEN` to be set in the environment.
+    GitlabMergeRequests {
+        owner: String,
+        repo: String,
+        #[serde(default)]
+        labels: Vec<String>,
+        #[serde(default = "default_gitlab_state")]
+        state: String,
+        #[serde(default)]
+        assignees: Option<Vec<String>>,
+    },
 }
 
 fn default_state() -> String {
     "open".to_string()
+}
+
+fn default_gitlab_state() -> String {
+    "opened".to_string()
 }
 
 /// Detected template type for a single YAML file.
@@ -663,6 +693,12 @@ pub async fn apply_workflow_file(
         SourceTemplate::Manual {} => TriggerConfig::Manual {},
         SourceTemplate::LinearIssues { team_key, project, status, labels, assignee } => {
             TriggerConfig::LinearIssues { team_key, project, status, labels, assignee }
+        }
+        SourceTemplate::GitlabIssues { owner, repo, labels, state, assignee } => {
+            TriggerConfig::GitlabIssues { owner, repo, labels, state, assignee }
+        }
+        SourceTemplate::GitlabMergeRequests { owner, repo, labels, state, assignees } => {
+            TriggerConfig::GitlabMergeRequests { owner, repo, labels, state, assignees }
         }
     };
 

--- a/crates/cli/src/commands/apply.rs
+++ b/crates/cli/src/commands/apply.rs
@@ -238,6 +238,8 @@ pub enum SourceTemplate {
         labels: Vec<String>,
         #[serde(default = "default_state")]
         state: String,
+        #[serde(default)]
+        assignee: Option<String>,
     },
     GithubPullRequests {
         owner: String,
@@ -246,6 +248,8 @@ pub enum SourceTemplate {
         labels: Vec<String>,
         #[serde(default = "default_state")]
         state: String,
+        #[serde(default)]
+        assignees: Option<Vec<String>>,
     },
     Cron {
         expression: String,
@@ -675,11 +679,11 @@ pub async fn apply_workflow_file(
     }
 
     let trigger_config = match tmpl.source {
-        SourceTemplate::GithubIssues { owner, repo, labels, state } => {
-            TriggerConfig::GithubIssues { owner, repo, labels, state }
+        SourceTemplate::GithubIssues { owner, repo, labels, state, assignee } => {
+            TriggerConfig::GithubIssues { owner, repo, labels, state, assignee }
         }
-        SourceTemplate::GithubPullRequests { owner, repo, labels, state } => {
-            TriggerConfig::GithubPullRequests { owner, repo, labels, state }
+        SourceTemplate::GithubPullRequests { owner, repo, labels, state, assignees } => {
+            TriggerConfig::GithubPullRequests { owner, repo, labels, state, assignees }
         }
         SourceTemplate::Cron { expression } => TriggerConfig::Cron { expression },
         SourceTemplate::Delay { run_at } => TriggerConfig::Delay { run_at },
@@ -1551,11 +1555,12 @@ state: closed
 "#;
         let src: SourceTemplate = serde_yaml::from_str(yaml).unwrap();
         match src {
-            SourceTemplate::GithubIssues { owner, repo, labels, state } => {
+            SourceTemplate::GithubIssues { owner, repo, labels, state, assignee } => {
                 assert_eq!(owner, "myorg");
                 assert_eq!(repo, "myrepo");
                 assert_eq!(labels, vec!["bug"]);
                 assert_eq!(state, "closed");
+                assert!(assignee.is_none());
             }
             other => panic!("Expected GithubIssues, got {:?}", other),
         }

--- a/crates/cli/src/commands/orchestrator.rs
+++ b/crates/cli/src/commands/orchestrator.rs
@@ -79,6 +79,10 @@ pub enum TriggerType {
     LinearIssues,
     /// Queue-based trigger — consumes tasks from a named internal queue.
     Queue,
+    /// GitLab issues trigger — polls GitLab for matching issues.
+    GitlabIssues,
+    /// GitLab merge requests trigger — polls GitLab for matching merge requests.
+    GitlabMergeRequests,
 }
 
 /// Orchestrator service management subcommands.
@@ -2541,6 +2545,40 @@ async fn create_workflow(
                 visibility_timeout_secs: queue_visibility_timeout,
             }
         }
+        TriggerType::GitlabIssues => {
+            let owner = owner
+                .ok_or_else(|| anyhow::anyhow!("--owner is required for gitlab-issues trigger"))?;
+            let repo = repo
+                .ok_or_else(|| anyhow::anyhow!("--repo is required for gitlab-issues trigger"))?;
+            let labels_vec: Vec<String> = labels
+                .map(|l| l.split(',').map(|s| s.trim().to_string()).collect())
+                .unwrap_or_default();
+            TriggerConfig::GitlabIssues {
+                owner: owner.to_string(),
+                repo: repo.to_string(),
+                labels: labels_vec,
+                state: state.unwrap_or("opened").to_string(),
+                assignee: None,
+            }
+        }
+        TriggerType::GitlabMergeRequests => {
+            let owner = owner.ok_or_else(|| {
+                anyhow::anyhow!("--owner is required for gitlab-merge-requests trigger")
+            })?;
+            let repo = repo.ok_or_else(|| {
+                anyhow::anyhow!("--repo is required for gitlab-merge-requests trigger")
+            })?;
+            let labels_vec: Vec<String> = labels
+                .map(|l| l.split(',').map(|s| s.trim().to_string()).collect())
+                .unwrap_or_default();
+            TriggerConfig::GitlabMergeRequests {
+                owner: owner.to_string(),
+                repo: repo.to_string(),
+                labels: labels_vec,
+                state: state.unwrap_or("opened").to_string(),
+                assignees: None,
+            }
+        }
     };
 
     let request = CreateWorkflowRequest {
@@ -2938,6 +2976,28 @@ fn display_workflow(workflow: &WorkflowResponse) {
             }
             if let Some(p) = response_pattern {
                 println!("{}: {}", "Response Pattern".bold(), p);
+            }
+        }
+        TriggerConfig::GitlabIssues { owner, repo, labels, state, assignee } => {
+            println!("{}: {}/{}", "Repository".bold(), owner, repo);
+            if !labels.is_empty() {
+                println!("{}: {}", "Labels".bold(), labels.join(", "));
+            }
+            println!("{}: {}", "State".bold(), state);
+            if let Some(a) = assignee {
+                println!("{}: {}", "Assignee".bold(), a);
+            }
+        }
+        TriggerConfig::GitlabMergeRequests { owner, repo, labels, state, assignees } => {
+            println!("{}: {}/{}", "Repository".bold(), owner, repo);
+            if !labels.is_empty() {
+                println!("{}: {}", "Labels".bold(), labels.join(", "));
+            }
+            println!("{}: {}", "State".bold(), state);
+            if let Some(assignee_list) = assignees {
+                if !assignee_list.is_empty() {
+                    println!("{}: {}", "Assignees".bold(), assignee_list.join(", "));
+                }
             }
         }
     }

--- a/crates/cli/src/commands/orchestrator.rs
+++ b/crates/cli/src/commands/orchestrator.rs
@@ -2470,6 +2470,7 @@ async fn create_workflow(
                 repo: repo.to_string(),
                 labels: labels_vec,
                 state: state.unwrap_or("open").to_string(),
+                assignee: None,
             }
         }
         TriggerType::GithubPullRequests => {
@@ -2487,6 +2488,7 @@ async fn create_workflow(
                 repo: repo.to_string(),
                 labels: labels_vec,
                 state: state.unwrap_or("open").to_string(),
+                assignees: None,
             }
         }
         TriggerType::Cron => {
@@ -2891,19 +2893,27 @@ fn display_workflow(workflow: &WorkflowResponse) {
     println!("{}: {}s", "Poll Interval".bold(), workflow.poll_interval_secs);
     println!("{}: {}", "Trigger Type".bold(), workflow.trigger_config.trigger_type());
     match &workflow.trigger_config {
-        TriggerConfig::GithubIssues { owner, repo, labels, state } => {
+        TriggerConfig::GithubIssues { owner, repo, labels, state, assignee } => {
             println!("{}: {}/{}", "Repository".bold(), owner, repo);
             if !labels.is_empty() {
                 println!("{}: {}", "Labels".bold(), labels.join(", "));
             }
             println!("{}: {}", "State".bold(), state);
+            if let Some(a) = assignee {
+                println!("{}: {}", "Assignee".bold(), a);
+            }
         }
-        TriggerConfig::GithubPullRequests { owner, repo, labels, state } => {
+        TriggerConfig::GithubPullRequests { owner, repo, labels, state, assignees } => {
             println!("{}: {}/{}", "Repository".bold(), owner, repo);
             if !labels.is_empty() {
                 println!("{}: {}", "Labels".bold(), labels.join(", "));
             }
             println!("{}: {}", "State".bold(), state);
+            if let Some(assignee_list) = assignees {
+                if !assignee_list.is_empty() {
+                    println!("{}: {}", "Assignees".bold(), assignee_list.join(", "));
+                }
+            }
         }
         TriggerConfig::Cron { expression } => {
             println!("{}: {}", "Expression".bold(), expression);

--- a/crates/cli/src/commands/orchestrator.rs
+++ b/crates/cli/src/commands/orchestrator.rs
@@ -2488,7 +2488,7 @@ async fn create_workflow(
                 repo: repo.to_string(),
                 labels: labels_vec,
                 state: state.unwrap_or("open").to_string(),
-                assignees: None,
+                assignee: None,
             }
         }
         TriggerType::Cron => {
@@ -2578,7 +2578,7 @@ async fn create_workflow(
                 repo: repo.to_string(),
                 labels: labels_vec,
                 state: state.unwrap_or("opened").to_string(),
-                assignees: None,
+                assignee: None,
             }
         }
     };
@@ -2903,16 +2903,14 @@ fn display_workflow(workflow: &WorkflowResponse) {
                 println!("{}: {}", "Assignee".bold(), a);
             }
         }
-        TriggerConfig::GithubPullRequests { owner, repo, labels, state, assignees } => {
+        TriggerConfig::GithubPullRequests { owner, repo, labels, state, assignee } => {
             println!("{}: {}/{}", "Repository".bold(), owner, repo);
             if !labels.is_empty() {
                 println!("{}: {}", "Labels".bold(), labels.join(", "));
             }
             println!("{}: {}", "State".bold(), state);
-            if let Some(assignee_list) = assignees {
-                if !assignee_list.is_empty() {
-                    println!("{}: {}", "Assignees".bold(), assignee_list.join(", "));
-                }
+            if let Some(a) = assignee {
+                println!("{}: {}", "Assignee".bold(), a);
             }
         }
         TriggerConfig::Cron { expression } => {
@@ -2998,16 +2996,14 @@ fn display_workflow(workflow: &WorkflowResponse) {
                 println!("{}: {}", "Assignee".bold(), a);
             }
         }
-        TriggerConfig::GitlabMergeRequests { owner, repo, labels, state, assignees } => {
+        TriggerConfig::GitlabMergeRequests { owner, repo, labels, state, assignee } => {
             println!("{}: {}/{}", "Repository".bold(), owner, repo);
             if !labels.is_empty() {
                 println!("{}: {}", "Labels".bold(), labels.join(", "));
             }
             println!("{}: {}", "State".bold(), state);
-            if let Some(assignee_list) = assignees {
-                if !assignee_list.is_empty() {
-                    println!("{}: {}", "Assignees".bold(), assignee_list.join(", "));
-                }
+            if let Some(a) = assignee {
+                println!("{}: {}", "Assignee".bold(), a);
             }
         }
     }
@@ -3098,6 +3094,7 @@ mod tests {
                 repo: "widgets".to_string(),
                 labels: vec!["bug".to_string()],
                 state: "open".to_string(),
+                assignee: None,
             },
             prompt_template: "Fix: {{title}}".to_string(),
             poll_interval_secs: 60,
@@ -3969,6 +3966,7 @@ mod tests {
             repo: "repo".into(),
             labels: vec!["review".into()],
             state: "open".into(),
+            assignees: None,
         };
         display_workflow(&w);
 
@@ -4160,6 +4158,7 @@ mod tests {
             repo: "b".into(),
             labels: vec![],
             state: "open".into(),
+            assignee: None,
         }
         .is_implemented());
         assert!(TriggerConfig::GithubPullRequests {
@@ -4167,6 +4166,7 @@ mod tests {
             repo: "b".into(),
             labels: vec![],
             state: "open".into(),
+            assignees: None,
         }
         .is_implemented());
         assert!(TriggerConfig::Cron { expression: "* * * * *".into() }.is_implemented());

--- a/crates/orchestrator/src/scheduler/api.rs
+++ b/crates/orchestrator/src/scheduler/api.rs
@@ -189,6 +189,25 @@ async fn create_workflow(
         TriggerConfig::AskResponse { .. } => {
             // No required fields — all filters (agent_id, category, response_pattern) are optional.
         }
+        TriggerConfig::GitlabIssues { owner, repo, state, .. }
+        | TriggerConfig::GitlabMergeRequests { owner, repo, state, .. } => {
+            if owner.trim().is_empty() || repo.trim().is_empty() {
+                return Err(ApiError::InvalidInput(
+                    "GitLab trigger requires non-empty 'owner' and 'repo'".to_string(),
+                ));
+            }
+            let valid_states: &[&str] = match &req.trigger_config {
+                TriggerConfig::GitlabIssues { .. } => &["opened", "closed", "all"],
+                _ => &["opened", "closed", "merged", "all"],
+            };
+            if !valid_states.contains(&state.as_str()) {
+                return Err(ApiError::InvalidInput(format!(
+                    "Invalid GitLab state '{}'. Valid values: {}",
+                    state,
+                    valid_states.join(", ")
+                )));
+            }
+        }
     }
 
     // Reject trigger types that are not yet implemented.
@@ -210,6 +229,19 @@ async fn create_workflow(
             "Linear API key not configured. \
              Set the AGENTD_LINEAR_API_KEY environment variable \
              or add 'api_key' to the [linear] section of the agentd config file."
+                .to_string(),
+        ));
+    }
+
+    if matches!(
+        req.trigger_config,
+        TriggerConfig::GitlabIssues { .. } | TriggerConfig::GitlabMergeRequests { .. }
+    ) && !crate::scheduler::gitlab::GitlabConfig::is_configured()
+    {
+        return Err(ApiError::InvalidInput(
+            "GitLab token not configured. \
+             Set the AGENTD_GITLAB_TOKEN environment variable \
+             or add 'token' to the [gitlab] section of the agentd config file."
                 .to_string(),
         ));
     }

--- a/crates/orchestrator/src/scheduler/github.rs
+++ b/crates/orchestrator/src/scheduler/github.rs
@@ -35,11 +35,18 @@ pub struct GithubIssueSource {
     repo: String,
     labels: Vec<String>,
     state: String,
+    assignee: Option<String>,
 }
 
 impl GithubIssueSource {
-    pub fn new(owner: String, repo: String, labels: Vec<String>, state: String) -> Self {
-        Self { owner, repo, labels, state }
+    pub fn new(
+        owner: String,
+        repo: String,
+        labels: Vec<String>,
+        state: String,
+        assignee: Option<String>,
+    ) -> Self {
+        Self { owner, repo, labels, state, assignee }
     }
 }
 
@@ -66,22 +73,13 @@ struct GhAssignee {
 #[async_trait]
 impl TaskSource for GithubIssueSource {
     async fn fetch_tasks(&self) -> anyhow::Result<Vec<Task>> {
-        let mut args = vec![
-            GH_PATH.clone(),
-            "issue".to_string(),
-            "list".to_string(),
-            "--json".to_string(),
-            "number,title,body,url,labels,assignees".to_string(),
-            "--repo".to_string(),
-            format!("{}/{}", self.owner, self.repo),
-            "--state".to_string(),
-            self.state.clone(),
-        ];
-
-        for label in &self.labels {
-            args.push("--label".to_string());
-            args.push(label.clone());
-        }
+        let args = build_issue_args(
+            &self.owner,
+            &self.repo,
+            &self.labels,
+            &self.state,
+            self.assignee.as_deref(),
+        );
 
         debug!(repo = %format!("{}/{}", self.owner, self.repo), "Fetching GitHub issues");
 
@@ -123,11 +121,18 @@ pub struct GithubPullRequestSource {
     repo: String,
     labels: Vec<String>,
     state: String,
+    assignees: Option<Vec<String>>,
 }
 
 impl GithubPullRequestSource {
-    pub fn new(owner: String, repo: String, labels: Vec<String>, state: String) -> Self {
-        Self { owner, repo, labels, state }
+    pub fn new(
+        owner: String,
+        repo: String,
+        labels: Vec<String>,
+        state: String,
+        assignees: Option<Vec<String>>,
+    ) -> Self {
+        Self { owner, repo, labels, state, assignees }
     }
 }
 
@@ -150,22 +155,13 @@ struct GhPullRequest {
 #[async_trait]
 impl TaskSource for GithubPullRequestSource {
     async fn fetch_tasks(&self) -> anyhow::Result<Vec<Task>> {
-        let mut args = vec![
-            GH_PATH.clone(),
-            "pr".to_string(),
-            "list".to_string(),
-            "--json".to_string(),
-            "number,title,body,url,labels,assignees,headRefName,baseRefName,isDraft".to_string(),
-            "--repo".to_string(),
-            format!("{}/{}", self.owner, self.repo),
-            "--state".to_string(),
-            self.state.clone(),
-        ];
-
-        for label in &self.labels {
-            args.push("--label".to_string());
-            args.push(label.clone());
-        }
+        let args = build_pr_args(
+            &self.owner,
+            &self.repo,
+            &self.labels,
+            &self.state,
+            self.assignees.as_deref(),
+        );
 
         debug!(repo = %format!("{}/{}", self.owner, self.repo), "Fetching GitHub pull requests");
 
@@ -206,6 +202,68 @@ impl TaskSource for GithubPullRequestSource {
     fn source_type(&self) -> &'static str {
         "github_pull_requests"
     }
+}
+
+/// Build the args list for `gh issue list` (extracted for testability).
+pub(crate) fn build_issue_args(
+    owner: &str,
+    repo: &str,
+    labels: &[String],
+    state: &str,
+    assignee: Option<&str>,
+) -> Vec<String> {
+    let mut args = vec![
+        GH_PATH.clone(),
+        "issue".to_string(),
+        "list".to_string(),
+        "--json".to_string(),
+        "number,title,body,url,labels,assignees".to_string(),
+        "--repo".to_string(),
+        format!("{}/{}", owner, repo),
+        "--state".to_string(),
+        state.to_string(),
+    ];
+    for label in labels {
+        args.push("--label".to_string());
+        args.push(label.clone());
+    }
+    if let Some(a) = assignee {
+        args.push("--assignee".to_string());
+        args.push(a.to_string());
+    }
+    args
+}
+
+/// Build the args list for `gh pr list` (extracted for testability).
+pub(crate) fn build_pr_args(
+    owner: &str,
+    repo: &str,
+    labels: &[String],
+    state: &str,
+    assignees: Option<&[String]>,
+) -> Vec<String> {
+    let mut args = vec![
+        GH_PATH.clone(),
+        "pr".to_string(),
+        "list".to_string(),
+        "--json".to_string(),
+        "number,title,body,url,labels,assignees,headRefName,baseRefName,isDraft".to_string(),
+        "--repo".to_string(),
+        format!("{}/{}", owner, repo),
+        "--state".to_string(),
+        state.to_string(),
+    ];
+    for label in labels {
+        args.push("--label".to_string());
+        args.push(label.clone());
+    }
+    if let Some(assignee_list) = assignees {
+        for a in assignee_list {
+            args.push("--assignee".to_string());
+            args.push(a.clone());
+        }
+    }
+    args
 }
 
 /// Parse `gh issue list --json` output into Tasks (useful for testing).
@@ -345,5 +403,53 @@ mod tests {
     fn test_parse_pull_requests_empty() {
         let tasks = parse_gh_pull_requests("[]").unwrap();
         assert!(tasks.is_empty());
+    }
+
+    #[test]
+    fn test_build_issue_args_no_assignee() {
+        let args = build_issue_args("myorg", "myrepo", &[], "open", None);
+        assert!(args.contains(&"--repo".to_string()));
+        assert!(args.contains(&"myorg/myrepo".to_string()));
+        assert!(args.contains(&"--state".to_string()));
+        assert!(args.contains(&"open".to_string()));
+        assert!(!args.contains(&"--assignee".to_string()));
+    }
+
+    #[test]
+    fn test_build_issue_args_with_assignee() {
+        let args = build_issue_args("myorg", "myrepo", &[], "open", Some("alice"));
+        assert!(args.contains(&"--assignee".to_string()));
+        assert!(args.contains(&"alice".to_string()));
+        // assignee arg should appear after --assignee flag
+        let idx = args.iter().position(|a| a == "--assignee").unwrap();
+        assert_eq!(args[idx + 1], "alice");
+    }
+
+    #[test]
+    fn test_build_issue_args_with_labels_and_assignee() {
+        let labels = vec!["bug".to_string(), "agent".to_string()];
+        let args = build_issue_args("myorg", "myrepo", &labels, "open", Some("bob"));
+        let label_count = args.iter().filter(|a| a.as_str() == "--label").count();
+        assert_eq!(label_count, 2);
+        assert!(args.contains(&"--assignee".to_string()));
+        assert!(args.contains(&"bob".to_string()));
+    }
+
+    #[test]
+    fn test_build_pr_args_no_assignees() {
+        let args = build_pr_args("myorg", "myrepo", &[], "open", None);
+        assert!(args.contains(&"--repo".to_string()));
+        assert!(args.contains(&"myorg/myrepo".to_string()));
+        assert!(!args.contains(&"--assignee".to_string()));
+    }
+
+    #[test]
+    fn test_build_pr_args_with_multiple_assignees() {
+        let assignees = vec!["alice".to_string(), "bob".to_string()];
+        let args = build_pr_args("myorg", "myrepo", &[], "open", Some(&assignees));
+        let assignee_count = args.iter().filter(|a| a.as_str() == "--assignee").count();
+        assert_eq!(assignee_count, 2);
+        assert!(args.contains(&"alice".to_string()));
+        assert!(args.contains(&"bob".to_string()));
     }
 }

--- a/crates/orchestrator/src/scheduler/github.rs
+++ b/crates/orchestrator/src/scheduler/github.rs
@@ -121,7 +121,7 @@ pub struct GithubPullRequestSource {
     repo: String,
     labels: Vec<String>,
     state: String,
-    assignees: Option<Vec<String>>,
+    assignee: Option<String>,
 }
 
 impl GithubPullRequestSource {
@@ -130,9 +130,9 @@ impl GithubPullRequestSource {
         repo: String,
         labels: Vec<String>,
         state: String,
-        assignees: Option<Vec<String>>,
+        assignee: Option<String>,
     ) -> Self {
-        Self { owner, repo, labels, state, assignees }
+        Self { owner, repo, labels, state, assignee }
     }
 }
 
@@ -160,7 +160,7 @@ impl TaskSource for GithubPullRequestSource {
             &self.repo,
             &self.labels,
             &self.state,
-            self.assignees.as_deref(),
+            self.assignee.as_deref(),
         );
 
         debug!(repo = %format!("{}/{}", self.owner, self.repo), "Fetching GitHub pull requests");
@@ -235,12 +235,16 @@ pub(crate) fn build_issue_args(
 }
 
 /// Build the args list for `gh pr list` (extracted for testability).
+///
+/// Note: `gh pr list --assignee` accepts a single username string (not an
+/// array). If multi-assignee filtering is ever needed, use
+/// `--search "assignee:alice assignee:bob"` instead.
 pub(crate) fn build_pr_args(
     owner: &str,
     repo: &str,
     labels: &[String],
     state: &str,
-    assignees: Option<&[String]>,
+    assignee: Option<&str>,
 ) -> Vec<String> {
     let mut args = vec![
         GH_PATH.clone(),
@@ -257,11 +261,9 @@ pub(crate) fn build_pr_args(
         args.push("--label".to_string());
         args.push(label.clone());
     }
-    if let Some(assignee_list) = assignees {
-        for a in assignee_list {
-            args.push("--assignee".to_string());
-            args.push(a.clone());
-        }
+    if let Some(a) = assignee {
+        args.push("--assignee".to_string());
+        args.push(a.to_string());
     }
     args
 }
@@ -436,7 +438,7 @@ mod tests {
     }
 
     #[test]
-    fn test_build_pr_args_no_assignees() {
+    fn test_build_pr_args_no_assignee() {
         let args = build_pr_args("myorg", "myrepo", &[], "open", None);
         assert!(args.contains(&"--repo".to_string()));
         assert!(args.contains(&"myorg/myrepo".to_string()));
@@ -444,12 +446,10 @@ mod tests {
     }
 
     #[test]
-    fn test_build_pr_args_with_multiple_assignees() {
-        let assignees = vec!["alice".to_string(), "bob".to_string()];
-        let args = build_pr_args("myorg", "myrepo", &[], "open", Some(&assignees));
+    fn test_build_pr_args_with_assignee() {
+        let args = build_pr_args("myorg", "myrepo", &[], "open", Some("alice"));
         let assignee_count = args.iter().filter(|a| a.as_str() == "--assignee").count();
-        assert_eq!(assignee_count, 2);
+        assert_eq!(assignee_count, 1);
         assert!(args.contains(&"alice".to_string()));
-        assert!(args.contains(&"bob".to_string()));
     }
 }

--- a/crates/orchestrator/src/scheduler/gitlab.rs
+++ b/crates/orchestrator/src/scheduler/gitlab.rs
@@ -302,8 +302,7 @@ impl GitlabIssueSource {
     }
 
     /// Create a source with an explicit token and base URL (for testing).
-    #[doc(hidden)]
-    #[allow(dead_code)]
+    #[cfg(test)]
     pub fn new_with_config(
         owner: String,
         repo: String,
@@ -409,7 +408,7 @@ impl TaskSource for GitlabIssueSource {
 ///
 /// - `state` — `opened`/`closed`/`merged`/`all`
 /// - `labels` — comma-separated label names
-/// - `assignees` — filter by `assignee_username` (first entry used)
+/// - `assignee` — filter by `assignee_username`
 ///
 /// # Pagination
 ///
@@ -419,7 +418,7 @@ pub struct GitlabMergeRequestSource {
     repo: String,
     labels: Vec<String>,
     state: String,
-    assignees: Option<Vec<String>>,
+    assignee: Option<String>,
     /// Pre-resolved token. Never logged.
     token: String,
     /// GitLab base URL.
@@ -434,7 +433,7 @@ impl std::fmt::Debug for GitlabMergeRequestSource {
             .field("repo", &self.repo)
             .field("labels", &self.labels)
             .field("state", &self.state)
-            .field("assignees", &self.assignees)
+            .field("assignee", &self.assignee)
             .field("token", &"<redacted>")
             .field("base_url", &self.base_url)
             .finish()
@@ -448,7 +447,7 @@ impl GitlabMergeRequestSource {
         repo: String,
         labels: Vec<String>,
         state: String,
-        assignees: Option<Vec<String>>,
+        assignee: Option<String>,
     ) -> Result<Self> {
         let config = GitlabConfig::resolve()?;
         Ok(Self {
@@ -456,7 +455,7 @@ impl GitlabMergeRequestSource {
             repo,
             labels,
             state,
-            assignees,
+            assignee,
             token: config.token().to_string(),
             base_url: config.base_url().to_string(),
             client: reqwest::Client::new(),
@@ -464,14 +463,13 @@ impl GitlabMergeRequestSource {
     }
 
     /// Create a source with an explicit token and base URL (for testing).
-    #[doc(hidden)]
-    #[allow(dead_code)]
+    #[cfg(test)]
     pub fn new_with_config(
         owner: String,
         repo: String,
         labels: Vec<String>,
         state: String,
-        assignees: Option<Vec<String>>,
+        assignee: Option<String>,
         token: String,
         base_url: String,
     ) -> Self {
@@ -480,7 +478,7 @@ impl GitlabMergeRequestSource {
             repo,
             labels,
             state,
-            assignees,
+            assignee,
             token,
             base_url,
             client: reqwest::Client::new(),
@@ -503,11 +501,8 @@ impl GitlabMergeRequestSource {
         if !self.labels.is_empty() {
             request = request.query(&[("labels", self.labels.join(","))]);
         }
-        // GitLab supports `assignee_username` filter for MRs (single value).
-        if let Some(assignees) = &self.assignees {
-            if let Some(first) = assignees.first() {
-                request = request.query(&[("assignee_username", first.as_str())]);
-            }
+        if let Some(assignee) = &self.assignee {
+            request = request.query(&[("assignee_username", assignee.as_str())]);
         }
 
         let response = request.send().await.context("Failed to connect to GitLab API")?;
@@ -614,25 +609,6 @@ fn map_merge_request(mr: GitlabMergeRequest) -> Task {
     }
 }
 
-/// Parse a JSON array of GitLab issue objects into [`Task`] structs.
-///
-/// Useful for testing and offline use, following the pattern established by
-/// `parse_gh_issues()` in `github.rs`.
-#[allow(dead_code)]
-pub fn parse_gitlab_issues(json: &str) -> Result<Vec<Task>> {
-    let issues: Vec<GitlabIssue> = serde_json::from_str(json)?;
-    Ok(map_issues(issues))
-}
-
-/// Parse a JSON array of GitLab merge request objects into [`Task`] structs.
-///
-/// Useful for testing and offline use.
-#[allow(dead_code)]
-pub fn parse_gitlab_merge_requests(json: &str) -> Result<Vec<Task>> {
-    let mrs: Vec<GitlabMergeRequest> = serde_json::from_str(json)?;
-    Ok(map_merge_requests(mrs))
-}
-
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -640,6 +616,23 @@ pub fn parse_gitlab_merge_requests(json: &str) -> Result<Vec<Task>> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Parse a JSON array of GitLab issue objects into [`Task`] structs.
+    ///
+    /// Useful for testing and offline use, following the pattern established by
+    /// `parse_gh_issues()` in `github.rs`.
+    pub fn parse_gitlab_issues(json: &str) -> Result<Vec<Task>> {
+        let issues: Vec<GitlabIssue> = serde_json::from_str(json)?;
+        Ok(map_issues(issues))
+    }
+
+    /// Parse a JSON array of GitLab merge request objects into [`Task`] structs.
+    ///
+    /// Useful for testing and offline use.
+    pub fn parse_gitlab_merge_requests(json: &str) -> Result<Vec<Task>> {
+        let mrs: Vec<GitlabMergeRequest> = serde_json::from_str(json)?;
+        Ok(map_merge_requests(mrs))
+    }
 
     // -------------------------------------------------------------------------
     // Shared env-var helpers

--- a/crates/orchestrator/src/scheduler/gitlab.rs
+++ b/crates/orchestrator/src/scheduler/gitlab.rs
@@ -1,0 +1,959 @@
+//! GitLab API integration: configuration, issue source, and merge request source.
+//!
+//! # Configuration
+//!
+//! The GitLab API token can be provided in two ways, checked in this order:
+//!
+//! ## 1. Environment variable (recommended)
+//!
+//! ```sh
+//! export AGENTD_GITLAB_TOKEN=glpat-xxxxxxxxxxxxxxxxxxxx
+//! ```
+//!
+//! ## 2. Config file (optional fallback)
+//!
+//! Add a `[gitlab]` section to the agentd config file:
+//!
+//! **Location (checked in order):**
+//! - `$AGENTD_CONFIG_FILE` — explicit path override
+//! - `~/.config/agentd/config.toml` (Linux / XDG)
+//! - `~/Library/Application Support/agentd/config.toml` (macOS)
+//!
+//! **Format:**
+//! ```toml
+//! [gitlab]
+//! token = "glpat-xxxxxxxxxxxxxxxxxxxx"
+//! ```
+//!
+//! ## Self-hosted GitLab
+//!
+//! Set `AGENTD_GITLAB_URL` to override the default `https://gitlab.com` base URL:
+//!
+//! ```sh
+//! export AGENTD_GITLAB_URL=https://gitlab.example.com
+//! ```
+//!
+//! # Authentication
+//!
+//! GitLab REST API v4 uses the `PRIVATE-TOKEN` header:
+//!
+//! ```text
+//! PRIVATE-TOKEN: glpat-xxxxxxxxxxxxxxxxxxxx
+//! ```
+//!
+//! # Security
+//!
+//! The token is **never** logged or included in error messages.
+
+use crate::scheduler::source::TaskSource;
+use crate::scheduler::types::Task;
+use anyhow::{Context, Result};
+use async_trait::async_trait;
+use serde::Deserialize;
+use std::collections::HashMap;
+use tracing::{debug, warn};
+
+/// Default GitLab base URL (gitlab.com SaaS instance).
+const DEFAULT_GITLAB_URL: &str = "https://gitlab.com";
+
+// ---------------------------------------------------------------------------
+// GitlabConfig
+// ---------------------------------------------------------------------------
+
+/// Configuration for the GitLab REST API integration.
+///
+/// # Security
+///
+/// The `token` field is intentionally excluded from [`std::fmt::Debug`] output
+/// to prevent accidental logging. Use [`GitlabConfig::is_configured`] to check
+/// availability without exposing the token value.
+pub struct GitlabConfig {
+    token: String,
+    base_url: String,
+}
+
+/// Manually implemented to prevent the token from appearing in log output.
+impl std::fmt::Debug for GitlabConfig {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("GitlabConfig")
+            .field("token", &"<redacted>")
+            .field("base_url", &self.base_url)
+            .finish()
+    }
+}
+
+impl GitlabConfig {
+    /// Resolve the GitLab token from the environment or config file.
+    ///
+    /// Checks sources in the following order:
+    ///
+    /// 1. `AGENTD_GITLAB_TOKEN` environment variable
+    /// 2. `[gitlab] token` in the agentd config file
+    ///
+    /// The base URL is read from `AGENTD_GITLAB_URL` (defaults to
+    /// `https://gitlab.com`).
+    ///
+    /// Returns an error if no token is found. The error message **never
+    /// includes** the token value.
+    pub fn resolve() -> Result<Self> {
+        let base_url =
+            std::env::var("AGENTD_GITLAB_URL").unwrap_or_else(|_| DEFAULT_GITLAB_URL.to_string());
+
+        // 1. Environment variable (preferred)
+        if let Ok(token) = std::env::var("AGENTD_GITLAB_TOKEN") {
+            if !token.trim().is_empty() {
+                return Ok(Self { token, base_url });
+            }
+        }
+
+        // 2. Config file fallback
+        if let Some(token) = Self::read_from_config_file()? {
+            return Ok(Self { token, base_url });
+        }
+
+        anyhow::bail!(
+            "GitLab token not configured. \
+             Set the AGENTD_GITLAB_TOKEN environment variable \
+             or add 'token' to the [gitlab] section of the agentd config file."
+        )
+    }
+
+    /// Check whether a GitLab token is available without loading it.
+    ///
+    /// Returns `true` if `AGENTD_GITLAB_TOKEN` is set to a non-empty value,
+    /// or if a token is present in the config file.
+    pub fn is_configured() -> bool {
+        if matches!(std::env::var("AGENTD_GITLAB_TOKEN"), Ok(v) if !v.trim().is_empty()) {
+            return true;
+        }
+        match Self::read_from_config_file() {
+            Ok(Some(_)) => true,
+            Ok(None) => false,
+            Err(e) => {
+                warn!(
+                    error = %e,
+                    "Failed to read agentd config file while checking GitLab token; \
+                     falling back to environment variable only"
+                );
+                false
+            }
+        }
+    }
+
+    /// Return the token value.
+    ///
+    /// # Security
+    ///
+    /// Do **not** log, format into error messages, or include in API responses.
+    pub fn token(&self) -> &str {
+        &self.token
+    }
+
+    /// Return the base URL (e.g. `https://gitlab.com` or a self-hosted URL).
+    pub fn base_url(&self) -> &str {
+        &self.base_url
+    }
+
+    /// Attempt to read the token from the agentd TOML config file.
+    ///
+    /// Returns `Ok(None)` if the config file does not exist or does not
+    /// contain a `[gitlab] token` entry.
+    fn read_from_config_file() -> Result<Option<String>> {
+        let Some(path) = Self::config_file_path()? else {
+            return Ok(None);
+        };
+
+        if !path.exists() {
+            return Ok(None);
+        }
+
+        let contents = std::fs::read_to_string(&path)
+            .with_context(|| format!("Failed to read agentd config file: {}", path.display()))?;
+
+        let value: toml::Value = toml::from_str(&contents)
+            .with_context(|| format!("Failed to parse agentd config file: {}", path.display()))?;
+
+        let token = value
+            .get("gitlab")
+            .and_then(|section| section.get("token"))
+            .and_then(|v| v.as_str())
+            .map(|s| s.to_string())
+            .filter(|s| !s.trim().is_empty());
+
+        Ok(token)
+    }
+
+    /// Determine the path to the agentd config file.
+    fn config_file_path() -> Result<Option<std::path::PathBuf>> {
+        if let Ok(p) = std::env::var("AGENTD_CONFIG_FILE") {
+            return Ok(Some(std::path::PathBuf::from(p)));
+        }
+
+        let path = directories::ProjectDirs::from("", "", "agentd")
+            .map(|d| d.config_dir().join("config.toml"));
+
+        Ok(path)
+    }
+}
+
+// ---------------------------------------------------------------------------
+// GitLab REST API response types
+// ---------------------------------------------------------------------------
+
+/// A GitLab user stub used in assignee lists.
+#[derive(Debug, Deserialize)]
+struct GitlabUser {
+    username: String,
+}
+
+/// A single GitLab issue as returned by `GET /api/v4/projects/:id/issues`.
+#[derive(Debug, Deserialize)]
+struct GitlabIssue {
+    iid: u64,
+    title: String,
+    description: Option<String>,
+    web_url: String,
+    state: String,
+    labels: Vec<String>,
+    assignees: Vec<GitlabUser>,
+    project_id: u64,
+}
+
+/// A single GitLab merge request as returned by
+/// `GET /api/v4/projects/:id/merge_requests`.
+#[derive(Debug, Deserialize)]
+struct GitlabMergeRequest {
+    iid: u64,
+    title: String,
+    description: Option<String>,
+    web_url: String,
+    state: String,
+    labels: Vec<String>,
+    assignees: Vec<GitlabUser>,
+    source_branch: String,
+    target_branch: String,
+    merge_status: Option<String>,
+    draft: bool,
+    project_id: u64,
+}
+
+// ---------------------------------------------------------------------------
+// GitlabIssueSource
+// ---------------------------------------------------------------------------
+
+/// Fetches GitLab issues via the REST API v4.
+///
+/// # Filters
+///
+/// - `state` — GitLab uses `opened`/`closed`/`all` (note: **`opened`**, not `open`)
+/// - `labels` — comma-separated label names
+/// - `assignee` — filter by `assignee_username`
+///
+/// # Pagination
+///
+/// Iterates through all pages (`per_page=100`) until no more results.
+pub struct GitlabIssueSource {
+    owner: String,
+    repo: String,
+    labels: Vec<String>,
+    state: String,
+    assignee: Option<String>,
+    /// Pre-resolved token. Never logged.
+    token: String,
+    /// GitLab base URL (e.g. `https://gitlab.com` or self-hosted).
+    base_url: String,
+    client: reqwest::Client,
+}
+
+impl std::fmt::Debug for GitlabIssueSource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("GitlabIssueSource")
+            .field("owner", &self.owner)
+            .field("repo", &self.repo)
+            .field("labels", &self.labels)
+            .field("state", &self.state)
+            .field("assignee", &self.assignee)
+            .field("token", &"<redacted>")
+            .field("base_url", &self.base_url)
+            .finish()
+    }
+}
+
+impl GitlabIssueSource {
+    /// Create a new source, resolving the GitLab token immediately.
+    pub fn new(
+        owner: String,
+        repo: String,
+        labels: Vec<String>,
+        state: String,
+        assignee: Option<String>,
+    ) -> Result<Self> {
+        let config = GitlabConfig::resolve()?;
+        Ok(Self {
+            owner,
+            repo,
+            labels,
+            state,
+            assignee,
+            token: config.token().to_string(),
+            base_url: config.base_url().to_string(),
+            client: reqwest::Client::new(),
+        })
+    }
+
+    /// Create a source with an explicit token and base URL (for testing).
+    #[doc(hidden)]
+    #[allow(dead_code)]
+    pub fn new_with_config(
+        owner: String,
+        repo: String,
+        labels: Vec<String>,
+        state: String,
+        assignee: Option<String>,
+        token: String,
+        base_url: String,
+    ) -> Self {
+        Self {
+            owner,
+            repo,
+            labels,
+            state,
+            assignee,
+            token,
+            base_url,
+            client: reqwest::Client::new(),
+        }
+    }
+
+    /// Fetch a single page of issues.
+    async fn fetch_page(&self, page: u32) -> Result<Vec<GitlabIssue>> {
+        // GitLab uses `owner%2Frepo` as the project identifier.
+        let project_id = format!("{}/{}", self.owner, self.repo);
+        let encoded = urlencoding::encode(&project_id);
+        let url = format!("{}/api/v4/projects/{}/issues", self.base_url, encoded);
+
+        let mut request = self
+            .client
+            .get(&url)
+            .header("PRIVATE-TOKEN", &self.token)
+            .query(&[("state", self.state.as_str()), ("per_page", "100")])
+            .query(&[("page", page)]);
+
+        if !self.labels.is_empty() {
+            request = request.query(&[("labels", self.labels.join(","))]);
+        }
+        if let Some(assignee) = &self.assignee {
+            request = request.query(&[("assignee_username", assignee.as_str())]);
+        }
+
+        let response = request.send().await.context("Failed to connect to GitLab API")?;
+
+        let status = response.status();
+        if !status.is_success() {
+            let body = response.text().await.unwrap_or_default();
+            anyhow::bail!("GitLab API returned HTTP {}: {}", status, body.trim());
+        }
+
+        let issues: Vec<GitlabIssue> =
+            response.json().await.context("Failed to parse GitLab issues response")?;
+        Ok(issues)
+    }
+}
+
+#[async_trait]
+impl TaskSource for GitlabIssueSource {
+    async fn fetch_tasks(&self) -> Result<Vec<Task>> {
+        debug!(
+            owner = %self.owner,
+            repo = %self.repo,
+            state = %self.state,
+            "Fetching GitLab issues"
+        );
+
+        let mut all_issues: Vec<GitlabIssue> = Vec::new();
+        let mut page = 1u32;
+
+        loop {
+            let page_issues = self
+                .fetch_page(page)
+                .await
+                .with_context(|| format!("GitLab issues page {page}"))?;
+
+            let fetched = page_issues.len();
+            all_issues.extend(page_issues);
+
+            debug!(fetched, total = all_issues.len(), page, "Fetched page of GitLab issues");
+
+            if fetched < 100 {
+                // Fewer than per_page results means this is the last page.
+                break;
+            }
+            page += 1;
+        }
+
+        Ok(map_issues(all_issues))
+    }
+
+    fn source_type(&self) -> &'static str {
+        "gitlab_issues"
+    }
+}
+
+// ---------------------------------------------------------------------------
+// GitlabMergeRequestSource
+// ---------------------------------------------------------------------------
+
+/// Fetches GitLab merge requests via the REST API v4.
+///
+/// # Filters
+///
+/// - `state` — `opened`/`closed`/`merged`/`all`
+/// - `labels` — comma-separated label names
+/// - `assignees` — filter by `assignee_username` (first entry used)
+///
+/// # Pagination
+///
+/// Iterates through all pages (`per_page=100`) until no more results.
+pub struct GitlabMergeRequestSource {
+    owner: String,
+    repo: String,
+    labels: Vec<String>,
+    state: String,
+    assignees: Option<Vec<String>>,
+    /// Pre-resolved token. Never logged.
+    token: String,
+    /// GitLab base URL.
+    base_url: String,
+    client: reqwest::Client,
+}
+
+impl std::fmt::Debug for GitlabMergeRequestSource {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("GitlabMergeRequestSource")
+            .field("owner", &self.owner)
+            .field("repo", &self.repo)
+            .field("labels", &self.labels)
+            .field("state", &self.state)
+            .field("assignees", &self.assignees)
+            .field("token", &"<redacted>")
+            .field("base_url", &self.base_url)
+            .finish()
+    }
+}
+
+impl GitlabMergeRequestSource {
+    /// Create a new source, resolving the GitLab token immediately.
+    pub fn new(
+        owner: String,
+        repo: String,
+        labels: Vec<String>,
+        state: String,
+        assignees: Option<Vec<String>>,
+    ) -> Result<Self> {
+        let config = GitlabConfig::resolve()?;
+        Ok(Self {
+            owner,
+            repo,
+            labels,
+            state,
+            assignees,
+            token: config.token().to_string(),
+            base_url: config.base_url().to_string(),
+            client: reqwest::Client::new(),
+        })
+    }
+
+    /// Create a source with an explicit token and base URL (for testing).
+    #[doc(hidden)]
+    #[allow(dead_code)]
+    pub fn new_with_config(
+        owner: String,
+        repo: String,
+        labels: Vec<String>,
+        state: String,
+        assignees: Option<Vec<String>>,
+        token: String,
+        base_url: String,
+    ) -> Self {
+        Self {
+            owner,
+            repo,
+            labels,
+            state,
+            assignees,
+            token,
+            base_url,
+            client: reqwest::Client::new(),
+        }
+    }
+
+    /// Fetch a single page of merge requests.
+    async fn fetch_page(&self, page: u32) -> Result<Vec<GitlabMergeRequest>> {
+        let project_id = format!("{}/{}", self.owner, self.repo);
+        let encoded = urlencoding::encode(&project_id);
+        let url = format!("{}/api/v4/projects/{}/merge_requests", self.base_url, encoded);
+
+        let mut request = self
+            .client
+            .get(&url)
+            .header("PRIVATE-TOKEN", &self.token)
+            .query(&[("state", self.state.as_str()), ("per_page", "100")])
+            .query(&[("page", page)]);
+
+        if !self.labels.is_empty() {
+            request = request.query(&[("labels", self.labels.join(","))]);
+        }
+        // GitLab supports `assignee_username` filter for MRs (single value).
+        if let Some(assignees) = &self.assignees {
+            if let Some(first) = assignees.first() {
+                request = request.query(&[("assignee_username", first.as_str())]);
+            }
+        }
+
+        let response = request.send().await.context("Failed to connect to GitLab API")?;
+
+        let status = response.status();
+        if !status.is_success() {
+            let body = response.text().await.unwrap_or_default();
+            anyhow::bail!("GitLab API returned HTTP {}: {}", status, body.trim());
+        }
+
+        let mrs: Vec<GitlabMergeRequest> =
+            response.json().await.context("Failed to parse GitLab merge requests response")?;
+        Ok(mrs)
+    }
+}
+
+#[async_trait]
+impl TaskSource for GitlabMergeRequestSource {
+    async fn fetch_tasks(&self) -> Result<Vec<Task>> {
+        debug!(
+            owner = %self.owner,
+            repo = %self.repo,
+            state = %self.state,
+            "Fetching GitLab merge requests"
+        );
+
+        let mut all_mrs: Vec<GitlabMergeRequest> = Vec::new();
+        let mut page = 1u32;
+
+        loop {
+            let page_mrs = self
+                .fetch_page(page)
+                .await
+                .with_context(|| format!("GitLab merge requests page {page}"))?;
+
+            let fetched = page_mrs.len();
+            all_mrs.extend(page_mrs);
+
+            debug!(fetched, total = all_mrs.len(), page, "Fetched page of GitLab merge requests");
+
+            if fetched < 100 {
+                break;
+            }
+            page += 1;
+        }
+
+        Ok(map_merge_requests(all_mrs))
+    }
+
+    fn source_type(&self) -> &'static str {
+        "gitlab_merge_requests"
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Mapping helpers
+// ---------------------------------------------------------------------------
+
+fn map_issues(issues: Vec<GitlabIssue>) -> Vec<Task> {
+    issues.into_iter().map(map_issue).collect()
+}
+
+fn map_issue(issue: GitlabIssue) -> Task {
+    let mut metadata = HashMap::new();
+    metadata.insert("gitlab_project_id".to_string(), issue.project_id.to_string());
+    metadata.insert("gitlab_iid".to_string(), issue.iid.to_string());
+    metadata.insert("state".to_string(), issue.state.clone());
+
+    Task {
+        source_id: issue.iid.to_string(),
+        title: issue.title,
+        body: issue.description.unwrap_or_default(),
+        url: issue.web_url,
+        labels: issue.labels,
+        assignee: issue.assignees.first().map(|u| u.username.clone()),
+        metadata,
+    }
+}
+
+fn map_merge_requests(mrs: Vec<GitlabMergeRequest>) -> Vec<Task> {
+    mrs.into_iter().map(map_merge_request).collect()
+}
+
+fn map_merge_request(mr: GitlabMergeRequest) -> Task {
+    let mut metadata = HashMap::new();
+    metadata.insert("gitlab_project_id".to_string(), mr.project_id.to_string());
+    metadata.insert("gitlab_iid".to_string(), mr.iid.to_string());
+    metadata.insert("state".to_string(), mr.state.clone());
+    metadata.insert("source_branch".to_string(), mr.source_branch.clone());
+    metadata.insert("target_branch".to_string(), mr.target_branch.clone());
+    if let Some(ms) = &mr.merge_status {
+        metadata.insert("merge_status".to_string(), ms.clone());
+    }
+    metadata.insert("draft".to_string(), mr.draft.to_string());
+
+    Task {
+        source_id: mr.iid.to_string(),
+        title: mr.title,
+        body: mr.description.unwrap_or_default(),
+        url: mr.web_url,
+        labels: mr.labels,
+        assignee: mr.assignees.first().map(|u| u.username.clone()),
+        metadata,
+    }
+}
+
+/// Parse a JSON array of GitLab issue objects into [`Task`] structs.
+///
+/// Useful for testing and offline use, following the pattern established by
+/// `parse_gh_issues()` in `github.rs`.
+#[allow(dead_code)]
+pub fn parse_gitlab_issues(json: &str) -> Result<Vec<Task>> {
+    let issues: Vec<GitlabIssue> = serde_json::from_str(json)?;
+    Ok(map_issues(issues))
+}
+
+/// Parse a JSON array of GitLab merge request objects into [`Task`] structs.
+///
+/// Useful for testing and offline use.
+#[allow(dead_code)]
+pub fn parse_gitlab_merge_requests(json: &str) -> Result<Vec<Task>> {
+    let mrs: Vec<GitlabMergeRequest> = serde_json::from_str(json)?;
+    Ok(map_merge_requests(mrs))
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // -------------------------------------------------------------------------
+    // Shared env-var helpers
+    // -------------------------------------------------------------------------
+
+    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+    fn with_env_lock(f: impl FnOnce()) {
+        let _guard = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        f();
+    }
+
+    struct EnvRestorer {
+        key: &'static str,
+        previous: Option<String>,
+    }
+
+    impl EnvRestorer {
+        fn set(key: &'static str, value: &str) -> Self {
+            let previous = std::env::var(key).ok();
+            std::env::set_var(key, value);
+            Self { key, previous }
+        }
+
+        fn unset(key: &'static str) -> Self {
+            let previous = std::env::var(key).ok();
+            std::env::remove_var(key);
+            Self { key, previous }
+        }
+    }
+
+    impl Drop for EnvRestorer {
+        fn drop(&mut self) {
+            match &self.previous {
+                Some(val) => std::env::set_var(self.key, val),
+                None => std::env::remove_var(self.key),
+            }
+        }
+    }
+
+    // -------------------------------------------------------------------------
+    // GitlabConfig tests
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn is_configured_returns_false_when_env_unset() {
+        with_env_lock(|| {
+            let _token = EnvRestorer::unset("AGENTD_GITLAB_TOKEN");
+            let tmp = std::env::temp_dir().join("agentd_gitlab_test_nonexistent.toml");
+            let _cfg = EnvRestorer::set("AGENTD_CONFIG_FILE", &tmp.to_string_lossy());
+            assert!(!GitlabConfig::is_configured());
+        });
+    }
+
+    #[test]
+    fn is_configured_returns_true_when_env_set() {
+        with_env_lock(|| {
+            let _token = EnvRestorer::set("AGENTD_GITLAB_TOKEN", "glpat-testtoken");
+            assert!(GitlabConfig::is_configured());
+        });
+    }
+
+    #[test]
+    fn resolve_succeeds_when_env_set() {
+        with_env_lock(|| {
+            let _token = EnvRestorer::set("AGENTD_GITLAB_TOKEN", "glpat-testtoken123");
+            let cfg = GitlabConfig::resolve().expect("should resolve from env");
+            assert_eq!(cfg.token(), "glpat-testtoken123");
+            assert_eq!(cfg.base_url(), DEFAULT_GITLAB_URL);
+        });
+    }
+
+    #[test]
+    fn resolve_uses_custom_url_from_env() {
+        with_env_lock(|| {
+            let _token = EnvRestorer::set("AGENTD_GITLAB_TOKEN", "glpat-tok");
+            let _url = EnvRestorer::set("AGENTD_GITLAB_URL", "https://gitlab.example.com");
+            let cfg = GitlabConfig::resolve().expect("should resolve");
+            assert_eq!(cfg.base_url(), "https://gitlab.example.com");
+        });
+    }
+
+    #[test]
+    fn resolve_fails_when_no_token_available() {
+        with_env_lock(|| {
+            let _token = EnvRestorer::unset("AGENTD_GITLAB_TOKEN");
+            let tmp = std::env::temp_dir().join("agentd_gitlab_test_nonexistent2.toml");
+            let _cfg = EnvRestorer::set("AGENTD_CONFIG_FILE", &tmp.to_string_lossy());
+            let err = GitlabConfig::resolve().expect_err("should fail without token");
+            let msg = err.to_string();
+            assert!(msg.contains("AGENTD_GITLAB_TOKEN"), "message: {msg}");
+        });
+    }
+
+    #[test]
+    fn resolve_reads_token_from_config_file() {
+        with_env_lock(|| {
+            let _token = EnvRestorer::unset("AGENTD_GITLAB_TOKEN");
+            let dir = tempfile::tempdir().expect("tempdir");
+            let path = dir.path().join("config.toml");
+            std::fs::write(&path, "[gitlab]\ntoken = \"glpat-fromfile\"\n").expect("write config");
+            let _cfg = EnvRestorer::set("AGENTD_CONFIG_FILE", &path.to_string_lossy());
+            let cfg = GitlabConfig::resolve().expect("should resolve from file");
+            assert_eq!(cfg.token(), "glpat-fromfile");
+        });
+    }
+
+    #[test]
+    fn resolve_env_takes_precedence_over_file() {
+        with_env_lock(|| {
+            let _token = EnvRestorer::set("AGENTD_GITLAB_TOKEN", "glpat-fromenv");
+            let dir = tempfile::tempdir().expect("tempdir");
+            let path = dir.path().join("config.toml");
+            std::fs::write(&path, "[gitlab]\ntoken = \"glpat-fromfile\"\n").expect("write config");
+            let _cfg = EnvRestorer::set("AGENTD_CONFIG_FILE", &path.to_string_lossy());
+            let cfg = GitlabConfig::resolve().expect("should resolve from env");
+            assert_eq!(cfg.token(), "glpat-fromenv");
+        });
+    }
+
+    #[test]
+    fn debug_does_not_expose_token() {
+        with_env_lock(|| {
+            let _token = EnvRestorer::set("AGENTD_GITLAB_TOKEN", "glpat-secret");
+            let cfg = GitlabConfig::resolve().unwrap();
+            let debug_str = format!("{cfg:?}");
+            assert!(debug_str.contains("<redacted>"));
+            assert!(!debug_str.contains("glpat-secret"));
+        });
+    }
+
+    // -------------------------------------------------------------------------
+    // parse_gitlab_issues tests
+    // -------------------------------------------------------------------------
+
+    fn full_issue_json() -> &'static str {
+        r#"[
+            {
+                "iid": 42,
+                "title": "Fix the widget",
+                "description": "The widget is broken.",
+                "web_url": "https://gitlab.com/myorg/myrepo/-/issues/42",
+                "state": "opened",
+                "labels": ["bug", "agent"],
+                "assignees": [{"username": "alice"}],
+                "project_id": 12345
+            },
+            {
+                "iid": 43,
+                "title": "Add feature X",
+                "description": null,
+                "web_url": "https://gitlab.com/myorg/myrepo/-/issues/43",
+                "state": "opened",
+                "labels": [],
+                "assignees": [],
+                "project_id": 12345
+            }
+        ]"#
+    }
+
+    #[test]
+    fn test_parse_gitlab_issues_full() {
+        let tasks = parse_gitlab_issues(full_issue_json()).unwrap();
+        assert_eq!(tasks.len(), 2);
+
+        let t0 = &tasks[0];
+        assert_eq!(t0.source_id, "42");
+        assert_eq!(t0.title, "Fix the widget");
+        assert_eq!(t0.body, "The widget is broken.");
+        assert_eq!(t0.url, "https://gitlab.com/myorg/myrepo/-/issues/42");
+        assert_eq!(t0.labels, vec!["bug", "agent"]);
+        assert_eq!(t0.assignee, Some("alice".to_string()));
+        assert_eq!(t0.metadata.get("gitlab_project_id").unwrap(), "12345");
+        assert_eq!(t0.metadata.get("gitlab_iid").unwrap(), "42");
+        assert_eq!(t0.metadata.get("state").unwrap(), "opened");
+    }
+
+    #[test]
+    fn test_parse_gitlab_issues_null_description() {
+        let tasks = parse_gitlab_issues(full_issue_json()).unwrap();
+        let t1 = &tasks[1];
+        assert_eq!(t1.source_id, "43");
+        assert_eq!(t1.body, "");
+        assert!(t1.assignee.is_none());
+        assert!(t1.labels.is_empty());
+    }
+
+    #[test]
+    fn test_parse_gitlab_issues_empty() {
+        let tasks = parse_gitlab_issues("[]").unwrap();
+        assert!(tasks.is_empty());
+    }
+
+    // -------------------------------------------------------------------------
+    // parse_gitlab_merge_requests tests
+    // -------------------------------------------------------------------------
+
+    fn full_mr_json() -> &'static str {
+        r#"[
+            {
+                "iid": 15,
+                "title": "Add new feature",
+                "description": "This MR adds a new feature.",
+                "web_url": "https://gitlab.com/myorg/myrepo/-/merge_requests/15",
+                "state": "opened",
+                "labels": ["enhancement"],
+                "assignees": [{"username": "bob"}],
+                "source_branch": "feature/new-thing",
+                "target_branch": "main",
+                "merge_status": "can_be_merged",
+                "draft": false,
+                "project_id": 12345
+            },
+            {
+                "iid": 16,
+                "title": "WIP: cleanup",
+                "description": null,
+                "web_url": "https://gitlab.com/myorg/myrepo/-/merge_requests/16",
+                "state": "opened",
+                "labels": [],
+                "assignees": [],
+                "source_branch": "cleanup/stuff",
+                "target_branch": "main",
+                "merge_status": null,
+                "draft": true,
+                "project_id": 12345
+            }
+        ]"#
+    }
+
+    #[test]
+    fn test_parse_gitlab_merge_requests_full() {
+        let tasks = parse_gitlab_merge_requests(full_mr_json()).unwrap();
+        assert_eq!(tasks.len(), 2);
+
+        let t0 = &tasks[0];
+        assert_eq!(t0.source_id, "15");
+        assert_eq!(t0.title, "Add new feature");
+        assert_eq!(t0.body, "This MR adds a new feature.");
+        assert_eq!(t0.url, "https://gitlab.com/myorg/myrepo/-/merge_requests/15");
+        assert_eq!(t0.labels, vec!["enhancement"]);
+        assert_eq!(t0.assignee, Some("bob".to_string()));
+        assert_eq!(t0.metadata.get("gitlab_project_id").unwrap(), "12345");
+        assert_eq!(t0.metadata.get("gitlab_iid").unwrap(), "15");
+        assert_eq!(t0.metadata.get("source_branch").unwrap(), "feature/new-thing");
+        assert_eq!(t0.metadata.get("target_branch").unwrap(), "main");
+        assert_eq!(t0.metadata.get("merge_status").unwrap(), "can_be_merged");
+        assert_eq!(t0.metadata.get("draft").unwrap(), "false");
+        assert_eq!(t0.metadata.get("state").unwrap(), "opened");
+    }
+
+    #[test]
+    fn test_parse_gitlab_merge_requests_draft() {
+        let tasks = parse_gitlab_merge_requests(full_mr_json()).unwrap();
+        let t1 = &tasks[1];
+        assert_eq!(t1.source_id, "16");
+        assert_eq!(t1.body, "");
+        assert!(t1.assignee.is_none());
+        assert_eq!(t1.metadata.get("draft").unwrap(), "true");
+        // null merge_status should not be in metadata
+        assert!(!t1.metadata.contains_key("merge_status"));
+    }
+
+    #[test]
+    fn test_parse_gitlab_merge_requests_empty() {
+        let tasks = parse_gitlab_merge_requests("[]").unwrap();
+        assert!(tasks.is_empty());
+    }
+
+    // -------------------------------------------------------------------------
+    // source_type tests
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn gitlab_issue_source_type() {
+        let src = GitlabIssueSource::new_with_config(
+            "org".into(),
+            "repo".into(),
+            vec![],
+            "opened".into(),
+            None,
+            "tok".into(),
+            DEFAULT_GITLAB_URL.into(),
+        );
+        assert_eq!(src.source_type(), "gitlab_issues");
+    }
+
+    #[test]
+    fn gitlab_mr_source_type() {
+        let src = GitlabMergeRequestSource::new_with_config(
+            "org".into(),
+            "repo".into(),
+            vec![],
+            "opened".into(),
+            None,
+            "tok".into(),
+            DEFAULT_GITLAB_URL.into(),
+        );
+        assert_eq!(src.source_type(), "gitlab_merge_requests");
+    }
+
+    #[test]
+    fn gitlab_issue_source_debug_redacts_token() {
+        let src = GitlabIssueSource::new_with_config(
+            "org".into(),
+            "repo".into(),
+            vec![],
+            "opened".into(),
+            None,
+            "glpat-secret".into(),
+            DEFAULT_GITLAB_URL.into(),
+        );
+        let debug_str = format!("{src:?}");
+        assert!(debug_str.contains("<redacted>"));
+        assert!(!debug_str.contains("glpat-secret"));
+    }
+}

--- a/crates/orchestrator/src/scheduler/mod.rs
+++ b/crates/orchestrator/src/scheduler/mod.rs
@@ -1,6 +1,7 @@
 pub mod api;
 pub mod events;
 pub mod github;
+pub mod gitlab;
 pub mod linear;
 pub mod runner;
 pub mod source;

--- a/crates/orchestrator/src/scheduler/runner.rs
+++ b/crates/orchestrator/src/scheduler/runner.rs
@@ -296,13 +296,13 @@ fn create_source(config: &TriggerConfig) -> anyhow::Result<Box<dyn TaskSource>> 
                 assignee.clone(),
             )))
         }
-        TriggerConfig::GithubPullRequests { owner, repo, labels, state, assignees } => {
+        TriggerConfig::GithubPullRequests { owner, repo, labels, state, assignee } => {
             Ok(Box::new(GithubPullRequestSource::new(
                 owner.clone(),
                 repo.clone(),
                 labels.clone(),
                 state.clone(),
-                assignees.clone(),
+                assignee.clone(),
             )))
         }
         TriggerConfig::LinearIssues { team_key, project, status, labels, assignee } => {
@@ -323,13 +323,13 @@ fn create_source(config: &TriggerConfig) -> anyhow::Result<Box<dyn TaskSource>> 
                 assignee.clone(),
             )?))
         }
-        TriggerConfig::GitlabMergeRequests { owner, repo, labels, state, assignees } => {
+        TriggerConfig::GitlabMergeRequests { owner, repo, labels, state, assignee } => {
             Ok(Box::new(GitlabMergeRequestSource::new(
                 owner.clone(),
                 repo.clone(),
                 labels.clone(),
                 state.clone(),
-                assignees.clone(),
+                assignee.clone(),
             )?))
         }
         other => anyhow::bail!(

--- a/crates/orchestrator/src/scheduler/runner.rs
+++ b/crates/orchestrator/src/scheduler/runner.rs
@@ -287,15 +287,22 @@ pub async fn notify_complete(
 /// (cron, delay, webhook, manual).
 fn create_source(config: &TriggerConfig) -> anyhow::Result<Box<dyn TaskSource>> {
     match config {
-        TriggerConfig::GithubIssues { owner, repo, labels, state } => Ok(Box::new(
-            GithubIssueSource::new(owner.clone(), repo.clone(), labels.clone(), state.clone()),
-        )),
-        TriggerConfig::GithubPullRequests { owner, repo, labels, state } => {
+        TriggerConfig::GithubIssues { owner, repo, labels, state, assignee } => {
+            Ok(Box::new(GithubIssueSource::new(
+                owner.clone(),
+                repo.clone(),
+                labels.clone(),
+                state.clone(),
+                assignee.clone(),
+            )))
+        }
+        TriggerConfig::GithubPullRequests { owner, repo, labels, state, assignees } => {
             Ok(Box::new(GithubPullRequestSource::new(
                 owner.clone(),
                 repo.clone(),
                 labels.clone(),
                 state.clone(),
+                assignees.clone(),
             )))
         }
         TriggerConfig::LinearIssues { team_key, project, status, labels, assignee } => {

--- a/crates/orchestrator/src/scheduler/runner.rs
+++ b/crates/orchestrator/src/scheduler/runner.rs
@@ -1,5 +1,6 @@
 use crate::scheduler::events::EventBus;
 use crate::scheduler::github::{GithubIssueSource, GithubPullRequestSource};
+use crate::scheduler::gitlab::{GitlabIssueSource, GitlabMergeRequestSource};
 use crate::scheduler::linear::LinearIssueSource;
 use crate::scheduler::source::TaskSource;
 use crate::scheduler::storage::SchedulerStorage;
@@ -306,8 +307,26 @@ fn create_source(config: &TriggerConfig) -> anyhow::Result<Box<dyn TaskSource>> 
                 assignee.clone(),
             )?))
         }
+        TriggerConfig::GitlabIssues { owner, repo, labels, state, assignee } => {
+            Ok(Box::new(GitlabIssueSource::new(
+                owner.clone(),
+                repo.clone(),
+                labels.clone(),
+                state.clone(),
+                assignee.clone(),
+            )?))
+        }
+        TriggerConfig::GitlabMergeRequests { owner, repo, labels, state, assignees } => {
+            Ok(Box::new(GitlabMergeRequestSource::new(
+                owner.clone(),
+                repo.clone(),
+                labels.clone(),
+                state.clone(),
+                assignees.clone(),
+            )?))
+        }
         other => anyhow::bail!(
-            "Trigger type '{}' is not yet implemented. Currently supported: github_issues, github_pull_requests, linear_issues",
+            "Trigger type '{}' is not yet implemented. Currently supported: github_issues, github_pull_requests, linear_issues, gitlab_issues, gitlab_merge_requests",
             other.trigger_type()
         ),
     }

--- a/crates/orchestrator/src/scheduler/storage.rs
+++ b/crates/orchestrator/src/scheduler/storage.rs
@@ -573,6 +573,7 @@ mod tests {
                 repo: "repo".to_string(),
                 labels: vec!["agent".to_string()],
                 state: "open".to_string(),
+                assignee: None,
             },
             prompt_template: "Fix: {{title}}".to_string(),
             poll_interval_secs: 60,

--- a/crates/orchestrator/src/scheduler/template.rs
+++ b/crates/orchestrator/src/scheduler/template.rs
@@ -19,6 +19,9 @@ use crate::scheduler::types::Task;
 /// | `status`             | dispatch_result        | Completion status (`completed` or `failed`)    |
 /// | `timestamp`          | dispatch_result        | RFC 3339 timestamp of the completion event     |
 /// | `original_source_id` | dispatch_result        | Source ID from the parent dispatch (if any)    |
+/// | `head_ref`           | github_pull_requests   | Source branch name of the PR                   |
+/// | `base_ref`           | github_pull_requests   | Target branch name of the PR                   |
+/// | `is_draft`           | github_pull_requests   | `"true"` if the PR is a draft                  |
 /// | `action`             | webhook (GitHub/Linear)| Event action (e.g., `"opened"`, `"create"`)    |
 /// | `github_event`       | webhook (GitHub)       | GitHub event type (e.g., `"issues"`)           |
 /// | `delivery_id`        | webhook (GitHub)       | GitHub delivery UUID (`X-GitHub-Delivery`)     |
@@ -34,6 +37,13 @@ use crate::scheduler::types::Task;
 /// | `team_name`          | linear_issues, webhook (Linear) | Linear team display name                    |
 /// | `project`            | linear_issues          | Linear project name                            |
 /// | `linear_id`          | linear_issues, webhook (Linear) | Internal Linear UUID (stable dedup key)     |
+/// | `gitlab_project_id`  | gitlab_issues, gitlab_merge_requests | GitLab numeric project ID             |
+/// | `gitlab_iid`         | gitlab_issues, gitlab_merge_requests | Issue/MR internal ID within the project|
+/// | `state`              | gitlab_issues, gitlab_merge_requests | Issue/MR state (e.g., `"opened"`)     |
+/// | `source_branch`      | gitlab_merge_requests  | Source branch name of the MR                   |
+/// | `target_branch`      | gitlab_merge_requests  | Target branch name of the MR                   |
+/// | `merge_status`       | gitlab_merge_requests  | Merge status (e.g., `"can_be_merged"`)         |
+/// | `draft`              | gitlab_merge_requests  | `"true"` if the MR is a draft                  |
 pub const KNOWN_VARIABLES: &[&str] = &[
     // Top-level task fields
     "title",
@@ -55,6 +65,10 @@ pub const KNOWN_VARIABLES: &[&str] = &[
     "status",
     "timestamp",
     "original_source_id",
+    // Metadata-backed (github_pull_requests trigger)
+    "head_ref",
+    "base_ref",
+    "is_draft",
     // Metadata-backed (webhook triggers — GitHub)
     // Note: `action` is also used by Linear webhooks as `linear_action`; the
     // GitHub `action` key and the Linear `linear_action` key are kept separate

--- a/crates/orchestrator/src/scheduler/template.rs
+++ b/crates/orchestrator/src/scheduler/template.rs
@@ -76,6 +76,14 @@ pub const KNOWN_VARIABLES: &[&str] = &[
     "team_name",
     "project",
     "linear_id",
+    // Metadata-backed (gitlab_issues trigger)
+    "gitlab_project_id",
+    "gitlab_iid",
+    // Metadata-backed (gitlab_merge_requests trigger)
+    "source_branch",
+    "target_branch",
+    "merge_status",
+    "draft",
     // Metadata-backed (composite triggers)
     "composite_sub_source_ids",
     // Metadata-backed (queue trigger)

--- a/crates/orchestrator/src/scheduler/types.rs
+++ b/crates/orchestrator/src/scheduler/types.rs
@@ -84,6 +84,8 @@ pub enum TriggerConfig {
         labels: Vec<String>,
         #[serde(default = "default_issue_state")]
         state: String,
+        #[serde(default)]
+        assignee: Option<String>,
     },
     GithubPullRequests {
         owner: String,
@@ -92,6 +94,8 @@ pub enum TriggerConfig {
         labels: Vec<String>,
         #[serde(default = "default_pr_state")]
         state: String,
+        #[serde(default)]
+        assignees: Option<Vec<String>>,
     },
     /// Cron-based trigger (Phase 2).
     Cron { expression: String },

--- a/crates/orchestrator/src/scheduler/types.rs
+++ b/crates/orchestrator/src/scheduler/types.rs
@@ -95,7 +95,7 @@ pub enum TriggerConfig {
         #[serde(default = "default_pr_state")]
         state: String,
         #[serde(default)]
-        assignees: Option<Vec<String>>,
+        assignee: Option<String>,
     },
     /// Cron-based trigger (Phase 2).
     Cron { expression: String },
@@ -289,7 +289,7 @@ pub enum TriggerConfig {
     /// - `repo` — GitLab project name.
     /// - `labels` — Label names the MR must carry.
     /// - `state` — MR state: `opened` (default), `closed`, `merged`, or `all`.
-    /// - `assignees` — Filter by assignee username(s). First entry is used.
+    /// - `assignee` — Filter by assignee username.
     GitlabMergeRequests {
         owner: String,
         repo: String,
@@ -298,7 +298,7 @@ pub enum TriggerConfig {
         #[serde(default = "default_gitlab_mr_state")]
         state: String,
         #[serde(default)]
-        assignees: Option<Vec<String>>,
+        assignee: Option<String>,
     },
 }
 
@@ -641,5 +641,144 @@ mod tests {
         assert_eq!(decoded.trigger_type(), "linear_issues");
         // Serialized tag must be snake_case.
         assert!(json.contains(r#""type":"linear_issues""#));
+    }
+
+    // -------------------------------------------------------------------------
+    // GitlabIssues TriggerConfig deserialization tests
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn test_trigger_config_gitlab_issues_trigger_type() {
+        let cfg = TriggerConfig::GitlabIssues {
+            owner: "mygroup".into(),
+            repo: "myproject".into(),
+            labels: vec![],
+            state: "opened".into(),
+            assignee: None,
+        };
+        assert_eq!(cfg.trigger_type(), "gitlab_issues");
+        assert!(cfg.is_implemented());
+    }
+
+    #[test]
+    fn test_trigger_config_gitlab_issues_serde_full() {
+        let json = r#"{
+            "type": "gitlab_issues",
+            "owner": "mygroup",
+            "repo": "myproject",
+            "labels": ["bug", "agent"],
+            "state": "opened",
+            "assignee": "alice"
+        }"#;
+        let cfg: TriggerConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(cfg.trigger_type(), "gitlab_issues");
+        if let TriggerConfig::GitlabIssues { owner, repo, labels, state, assignee } = cfg {
+            assert_eq!(owner, "mygroup");
+            assert_eq!(repo, "myproject");
+            assert_eq!(labels, vec!["bug", "agent"]);
+            assert_eq!(state, "opened");
+            assert_eq!(assignee.as_deref(), Some("alice"));
+        } else {
+            panic!("Expected GitlabIssues variant");
+        }
+    }
+
+    #[test]
+    fn test_trigger_config_gitlab_issues_serde_minimal_defaults() {
+        // Only required fields — state should default to "opened", others empty/None.
+        let json = r#"{"type": "gitlab_issues", "owner": "mygroup", "repo": "myproject"}"#;
+        let cfg: TriggerConfig = serde_json::from_str(json).unwrap();
+        if let TriggerConfig::GitlabIssues { owner, repo, labels, state, assignee } = cfg {
+            assert_eq!(owner, "mygroup");
+            assert_eq!(repo, "myproject");
+            assert!(labels.is_empty());
+            assert_eq!(state, "opened");
+            assert!(assignee.is_none());
+        } else {
+            panic!("Expected GitlabIssues variant");
+        }
+    }
+
+    #[test]
+    fn test_trigger_config_gitlab_issues_serde_roundtrip() {
+        let original = TriggerConfig::GitlabIssues {
+            owner: "mygroup".into(),
+            repo: "myproject".into(),
+            labels: vec!["agent".into()],
+            state: "closed".into(),
+            assignee: Some("bob".into()),
+        };
+        let json = serde_json::to_string(&original).unwrap();
+        let decoded: TriggerConfig = serde_json::from_str(&json).unwrap();
+        assert_eq!(decoded.trigger_type(), "gitlab_issues");
+        assert!(json.contains(r#""type":"gitlab_issues""#));
+    }
+
+    // -------------------------------------------------------------------------
+    // GitlabMergeRequests TriggerConfig deserialization tests
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn test_trigger_config_gitlab_merge_requests_trigger_type() {
+        let cfg = TriggerConfig::GitlabMergeRequests {
+            owner: "mygroup".into(),
+            repo: "myproject".into(),
+            labels: vec![],
+            state: "opened".into(),
+            assignees: None,
+        };
+        assert_eq!(cfg.trigger_type(), "gitlab_merge_requests");
+        assert!(cfg.is_implemented());
+    }
+
+    #[test]
+    fn test_trigger_config_gitlab_merge_requests_serde_full() {
+        let json = r#"{
+            "type": "gitlab_merge_requests",
+            "owner": "mygroup",
+            "repo": "myproject",
+            "labels": ["needs-review"],
+            "state": "opened",
+            "assignees": ["alice", "bob"]
+        }"#;
+        let cfg: TriggerConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(cfg.trigger_type(), "gitlab_merge_requests");
+        if let TriggerConfig::GitlabMergeRequests { owner, repo, labels, state, assignees } = cfg {
+            assert_eq!(owner, "mygroup");
+            assert_eq!(repo, "myproject");
+            assert_eq!(labels, vec!["needs-review"]);
+            assert_eq!(state, "opened");
+            assert_eq!(assignees.as_deref(), Some(&["alice".to_string(), "bob".to_string()][..]));
+        } else {
+            panic!("Expected GitlabMergeRequests variant");
+        }
+    }
+
+    #[test]
+    fn test_trigger_config_gitlab_merge_requests_serde_minimal_defaults() {
+        let json = r#"{"type": "gitlab_merge_requests", "owner": "mygroup", "repo": "myproject"}"#;
+        let cfg: TriggerConfig = serde_json::from_str(json).unwrap();
+        if let TriggerConfig::GitlabMergeRequests { labels, state, assignees, .. } = cfg {
+            assert!(labels.is_empty());
+            assert_eq!(state, "opened");
+            assert!(assignees.is_none());
+        } else {
+            panic!("Expected GitlabMergeRequests variant");
+        }
+    }
+
+    #[test]
+    fn test_trigger_config_gitlab_merge_requests_serde_roundtrip() {
+        let original = TriggerConfig::GitlabMergeRequests {
+            owner: "mygroup".into(),
+            repo: "myproject".into(),
+            labels: vec!["enhancement".into()],
+            state: "merged".into(),
+            assignees: Some(vec!["carol".into()]),
+        };
+        let json = serde_json::to_string(&original).unwrap();
+        let decoded: TriggerConfig = serde_json::from_str(&json).unwrap();
+        assert_eq!(decoded.trigger_type(), "gitlab_merge_requests");
+        assert!(json.contains(r#""type":"gitlab_merge_requests""#));
     }
 }

--- a/crates/orchestrator/src/scheduler/types.rs
+++ b/crates/orchestrator/src/scheduler/types.rs
@@ -251,6 +251,51 @@ pub enum TriggerConfig {
         #[serde(default)]
         response_pattern: Option<String>,
     },
+    /// GitLab issues trigger — polls GitLab for issues matching the given filters.
+    ///
+    /// Requires `AGENTD_GITLAB_TOKEN` to be set in the environment (or in the
+    /// `[gitlab]` section of the agentd config file).
+    ///
+    /// # Fields
+    ///
+    /// - `owner` — GitLab namespace (user or group).
+    /// - `repo` — GitLab project name.
+    /// - `labels` — Label names the issue must carry (comma-AND).
+    /// - `state` — Issue state: `opened` (default), `closed`, or `all`.
+    ///   Note: GitLab uses `opened`, not `open`.
+    /// - `assignee` — Filter by assignee username.
+    GitlabIssues {
+        owner: String,
+        repo: String,
+        #[serde(default)]
+        labels: Vec<String>,
+        #[serde(default = "default_gitlab_issue_state")]
+        state: String,
+        #[serde(default)]
+        assignee: Option<String>,
+    },
+    /// GitLab merge requests trigger — polls GitLab for MRs matching the given filters.
+    ///
+    /// Requires `AGENTD_GITLAB_TOKEN` to be set in the environment (or in the
+    /// `[gitlab]` section of the agentd config file).
+    ///
+    /// # Fields
+    ///
+    /// - `owner` — GitLab namespace (user or group).
+    /// - `repo` — GitLab project name.
+    /// - `labels` — Label names the MR must carry.
+    /// - `state` — MR state: `opened` (default), `closed`, `merged`, or `all`.
+    /// - `assignees` — Filter by assignee username(s). First entry is used.
+    GitlabMergeRequests {
+        owner: String,
+        repo: String,
+        #[serde(default)]
+        labels: Vec<String>,
+        #[serde(default = "default_gitlab_mr_state")]
+        state: String,
+        #[serde(default)]
+        assignees: Option<Vec<String>>,
+    },
 }
 
 fn default_issue_state() -> String {
@@ -259,6 +304,14 @@ fn default_issue_state() -> String {
 
 fn default_pr_state() -> String {
     "open".to_string()
+}
+
+fn default_gitlab_issue_state() -> String {
+    "opened".to_string()
+}
+
+fn default_gitlab_mr_state() -> String {
+    "opened".to_string()
 }
 
 impl TriggerConfig {
@@ -277,6 +330,8 @@ impl TriggerConfig {
             TriggerConfig::Composite { .. } => "composite",
             TriggerConfig::Queue { .. } => "queue",
             TriggerConfig::AskResponse { .. } => "ask_response",
+            TriggerConfig::GitlabIssues { .. } => "gitlab_issues",
+            TriggerConfig::GitlabMergeRequests { .. } => "gitlab_merge_requests",
         }
     }
 
@@ -295,7 +350,9 @@ impl TriggerConfig {
             | TriggerConfig::LinearIssues { .. }
             | TriggerConfig::Composite { .. }
             | TriggerConfig::Queue { .. }
-            | TriggerConfig::AskResponse { .. } => true,
+            | TriggerConfig::AskResponse { .. }
+            | TriggerConfig::GitlabIssues { .. }
+            | TriggerConfig::GitlabMergeRequests { .. } => true,
         }
     }
 

--- a/crates/orchestrator/tests/scheduler_integration.rs
+++ b/crates/orchestrator/tests/scheduler_integration.rs
@@ -140,6 +140,7 @@ async fn non_manual_workflow_trigger_creates_dispatched_record() {
         repo: "repo".to_string(),
         labels: vec![],
         state: "open".to_string(),
+        assignee: None,
     };
     let workflow = make_workflow(agent_id, trigger);
     storage.add_workflow(&workflow).await.unwrap();
@@ -179,6 +180,7 @@ async fn trigger_workflow_fails_when_agent_not_connected() {
         repo: "repo".to_string(),
         labels: vec![],
         state: "open".to_string(),
+        assignee: None,
     };
     let workflow = make_workflow(agent_id, trigger);
     storage.add_workflow(&workflow).await.unwrap();
@@ -243,6 +245,7 @@ async fn notify_task_complete_marks_dispatched_record_completed() {
             repo: "repo".to_string(),
             labels: vec![],
             state: "open".to_string(),
+            assignee: None,
         },
     );
     storage.add_workflow(&workflow).await.unwrap();
@@ -284,6 +287,7 @@ async fn notify_task_complete_marks_dispatched_record_failed() {
             repo: "repo".to_string(),
             labels: vec![],
             state: "open".to_string(),
+            assignee: None,
         },
     );
     storage.add_workflow(&workflow).await.unwrap();
@@ -346,6 +350,7 @@ async fn concurrent_workflows_different_trigger_types() {
             repo: "repo".to_string(),
             labels: vec![],
             state: "open".to_string(),
+            assignee: None,
         },
     );
     wf_b.name = "workflow-b-github".to_string();

--- a/docs/public/templates.md
+++ b/docs/public/templates.md
@@ -293,6 +293,18 @@ Available `{{placeholders}}` in prompt templates:
 | `{{issue_number}}` | `webhook` (GitHub issues) | Issue number | `42` |
 | `{{pr_number}}` | `webhook` (GitHub PRs) | Pull request number | `99` |
 
+**GitLab trigger variables** - populated by `gitlab_issues` and `gitlab_merge_requests` triggers:
+
+| Variable | Trigger | Description | Example |
+|----------|---------|-------------|---------|
+| `{{gitlab_project_id}}` | both | GitLab internal project ID | `"12345"` |
+| `{{gitlab_iid}}` | both | Project-scoped issue/MR number | `"42"` |
+| `{{state}}` | both | Issue or MR state | `"opened"` |
+| `{{source_branch}}` | `gitlab_merge_requests` | Source branch name | `"feature/new-thing"` |
+| `{{target_branch}}` | `gitlab_merge_requests` | Target branch name | `"main"` |
+| `{{merge_status}}` | `gitlab_merge_requests` | GitLab merge status | `"can_be_merged"` |
+| `{{draft}}` | `gitlab_merge_requests` | Whether the MR is a draft | `"true"`, `"false"` |
+
 **Linear trigger variables** - populated by the `linear_issues` trigger:
 
 | Variable | Description | Example |
@@ -339,6 +351,7 @@ source:
   repo: myrepo           # Repository name
   labels: [bug, agent]   # Filter by labels (optional)
   state: open            # Issue state filter (default: open)
+  assignee: alice        # Filter by assignee username (optional)
 ```
 
 **GitHub Pull Requests:**
@@ -349,7 +362,34 @@ source:
   repo: myrepo           # Repository name
   labels: [needs-review] # Filter by labels (optional)
   state: open            # PR state filter (default: open)
+  assignees: [alice, bob] # Filter by assignee usernames (optional)
 ```
+
+**GitLab Issues:**
+```yaml
+source:
+  type: gitlab_issues
+  owner: mygroup         # GitLab namespace (user or group)
+  repo: myproject        # GitLab project path name
+  labels: [bug, agent]   # Filter by labels (optional)
+  state: opened          # Issue state filter — note: 'opened' not 'open' (default: opened)
+  assignee: alice        # Filter by assignee username (optional)
+```
+
+Requires `AGENTD_GITLAB_TOKEN` to be set in the environment. For self-hosted GitLab, also set `AGENTD_GITLAB_URL`. GitLab-specific variables (`{{gitlab_project_id}}`, `{{gitlab_iid}}`, `{{state}}`) are available in the prompt template.
+
+**GitLab Merge Requests:**
+```yaml
+source:
+  type: gitlab_merge_requests
+  owner: mygroup         # GitLab namespace (user or group)
+  repo: myproject        # GitLab project path name
+  labels: [needs-review] # Filter by labels (optional)
+  state: opened          # MR state filter — note: 'opened' not 'open' (default: opened)
+  assignees: [alice, bob] # Filter by assignee usernames (optional)
+```
+
+Requires `AGENTD_GITLAB_TOKEN`. MR-specific variables (`{{source_branch}}`, `{{target_branch}}`, `{{merge_status}}`, `{{draft}}`) are available in the prompt template.
 
 **Cron (recurring schedule):**
 ```yaml

--- a/docs/public/trigger-reference.md
+++ b/docs/public/trigger-reference.md
@@ -10,6 +10,8 @@ This page is a consolidated quick-reference for all workflow trigger types. For 
 |---------|--------------|----------|--------------------------|-------------|--------------|
 | `github_issues` | New or updated GitHub issues matching filters | Yes - polls continuously | No | Yes | Yes |
 | `github_pull_requests` | New or updated GitHub PRs matching filters | Yes - polls continuously | No | Yes | Yes |
+| `gitlab_issues` | New or updated GitLab issues matching filters | Yes - polls continuously | No | Yes | Yes |
+| `gitlab_merge_requests` | New or updated GitLab MRs matching filters | Yes - polls continuously | No | Yes | Yes |
 | `linear_issues` | New or updated Linear issues matching filters | Yes - polls continuously | No | Yes | Yes |
 | `cron` | On a recurring cron schedule | Yes - indefinitely | No | Yes | Yes |
 | `delay` | Once at a specific datetime | No - auto-disables | No | Yes | Yes |
@@ -37,6 +39,24 @@ Do not use when:
 
 - You need sub-second latency (use `webhook` instead)
 - The trigger source is not GitHub
+
+### `gitlab_issues` / `gitlab_merge_requests`
+
+Use when:
+
+- You want an agent to react to GitLab issues or merge requests automatically
+- Your team uses GitLab (gitlab.com or self-hosted) as the primary issue tracker or code review platform
+- You are behind a firewall or don't want to expose a public endpoint
+- Latency of up to `poll_interval_secs` is acceptable (default: 60 s)
+
+Do not use when:
+
+- You need sub-second latency (use `webhook` instead)
+- The trigger source is not GitLab
+
+**Configuration:** Set `AGENTD_GITLAB_TOKEN` in the orchestrator's environment (or `[gitlab] token` in the agentd config file). For self-hosted GitLab, also set `AGENTD_GITLAB_URL` (default: `https://gitlab.com`).
+
+**State values:** GitLab uses `opened` (not `open`) — this differs from GitHub's state values.
 
 ### `linear_issues`
 
@@ -162,9 +182,11 @@ Use when:
 All trigger types use the `trigger_config` field with a `"type"` discriminant:
 
 ```json
-{ "type": "github_issues",        "owner": "myorg", "repo": "myrepo", "labels": ["agent"], "state": "open" }
-{ "type": "github_pull_requests", "owner": "myorg", "repo": "myrepo", "labels": [],        "state": "open" }
-{ "type": "linear_issues",        "team_key": "ENG", "status": ["Triage"], "labels": ["bug"] }
+{ "type": "github_issues",           "owner": "myorg", "repo": "myrepo", "labels": ["agent"], "state": "open" }
+{ "type": "github_pull_requests",    "owner": "myorg", "repo": "myrepo", "labels": [],        "state": "open" }
+{ "type": "gitlab_issues",           "owner": "mygroup", "repo": "myproject", "labels": ["agent"], "state": "opened" }
+{ "type": "gitlab_merge_requests",   "owner": "mygroup", "repo": "myproject", "labels": [],          "state": "opened" }
+{ "type": "linear_issues",           "team_key": "ENG", "status": ["Triage"], "labels": ["bug"] }
 { "type": "cron",                 "expression": "0 9 * * MON-FRI" }
 { "type": "delay",                "run_at": "2026-04-01T09:00:00Z" }
 { "type": "agent_lifecycle",      "event": "session_start" }
@@ -186,6 +208,7 @@ source:
   repo: myrepo
   labels: [agent]
   state: open
+  # assignee: alice   # optional - filter by assignee username
 
 # GitHub Pull Requests
 source:
@@ -193,6 +216,24 @@ source:
   owner: myorg
   repo: myrepo
   state: open
+  # assignees: [alice, bob]   # optional - filter by assignee usernames
+
+# GitLab Issues (note: 'opened' not 'open')
+source:
+  type: gitlab_issues
+  owner: mygroup
+  repo: myproject
+  labels: [agent]
+  state: opened
+  # assignee: alice   # optional - filter by assignee username
+
+# GitLab Merge Requests
+source:
+  type: gitlab_merge_requests
+  owner: mygroup
+  repo: myproject
+  state: opened
+  # assignees: [alice, bob]   # optional - filter by assignee usernames
 
 # Linear Issues
 source:
@@ -312,8 +353,40 @@ agent orchestrator create-workflow --name wf --agent-name agent \
 | `{{body}}` | Issue or PR body (markdown) |
 | `{{url}}` | GitHub HTML URL |
 | `{{labels}}` | Comma-separated label names |
-| `{{assignee}}` | Assignee login |
+| `{{assignee}}` | Assignee login (first assignee) |
 | `{{source_id}}` | Issue or PR number (string) |
+
+### `gitlab_issues`
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `{{title}}` | Issue title | `"Fix the widget"` |
+| `{{body}}` | Issue description (markdown) | Full markdown content |
+| `{{url}}` | GitLab issue web URL | `https://gitlab.com/mygroup/myproject/-/issues/42` |
+| `{{labels}}` | Comma-separated label names | `"bug, agent"` |
+| `{{assignee}}` | First assignee's username (empty if unassigned) | `alice` |
+| `{{source_id}}` | Project-scoped issue number (`iid`) as string | `"42"` |
+| `{{gitlab_project_id}}` | GitLab internal project ID | `"12345"` |
+| `{{gitlab_iid}}` | Project-scoped issue number (same as `source_id`) | `"42"` |
+| `{{state}}` | Issue state | `"opened"`, `"closed"` |
+
+### `gitlab_merge_requests`
+
+| Variable | Description | Example |
+|----------|-------------|---------|
+| `{{title}}` | MR title | `"Add new feature"` |
+| `{{body}}` | MR description (markdown) | Full markdown content |
+| `{{url}}` | GitLab MR web URL | `https://gitlab.com/mygroup/myproject/-/merge_requests/15` |
+| `{{labels}}` | Comma-separated label names | `"enhancement"` |
+| `{{assignee}}` | First assignee's username (empty if unassigned) | `bob` |
+| `{{source_id}}` | Project-scoped MR number (`iid`) as string | `"15"` |
+| `{{gitlab_project_id}}` | GitLab internal project ID | `"12345"` |
+| `{{gitlab_iid}}` | Project-scoped MR number (same as `source_id`) | `"15"` |
+| `{{source_branch}}` | Source branch name | `"feature/new-thing"` |
+| `{{target_branch}}` | Target branch name | `"main"` |
+| `{{merge_status}}` | GitLab merge status | `"can_be_merged"` |
+| `{{draft}}` | Whether the MR is a draft | `"true"`, `"false"` |
+| `{{state}}` | MR state | `"opened"`, `"closed"`, `"merged"` |
 
 ### `linear_issues`
 

--- a/schemas/workflow.yml
+++ b/schemas/workflow.yml
@@ -192,15 +192,12 @@ definitions:
         type: string
         enum: [open, closed, all]
         default: "open"
-      assignees:
-        description: "Filter PRs to those assigned to any of these GitHub usernames."
-        type: array
-        items:
-          type: string
-        default: []
+      assignee:
+        description: "Filter PRs to those assigned to this GitHub username."
+        type: string
     required: [type, owner, repo]
     additionalProperties: false
-    propertyOrder: [type, owner, repo, labels, state, assignees]
+    propertyOrder: [type, owner, repo, labels, state, assignee]
 
   # ---------------------------------------------------------------------------
   # Cron
@@ -539,15 +536,12 @@ definitions:
         type: string
         enum: [opened, closed, merged, all]
         default: "opened"
-      assignees:
-        description: "Filter MRs assigned to any of these GitLab usernames."
-        type: array
-        items:
-          type: string
-        default: []
+      assignee:
+        description: "Filter MRs assigned to this GitLab username."
+        type: string
     required: [type, owner, repo]
     additionalProperties: false
-    propertyOrder: [type, owner, repo, labels, state, assignees]
+    propertyOrder: [type, owner, repo, labels, state, assignee]
     examples:
       -
         - "Open GitLab MRs labelled 'needs-review'"
@@ -557,13 +551,13 @@ definitions:
           repo: myproject
           labels: [needs-review]
       -
-        - "Draft MRs assigned to the team"
+        - "Draft MR assigned to a specific user"
         - |
           type: gitlab_merge_requests
           owner: mygroup
           repo: myproject
           state: opened
-          assignees: [alice, bob]
+          assignee: alice
 
 examples:
   -

--- a/schemas/workflow.yml
+++ b/schemas/workflow.yml
@@ -137,9 +137,12 @@ definitions:
         type: string
         enum: [open, closed, all]
         default: "open"
+      assignee:
+        description: "Filter issues to those assigned to this GitHub username."
+        type: string
     required: [type, owner, repo]
     additionalProperties: false
-    propertyOrder: [type, owner, repo, labels, state]
+    propertyOrder: [type, owner, repo, labels, state, assignee]
     examples:
       -
         - "Issues labelled 'agent' in open state"
@@ -148,6 +151,13 @@ definitions:
           owner: myorg
           repo: myrepo
           labels: [agent]
+      -
+        - "Issues assigned to a specific user"
+        - |
+          type: github_issues
+          owner: myorg
+          repo: myrepo
+          assignee: alice
 
   # ---------------------------------------------------------------------------
   # GitHub Pull Requests
@@ -180,9 +190,15 @@ definitions:
         type: string
         enum: [open, closed, all]
         default: "open"
+      assignees:
+        description: "Filter PRs to those assigned to any of these GitHub usernames."
+        type: array
+        items:
+          type: string
+        default: []
     required: [type, owner, repo]
     additionalProperties: false
-    propertyOrder: [type, owner, repo, labels, state]
+    propertyOrder: [type, owner, repo, labels, state, assignees]
 
   # ---------------------------------------------------------------------------
   # Cron

--- a/schemas/workflow.yml
+++ b/schemas/workflow.yml
@@ -105,6 +105,8 @@ definitions:
       - $ref: "#/definitions/source_webhook"
       - $ref: "#/definitions/source_manual"
       - $ref: "#/definitions/source_linear_issues"
+      - $ref: "#/definitions/source_gitlab_issues"
+      - $ref: "#/definitions/source_gitlab_merge_requests"
 
   # ---------------------------------------------------------------------------
   # GitHub Issues
@@ -435,6 +437,133 @@ definitions:
           status: ["Todo", "In Progress"]
           labels: ["needs-review"]
           assignee: "alice@example.com"
+
+  # ---------------------------------------------------------------------------
+  # GitLab Issues
+  # ---------------------------------------------------------------------------
+  source_gitlab_issues:
+    description: |
+      Polls GitLab for issues matching the given filters via REST API v4.
+
+      Requires AGENTD_GITLAB_TOKEN to be set in the orchestrator's
+      environment or configured in the agentd config file under
+      [gitlab].token. For self-hosted GitLab, set AGENTD_GITLAB_URL.
+
+      Note: GitLab uses 'opened' (not 'open') as the default state value.
+
+      Template variables: {{title}}, {{body}}, {{url}}, {{labels}},
+      {{assignee}}, {{source_id}}, {{gitlab_project_id}}, {{gitlab_iid}},
+      {{state}}.
+    type: object
+    properties:
+      type:
+        type: string
+        enum: [gitlab_issues]
+      owner:
+        description: "GitLab namespace (user or group) owning the project."
+        type: string
+      repo:
+        description: "GitLab project name (path component, not display name)."
+        type: string
+      labels:
+        description: "Filter issues to those carrying all listed labels."
+        type: array
+        items:
+          type: string
+        default: []
+      state:
+        description: |
+          Issue state filter. GitLab uses 'opened' (not 'open').
+        type: string
+        enum: [opened, closed, all]
+        default: "opened"
+      assignee:
+        description: "Filter issues assigned to this GitLab username."
+        type: string
+    required: [type, owner, repo]
+    additionalProperties: false
+    propertyOrder: [type, owner, repo, labels, state, assignee]
+    examples:
+      -
+        - "GitLab issues labelled 'agent' in opened state"
+        - |
+          type: gitlab_issues
+          owner: mygroup
+          repo: myproject
+          labels: [agent]
+      -
+        - "GitLab issues assigned to a specific user"
+        - |
+          type: gitlab_issues
+          owner: mygroup
+          repo: myproject
+          assignee: alice
+          state: opened
+
+  # ---------------------------------------------------------------------------
+  # GitLab Merge Requests
+  # ---------------------------------------------------------------------------
+  source_gitlab_merge_requests:
+    description: |
+      Polls GitLab for merge requests matching the given filters via
+      REST API v4.
+
+      Requires AGENTD_GITLAB_TOKEN to be set in the orchestrator's
+      environment or configured in the agentd config file under
+      [gitlab].token. For self-hosted GitLab, set AGENTD_GITLAB_URL.
+
+      Template variables: {{title}}, {{body}}, {{url}}, {{labels}},
+      {{assignee}}, {{source_id}}, {{gitlab_project_id}}, {{gitlab_iid}},
+      {{source_branch}}, {{target_branch}}, {{merge_status}}, {{draft}},
+      {{state}}.
+    type: object
+    properties:
+      type:
+        type: string
+        enum: [gitlab_merge_requests]
+      owner:
+        description: "GitLab namespace (user or group) owning the project."
+        type: string
+      repo:
+        description: "GitLab project name (path component, not display name)."
+        type: string
+      labels:
+        description: "Filter MRs to those carrying all listed labels."
+        type: array
+        items:
+          type: string
+        default: []
+      state:
+        description: |
+          Merge request state filter. GitLab uses 'opened' (not 'open').
+        type: string
+        enum: [opened, closed, merged, all]
+        default: "opened"
+      assignees:
+        description: "Filter MRs assigned to any of these GitLab usernames."
+        type: array
+        items:
+          type: string
+        default: []
+    required: [type, owner, repo]
+    additionalProperties: false
+    propertyOrder: [type, owner, repo, labels, state, assignees]
+    examples:
+      -
+        - "Open GitLab MRs labelled 'needs-review'"
+        - |
+          type: gitlab_merge_requests
+          owner: mygroup
+          repo: myproject
+          labels: [needs-review]
+      -
+        - "Draft MRs assigned to the team"
+        - |
+          type: gitlab_merge_requests
+          owner: mygroup
+          repo: myproject
+          state: opened
+          assignees: [alice, bob]
 
 examples:
   -


### PR DESCRIPTION
Add GitLab as a trigger source for agentd workflows. Implements the core scaffolding:

- `gitlab.rs`: `GitlabConfig` (env/file token resolution), `GitlabIssueSource`, `GitlabMergeRequestSource` with full REST API v4 pagination
- `TriggerConfig::GitlabIssues` and `TriggerConfig::GitlabMergeRequests` variants with `owner`, `repo`, `labels`, `state`, `assignee`/`assignees` fields
- Scheduler runner wired to instantiate GitLab sources
- API validation for GitLab trigger configs (non-empty owner/repo, valid state values, credential check)
- `KNOWN_VARIABLES` updated with GitLab-specific template variables
- CLI `apply` and `orchestrator create-workflow` commands support new trigger types

Closes #1180