### PR TITLE
feat: add ValidateConfig trait and per-service validation

### DIFF
--- a/crates/ask/src/config.rs
+++ b/crates/ask/src/config.rs
@@ -11,6 +11,8 @@
 //! | `AGENTD_PORT`             | `17001`                    | HTTP listen port          |
 //! | `AGENTD_ORCHESTRATOR_URL` | `http://localhost:17006`   | Orchestrator callback URL |
 
+use agentd_common::config::ValidateConfig;
+use anyhow::{bail, Result};
 use std::env;
 
 /// Configuration for the agentd-ask service.
@@ -40,6 +42,23 @@ impl AskConfig {
         let orchestrator_url = env::var("AGENTD_ORCHESTRATOR_URL").unwrap_or(base.orchestrator_url);
 
         Self { host, port, orchestrator_url }
+    }
+}
+
+impl ValidateConfig for AskConfig {
+    fn validate(&self) -> Result<()> {
+        if self.port == 0 {
+            bail!("ask.port must be non-zero");
+        }
+        if !self.orchestrator_url.starts_with("http://")
+            && !self.orchestrator_url.starts_with("https://")
+        {
+            bail!(
+                "ask.orchestrator_url must be a valid HTTP/HTTPS URL, got: {}",
+                self.orchestrator_url
+            );
+        }
+        Ok(())
     }
 }
 
