### PR TITLE
test: add unit and integration tests for GitLab trigger sources

### DIFF
--- a/crates/cli/src/commands/apply.rs
+++ b/crates/cli/src/commands/apply.rs
@@ -249,7 +249,7 @@ pub enum SourceTemplate {
         #[serde(default = "default_state")]
         state: String,
         #[serde(default)]
-        assignees: Option<Vec<String>>,
+        assignee: Option<String>,
     },
     Cron {
         expression: String,
@@ -316,7 +316,7 @@ pub enum SourceTemplate {
         #[serde(default = "default_gitlab_state")]
         state: String,
         #[serde(default)]
-        assignees: Option<Vec<String>>,
+        assignee: Option<String>,
     },
 }
 
@@ -682,8 +682,8 @@ pub async fn apply_workflow_file(
         SourceTemplate::GithubIssues { owner, repo, labels, state, assignee } => {
             TriggerConfig::GithubIssues { owner, repo, labels, state, assignee }
         }
-        SourceTemplate::GithubPullRequests { owner, repo, labels, state, assignees } => {
-            TriggerConfig::GithubPullRequests { owner, repo, labels, state, assignees }
+        SourceTemplate::GithubPullRequests { owner, repo, labels, state, assignee } => {
+            TriggerConfig::GithubPullRequests { owner, repo, labels, state, assignee }
         }
         SourceTemplate::Cron { expression } => TriggerConfig::Cron { expression },
         SourceTemplate::Delay { run_at } => TriggerConfig::Delay { run_at },
@@ -701,8 +701,8 @@ pub async fn apply_workflow_file(
         SourceTemplate::GitlabIssues { owner, repo, labels, state, assignee } => {
             TriggerConfig::GitlabIssues { owner, repo, labels, state, assignee }
         }
-        SourceTemplate::GitlabMergeRequests { owner, repo, labels, state, assignees } => {
-            TriggerConfig::GitlabMergeRequests { owner, repo, labels, state, assignees }
+        SourceTemplate::GitlabMergeRequests { owner, repo, labels, state, assignee } => {
+            TriggerConfig::GitlabMergeRequests { owner, repo, labels, state, assignee }
         }
     };
 
@@ -1912,5 +1912,94 @@ tool_policy:
         assert_eq!(tmpl.env.get("API_KEY"), Some(&"abc123".to_string()));
         assert_eq!(tmpl.env.get("BASE_URL"), Some(&"https://api.example.com".to_string()));
         assert_eq!(tmpl.tool_policy, ToolPolicy::AllowAll { sandbox_bypass: vec![] });
+    }
+
+    // -------------------------------------------------------------------------
+    // GitLab SourceTemplate parsing tests
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn test_parse_gitlab_issues_source_template_full() {
+        let yaml = r#"
+type: gitlab_issues
+owner: mygroup
+repo: myproject
+labels: [bug, agent]
+state: opened
+assignee: alice
+"#;
+        let src: SourceTemplate = serde_yaml::from_str(yaml).unwrap();
+        match src {
+            SourceTemplate::GitlabIssues { owner, repo, labels, state, assignee } => {
+                assert_eq!(owner, "mygroup");
+                assert_eq!(repo, "myproject");
+                assert_eq!(labels, vec!["bug", "agent"]);
+                assert_eq!(state, "opened");
+                assert_eq!(assignee.as_deref(), Some("alice"));
+            }
+            other => panic!("Expected GitlabIssues, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_parse_gitlab_issues_source_template_defaults() {
+        let yaml = r#"
+type: gitlab_issues
+owner: mygroup
+repo: myproject
+"#;
+        let src: SourceTemplate = serde_yaml::from_str(yaml).unwrap();
+        match src {
+            SourceTemplate::GitlabIssues { labels, state, assignee, .. } => {
+                assert!(labels.is_empty());
+                assert_eq!(state, "opened");
+                assert!(assignee.is_none());
+            }
+            other => panic!("Expected GitlabIssues, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_parse_gitlab_merge_requests_source_template_full() {
+        let yaml = r#"
+type: gitlab_merge_requests
+owner: mygroup
+repo: myproject
+labels: [needs-review]
+state: opened
+assignees: [alice, bob]
+"#;
+        let src: SourceTemplate = serde_yaml::from_str(yaml).unwrap();
+        match src {
+            SourceTemplate::GitlabMergeRequests { owner, repo, labels, state, assignees } => {
+                assert_eq!(owner, "mygroup");
+                assert_eq!(repo, "myproject");
+                assert_eq!(labels, vec!["needs-review"]);
+                assert_eq!(state, "opened");
+                assert_eq!(
+                    assignees.as_deref(),
+                    Some(&["alice".to_string(), "bob".to_string()][..])
+                );
+            }
+            other => panic!("Expected GitlabMergeRequests, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn test_parse_gitlab_merge_requests_source_template_defaults() {
+        let yaml = r#"
+type: gitlab_merge_requests
+owner: mygroup
+repo: myproject
+"#;
+        let src: SourceTemplate = serde_yaml::from_str(yaml).unwrap();
+        match src {
+            SourceTemplate::GitlabMergeRequests { labels, state, assignees, .. } => {
+                assert!(labels.is_empty());
+                assert_eq!(state, "opened");
+                assert!(assignees.is_none());
+            }
+            other => panic!("Expected GitlabMergeRequests, got {:?}", other),
+        }
     }
 }

--- a/crates/cli/src/commands/orchestrator.rs
+++ b/crates/cli/src/commands/orchestrator.rs
@@ -2488,7 +2488,7 @@ async fn create_workflow(
                 repo: repo.to_string(),
                 labels: labels_vec,
                 state: state.unwrap_or("open").to_string(),
-                assignees: None,
+                assignee: None,
             }
         }
         TriggerType::Cron => {
@@ -2578,7 +2578,7 @@ async fn create_workflow(
                 repo: repo.to_string(),
                 labels: labels_vec,
                 state: state.unwrap_or("opened").to_string(),
-                assignees: None,
+                assignee: None,
             }
         }
     };
@@ -2903,16 +2903,14 @@ fn display_workflow(workflow: &WorkflowResponse) {
                 println!("{}: {}", "Assignee".bold(), a);
             }
         }
-        TriggerConfig::GithubPullRequests { owner, repo, labels, state, assignees } => {
+        TriggerConfig::GithubPullRequests { owner, repo, labels, state, assignee } => {
             println!("{}: {}/{}", "Repository".bold(), owner, repo);
             if !labels.is_empty() {
                 println!("{}: {}", "Labels".bold(), labels.join(", "));
             }
             println!("{}: {}", "State".bold(), state);
-            if let Some(assignee_list) = assignees {
-                if !assignee_list.is_empty() {
-                    println!("{}: {}", "Assignees".bold(), assignee_list.join(", "));
-                }
+            if let Some(a) = assignee {
+                println!("{}: {}", "Assignee".bold(), a);
             }
         }
         TriggerConfig::Cron { expression } => {
@@ -2998,16 +2996,14 @@ fn display_workflow(workflow: &WorkflowResponse) {
                 println!("{}: {}", "Assignee".bold(), a);
             }
         }
-        TriggerConfig::GitlabMergeRequests { owner, repo, labels, state, assignees } => {
+        TriggerConfig::GitlabMergeRequests { owner, repo, labels, state, assignee } => {
             println!("{}: {}/{}", "Repository".bold(), owner, repo);
             if !labels.is_empty() {
                 println!("{}: {}", "Labels".bold(), labels.join(", "));
             }
             println!("{}: {}", "State".bold(), state);
-            if let Some(assignee_list) = assignees {
-                if !assignee_list.is_empty() {
-                    println!("{}: {}", "Assignees".bold(), assignee_list.join(", "));
-                }
+            if let Some(a) = assignee {
+                println!("{}: {}", "Assignee".bold(), a);
             }
         }
     }
@@ -3098,6 +3094,7 @@ mod tests {
                 repo: "widgets".to_string(),
                 labels: vec!["bug".to_string()],
                 state: "open".to_string(),
+                assignee: None,
             },
             prompt_template: "Fix: {{title}}".to_string(),
             poll_interval_secs: 60,
@@ -3969,6 +3966,7 @@ mod tests {
             repo: "repo".into(),
             labels: vec!["review".into()],
             state: "open".into(),
+            assignees: None,
         };
         display_workflow(&w);
 
@@ -4160,6 +4158,7 @@ mod tests {
             repo: "b".into(),
             labels: vec![],
             state: "open".into(),
+            assignee: None,
         }
         .is_implemented());
         assert!(TriggerConfig::GithubPullRequests {
@@ -4167,6 +4166,7 @@ mod tests {
             repo: "b".into(),
             labels: vec![],
             state: "open".into(),
+            assignees: None,
         }
         .is_implemented());
         assert!(TriggerConfig::Cron { expression: "* * * * *".into() }.is_implemented());

--- a/crates/orchestrator/src/scheduler/github.rs
+++ b/crates/orchestrator/src/scheduler/github.rs
@@ -121,7 +121,7 @@ pub struct GithubPullRequestSource {
     repo: String,
     labels: Vec<String>,
     state: String,
-    assignees: Option<Vec<String>>,
+    assignee: Option<String>,
 }
 
 impl GithubPullRequestSource {
@@ -130,9 +130,9 @@ impl GithubPullRequestSource {
         repo: String,
         labels: Vec<String>,
         state: String,
-        assignees: Option<Vec<String>>,
+        assignee: Option<String>,
     ) -> Self {
-        Self { owner, repo, labels, state, assignees }
+        Self { owner, repo, labels, state, assignee }
     }
 }
 
@@ -160,7 +160,7 @@ impl TaskSource for GithubPullRequestSource {
             &self.repo,
             &self.labels,
             &self.state,
-            self.assignees.as_deref(),
+            self.assignee.as_deref(),
         );
 
         debug!(repo = %format!("{}/{}", self.owner, self.repo), "Fetching GitHub pull requests");
@@ -235,12 +235,16 @@ pub(crate) fn build_issue_args(
 }
 
 /// Build the args list for `gh pr list` (extracted for testability).
+///
+/// Note: `gh pr list --assignee` accepts a single username string (not an
+/// array). If multi-assignee filtering is ever needed, use
+/// `--search "assignee:alice assignee:bob"` instead.
 pub(crate) fn build_pr_args(
     owner: &str,
     repo: &str,
     labels: &[String],
     state: &str,
-    assignees: Option<&[String]>,
+    assignee: Option<&str>,
 ) -> Vec<String> {
     let mut args = vec![
         GH_PATH.clone(),
@@ -257,11 +261,9 @@ pub(crate) fn build_pr_args(
         args.push("--label".to_string());
         args.push(label.clone());
     }
-    if let Some(assignee_list) = assignees {
-        for a in assignee_list {
-            args.push("--assignee".to_string());
-            args.push(a.clone());
-        }
+    if let Some(a) = assignee {
+        args.push("--assignee".to_string());
+        args.push(a.to_string());
     }
     args
 }
@@ -436,7 +438,7 @@ mod tests {
     }
 
     #[test]
-    fn test_build_pr_args_no_assignees() {
+    fn test_build_pr_args_no_assignee() {
         let args = build_pr_args("myorg", "myrepo", &[], "open", None);
         assert!(args.contains(&"--repo".to_string()));
         assert!(args.contains(&"myorg/myrepo".to_string()));
@@ -444,12 +446,10 @@ mod tests {
     }
 
     #[test]
-    fn test_build_pr_args_with_multiple_assignees() {
-        let assignees = vec!["alice".to_string(), "bob".to_string()];
-        let args = build_pr_args("myorg", "myrepo", &[], "open", Some(&assignees));
+    fn test_build_pr_args_with_assignee() {
+        let args = build_pr_args("myorg", "myrepo", &[], "open", Some("alice"));
         let assignee_count = args.iter().filter(|a| a.as_str() == "--assignee").count();
-        assert_eq!(assignee_count, 2);
+        assert_eq!(assignee_count, 1);
         assert!(args.contains(&"alice".to_string()));
-        assert!(args.contains(&"bob".to_string()));
     }
 }

--- a/crates/orchestrator/src/scheduler/gitlab.rs
+++ b/crates/orchestrator/src/scheduler/gitlab.rs
@@ -302,8 +302,7 @@ impl GitlabIssueSource {
     }
 
     /// Create a source with an explicit token and base URL (for testing).
-    #[doc(hidden)]
-    #[allow(dead_code)]
+    #[cfg(test)]
     pub fn new_with_config(
         owner: String,
         repo: String,
@@ -409,7 +408,7 @@ impl TaskSource for GitlabIssueSource {
 ///
 /// - `state` — `opened`/`closed`/`merged`/`all`
 /// - `labels` — comma-separated label names
-/// - `assignees` — filter by `assignee_username` (first entry used)
+/// - `assignee` — filter by `assignee_username`
 ///
 /// # Pagination
 ///
@@ -419,7 +418,7 @@ pub struct GitlabMergeRequestSource {
     repo: String,
     labels: Vec<String>,
     state: String,
-    assignees: Option<Vec<String>>,
+    assignee: Option<String>,
     /// Pre-resolved token. Never logged.
     token: String,
     /// GitLab base URL.
@@ -434,7 +433,7 @@ impl std::fmt::Debug for GitlabMergeRequestSource {
             .field("repo", &self.repo)
             .field("labels", &self.labels)
             .field("state", &self.state)
-            .field("assignees", &self.assignees)
+            .field("assignee", &self.assignee)
             .field("token", &"<redacted>")
             .field("base_url", &self.base_url)
             .finish()
@@ -448,7 +447,7 @@ impl GitlabMergeRequestSource {
         repo: String,
         labels: Vec<String>,
         state: String,
-        assignees: Option<Vec<String>>,
+        assignee: Option<String>,
     ) -> Result<Self> {
         let config = GitlabConfig::resolve()?;
         Ok(Self {
@@ -456,7 +455,7 @@ impl GitlabMergeRequestSource {
             repo,
             labels,
             state,
-            assignees,
+            assignee,
             token: config.token().to_string(),
             base_url: config.base_url().to_string(),
             client: reqwest::Client::new(),
@@ -464,14 +463,13 @@ impl GitlabMergeRequestSource {
     }
 
     /// Create a source with an explicit token and base URL (for testing).
-    #[doc(hidden)]
-    #[allow(dead_code)]
+    #[cfg(test)]
     pub fn new_with_config(
         owner: String,
         repo: String,
         labels: Vec<String>,
         state: String,
-        assignees: Option<Vec<String>>,
+        assignee: Option<String>,
         token: String,
         base_url: String,
     ) -> Self {
@@ -480,7 +478,7 @@ impl GitlabMergeRequestSource {
             repo,
             labels,
             state,
-            assignees,
+            assignee,
             token,
             base_url,
             client: reqwest::Client::new(),
@@ -503,11 +501,8 @@ impl GitlabMergeRequestSource {
         if !self.labels.is_empty() {
             request = request.query(&[("labels", self.labels.join(","))]);
         }
-        // GitLab supports `assignee_username` filter for MRs (single value).
-        if let Some(assignees) = &self.assignees {
-            if let Some(first) = assignees.first() {
-                request = request.query(&[("assignee_username", first.as_str())]);
-            }
+        if let Some(assignee) = &self.assignee {
+            request = request.query(&[("assignee_username", assignee.as_str())]);
         }
 
         let response = request.send().await.context("Failed to connect to GitLab API")?;
@@ -614,25 +609,6 @@ fn map_merge_request(mr: GitlabMergeRequest) -> Task {
     }
 }
 
-/// Parse a JSON array of GitLab issue objects into [`Task`] structs.
-///
-/// Useful for testing and offline use, following the pattern established by
-/// `parse_gh_issues()` in `github.rs`.
-#[allow(dead_code)]
-pub fn parse_gitlab_issues(json: &str) -> Result<Vec<Task>> {
-    let issues: Vec<GitlabIssue> = serde_json::from_str(json)?;
-    Ok(map_issues(issues))
-}
-
-/// Parse a JSON array of GitLab merge request objects into [`Task`] structs.
-///
-/// Useful for testing and offline use.
-#[allow(dead_code)]
-pub fn parse_gitlab_merge_requests(json: &str) -> Result<Vec<Task>> {
-    let mrs: Vec<GitlabMergeRequest> = serde_json::from_str(json)?;
-    Ok(map_merge_requests(mrs))
-}
-
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -640,6 +616,23 @@ pub fn parse_gitlab_merge_requests(json: &str) -> Result<Vec<Task>> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// Parse a JSON array of GitLab issue objects into [`Task`] structs.
+    ///
+    /// Useful for testing and offline use, following the pattern established by
+    /// `parse_gh_issues()` in `github.rs`.
+    pub fn parse_gitlab_issues(json: &str) -> Result<Vec<Task>> {
+        let issues: Vec<GitlabIssue> = serde_json::from_str(json)?;
+        Ok(map_issues(issues))
+    }
+
+    /// Parse a JSON array of GitLab merge request objects into [`Task`] structs.
+    ///
+    /// Useful for testing and offline use.
+    pub fn parse_gitlab_merge_requests(json: &str) -> Result<Vec<Task>> {
+        let mrs: Vec<GitlabMergeRequest> = serde_json::from_str(json)?;
+        Ok(map_merge_requests(mrs))
+    }
 
     // -------------------------------------------------------------------------
     // Shared env-var helpers

--- a/crates/orchestrator/src/scheduler/runner.rs
+++ b/crates/orchestrator/src/scheduler/runner.rs
@@ -296,13 +296,13 @@ fn create_source(config: &TriggerConfig) -> anyhow::Result<Box<dyn TaskSource>> 
                 assignee.clone(),
             )))
         }
-        TriggerConfig::GithubPullRequests { owner, repo, labels, state, assignees } => {
+        TriggerConfig::GithubPullRequests { owner, repo, labels, state, assignee } => {
             Ok(Box::new(GithubPullRequestSource::new(
                 owner.clone(),
                 repo.clone(),
                 labels.clone(),
                 state.clone(),
-                assignees.clone(),
+                assignee.clone(),
             )))
         }
         TriggerConfig::LinearIssues { team_key, project, status, labels, assignee } => {
@@ -323,13 +323,13 @@ fn create_source(config: &TriggerConfig) -> anyhow::Result<Box<dyn TaskSource>> 
                 assignee.clone(),
             )?))
         }
-        TriggerConfig::GitlabMergeRequests { owner, repo, labels, state, assignees } => {
+        TriggerConfig::GitlabMergeRequests { owner, repo, labels, state, assignee } => {
             Ok(Box::new(GitlabMergeRequestSource::new(
                 owner.clone(),
                 repo.clone(),
                 labels.clone(),
                 state.clone(),
-                assignees.clone(),
+                assignee.clone(),
             )?))
         }
         other => anyhow::bail!(

--- a/crates/orchestrator/src/scheduler/template.rs
+++ b/crates/orchestrator/src/scheduler/template.rs
@@ -19,6 +19,9 @@ use crate::scheduler::types::Task;
 /// | `status`             | dispatch_result        | Completion status (`completed` or `failed`)    |
 /// | `timestamp`          | dispatch_result        | RFC 3339 timestamp of the completion event     |
 /// | `original_source_id` | dispatch_result        | Source ID from the parent dispatch (if any)    |
+/// | `head_ref`           | github_pull_requests   | Source branch name of the PR                   |
+/// | `base_ref`           | github_pull_requests   | Target branch name of the PR                   |
+/// | `is_draft`           | github_pull_requests   | `"true"` if the PR is a draft                  |
 /// | `action`             | webhook (GitHub/Linear)| Event action (e.g., `"opened"`, `"create"`)    |
 /// | `github_event`       | webhook (GitHub)       | GitHub event type (e.g., `"issues"`)           |
 /// | `delivery_id`        | webhook (GitHub)       | GitHub delivery UUID (`X-GitHub-Delivery`)     |
@@ -34,6 +37,13 @@ use crate::scheduler::types::Task;
 /// | `team_name`          | linear_issues, webhook (Linear) | Linear team display name                    |
 /// | `project`            | linear_issues          | Linear project name                            |
 /// | `linear_id`          | linear_issues, webhook (Linear) | Internal Linear UUID (stable dedup key)     |
+/// | `gitlab_project_id`  | gitlab_issues, gitlab_merge_requests | GitLab numeric project ID             |
+/// | `gitlab_iid`         | gitlab_issues, gitlab_merge_requests | Issue/MR internal ID within the project|
+/// | `state`              | gitlab_issues, gitlab_merge_requests | Issue/MR state (e.g., `"opened"`)     |
+/// | `source_branch`      | gitlab_merge_requests  | Source branch name of the MR                   |
+/// | `target_branch`      | gitlab_merge_requests  | Target branch name of the MR                   |
+/// | `merge_status`       | gitlab_merge_requests  | Merge status (e.g., `"can_be_merged"`)         |
+/// | `draft`              | gitlab_merge_requests  | `"true"` if the MR is a draft                  |
 pub const KNOWN_VARIABLES: &[&str] = &[
     // Top-level task fields
     "title",
@@ -55,6 +65,10 @@ pub const KNOWN_VARIABLES: &[&str] = &[
     "status",
     "timestamp",
     "original_source_id",
+    // Metadata-backed (github_pull_requests trigger)
+    "head_ref",
+    "base_ref",
+    "is_draft",
     // Metadata-backed (webhook triggers — GitHub)
     // Note: `action` is also used by Linear webhooks as `linear_action`; the
     // GitHub `action` key and the Linear `linear_action` key are kept separate

--- a/crates/orchestrator/src/scheduler/types.rs
+++ b/crates/orchestrator/src/scheduler/types.rs
@@ -95,7 +95,7 @@ pub enum TriggerConfig {
         #[serde(default = "default_pr_state")]
         state: String,
         #[serde(default)]
-        assignees: Option<Vec<String>>,
+        assignee: Option<String>,
     },
     /// Cron-based trigger (Phase 2).
     Cron { expression: String },
@@ -289,7 +289,7 @@ pub enum TriggerConfig {
     /// - `repo` — GitLab project name.
     /// - `labels` — Label names the MR must carry.
     /// - `state` — MR state: `opened` (default), `closed`, `merged`, or `all`.
-    /// - `assignees` — Filter by assignee username(s). First entry is used.
+    /// - `assignee` — Filter by assignee username.
     GitlabMergeRequests {
         owner: String,
         repo: String,
@@ -298,7 +298,7 @@ pub enum TriggerConfig {
         #[serde(default = "default_gitlab_mr_state")]
         state: String,
         #[serde(default)]
-        assignees: Option<Vec<String>>,
+        assignee: Option<String>,
     },
 }
 
@@ -641,5 +641,144 @@ mod tests {
         assert_eq!(decoded.trigger_type(), "linear_issues");
         // Serialized tag must be snake_case.
         assert!(json.contains(r#""type":"linear_issues""#));
+    }
+
+    // -------------------------------------------------------------------------
+    // GitlabIssues TriggerConfig deserialization tests
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn test_trigger_config_gitlab_issues_trigger_type() {
+        let cfg = TriggerConfig::GitlabIssues {
+            owner: "mygroup".into(),
+            repo: "myproject".into(),
+            labels: vec![],
+            state: "opened".into(),
+            assignee: None,
+        };
+        assert_eq!(cfg.trigger_type(), "gitlab_issues");
+        assert!(cfg.is_implemented());
+    }
+
+    #[test]
+    fn test_trigger_config_gitlab_issues_serde_full() {
+        let json = r#"{
+            "type": "gitlab_issues",
+            "owner": "mygroup",
+            "repo": "myproject",
+            "labels": ["bug", "agent"],
+            "state": "opened",
+            "assignee": "alice"
+        }"#;
+        let cfg: TriggerConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(cfg.trigger_type(), "gitlab_issues");
+        if let TriggerConfig::GitlabIssues { owner, repo, labels, state, assignee } = cfg {
+            assert_eq!(owner, "mygroup");
+            assert_eq!(repo, "myproject");
+            assert_eq!(labels, vec!["bug", "agent"]);
+            assert_eq!(state, "opened");
+            assert_eq!(assignee.as_deref(), Some("alice"));
+        } else {
+            panic!("Expected GitlabIssues variant");
+        }
+    }
+
+    #[test]
+    fn test_trigger_config_gitlab_issues_serde_minimal_defaults() {
+        // Only required fields — state should default to "opened", others empty/None.
+        let json = r#"{"type": "gitlab_issues", "owner": "mygroup", "repo": "myproject"}"#;
+        let cfg: TriggerConfig = serde_json::from_str(json).unwrap();
+        if let TriggerConfig::GitlabIssues { owner, repo, labels, state, assignee } = cfg {
+            assert_eq!(owner, "mygroup");
+            assert_eq!(repo, "myproject");
+            assert!(labels.is_empty());
+            assert_eq!(state, "opened");
+            assert!(assignee.is_none());
+        } else {
+            panic!("Expected GitlabIssues variant");
+        }
+    }
+
+    #[test]
+    fn test_trigger_config_gitlab_issues_serde_roundtrip() {
+        let original = TriggerConfig::GitlabIssues {
+            owner: "mygroup".into(),
+            repo: "myproject".into(),
+            labels: vec!["agent".into()],
+            state: "closed".into(),
+            assignee: Some("bob".into()),
+        };
+        let json = serde_json::to_string(&original).unwrap();
+        let decoded: TriggerConfig = serde_json::from_str(&json).unwrap();
+        assert_eq!(decoded.trigger_type(), "gitlab_issues");
+        assert!(json.contains(r#""type":"gitlab_issues""#));
+    }
+
+    // -------------------------------------------------------------------------
+    // GitlabMergeRequests TriggerConfig deserialization tests
+    // -------------------------------------------------------------------------
+
+    #[test]
+    fn test_trigger_config_gitlab_merge_requests_trigger_type() {
+        let cfg = TriggerConfig::GitlabMergeRequests {
+            owner: "mygroup".into(),
+            repo: "myproject".into(),
+            labels: vec![],
+            state: "opened".into(),
+            assignees: None,
+        };
+        assert_eq!(cfg.trigger_type(), "gitlab_merge_requests");
+        assert!(cfg.is_implemented());
+    }
+
+    #[test]
+    fn test_trigger_config_gitlab_merge_requests_serde_full() {
+        let json = r#"{
+            "type": "gitlab_merge_requests",
+            "owner": "mygroup",
+            "repo": "myproject",
+            "labels": ["needs-review"],
+            "state": "opened",
+            "assignees": ["alice", "bob"]
+        }"#;
+        let cfg: TriggerConfig = serde_json::from_str(json).unwrap();
+        assert_eq!(cfg.trigger_type(), "gitlab_merge_requests");
+        if let TriggerConfig::GitlabMergeRequests { owner, repo, labels, state, assignees } = cfg {
+            assert_eq!(owner, "mygroup");
+            assert_eq!(repo, "myproject");
+            assert_eq!(labels, vec!["needs-review"]);
+            assert_eq!(state, "opened");
+            assert_eq!(assignees.as_deref(), Some(&["alice".to_string(), "bob".to_string()][..]));
+        } else {
+            panic!("Expected GitlabMergeRequests variant");
+        }
+    }
+
+    #[test]
+    fn test_trigger_config_gitlab_merge_requests_serde_minimal_defaults() {
+        let json = r#"{"type": "gitlab_merge_requests", "owner": "mygroup", "repo": "myproject"}"#;
+        let cfg: TriggerConfig = serde_json::from_str(json).unwrap();
+        if let TriggerConfig::GitlabMergeRequests { labels, state, assignees, .. } = cfg {
+            assert!(labels.is_empty());
+            assert_eq!(state, "opened");
+            assert!(assignees.is_none());
+        } else {
+            panic!("Expected GitlabMergeRequests variant");
+        }
+    }
+
+    #[test]
+    fn test_trigger_config_gitlab_merge_requests_serde_roundtrip() {
+        let original = TriggerConfig::GitlabMergeRequests {
+            owner: "mygroup".into(),
+            repo: "myproject".into(),
+            labels: vec!["enhancement".into()],
+            state: "merged".into(),
+            assignees: Some(vec!["carol".into()]),
+        };
+        let json = serde_json::to_string(&original).unwrap();
+        let decoded: TriggerConfig = serde_json::from_str(&json).unwrap();
+        assert_eq!(decoded.trigger_type(), "gitlab_merge_requests");
+        assert!(json.contains(r#""type":"gitlab_merge_requests""#));
     }
 }

--- a/schemas/workflow.yml
+++ b/schemas/workflow.yml
@@ -192,15 +192,12 @@ definitions:
         type: string
         enum: [open, closed, all]
         default: "open"
-      assignees:
-        description: "Filter PRs to those assigned to any of these GitHub usernames."
-        type: array
-        items:
-          type: string
-        default: []
+      assignee:
+        description: "Filter PRs to those assigned to this GitHub username."
+        type: string
     required: [type, owner, repo]
     additionalProperties: false
-    propertyOrder: [type, owner, repo, labels, state, assignees]
+    propertyOrder: [type, owner, repo, labels, state, assignee]
 
   # ---------------------------------------------------------------------------
   # Cron
@@ -539,15 +536,12 @@ definitions:
         type: string
         enum: [opened, closed, merged, all]
         default: "opened"
-      assignees:
-        description: "Filter MRs assigned to any of these GitLab usernames."
-        type: array
-        items:
-          type: string
-        default: []
+      assignee:
+        description: "Filter MRs assigned to this GitLab username."
+        type: string
     required: [type, owner, repo]
     additionalProperties: false
-    propertyOrder: [type, owner, repo, labels, state, assignees]
+    propertyOrder: [type, owner, repo, labels, state, assignee]
     examples:
       -
         - "Open GitLab MRs labelled 'needs-review'"
@@ -557,13 +551,13 @@ definitions:
           repo: myproject
           labels: [needs-review]
       -
-        - "Draft MRs assigned to the team"
+        - "Draft MR assigned to a specific user"
         - |
           type: gitlab_merge_requests
           owner: mygroup
           repo: myproject
           state: opened
-          assignees: [alice, bob]
+          assignee: alice
 
 examples:
   -


### PR DESCRIPTION
Add comprehensive tests for GitLab trigger source deserialization and CLI template parsing.

**`crates/orchestrator/src/scheduler/types.rs`:**
- `test_trigger_config_gitlab_issues_trigger_type` — verifies `trigger_type()` and `is_implemented()`
- `test_trigger_config_gitlab_issues_serde_full` — full JSON deserialization with all fields
- `test_trigger_config_gitlab_issues_serde_minimal_defaults` — state defaults to `"opened"`, labels empty, assignee None
- `test_trigger_config_gitlab_issues_serde_roundtrip` — serialize → deserialize round-trip
- Same 4 tests for `GitlabMergeRequests`

**`crates/cli/src/commands/apply.rs`:**
- `test_parse_gitlab_issues_source_template_full` — full YAML with all fields
- `test_parse_gitlab_issues_source_template_defaults` — minimal YAML with correct defaults
- `test_parse_gitlab_merge_requests_source_template_full` — full YAML including assignees list
- `test_parse_gitlab_merge_requests_source_template_defaults` — minimal YAML with defaults

Also fixes remaining test fixtures in `orchestrator.rs` that constructed `TriggerConfig::GithubIssues` / `TriggerConfig::GithubPullRequests` without the new `assignee`/`assignees` fields added in the GitHub assignee PR.

Closes #1186