@@ -87,5 +106,45 @@ mod tests {
         env::remove_var("AGENTD_ORCHESTRATOR_URL");
         assert_eq!(config.port, 9001);
         assert_eq!(config.orchestrator_url, "http://10.0.0.1:17006");
+    }
+
+    #[test]
+    fn test_validate_default_passes() {
+        let config = AskConfig {
+            host: "0.0.0.0".to_string(),
+            port: 17001,
+            orchestrator_url: "http://localhost:17006".to_string(),
+        };
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn test_validate_zero_port_fails() {
+        let config = AskConfig {
+            host: "0.0.0.0".to_string(),
+            port: 0,
+            orchestrator_url: "http://localhost:17006".to_string(),
+        };
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn test_validate_bad_orchestrator_url_fails() {
+        let config = AskConfig {
+            host: "0.0.0.0".to_string(),
+            port: 17001,
+            orchestrator_url: "localhost:17006".to_string(),
+        };
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn test_validate_https_orchestrator_url_passes() {
+        let config = AskConfig {
+            host: "0.0.0.0".to_string(),
+            port: 17001,
+            orchestrator_url: "https://orchestrator.example.com".to_string(),
+        };
+        assert!(config.validate().is_ok());
     }
 }

--- a/crates/ask/src/main.rs
+++ b/crates/ask/src/main.rs
@@ -17,6 +17,7 @@ mod state;
 mod storage;
 mod types;
 
+use agentd_common::config::ValidateConfig;
 use anyhow::Result;
 use api::{create_router_with_tracing, ApiState};
 use axum::{extract::State, response::IntoResponse, routing::get};
@@ -45,6 +46,7 @@ async fn main() -> Result<()> {
     info!("Starting agentd-ask service...");
 
     let cfg = AskConfig::load();
+    cfg.validate()?;
     info!("Configuration: port={}, orchestrator={}", cfg.port, cfg.orchestrator_url);
 
     // Initialize persistent storage.

--- a/crates/common/src/config.rs
+++ b/crates/common/src/config.rs
@@ -429,7 +429,10 @@ fn validate_port(port: u16, service: &str) -> Result<()> {
 }
 
 /// Returns `Err` if the string does not start with `http://` or `https://`.
-fn validate_url(url: &str, field: &str) -> Result<()> {
+///
+/// Service crates can import this helper to avoid duplicating the same check
+/// in their own `ValidateConfig` implementations.
+pub fn validate_url(url: &str, field: &str) -> Result<()> {
     if !url.starts_with("http://") && !url.starts_with("https://") {
         bail!("{field} must be a valid HTTP/HTTPS URL, got: {url}");
     }

--- a/crates/common/src/config.rs
+++ b/crates/common/src/config.rs
@@ -59,11 +59,23 @@
 //! | `AGENTD_UI_PORT`                     | `services.ui.port`                            |
 //! | `AGENTD_UI_DIR`                      | `services.ui.ui_dir`                          |
 
-use anyhow::{Context, Result};
+use anyhow::{bail, Context, Result};
 use directories::ProjectDirs;
 use serde::{Deserialize, Serialize};
 use std::env;
 use std::path::PathBuf;
+
+// ---------------------------------------------------------------------------
+// ValidateConfig trait
+// ---------------------------------------------------------------------------
+
+/// Trait for validating a configuration section.
+///
+/// Implementations should return `Ok(())` when the configuration is valid, or
+/// an error with a descriptive message indicating which field is invalid and why.
+pub trait ValidateConfig {
+    fn validate(&self) -> Result<()>;
+}
 
 // ---------------------------------------------------------------------------
 // GeneralConfig
@@ -402,6 +414,196 @@ pub struct AgentdConfig {
     pub general: GeneralConfig,
     /// Per-service configuration sections.
     pub services: ServicesConfig,
+}
+
+// ---------------------------------------------------------------------------
+// ValidateConfig implementations for shared config sections
+// ---------------------------------------------------------------------------
+
+/// Returns `Err` if the port is 0.
+fn validate_port(port: u16, service: &str) -> Result<()> {
+    if port == 0 {
+        bail!("{service}.port must be non-zero");
+    }
+    Ok(())
+}
+
+/// Returns `Err` if the string does not start with `http://` or `https://`.
+fn validate_url(url: &str, field: &str) -> Result<()> {
+    if !url.starts_with("http://") && !url.starts_with("https://") {
+        bail!("{field} must be a valid HTTP/HTTPS URL, got: {url}");
+    }
+    Ok(())
+}
+
+impl ValidateConfig for AskConfig {
+    fn validate(&self) -> Result<()> {
+        validate_port(self.port, "ask")
+    }
+}
+
+impl ValidateConfig for NotifyConfig {
+    fn validate(&self) -> Result<()> {
+        validate_port(self.port, "notify")
+    }
+}
+
+impl ValidateConfig for OrchestratorConfig {
+    fn validate(&self) -> Result<()> {
+        validate_port(self.port, "orchestrator")?;
+        match self.backend.as_str() {
+            "tmux" | "docker" | "pty" | "subprocess" => {}
+            other => bail!(
+                "orchestrator.backend must be one of tmux, docker, pty, subprocess; got: {other}"
+            ),
+        }
+        Ok(())
+    }
+}
+
+impl ValidateConfig for WrapConfig {
+    fn validate(&self) -> Result<()> {
+        validate_port(self.port, "wrap")?;
+        match self.backend.as_str() {
+            "tmux" | "docker" | "pty" | "subprocess" => {}
+            other => {
+                bail!("wrap.backend must be one of tmux, docker, pty, subprocess; got: {other}")
+            }
+        }
+        Ok(())
+    }
+}
+
+impl ValidateConfig for MemoryConfig {
+    fn validate(&self) -> Result<()> {
+        validate_port(self.port, "memory")?;
+        match self.embedding_provider.as_str() {
+            "none" | "ollama" | "openai" => {}
+            other => {
+                bail!("memory.embedding_provider must be one of none, ollama, openai; got: {other}")
+            }
+        }
+        Ok(())
+    }
+}
+
+impl ValidateConfig for IndexConfig {
+    fn validate(&self) -> Result<()> {
+        validate_port(self.port, "index")?;
+        if self.languages.is_empty() {
+            bail!("index.languages must contain at least one language");
+        }
+        match self.embedding_provider.as_str() {
+            "ollama" | "openai" => {}
+            other => bail!("index.embedding_provider must be one of ollama, openai; got: {other}"),
+        }
+        Ok(())
+    }
+}
+
+impl ValidateConfig for HookConfig {
+    fn validate(&self) -> Result<()> {
+        validate_port(self.port, "hook")?;
+        if self.history_size == 0 {
+            bail!("hook.history_size must be greater than 0");
+        }
+        if let Some(ref url) = self.notify_service_url {
+            validate_url(url, "hook.notify_service_url")?;
+        }
+        Ok(())
+    }
+}
+
+impl ValidateConfig for MonitorConfig {
+    fn validate(&self) -> Result<()> {
+        validate_port(self.port, "monitor")?;
+        if self.collection_interval_secs == 0 {
+            bail!("monitor.collection_interval_secs must be greater than 0");
+        }
+        Ok(())
+    }
+}
+
+impl ValidateConfig for McpConfig {
+    fn validate(&self) -> Result<()> {
+        for (name, url) in [
+            ("mcp.orchestrator_url", self.orchestrator_url.as_str()),
+            ("mcp.notify_url", self.notify_url.as_str()),
+            ("mcp.ask_url", self.ask_url.as_str()),
+            ("mcp.memory_url", self.memory_url.as_str()),
+            ("mcp.communicate_url", self.communicate_url.as_str()),
+            ("mcp.wrap_url", self.wrap_url.as_str()),
+            ("mcp.monitor_url", self.monitor_url.as_str()),
+            ("mcp.hook_url", self.hook_url.as_str()),
+        ] {
+            validate_url(url, name)?;
+        }
+        Ok(())
+    }
+}
+
+impl ValidateConfig for UiConfig {
+    fn validate(&self) -> Result<()> {
+        validate_port(self.port, "ui")?;
+        if self.ui_dir.is_empty() {
+            bail!("ui.ui_dir must not be empty");
+        }
+        Ok(())
+    }
+}
+
+impl ValidateConfig for CoreConfig {
+    fn validate(&self) -> Result<()> {
+        validate_port(self.port, "core")
+    }
+}
+
+impl ValidateConfig for CommunicateConfig {
+    fn validate(&self) -> Result<()> {
+        validate_port(self.port, "communicate")
+    }
+}
+
+impl AgentdConfig {
+    /// Validate all service configuration sections.
+    ///
+    /// Collects errors from every section rather than stopping at the first
+    /// failure, so operators see all problems at once.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error listing all invalid settings if any section fails
+    /// validation.
+    pub fn validate(&self) -> Result<()> {
+        let mut errors: Vec<String> = Vec::new();
+
+        let checks: &[(&str, Result<()>)] = &[
+            ("[services.ask]", self.services.ask.validate()),
+            ("[services.notify]", self.services.notify.validate()),
+            ("[services.orchestrator]", self.services.orchestrator.validate()),
+            ("[services.wrap]", self.services.wrap.validate()),
+            ("[services.memory]", self.services.memory.validate()),
+            ("[services.index]", self.services.index.validate()),
+            ("[services.hook]", self.services.hook.validate()),
+            ("[services.monitor]", self.services.monitor.validate()),
+            ("[services.mcp]", self.services.mcp.validate()),
+            ("[services.ui]", self.services.ui.validate()),
+            ("[services.core]", self.services.core.validate()),
+            ("[services.communicate]", self.services.communicate.validate()),
+        ];
+
+        for (section, result) in checks {
+            if let Err(e) = result {
+                errors.push(format!("{section}: {e}"));
+            }
+        }
+
+        if errors.is_empty() {
+            Ok(())
+        } else {
+            bail!("configuration validation failed:\n  {}", errors.join("\n  "))
+        }
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/communicate/src/config.rs
+++ b/crates/communicate/src/config.rs
@@ -10,6 +10,8 @@
 //! | `AGENTD_HOST`   | `127.0.0.1`   | HTTP bind host   |
 //! | `AGENTD_PORT`   | `17010`       | HTTP listen port |
 
+use agentd_common::config::ValidateConfig;
+use anyhow::{bail, Result};
 use std::env;
 
 /// Configuration for the agentd-communicate service.
@@ -37,6 +39,15 @@ impl CommunicateConfig {
             .unwrap_or(shared.services.communicate.port);
 
         Self { host, port }
+    }
+}
+
+impl ValidateConfig for CommunicateConfig {
+    fn validate(&self) -> Result<()> {
+        if self.port == 0 {
+            bail!("communicate.port must be non-zero");
+        }
+        Ok(())
     }
 }
 
@@ -75,5 +86,17 @@ mod tests {
         let config = CommunicateConfig::load();
         env::remove_var("AGENTD_PORT");
         assert_eq!(config.port, 9010);
+    }
+
+    #[test]
+    fn test_validate_default_passes() {
+        let config = CommunicateConfig { host: "127.0.0.1".to_string(), port: 17010 };
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn test_validate_zero_port_fails() {
+        let config = CommunicateConfig { host: "127.0.0.1".to_string(), port: 0 };
+        assert!(config.validate().is_err());
     }
 }

--- a/crates/communicate/src/main.rs
+++ b/crates/communicate/src/main.rs
@@ -11,6 +11,7 @@ mod storage;
 mod types;
 mod websocket;
 
+use agentd_common::config::ValidateConfig;
 use api::{create_router, ApiState};
 use axum::{extract::State, response::IntoResponse, routing::get};
 use config::CommunicateConfig;
@@ -60,6 +61,7 @@ async fn main() -> anyhow::Result<()> {
         .layer(agentd_common::server::cors_layer());
 
     let cfg = CommunicateConfig::load();
+    cfg.validate()?;
     let addr = format!("{}:{}", cfg.host, cfg.port);
     let listener = tokio::net::TcpListener::bind(&addr).await?;
     info!("Communicate API server listening on http://{}", addr);

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -10,6 +10,8 @@
 //! | `AGENTD_HOST`   | `127.0.0.1`   | HTTP bind host       |
 //! | `AGENTD_PORT`   | `17000`       | HTTP listen port     |
 
+use agentd_common::config::ValidateConfig;
+use anyhow::{bail, Result};
 use std::env;
 
 /// Configuration for the agentd-core service.
@@ -37,6 +39,15 @@ impl CoreConfig {
             .unwrap_or(shared.services.core.port);
 
         Self { host, port }
+    }
+}
+
+impl ValidateConfig for CoreConfig {
+    fn validate(&self) -> Result<()> {
+        if self.port == 0 {
+            bail!("core.port must be non-zero");
+        }
+        Ok(())
     }
 }
 
@@ -75,5 +86,17 @@ mod tests {
         let config = CoreConfig::load();
         env::remove_var("AGENTD_PORT");
         assert_eq!(config.port, 9000);
+    }
+
+    #[test]
+    fn test_validate_default_passes() {
+        let config = CoreConfig { host: "127.0.0.1".to_string(), port: 17000 };
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn test_validate_zero_port_fails() {
+        let config = CoreConfig { host: "127.0.0.1".to_string(), port: 0 };
+        assert!(config.validate().is_err());
     }
 }

--- a/crates/core/src/main.rs
+++ b/crates/core/src/main.rs
@@ -10,6 +10,7 @@
 //! | `RUST_LOG`          | `info`  | Log level / filter     |
 //! | `AGENTD_LOG_FORMAT` | (text)  | Set to `json` for JSON |
 
+use agentd_common::config::ValidateConfig;
 use axum::{extract::State, response::IntoResponse, routing::get};
 use metrics_exporter_prometheus::PrometheusHandle;
 use std::future::IntoFuture;
@@ -60,6 +61,7 @@ async fn main() -> anyhow::Result<()> {
         .layer(agentd_common::server::cors_layer());
 
     let cfg = agentd_core::config::CoreConfig::load();
+    cfg.validate()?;
     let addr = format!("{}:{}", cfg.host, cfg.port);
     let listener = tokio::net::TcpListener::bind(&addr).await?;
     info!("Core API listening on http://{}", addr);

--- a/crates/hook/src/config.rs
+++ b/crates/hook/src/config.rs
@@ -2,6 +2,8 @@
 //!
 //! All settings can be overridden via environment variables at startup.
 
+use agentd_common::config::ValidateConfig;
+use anyhow::{bail, Result};
 use std::env;
 
 /// Configuration for the hook daemon.
@@ -93,6 +95,23 @@ impl Default for HookConfig {
     }
 }
 
+impl ValidateConfig for HookConfig {
+    fn validate(&self) -> Result<()> {
+        if self.port == 0 {
+            bail!("hook.port must be non-zero");
+        }
+        if self.history_size == 0 {
+            bail!("hook.history_size must be greater than 0");
+        }
+        if let Some(ref url) = self.notify_service_url {
+            if !url.starts_with("http://") && !url.starts_with("https://") {
+                bail!("hook.notify_service_url must be a valid HTTP/HTTPS URL, got: {url}");
+            }
+        }
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -114,5 +133,40 @@ mod tests {
         let cloned = config.clone();
         assert_eq!(config.port, cloned.port);
         assert_eq!(config.history_size, cloned.history_size);
+    }
+
+    #[test]
+    fn test_validate_default_passes() {
+        assert!(HookConfig::default().validate().is_ok());
+    }
+
+    #[test]
+    fn test_validate_zero_port_fails() {
+        let config = HookConfig { port: 0, ..HookConfig::default() };
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn test_validate_zero_history_size_fails() {
+        let config = HookConfig { history_size: 0, ..HookConfig::default() };
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn test_validate_invalid_notify_url_fails() {
+        let config = HookConfig {
+            notify_service_url: Some("not-a-url".to_string()),
+            ..HookConfig::default()
+        };
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn test_validate_valid_notify_url_passes() {
+        let config = HookConfig {
+            notify_service_url: Some("http://notify:17004".to_string()),
+            ..HookConfig::default()
+        };
+        assert!(config.validate().is_ok());
     }
 }

--- a/crates/hook/src/main.rs
+++ b/crates/hook/src/main.rs
@@ -18,11 +18,14 @@
 //! AGENTD_LOG_FORMAT=json agentd-hook
 //! ```
 
+use agentd_common::config::ValidateConfig;
 use anyhow::Result;
 use hook::config::HookConfig;
 
 #[tokio::main]
 async fn main() -> Result<()> {
     agentd_common::server::init_tracing();
-    hook::run(HookConfig::load()).await
+    let cfg = HookConfig::load();
+    cfg.validate()?;
+    hook::run(cfg).await
 }

--- a/crates/index/src/config.rs
+++ b/crates/index/src/config.rs
@@ -468,7 +468,9 @@ impl IndexConfig {
     pub fn from_env() -> Self {
         Self::load()
     }
+}
 
+impl ValidateConfig for IndexConfig {
     /// Validate the configuration, returning an error for invalid values.
     ///
     /// Checks:
@@ -476,11 +478,7 @@ impl IndexConfig {
     /// - At least one language must be configured.
     /// - Watch interval must be non-zero.
     /// - Embedding provider must be `"ollama"` or `"openai"`.
-    pub fn validate(&self) -> Result<()> {
-        self.validate_inner()
-    }
-
-    fn validate_inner(&self) -> Result<()> {
+    fn validate(&self) -> Result<()> {
         if self.port == 0 {
             bail!("port must be non-zero");
         }
@@ -497,12 +495,6 @@ impl IndexConfig {
             }
         }
         Ok(())
-    }
-}
-
-impl ValidateConfig for IndexConfig {
-    fn validate(&self) -> Result<()> {
-        self.validate_inner()
     }
 }
 
@@ -534,6 +526,7 @@ fn default_ignore_patterns() -> Vec<String> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use agentd_common::config::ValidateConfig;
     use std::sync::Mutex;
 
     /// Serialises tests that call `load()` / `from_env()` so env var mutations

--- a/crates/index/src/config.rs
+++ b/crates/index/src/config.rs
@@ -19,6 +19,7 @@
 //! | `AGENTD_INDEX_IGNORE_PATTERNS`        | `.git,target,node_modules,dist`      | Comma-separated glob patterns        |
 
 use agentd_common::config::IndexConfig as SharedIndexConfig;
+use agentd_common::config::ValidateConfig;
 use anyhow::{bail, Result};
 use serde::{Deserialize, Serialize};
 use std::env;
@@ -476,6 +477,10 @@ impl IndexConfig {
     /// - Watch interval must be non-zero.
     /// - Embedding provider must be `"ollama"` or `"openai"`.
     pub fn validate(&self) -> Result<()> {
+        self.validate_inner()
+    }
+
+    fn validate_inner(&self) -> Result<()> {
         if self.port == 0 {
             bail!("port must be non-zero");
         }
@@ -492,6 +497,12 @@ impl IndexConfig {
             }
         }
         Ok(())
+    }
+}
+
+impl ValidateConfig for IndexConfig {
+    fn validate(&self) -> Result<()> {
+        self.validate_inner()
     }
 }
 

--- a/crates/index/src/main.rs
+++ b/crates/index/src/main.rs
@@ -38,6 +38,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 
+use agentd_common::config::ValidateConfig;
 use axum::{extract::State, response::IntoResponse, routing::get};
 use index::api::{create_router_with_state, AppState};
 use index::config::IndexConfig;

--- a/crates/index/src/main.rs
+++ b/crates/index/src/main.rs
@@ -96,6 +96,7 @@ async fn main() -> anyhow::Result<()> {
     info!("Starting agentd-index service...");
 
     let config = IndexConfig::load();
+    config.validate()?;
 
     // ── LanceDB directory ─────────────────────────────────────────────────
     std::fs::create_dir_all(&config.lance.path)?;

--- a/crates/mcp/src/config.rs
+++ b/crates/mcp/src/config.rs
@@ -4,6 +4,8 @@
 //! Each agentd service has a corresponding URL that defaults to the
 //! standard localhost port for that service.
 
+use agentd_common::config::ValidateConfig;
+use anyhow::{bail, Result};
 use std::env;
 
 /// Configuration for connecting to agentd services.
@@ -68,6 +70,27 @@ impl AgentdMcpConfig {
     }
 }
 
+impl ValidateConfig for AgentdMcpConfig {
+    fn validate(&self) -> Result<()> {
+        let urls = [
+            ("mcp.orchestrator_url", self.orchestrator_url.as_str()),
+            ("mcp.communicate_url", self.communicate_url.as_str()),
+            ("mcp.memory_url", self.memory_url.as_str()),
+            ("mcp.notify_url", self.notify_url.as_str()),
+            ("mcp.ask_url", self.ask_url.as_str()),
+            ("mcp.wrap_url", self.wrap_url.as_str()),
+            ("mcp.monitor_url", self.monitor_url.as_str()),
+            ("mcp.hook_url", self.hook_url.as_str()),
+        ];
+        for (field, url) in urls {
+            if !url.starts_with("http://") && !url.starts_with("https://") {
+                bail!("{field} must be a valid HTTP/HTTPS URL, got: {url}");
+            }
+        }
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -119,5 +142,48 @@ mod tests {
         let config = AgentdMcpConfig::from_env();
         env::remove_var("AGENTD_ORCHESTRATOR_URL");
         assert_eq!(config.orchestrator_url, "http://10.0.0.1:9000");
+    }
+
+    #[test]
+    fn test_validate_default_passes() {
+        let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+        let vars = [
+            "AGENTD_ORCHESTRATOR_URL",
+            "AGENTD_COMMUNICATE_URL",
+            "AGENTD_MEMORY_URL",
+            "AGENTD_NOTIFY_URL",
+            "AGENTD_ASK_URL",
+            "AGENTD_WRAP_URL",
+            "AGENTD_MONITOR_URL",
+            "AGENTD_HOOK_URL",
+        ];
+        let saved: Vec<_> = vars.iter().map(|k| (k, env::var(k).ok())).collect();
+        for k in &vars {
+            env::remove_var(k);
+        }
+        let config = AgentdMcpConfig::load();
+        let result = config.validate();
+        for (k, v) in saved {
+            if let Some(val) = v {
+                env::set_var(k, val);
+            }
+        }
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_validate_bad_url_fails() {
+        let config = AgentdMcpConfig {
+            orchestrator_url: "not-a-url".to_string(),
+            communicate_url: "http://127.0.0.1:17010".to_string(),
+            memory_url: "http://127.0.0.1:17008".to_string(),
+            notify_url: "http://127.0.0.1:17004".to_string(),
+            ask_url: "http://127.0.0.1:17001".to_string(),
+            wrap_url: "http://127.0.0.1:17005".to_string(),
+            monitor_url: "http://127.0.0.1:17003".to_string(),
+            hook_url: "http://127.0.0.1:17002".to_string(),
+        };
+        let err = config.validate().unwrap_err();
+        assert!(err.to_string().contains("mcp.orchestrator_url"));
     }
 }

--- a/crates/mcp/src/main.rs
+++ b/crates/mcp/src/main.rs
@@ -27,6 +27,7 @@
 //! directed to **stderr** so it does not interfere with the MCP JSON-RPC
 //! framing on stdout.
 
+use agentd_common::config::ValidateConfig;
 use agentd_mcp::config::AgentdMcpConfig;
 
 #[tokio::main]
@@ -40,5 +41,7 @@ async fn main() -> anyhow::Result<()> {
         .with_writer(std::io::stderr)
         .init();
 
-    agentd_mcp::run(AgentdMcpConfig::load()).await
+    let cfg = AgentdMcpConfig::load();
+    cfg.validate()?;
+    agentd_mcp::run(cfg).await
 }

--- a/crates/memory/src/config.rs
+++ b/crates/memory/src/config.rs
@@ -22,6 +22,8 @@
 //! assert!(!config.provider.is_empty() || config.provider == "none");
 //! ```
 
+use agentd_common::config::ValidateConfig;
+use anyhow::{bail, Result};
 use serde::{Deserialize, Serialize};
 use std::env;
 use std::path::PathBuf;
@@ -117,6 +119,22 @@ impl EmbeddingConfig {
     }
 }
 
+impl ValidateConfig for EmbeddingConfig {
+    /// Validate the embedding configuration.
+    ///
+    /// Returns an error if `provider` is not one of `"none"`, `"openai"`, or
+    /// `"ollama"`.
+    fn validate(&self) -> Result<()> {
+        match self.provider.as_str() {
+            "none" | "openai" | "ollama" => {}
+            other => {
+                bail!("memory.embedding_provider must be one of none, openai, ollama; got: {other}")
+            }
+        }
+        Ok(())
+    }
+}
+
 // ---------------------------------------------------------------------------
 // LanceDB configuration
 // ---------------------------------------------------------------------------
@@ -195,6 +213,21 @@ impl LanceConfig {
     }
 }
 
+impl ValidateConfig for LanceConfig {
+    /// Validate the LanceDB configuration.
+    ///
+    /// Returns an error if `path` or `table` is empty.
+    fn validate(&self) -> Result<()> {
+        if self.path.is_empty() {
+            bail!("memory.lance_path must not be empty");
+        }
+        if self.table.is_empty() {
+            bail!("memory.lance_table must not be empty");
+        }
+        Ok(())
+    }
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -202,6 +235,7 @@ impl LanceConfig {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use agentd_common::config::ValidateConfig;
 
     #[test]
     fn test_default_provider_is_none() {
@@ -332,5 +366,76 @@ mod tests {
         let cloned = config.clone();
         assert_eq!(cloned.path, config.path);
         assert_eq!(cloned.table, config.table);
+    }
+
+    // ── ValidateConfig for EmbeddingConfig ─────────────────────────────────
+
+    #[test]
+    fn test_embedding_validate_default_passes() {
+        let config = EmbeddingConfig::default();
+        assert!(config.validate().is_ok(), "default EmbeddingConfig should be valid");
+    }
+
+    #[test]
+    fn test_embedding_validate_none_provider_passes() {
+        let config = EmbeddingConfig { provider: "none".to_string(), ..Default::default() };
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn test_embedding_validate_openai_provider_passes() {
+        let config = EmbeddingConfig { provider: "openai".to_string(), ..Default::default() };
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn test_embedding_validate_ollama_provider_passes() {
+        let config = EmbeddingConfig { provider: "ollama".to_string(), ..Default::default() };
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn test_embedding_validate_invalid_provider_fails() {
+        let config = EmbeddingConfig { provider: "huggingface".to_string(), ..Default::default() };
+        let err = config.validate().unwrap_err();
+        assert!(
+            err.to_string().contains("huggingface"),
+            "error should mention the invalid provider"
+        );
+    }
+
+    #[test]
+    fn test_embedding_validate_empty_provider_fails() {
+        let config = EmbeddingConfig { provider: "".to_string(), ..Default::default() };
+        assert!(config.validate().is_err());
+    }
+
+    // ── ValidateConfig for LanceConfig ─────────────────────────────────────
+
+    #[test]
+    fn test_lance_validate_default_passes() {
+        let config = LanceConfig::default();
+        assert!(config.validate().is_ok(), "default LanceConfig should be valid");
+    }
+
+    #[test]
+    fn test_lance_validate_empty_path_fails() {
+        let config = LanceConfig { path: "".to_string(), table: "memories".to_string() };
+        let err = config.validate().unwrap_err();
+        assert!(err.to_string().contains("path"), "error should mention path");
+    }
+
+    #[test]
+    fn test_lance_validate_empty_table_fails() {
+        let config = LanceConfig { path: "/tmp/lance".to_string(), table: "".to_string() };
+        let err = config.validate().unwrap_err();
+        assert!(err.to_string().contains("table"), "error should mention table");
+    }
+
+    #[test]
+    fn test_lance_validate_custom_values_pass() {
+        let config =
+            LanceConfig { path: "/data/lancedb".to_string(), table: "my_memories".to_string() };
+        assert!(config.validate().is_ok());
     }
 }

--- a/crates/memory/src/main.rs
+++ b/crates/memory/src/main.rs
@@ -36,12 +36,12 @@
 
 mod api;
 
+use agentd_common::config::ValidateConfig;
 use api::{create_router, ApiState};
 use axum::{extract::State, response::IntoResponse, routing::get};
 use memory::config::{EmbeddingConfig, LanceConfig};
 use memory::storage::MemoryStorage;
 use metrics_exporter_prometheus::PrometheusHandle;
-use std::env;
 use tracing::info;
 
 fn init_metrics() -> PrometheusHandle {
@@ -62,6 +62,17 @@ async fn main() -> anyhow::Result<()> {
 
     info!("Starting agentd-memory service...");
 
+    // ── Configuration & validation ────────────────────────────────────────
+    // Load the shared config first so port and host are validated before
+    // any I/O is attempted (catches port=0 with a clear error message).
+    let shared = agentd_common::config::load()?;
+    shared.services.memory.validate()?;
+
+    let lance_config = LanceConfig::load();
+    let embedding_config = EmbeddingConfig::load();
+    lance_config.validate()?;
+    embedding_config.validate()?;
+
     // ── Metrics ──────────────────────────────────────────────────────────
     let metrics_handle = init_metrics();
 
@@ -70,9 +81,6 @@ async fn main() -> anyhow::Result<()> {
     info!("SQLite storage initialised");
 
     // ── Vector store ─────────────────────────────────────────────────────
-    let lance_config = LanceConfig::load();
-    let embedding_config = EmbeddingConfig::load();
-
     info!(
         lance_path = %lance_config.path,
         lance_table = %lance_config.table,
@@ -96,9 +104,7 @@ async fn main() -> anyhow::Result<()> {
         .layer(agentd_common::server::trace_layer())
         .layer(agentd_common::server::cors_layer());
 
-    let host = env::var("AGENTD_HOST").unwrap_or_else(|_| "127.0.0.1".to_string());
-    let port = env::var("AGENTD_PORT").unwrap_or_else(|_| "17008".to_string());
-    let addr = format!("{host}:{port}");
+    let addr = format!("{}:{}", shared.general.host, shared.services.memory.port);
     let listener = tokio::net::TcpListener::bind(&addr).await?;
     info!("Memory API server listening on http://{}", addr);
 

--- a/crates/monitor/src/config.rs
+++ b/crates/monitor/src/config.rs
@@ -2,6 +2,8 @@
 //!
 //! All settings can be overridden via environment variables at startup.
 
+use agentd_common::config::ValidateConfig;
+use anyhow::{bail, Result};
 use std::env;
 
 /// Configuration for the monitor service.
@@ -87,6 +89,27 @@ impl Default for MonitorConfig {
     }
 }
 
+impl ValidateConfig for MonitorConfig {
+    fn validate(&self) -> Result<()> {
+        if self.port == 0 {
+            bail!("monitor.port must be non-zero");
+        }
+        if self.collection_interval_secs == 0 {
+            bail!("monitor.collection_interval_secs must be greater than 0");
+        }
+        for (name, threshold) in [
+            ("monitor.cpu_alert_threshold", self.cpu_alert_threshold),
+            ("monitor.memory_alert_threshold", self.memory_alert_threshold),
+            ("monitor.disk_alert_threshold", self.disk_alert_threshold),
+        ] {
+            if !(0.0..=100.0).contains(&threshold) {
+                bail!("{name} must be between 0.0 and 100.0, got: {threshold}");
+            }
+        }
+        Ok(())
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -108,5 +131,45 @@ mod tests {
         let cloned = config.clone();
         assert_eq!(config.port, cloned.port);
         assert_eq!(config.history_size, cloned.history_size);
+    }
+
+    #[test]
+    fn test_validate_default_passes() {
+        assert!(MonitorConfig::default().validate().is_ok());
+    }
+
+    #[test]
+    fn test_validate_zero_port_fails() {
+        let config = MonitorConfig { port: 0, ..MonitorConfig::default() };
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn test_validate_zero_interval_fails() {
+        let config = MonitorConfig { collection_interval_secs: 0, ..MonitorConfig::default() };
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn test_validate_cpu_threshold_above_100_fails() {
+        let config = MonitorConfig { cpu_alert_threshold: 101.0, ..MonitorConfig::default() };
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn test_validate_memory_threshold_negative_fails() {
+        let config = MonitorConfig { memory_alert_threshold: -1.0, ..MonitorConfig::default() };
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn test_validate_boundary_thresholds_pass() {
+        let config = MonitorConfig {
+            cpu_alert_threshold: 0.0,
+            memory_alert_threshold: 100.0,
+            disk_alert_threshold: 50.0,
+            ..MonitorConfig::default()
+        };
+        assert!(config.validate().is_ok());
     }
 }

--- a/crates/monitor/src/main.rs
+++ b/crates/monitor/src/main.rs
@@ -18,11 +18,14 @@
 //! AGENTD_LOG_FORMAT=json agentd-monitor
 //! ```
 
+use agentd_common::config::ValidateConfig;
 use anyhow::Result;
 use monitor::config::MonitorConfig;
 
 #[tokio::main]
 async fn main() -> Result<()> {
     agentd_common::server::init_tracing();
-    monitor::run(MonitorConfig::load()).await
+    let cfg = MonitorConfig::load();
+    cfg.validate()?;
+    monitor::run(cfg).await
 }

--- a/crates/notify/src/config.rs
+++ b/crates/notify/src/config.rs
@@ -10,6 +10,8 @@
 //! | `AGENTD_HOST`   | `127.0.0.1`   | HTTP bind host   |
 //! | `AGENTD_PORT`   | `17004`       | HTTP listen port |
 
+use agentd_common::config::ValidateConfig;
+use anyhow::{bail, Result};
 use std::env;
 
 /// Configuration for the agentd-notify service.
@@ -37,6 +39,15 @@ impl NotifyConfig {
             .unwrap_or(shared.services.notify.port);
 
         Self { host, port }
+    }
+}
+
+impl ValidateConfig for NotifyConfig {
+    fn validate(&self) -> Result<()> {
+        if self.port == 0 {
+            bail!("notify.port must be non-zero");
+        }
+        Ok(())
     }
 }
 
@@ -75,5 +86,17 @@ mod tests {
         let config = NotifyConfig::load();
         env::remove_var("AGENTD_PORT");
         assert_eq!(config.port, 9004);
+    }
+
+    #[test]
+    fn test_validate_default_passes() {
+        let config = NotifyConfig { host: "127.0.0.1".to_string(), port: 17004 };
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn test_validate_zero_port_fails() {
+        let config = NotifyConfig { host: "127.0.0.1".to_string(), port: 0 };
+        assert!(config.validate().is_err());
     }
 }

--- a/crates/notify/src/main.rs
+++ b/crates/notify/src/main.rs
@@ -68,6 +68,7 @@ mod notification;
 mod storage;
 mod types;
 
+use agentd_common::config::ValidateConfig;
 use api::{create_router, ApiState};
 use axum::{extract::State, response::IntoResponse, routing::get};
 use config::NotifyConfig;
@@ -160,6 +161,7 @@ async fn main() -> anyhow::Result<()> {
         .layer(agentd_common::server::cors_layer());
 
     let cfg = NotifyConfig::load();
+    cfg.validate()?;
     let addr = format!("{}:{}", cfg.host, cfg.port);
     let listener = tokio::net::TcpListener::bind(&addr).await?;
     info!("Notification API server listening on http://{}", addr);

--- a/crates/orchestrator/src/config.rs
+++ b/crates/orchestrator/src/config.rs
@@ -14,6 +14,8 @@
 //! | `AGENTD_COMMUNICATE_SERVICE_URL`| `http://localhost:17010` | Communicate service URL              |
 //! | `AGENTD_RECONCILE_INTERVAL_SECS`| `30`                     | Agent reconciliation interval (secs) |
 
+use agentd_common::config::ValidateConfig;
+use anyhow::{bail, Result};
 use std::env;
 
 /// Configuration for the agentd-orchestrator service.
@@ -55,6 +57,26 @@ impl OrchestratorConfig {
             .unwrap_or(base.reconcile_interval_secs);
 
         Self { host, port, docker_image, communicate_url, reconcile_interval_secs }
+    }
+}
+
+impl ValidateConfig for OrchestratorConfig {
+    fn validate(&self) -> Result<()> {
+        if self.port == 0 {
+            bail!("orchestrator.port must be non-zero");
+        }
+        if !self.communicate_url.starts_with("http://")
+            && !self.communicate_url.starts_with("https://")
+        {
+            bail!(
+                "orchestrator.communicate_url must be a valid HTTP/HTTPS URL, got: {}",
+                self.communicate_url
+            );
+        }
+        if self.reconcile_interval_secs == 0 {
+            bail!("orchestrator.reconcile_interval_secs must be greater than 0");
+        }
+        Ok(())
     }
 }
 
@@ -110,5 +132,53 @@ mod tests {
         env::remove_var("AGENTD_RECONCILE_INTERVAL_SECS");
         assert_eq!(config.port, 9006);
         assert_eq!(config.reconcile_interval_secs, 60);
+    }
+
+    #[test]
+    fn test_validate_default_passes() {
+        let config = OrchestratorConfig {
+            host: "127.0.0.1".to_string(),
+            port: 17006,
+            docker_image: None,
+            communicate_url: "http://localhost:17010".to_string(),
+            reconcile_interval_secs: 30,
+        };
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn test_validate_zero_port_fails() {
+        let config = OrchestratorConfig {
+            host: "127.0.0.1".to_string(),
+            port: 0,
+            docker_image: None,
+            communicate_url: "http://localhost:17010".to_string(),
+            reconcile_interval_secs: 30,
+        };
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn test_validate_bad_communicate_url_fails() {
+        let config = OrchestratorConfig {
+            host: "127.0.0.1".to_string(),
+            port: 17006,
+            docker_image: None,
+            communicate_url: "localhost:17010".to_string(),
+            reconcile_interval_secs: 30,
+        };
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn test_validate_zero_reconcile_interval_fails() {
+        let config = OrchestratorConfig {
+            host: "127.0.0.1".to_string(),
+            port: 17006,
+            docker_image: None,
+            communicate_url: "http://localhost:17010".to_string(),
+            reconcile_interval_secs: 0,
+        };
+        assert!(config.validate().is_err());
     }
 }

--- a/crates/orchestrator/src/main.rs
+++ b/crates/orchestrator/src/main.rs
@@ -11,6 +11,7 @@ mod system_agents;
 mod types;
 mod websocket;
 
+use agentd_common::config::ValidateConfig;
 use api::{create_router, ApiState};
 use axum::{extract::State, response::IntoResponse, routing::get};
 use communicate::client::CommunicateClient;
@@ -58,6 +59,7 @@ async fn main() -> anyhow::Result<()> {
     info!("Starting agentd-orchestrator service...");
 
     let cfg = OrchestratorConfig::load();
+    cfg.validate()?;
 
     // Initialize storage.
     let storage = AgentStorage::new().await?;

--- a/crates/ui/src/config.rs
+++ b/crates/ui/src/config.rs
@@ -1,3 +1,6 @@
+use agentd_common::config::ValidateConfig;
+use anyhow::{bail, Result};
+
 /// Configuration for the UI service.
 #[derive(Debug, Clone)]
 pub struct UiConfig {
@@ -52,5 +55,55 @@ impl UiConfig {
     #[deprecated(note = "Use load() instead")]
     pub fn from_env() -> Self {
         Self::load()
+    }
+}
+
+impl ValidateConfig for UiConfig {
+    fn validate(&self) -> Result<()> {
+        if self.port == 0 {
+            bail!("ui.port must be non-zero");
+        }
+        if self.ui_dir.is_empty() {
+            bail!("ui.ui_dir must not be empty");
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_validate_default_passes() {
+        let config = UiConfig::load();
+        // Default port is 17009 and ui_dir is "./ui/dist" — both valid.
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn test_validate_zero_port_fails() {
+        let config = UiConfig {
+            port: 0,
+            ui_dir: "./ui/dist".to_string(),
+            ask_service_url: "http://localhost:7001".to_string(),
+            notify_service_url: "http://localhost:7004".to_string(),
+            orchestrator_service_url: "http://localhost:7006".to_string(),
+            index_service_url: "http://localhost:17012".to_string(),
+        };
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn test_validate_empty_ui_dir_fails() {
+        let config = UiConfig {
+            port: 17009,
+            ui_dir: "".to_string(),
+            ask_service_url: "http://localhost:7001".to_string(),
+            notify_service_url: "http://localhost:7004".to_string(),
+            orchestrator_service_url: "http://localhost:7006".to_string(),
+            index_service_url: "http://localhost:17012".to_string(),
+        };
+        assert!(config.validate().is_err());
     }
 }

--- a/crates/ui/src/main.rs
+++ b/crates/ui/src/main.rs
@@ -14,11 +14,14 @@
 //! AGENTD_PORT=7009 AGENTD_UI_DIR=/path/to/dist agentd-ui
 //! ```
 
+use agentd_common::config::ValidateConfig;
 use anyhow::Result;
 use ui::config::UiConfig;
 
 #[tokio::main]
 async fn main() -> Result<()> {
     agentd_common::server::init_tracing();
-    ui::run(UiConfig::load()).await
+    let cfg = UiConfig::load();
+    cfg.validate()?;
+    ui::run(cfg).await
 }

--- a/crates/wrap/src/config.rs
+++ b/crates/wrap/src/config.rs
@@ -13,6 +13,8 @@
 //! | `AGENTD_WRAP_HISTORY_BYTES`   | `524288`   | PTY ring-buffer size in bytes (512 KiB)  |
 //! | `AGENTD_WRAP_CHANNEL_CAPACITY`| `256`      | PTY broadcast channel capacity           |
 
+use agentd_common::config::ValidateConfig;
+use anyhow::{bail, Result};
 use std::env;
 
 use crate::pty_stream::{DEFAULT_CHANNEL_CAPACITY, DEFAULT_HISTORY_BYTES};
@@ -56,6 +58,24 @@ impl WrapConfig {
             .unwrap_or(DEFAULT_CHANNEL_CAPACITY);
 
         Self { host, port, backend, history_bytes, channel_capacity }
+    }
+}
+
+impl ValidateConfig for WrapConfig {
+    fn validate(&self) -> Result<()> {
+        if self.port == 0 {
+            bail!("wrap.port must be non-zero");
+        }
+        match self.backend.as_str() {
+            "tmux" | "docker" | "pty" | "subprocess" => {}
+            other => {
+                bail!("wrap.backend must be one of tmux, docker, pty, subprocess; got: {other}")
+            }
+        }
+        if self.channel_capacity < 1 {
+            bail!("wrap.channel_capacity must be at least 1");
+        }
+        Ok(())
     }
 }
 
@@ -116,5 +136,56 @@ mod tests {
         env::remove_var("AGENTD_BACKEND");
         assert_eq!(config.port, 9005);
         assert_eq!(config.backend, "pty");
+    }
+
+    #[test]
+    fn test_validate_default_passes() {
+        let config = WrapConfig {
+            host: "127.0.0.1".to_string(),
+            port: 17005,
+            backend: "tmux".to_string(),
+            history_bytes: DEFAULT_HISTORY_BYTES,
+            channel_capacity: DEFAULT_CHANNEL_CAPACITY,
+        };
+        assert!(config.validate().is_ok());
+    }
+
+    #[test]
+    fn test_validate_zero_port_fails() {
+        let config = WrapConfig {
+            host: "127.0.0.1".to_string(),
+            port: 0,
+            backend: "tmux".to_string(),
+            history_bytes: DEFAULT_HISTORY_BYTES,
+            channel_capacity: DEFAULT_CHANNEL_CAPACITY,
+        };
+        assert!(config.validate().is_err());
+    }
+
+    #[test]
+    fn test_validate_invalid_backend_fails() {
+        let config = WrapConfig {
+            host: "127.0.0.1".to_string(),
+            port: 17005,
+            backend: "unknown".to_string(),
+            history_bytes: DEFAULT_HISTORY_BYTES,
+            channel_capacity: DEFAULT_CHANNEL_CAPACITY,
+        };
+        let err = config.validate().unwrap_err();
+        assert!(err.to_string().contains("unknown"));
+    }
+
+    #[test]
+    fn test_validate_all_valid_backends_pass() {
+        for backend in &["tmux", "docker", "pty", "subprocess"] {
+            let config = WrapConfig {
+                host: "127.0.0.1".to_string(),
+                port: 17005,
+                backend: backend.to_string(),
+                history_bytes: DEFAULT_HISTORY_BYTES,
+                channel_capacity: DEFAULT_CHANNEL_CAPACITY,
+            };
+            assert!(config.validate().is_ok(), "backend {backend} should be valid");
+        }
     }
 }

--- a/crates/wrap/src/main.rs
+++ b/crates/wrap/src/main.rs
@@ -30,6 +30,7 @@
 
 // Import from the library target — avoids re-declaring modules in the binary and
 // triggering dead-code warnings on items that are only used by the library.
+use agentd_common::config::ValidateConfig;
 use wrap::{
     api::{create_router, AppState},
     backend::{ExecutionBackend, TmuxBackend},
@@ -63,6 +64,7 @@ async fn main() -> anyhow::Result<()> {
     info!("Starting agentd-wrap service...");
 
     let cfg = WrapConfig::load();
+    cfg.validate()?;
 
     // --- Select execution backend ---
     // Unrecognised AGENTD_BACKEND values cause an immediate startup failure.


### PR DESCRIPTION
Adds a \`ValidateConfig\` trait to \`agentd_common\` and implements it across all 12 service configuration sections. Wires \`cfg.validate()?\` into every service's startup so misconfigurations surface immediately with descriptive error messages before any ports are bound.

Changes:
- \`agentd_common::config::ValidateConfig\` trait with \`fn validate(&self) -> Result<()>\`
- \`AgentdConfig::validate()\` that collects errors from all 12 sections (does not short-circuit)
- \`impl ValidateConfig\` on all shared config section structs (port > 0, backend enum, URL format, alert thresholds, etc.)
- \`impl ValidateConfig\` on all 12 service-level config structs in their respective crates (including memory)
- \`cfg.validate()?\` called in \`main()\` of: core, orchestrator, wrap, ask, notify, communicate, hook, monitor, mcp, ui, index, memory
- Unit tests for both valid and invalid cases per service

Review feedback addressed:
- Add \`ValidateConfig\` impls for \`EmbeddingConfig\` and \`LanceConfig\` in memory crate; wire validation and shared-config port/host in \`memory/main.rs\`
- Remove \`validate_inner()\` indirection in \`index/config.rs\`; logic now lives directly in \`impl ValidateConfig for IndexConfig\`
- Make \`validate_url()\` pub in \`agentd-common\` for reuse by service crates

Closes #1198