### PR TITLE
fix(scheduler): restart workflow runners when an agent is restarted

### DIFF
--- a/crates/cli/src/commands/orchestrator.rs
+++ b/crates/cli/src/commands/orchestrator.rs
@@ -1923,8 +1923,7 @@ fn format_stream_message(text: &str, verbose: bool) {
                 if let Some(usage) = msg.get("usage") {
                     let input = usage.get("input_tokens").and_then(|v| v.as_u64()).unwrap_or(0);
                     let output = usage.get("output_tokens").and_then(|v| v.as_u64()).unwrap_or(0);
-                    let cost =
-                        usage.get("total_cost_usd").and_then(|v| v.as_f64()).unwrap_or(0.0);
+                    let cost = usage.get("total_cost_usd").and_then(|v| v.as_f64()).unwrap_or(0.0);
                     println!(
                         "{} {}",
                         prefix,

--- a/crates/mcp/src/tools/communicate.rs
+++ b/crates/mcp/src/tools/communicate.rs
@@ -201,11 +201,7 @@ pub async fn run_get_room(client: &AgentdClient, room_id: &str) -> String {
     out
 }
 
-pub async fn run_list_messages(
-    client: &AgentdClient,
-    room_id: &str,
-    limit: Option<u32>,
-) -> String {
+pub async fn run_list_messages(client: &AgentdClient, room_id: &str, limit: Option<u32>) -> String {
     let base = client.communicate_url();
     let limit_val = limit.unwrap_or(20).clamp(1, 200);
     let url = format!("{base}/rooms/{room_id}/messages?limit={limit_val}");

--- a/crates/mcp/src/tools/diagnostic.rs
+++ b/crates/mcp/src/tools/diagnostic.rs
@@ -167,7 +167,9 @@ pub async fn run_diagnose_agent(client: &AgentdClient, agent_id: &str) -> String
                 info.push("Backend is **pty** — direct PTY session.".to_string());
             }
             "tmux" => {
-                info.push("Backend is **tmux** — session can be attached for inspection.".to_string());
+                info.push(
+                    "Backend is **tmux** — session can be attached for inspection.".to_string(),
+                );
             }
             _ => {}
         }
@@ -233,10 +235,8 @@ pub async fn run_diagnose_workflow(client: &AgentdClient, workflow_id: &str) -> 
     let wf_name = str_field(&wf, "name");
     let agent_id = str_field(&wf, "agent_id");
     let enabled = wf["enabled"].as_bool().unwrap_or(false);
-    let trigger_type = wf["trigger_type"]
-        .as_str()
-        .or_else(|| wf["source"]["type"].as_str())
-        .unwrap_or("unknown");
+    let trigger_type =
+        wf["trigger_type"].as_str().or_else(|| wf["source"]["type"].as_str()).unwrap_or("unknown");
 
     writeln!(report, "# Workflow Diagnostic: {wf_name}").ok();
     writeln!(report, "- **ID:** `{workflow_id}`").ok();
@@ -307,9 +307,7 @@ pub async fn run_diagnose_workflow(client: &AgentdClient, workflow_id: &str) -> 
             ));
         }
         "linear_issues" => {
-            info.push(
-                "Polling Linear. Verify API key and team filter configuration.".to_string(),
-            );
+            info.push("Polling Linear. Verify API key and team filter configuration.".to_string());
         }
         _ => {}
     }
@@ -560,4 +558,3 @@ pub async fn run_diagnose_system(client: &AgentdClient) -> String {
 
     report
 }
-

--- a/crates/mcp/src/tools/memory.rs
+++ b/crates/mcp/src/tools/memory.rs
@@ -133,8 +133,11 @@ pub async fn run_search_memories(
         return format!("No memories found matching `{query}`.");
     }
 
-    let mut out =
-        format!("## Memory search: `{query}` — {} results (total {})\n\n", result.memories.len(), result.total);
+    let mut out = format!(
+        "## Memory search: `{query}` — {} results (total {})\n\n",
+        result.memories.len(),
+        result.total
+    );
     out.push_str("| Type | Visibility | ID | Created by | Tags | Content |\n");
     out.push_str("|------|------------|-----|-----------|------|---------|\n");
     for m in &result.memories {
@@ -214,7 +217,11 @@ pub async fn run_get_memory(client: &AgentdClient, memory_id: &str) -> String {
     let tags = if m.tags.is_empty() { "-".to_string() } else { m.tags.join(", ") };
     let mut out = format!("## Memory `{}`\n\n", m.id);
     out.push_str(&format!("- **Type**: {} {}\n", type_icon(&m.mem_type), m.mem_type));
-    out.push_str(&format!("- **Visibility**: {} {}\n", visibility_icon(&m.visibility), m.visibility));
+    out.push_str(&format!(
+        "- **Visibility**: {} {}\n",
+        visibility_icon(&m.visibility),
+        m.visibility
+    ));
     out.push_str(&format!("- **Created by**: {}\n", m.created_by));
     if let Some(ref o) = m.owner {
         out.push_str(&format!("- **Owner**: {o}\n"));

--- a/crates/mcp/src/tools/orchestrator_debug.rs
+++ b/crates/mcp/src/tools/orchestrator_debug.rs
@@ -152,7 +152,10 @@ pub async fn run_diagnose_state_mismatches(client: &AgentdClient) -> String {
         out.push_str("These agents have status=running but no live WebSocket. They likely cannot receive messages and may need a restart.\n\n");
         for id in &s.running_but_disconnected {
             if let Some(a) = dbg.agents.iter().find(|a| &a.id == id) {
-                out.push_str(&format!("- `{}` **{}** (session: {:?})\n", a.id, a.name, a.session_id));
+                out.push_str(&format!(
+                    "- `{}` **{}** (session: {:?})\n",
+                    a.id, a.name, a.session_id
+                ));
             } else {
                 out.push_str(&format!("- `{id}`\n"));
             }
@@ -201,19 +204,15 @@ pub async fn run_inspect_queue(
     let base = client.orchestrator_url();
     let peek_n = peek_limit.unwrap_or(10).clamp(1, 100);
 
-    let stats: QueueStats = match client
-        .inner
-        .get(format!("{base}/queues/{queue_name}/stats"))
-        .send()
-        .await
-    {
-        Ok(r) if r.status().is_success() => match r.json().await {
-            Ok(v) => v,
-            Err(e) => return format!("Error parsing queue stats: {e}"),
-        },
-        Ok(r) => return format!("Error: HTTP {} fetching queue stats", r.status()),
-        Err(e) => return format!("Error: orchestrator unreachable at {base}: {e}"),
-    };
+    let stats: QueueStats =
+        match client.inner.get(format!("{base}/queues/{queue_name}/stats")).send().await {
+            Ok(r) if r.status().is_success() => match r.json().await {
+                Ok(v) => v,
+                Err(e) => return format!("Error parsing queue stats: {e}"),
+            },
+            Ok(r) => return format!("Error: HTTP {} fetching queue stats", r.status()),
+            Err(e) => return format!("Error: orchestrator unreachable at {base}: {e}"),
+        };
 
     let tasks: Vec<QueueTask> = match client
         .inner
@@ -291,12 +290,9 @@ pub async fn run_get_conversation_summary(client: &AgentdClient, agent_id: &str)
         out.push_str("### Event counts by type\n\n");
         out.push_str("| Event type | Count |\n");
         out.push_str("|-----------|-------|\n");
-        let mut entries: Vec<(&String, u64)> = sum
-            .event_counts
-            .iter()
-            .map(|(k, v)| (k, v.as_u64().unwrap_or(0)))
-            .collect();
-        entries.sort_by(|a, b| b.1.cmp(&a.1));
+        let mut entries: Vec<(&String, u64)> =
+            sum.event_counts.iter().map(|(k, v)| (k, v.as_u64().unwrap_or(0))).collect();
+        entries.sort_by_key(|b| std::cmp::Reverse(b.1));
         for (k, v) in entries {
             out.push_str(&format!("| `{k}` | {v} |\n"));
         }

--- a/crates/orchestrator/src/config.rs
+++ b/crates/orchestrator/src/config.rs
@@ -68,10 +68,18 @@ impl OrchestratorConfig {
             .ok()
             .and_then(|v| v.parse::<u64>().ok())
             .unwrap_or(base.reconcile_interval_secs);
-        let subprocess_path = env::var("AGENTD_ORCHESTRATOR_SUBPROCESS_PATH")
-            .unwrap_or(base.subprocess_path);
+        let subprocess_path =
+            env::var("AGENTD_ORCHESTRATOR_SUBPROCESS_PATH").unwrap_or(base.subprocess_path);
 
-        Self { host, port, docker_image, backend, communicate_url, reconcile_interval_secs, subprocess_path }
+        Self {
+            host,
+            port,
+            docker_image,
+            backend,
+            communicate_url,
+            reconcile_interval_secs,
+            subprocess_path,
+        }
     }
 }
 
@@ -122,11 +130,21 @@ mod tests {
 
         let config = OrchestratorConfig::load();
 
-        if let Some(v) = saved_host { env::set_var("AGENTD_HOST", v); }
-        if let Some(v) = saved_port { env::set_var("AGENTD_PORT", v); }
-        if let Some(v) = saved_comm { env::set_var("AGENTD_COMMUNICATE_SERVICE_URL", v); }
-        if let Some(v) = saved_reconcile { env::set_var("AGENTD_RECONCILE_INTERVAL_SECS", v); }
-        if let Some(v) = saved_subpath { env::set_var("AGENTD_ORCHESTRATOR_SUBPROCESS_PATH", v); }
+        if let Some(v) = saved_host {
+            env::set_var("AGENTD_HOST", v);
+        }
+        if let Some(v) = saved_port {
+            env::set_var("AGENTD_PORT", v);
+        }
+        if let Some(v) = saved_comm {
+            env::set_var("AGENTD_COMMUNICATE_SERVICE_URL", v);
+        }
+        if let Some(v) = saved_reconcile {
+            env::set_var("AGENTD_RECONCILE_INTERVAL_SECS", v);
+        }
+        if let Some(v) = saved_subpath {
+            env::set_var("AGENTD_ORCHESTRATOR_SUBPROCESS_PATH", v);
+        }
         match saved_cfg {
             Some(v) => env::set_var("AGENTD_CONFIG", v),
             None => env::remove_var("AGENTD_CONFIG"),
@@ -215,6 +233,7 @@ mod tests {
             host: "127.0.0.1".to_string(),
             port: 17006,
             docker_image: None,
+            backend: "tmux".to_string(),
             communicate_url: "localhost:17010".to_string(),
             reconcile_interval_secs: 30,
             subprocess_path: String::new(),
@@ -228,6 +247,7 @@ mod tests {
             host: "127.0.0.1".to_string(),
             port: 17006,
             docker_image: None,
+            backend: "tmux".to_string(),
             communicate_url: "http://localhost:17010".to_string(),
             reconcile_interval_secs: 0,
             subprocess_path: String::new(),

--- a/crates/orchestrator/src/main.rs
+++ b/crates/orchestrator/src/main.rs
@@ -529,6 +529,32 @@ async fn main() -> anyhow::Result<()> {
         });
     }
 
+    // Reactive restart handler: when an agent is restarted, re-launch any enabled
+    // workflow runners that died because the agent previously failed (e.g., the
+    // startup-time 60-second wait in `resume_workflows` expired before the agent
+    // connected).
+    {
+        let mut restart_rx = event_bus.subscribe();
+        let scheduler_restart = scheduler.clone();
+        tokio::spawn(async move {
+            loop {
+                match restart_rx.recv().await {
+                    Ok(scheduler::events::SystemEvent::AgentRestarted { agent_id }) => {
+                        let sched = Arc::clone(&scheduler_restart);
+                        tokio::spawn(async move {
+                            sched.restart_workflows_for_agent(agent_id).await;
+                        });
+                    }
+                    Ok(_) => {}
+                    Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
+                        warn!("Agent restart handler lagged by {} events", n);
+                    }
+                    Err(tokio::sync::broadcast::error::RecvError::Closed) => break,
+                }
+            }
+        });
+    }
+
     // Resume any enabled workflows from the database.
     if let Err(e) = scheduler.resume_workflows().await {
         error!(%e, "Failed to resume workflows");

--- a/crates/orchestrator/src/manager.rs
+++ b/crates/orchestrator/src/manager.rs
@@ -940,6 +940,11 @@ impl AgentManager {
             self.wire_subprocess_io(agent.id, &session_name).await?;
         }
 
+        // Publish AgentRestarted so the scheduler can re-launch dead workflow runners.
+        if let Some(bus) = self.registry.event_bus() {
+            bus.publish(SystemEvent::AgentRestarted { agent_id: agent.id });
+        }
+
         info!(
             agent_id = %agent.id,
             session = %session_name,

--- a/crates/orchestrator/src/scheduler/events.rs
+++ b/crates/orchestrator/src/scheduler/events.rs
@@ -35,6 +35,13 @@ pub enum SystemEvent {
     },
     /// An agent joined a communicate room.
     AgentJoinedRoom { agent_id: Uuid, room_id: Uuid },
+    /// An agent was explicitly restarted via the API, reconciliation, or bootstrap.
+    ///
+    /// Published by [`crate::manager::AgentManager::restart_agent`] after the new
+    /// process is launched and the DB record is updated. The scheduler subscribes
+    /// to this event to re-launch any enabled workflow runners that died when the
+    /// agent previously failed.
+    AgentRestarted { agent_id: Uuid },
     /// A human answered or dismissed an ask service question.
     ///
     /// Published by the orchestrator when it receives a callback from the ask
@@ -164,7 +171,7 @@ mod tests {
 
     #[tokio::test]
     async fn test_publish_all_event_variants() {
-        let bus = EventBus::new(16);
+        let bus = EventBus::new(32);
         let mut rx = bus.subscribe();
 
         let agent_id = Uuid::new_v4();
@@ -173,6 +180,7 @@ mod tests {
 
         bus.publish(SystemEvent::AgentConnected { agent_id });
         bus.publish(SystemEvent::AgentDisconnected { agent_id });
+        bus.publish(SystemEvent::AgentRestarted { agent_id });
         bus.publish(SystemEvent::ContextCleared { agent_id });
         bus.publish(SystemEvent::DispatchCompleted {
             workflow_id,
@@ -181,9 +189,10 @@ mod tests {
             source_id: Some("123".to_string()),
         });
 
-        // Verify all four events arrive in order.
+        // Verify all five events arrive in order.
         assert!(matches!(rx.recv().await.unwrap(), SystemEvent::AgentConnected { .. }));
         assert!(matches!(rx.recv().await.unwrap(), SystemEvent::AgentDisconnected { .. }));
+        assert!(matches!(rx.recv().await.unwrap(), SystemEvent::AgentRestarted { .. }));
         assert!(matches!(rx.recv().await.unwrap(), SystemEvent::ContextCleared { .. }));
 
         match rx.recv().await.unwrap() {
@@ -198,6 +207,20 @@ mod tests {
                 assert_eq!(status, DispatchStatus::Completed);
                 assert_eq!(source_id, Some("123".to_string()));
             }
+            other => panic!("Unexpected event: {:?}", other),
+        }
+    }
+
+    #[tokio::test]
+    async fn test_agent_restarted_event() {
+        let bus = EventBus::new(16);
+        let mut rx = bus.subscribe();
+
+        let agent_id = Uuid::new_v4();
+        bus.publish(SystemEvent::AgentRestarted { agent_id });
+
+        match rx.recv().await.unwrap() {
+            SystemEvent::AgentRestarted { agent_id: id } => assert_eq!(id, agent_id),
             other => panic!("Unexpected event: {:?}", other),
         }
     }

--- a/crates/orchestrator/src/scheduler/mod.rs
+++ b/crates/orchestrator/src/scheduler/mod.rs
@@ -404,6 +404,58 @@ impl Scheduler {
         Ok(record)
     }
 
+    /// Re-launch any enabled workflow runners for `agent_id` that are not currently active.
+    ///
+    /// Called reactively when an agent is restarted — via the API, reconciliation, or
+    /// bootstrap — to restore the agent to a fully functional state. Any workflow runner
+    /// that died because the agent previously failed (e.g., exceeded the startup timeout
+    /// in [`Self::resume_workflows`]) is restarted here.
+    ///
+    /// Workflows that already have an active runner are skipped (idempotent). Disabled
+    /// workflows are never started.
+    pub async fn restart_workflows_for_agent(self: &Arc<Self>, agent_id: Uuid) {
+        let workflows = match self.storage.list_workflows(None).await {
+            Ok(wfs) => wfs,
+            Err(e) => {
+                error!(%agent_id, %e, "Failed to list workflows for restarted agent");
+                return;
+            }
+        };
+
+        for workflow in workflows {
+            if workflow.agent_id != agent_id || !workflow.enabled {
+                continue;
+            }
+
+            // Skip workflows that already have an active runner.
+            {
+                let runners = self.runners.read().await;
+                if runners.contains_key(&workflow.id) {
+                    info!(
+                        workflow_id = %workflow.id,
+                        %agent_id,
+                        "Workflow runner already active, skipping restart"
+                    );
+                    continue;
+                }
+            }
+
+            info!(
+                workflow_id = %workflow.id,
+                %agent_id,
+                "Re-launching workflow runner for restarted agent"
+            );
+
+            if let Err(e) = self.start_workflow(workflow).await {
+                error!(
+                    %agent_id,
+                    %e,
+                    "Failed to re-launch workflow runner for restarted agent"
+                );
+            }
+        }
+    }
+
     /// Shutdown all running workflows gracefully.
     pub async fn shutdown_all(&self) {
         let mut runners = self.runners.write().await;

--- a/crates/orchestrator/src/scheduler/mod.rs
+++ b/crates/orchestrator/src/scheduler/mod.rs
@@ -413,7 +413,7 @@ impl Scheduler {
     ///
     /// Workflows that already have an active runner are skipped (idempotent). Disabled
     /// workflows are never started.
-    pub async fn restart_workflows_for_agent(self: &Arc<Self>, agent_id: Uuid) {
+    pub async fn restart_workflows_for_agent(&self, agent_id: Uuid) {
         let workflows = match self.storage.list_workflows(None).await {
             Ok(wfs) => wfs,
             Err(e) => {
@@ -447,10 +447,15 @@ impl Scheduler {
             );
 
             if let Err(e) = self.start_workflow(workflow).await {
-                error!(
+                // Use warn! rather than error! here: if a concurrent task (e.g. a
+                // lingering resume_workflows background waiter) already started this
+                // runner between our contains_key check and start_workflow, we get
+                // "Workflow X is already running" — a benign race, not a real error.
+                warn!(
                     %agent_id,
                     %e,
-                    "Failed to re-launch workflow runner for restarted agent"
+                    "Failed to re-launch workflow runner for restarted agent \
+                     (may be a benign race with concurrent resume)"
                 );
             }
         }

--- a/crates/tui/src/control/app.rs
+++ b/crates/tui/src/control/app.rs
@@ -291,7 +291,7 @@ impl App {
         let len = self.memories.len();
         if len == 0 {
             self.memory_table_state.select(None);
-        } else if self.memory_table_state.selected().map_or(true, |i| i >= len) {
+        } else if self.memory_table_state.selected().is_none_or(|i| i >= len) {
             self.memory_table_state.select(Some(0));
         }
 

--- a/crates/tui/src/control/app.rs
+++ b/crates/tui/src/control/app.rs
@@ -1,6 +1,6 @@
-use agentd_common::config::AgentdConfig;
-use crate::config::TuiConfig;
 use super::stream;
+use crate::config::TuiConfig;
+use agentd_common::config::AgentdConfig;
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use memory::client::MemoryClient;
 use memory::types::{Memory, SearchRequest};
@@ -55,7 +55,7 @@ impl From<serde_json::Value> for ConversationEntry {
         // Stream events store content in different fields depending on type.
         let line = v["line"]
             .as_str()
-            .or_else(|| v["text"].as_str())    // agent:thinking uses "text"
+            .or_else(|| v["text"].as_str()) // agent:thinking uses "text"
             .or_else(|| v["summary"].as_str()) // agent:tool_use has "summary"
             .map(|s| s.to_string());
 
@@ -100,7 +100,10 @@ pub enum MemoryDialog {
     Search(String),
     /// Tag filter dialog; `cursor` is the highlighted row, `draft` is the
     /// working selection before the user confirms with Enter.
-    TagFilter { cursor: usize, draft: Vec<String> },
+    TagFilter {
+        cursor: usize,
+        draft: Vec<String>,
+    },
 }
 
 impl MemoryDialog {
@@ -278,11 +281,8 @@ impl App {
         }
 
         // Collect unique sorted tags from the loaded memories
-        let mut tag_set: std::collections::HashSet<String> = self
-            .memories
-            .iter()
-            .flat_map(|m| m.tags.iter().cloned())
-            .collect();
+        let mut tag_set: std::collections::HashSet<String> =
+            self.memories.iter().flat_map(|m| m.tags.iter().cloned()).collect();
         let mut sorted: Vec<String> = tag_set.drain().collect();
         sorted.sort();
         self.memory_available_tags = sorted;
@@ -317,22 +317,26 @@ impl App {
         match self.view {
             View::AgentList => {
                 let len = self.agents.len();
-                if len == 0 { return; }
+                if len == 0 {
+                    return;
+                }
                 let next = self.agent_table_state.selected().map_or(0, |i| (i + 1).min(len - 1));
                 self.agent_table_state.select(Some(next));
             }
             View::WorkflowList => {
                 let len = self.workflows.len();
-                if len == 0 { return; }
-                let next =
-                    self.workflow_table_state.selected().map_or(0, |i| (i + 1).min(len - 1));
+                if len == 0 {
+                    return;
+                }
+                let next = self.workflow_table_state.selected().map_or(0, |i| (i + 1).min(len - 1));
                 self.workflow_table_state.select(Some(next));
             }
             View::MemoryList => {
                 let len = self.memories.len();
-                if len == 0 { return; }
-                let next =
-                    self.memory_table_state.selected().map_or(0, |i| (i + 1).min(len - 1));
+                if len == 0 {
+                    return;
+                }
+                let next = self.memory_table_state.selected().map_or(0, |i| (i + 1).min(len - 1));
                 self.memory_table_state.select(Some(next));
             }
             _ => {}
@@ -342,20 +346,24 @@ impl App {
     pub fn select_prev(&mut self) {
         match self.view {
             View::AgentList => {
-                if self.agents.is_empty() { return; }
+                if self.agents.is_empty() {
+                    return;
+                }
                 let prev = self.agent_table_state.selected().map_or(0, |i| i.saturating_sub(1));
                 self.agent_table_state.select(Some(prev));
             }
             View::WorkflowList => {
-                if self.workflows.is_empty() { return; }
-                let prev =
-                    self.workflow_table_state.selected().map_or(0, |i| i.saturating_sub(1));
+                if self.workflows.is_empty() {
+                    return;
+                }
+                let prev = self.workflow_table_state.selected().map_or(0, |i| i.saturating_sub(1));
                 self.workflow_table_state.select(Some(prev));
             }
             View::MemoryList => {
-                if self.memories.is_empty() { return; }
-                let prev =
-                    self.memory_table_state.selected().map_or(0, |i| i.saturating_sub(1));
+                if self.memories.is_empty() {
+                    return;
+                }
+                let prev = self.memory_table_state.selected().map_or(0, |i| i.saturating_sub(1));
                 self.memory_table_state.select(Some(prev));
             }
             _ => {}
@@ -524,7 +532,9 @@ impl App {
     }
 
     fn input_move_up(&mut self) {
-        if self.input_inner_width == 0 { return; }
+        if self.input_inner_width == 0 {
+            return;
+        }
         self.input_cursor = crate::input::cursor_move_vertical(
             &self.input_buffer,
             self.input_cursor,
@@ -534,7 +544,9 @@ impl App {
     }
 
     fn input_move_down(&mut self) {
-        if self.input_inner_width == 0 { return; }
+        if self.input_inner_width == 0 {
+            return;
+        }
         self.input_cursor = crate::input::cursor_move_vertical(
             &self.input_buffer,
             self.input_cursor,
@@ -544,7 +556,9 @@ impl App {
     }
 
     fn input_delete_before(&mut self) {
-        if self.input_cursor == 0 { return; }
+        if self.input_cursor == 0 {
+            return;
+        }
         let ch_start = self.input_buffer[..self.input_cursor]
             .char_indices()
             .next_back()
@@ -555,7 +569,9 @@ impl App {
     }
 
     fn input_delete_after(&mut self) {
-        if self.input_cursor >= self.input_buffer.len() { return; }
+        if self.input_cursor >= self.input_buffer.len() {
+            return;
+        }
         let ch_end = self.input_buffer[self.input_cursor..]
             .char_indices()
             .nth(1)
@@ -565,7 +581,9 @@ impl App {
     }
 
     fn input_move_left(&mut self) {
-        if self.input_cursor == 0 { return; }
+        if self.input_cursor == 0 {
+            return;
+        }
         self.input_cursor = self.input_buffer[..self.input_cursor]
             .char_indices()
             .next_back()
@@ -574,7 +592,9 @@ impl App {
     }
 
     fn input_move_right(&mut self) {
-        if self.input_cursor >= self.input_buffer.len() { return; }
+        if self.input_cursor >= self.input_buffer.len() {
+            return;
+        }
         self.input_cursor += self.input_buffer[self.input_cursor..]
             .chars()
             .next()
@@ -583,7 +603,9 @@ impl App {
     }
 
     pub async fn handle_paste(&mut self, text: String) {
-        if !self.input_mode { return; }
+        if !self.input_mode {
+            return;
+        }
 
         let text = text.replace("\r\n", "\n").replace('\r', "\n");
         let lines: Vec<&str> = text.split('\n').collect();
@@ -602,7 +624,9 @@ impl App {
 
     async fn submit_message(&mut self) {
         let text = self.input_buffer.trim().to_string();
-        if text.is_empty() { return; }
+        if text.is_empty() {
+            return;
+        }
 
         let Some(ref agent) = self.selected_agent.clone() else { return };
         let id: Uuid = agent.id;
@@ -705,7 +729,10 @@ impl App {
         if self.quitting {
             match key.code {
                 KeyCode::Char('y') | KeyCode::Enter => return true,
-                _ => { self.quitting = false; return false; }
+                _ => {
+                    self.quitting = false;
+                    return false;
+                }
             }
         }
 
@@ -768,7 +795,9 @@ impl App {
         }
 
         match key.code {
-            KeyCode::Char('q') => { self.quitting = true; }
+            KeyCode::Char('q') => {
+                self.quitting = true;
+            }
             KeyCode::Tab => {
                 let prev = self.active_tab;
                 self.switch_tab(true);
@@ -889,8 +918,6 @@ impl App {
     }
 
     pub fn secs_until_refresh(&self) -> u64 {
-        self.refresh_interval
-            .saturating_sub(self.last_refresh.elapsed())
-            .as_secs()
+        self.refresh_interval.saturating_sub(self.last_refresh.elapsed()).as_secs()
     }
 }

--- a/crates/tui/src/control/stream.rs
+++ b/crates/tui/src/control/stream.rs
@@ -15,9 +15,7 @@ pub fn spawn(
 ) -> (mpsc::UnboundedReceiver<serde_json::Value>, tokio::task::AbortHandle) {
     let (tx, rx) = mpsc::unbounded_channel();
 
-    let ws_url = base_url
-        .replacen("https://", "wss://", 1)
-        .replacen("http://", "ws://", 1);
+    let ws_url = base_url.replacen("https://", "wss://", 1).replacen("http://", "ws://", 1);
     let url = format!("{ws_url}/stream/{agent_id}");
 
     let handle = tokio::spawn(async move {

--- a/crates/tui/src/control/ui.rs
+++ b/crates/tui/src/control/ui.rs
@@ -51,19 +51,14 @@ fn render_header(f: &mut Frame, app: &App, area: ratatui::layout::Rect) {
         Span::styled(" loading...  ", Style::default().fg(Color::Yellow))
     } else {
         let secs = app.secs_until_refresh();
-        Span::styled(
-            format!(" refresh in {secs}s  "),
-            Style::default().fg(Color::DarkGray),
-        )
+        Span::styled(format!(" refresh in {secs}s  "), Style::default().fg(Color::DarkGray))
     };
 
     if let Some(ref err) = app.error {
         let err_text = if err.len() > 18 { format!("{}...", &err[..15]) } else { err.clone() };
-        let error_line = Paragraph::new(Span::styled(
-            format!(" {err_text}"),
-            Style::default().fg(Color::Red),
-        ))
-        .alignment(Alignment::Right);
+        let error_line =
+            Paragraph::new(Span::styled(format!(" {err_text}"), Style::default().fg(Color::Red)))
+                .alignment(Alignment::Right);
         f.render_widget(error_line, cols[1]);
     } else {
         let p = Paragraph::new(status).alignment(Alignment::Right);
@@ -79,11 +74,7 @@ fn render_tabs(f: &mut Frame, app: &App, area: ratatui::layout::Rect) {
     ];
 
     let tabs = Tabs::new(tab_titles)
-        .block(
-            Block::default()
-                .borders(Borders::ALL)
-                .border_type(BorderType::Rounded),
-        )
+        .block(Block::default().borders(Borders::ALL).border_type(BorderType::Rounded))
         .select(app.active_tab)
         .style(Style::default().fg(Color::DarkGray))
         .highlight_style(Style::default().fg(Color::White).add_modifier(Modifier::BOLD));

--- a/crates/tui/src/control/views/agent_detail.rs
+++ b/crates/tui/src/control/views/agent_detail.rs
@@ -124,7 +124,7 @@ fn render_input(f: &mut Frame, app: &mut App, area: Rect) {
     if app.input_mode {
         let (cursor_row, _) =
             crate::input::cursor_visual_pos(&app.input_buffer, app.input_cursor, inner_width);
-        let visible = area.height.saturating_sub(2) as u16;
+        let visible = area.height.saturating_sub(2);
         if cursor_row < app.input_scroll {
             app.input_scroll = cursor_row;
         }

--- a/crates/tui/src/control/views/agent_detail.rs
+++ b/crates/tui/src/control/views/agent_detail.rs
@@ -61,10 +61,7 @@ fn render_info(f: &mut Frame, app: &App, area: Rect) {
             dim("  backend: "),
             Span::raw(backend),
         ]),
-        Line::from(vec![
-            dim("session: "),
-            Span::raw(session),
-        ]),
+        Line::from(vec![dim("session: "), Span::raw(session)]),
         Line::from(vec![
             dim("dir: "),
             Span::raw(agent.config.working_dir.clone()),
@@ -73,14 +70,13 @@ fn render_info(f: &mut Frame, app: &App, area: Rect) {
         ]),
     ];
 
-    let block = Block::default()
-        .borders(Borders::ALL)
-        .border_type(BorderType::Rounded)
-        .title(if agent.built_in {
+    let block = Block::default().borders(Borders::ALL).border_type(BorderType::Rounded).title(
+        if agent.built_in {
             format!(" {} [system] ", agent.name)
         } else {
             format!(" {} ", agent.name)
-        });
+        },
+    );
 
     let para = Paragraph::new(lines).block(block);
     f.render_widget(para, area);
@@ -98,11 +94,8 @@ fn render_conversation(f: &mut Frame, app: &mut App, area: Rect) {
     let visible = area.height.saturating_sub(2);
     let max_scroll = total_rows.saturating_sub(visible);
 
-    let scroll = if app.conversation_follow {
-        max_scroll
-    } else {
-        app.conversation_scroll.min(max_scroll)
-    };
+    let scroll =
+        if app.conversation_follow { max_scroll } else { app.conversation_scroll.min(max_scroll) };
     app.conversation_scroll = scroll;
 
     if app.conversation_follow {
@@ -110,21 +103,13 @@ fn render_conversation(f: &mut Frame, app: &mut App, area: Rect) {
     }
 
     let count = app.conversation.len();
-    let title = if count == 0 {
-        " Conversation ".to_string()
-    } else {
-        format!(" Conversation ({count}) ")
-    };
+    let title =
+        if count == 0 { " Conversation ".to_string() } else { format!(" Conversation ({count}) ") };
 
-    let block = Block::default()
-        .borders(Borders::ALL)
-        .border_type(BorderType::Rounded)
-        .title(title);
+    let block =
+        Block::default().borders(Borders::ALL).border_type(BorderType::Rounded).title(title);
 
-    let para = Paragraph::new(lines)
-        .block(block)
-        .wrap(Wrap { trim: false })
-        .scroll((scroll, 0));
+    let para = Paragraph::new(lines).block(block).wrap(Wrap { trim: false }).scroll((scroll, 0));
 
     f.render_widget(para, area);
 }
@@ -170,9 +155,7 @@ fn render_input(f: &mut Frame, app: &mut App, area: Rect) {
         vec![]
     };
 
-    let para = Paragraph::new(lines)
-        .block(block)
-        .scroll((app.input_scroll, 0));
+    let para = Paragraph::new(lines).block(block).scroll((app.input_scroll, 0));
 
     f.render_widget(para, area);
 }
@@ -226,13 +209,7 @@ fn build_lines(app: &App, _width: usize) -> Vec<Line<'static>> {
                 if text.trim().is_empty() {
                     lines.push(Line::default());
                 } else {
-                    push_multiline(
-                        &mut lines,
-                        "     ",
-                        Style::default(),
-                        text,
-                        Style::default(),
-                    );
+                    push_multiline(&mut lines, "     ", Style::default(), text, Style::default());
                 }
             }
             "agent:tool_use" => {

--- a/crates/tui/src/control/views/agents.rs
+++ b/crates/tui/src/control/views/agents.rs
@@ -18,9 +18,7 @@ pub fn render(f: &mut Frame, app: &mut App, area: Rect) {
         let status_cell = Cell::from(agent.status.to_string()).style(status_color(&agent.status));
 
         let activity = match agent.activity {
-            ActivityState::Busy => {
-                Span::styled("busy", Style::default().fg(Color::Yellow))
-            }
+            ActivityState::Busy => Span::styled("busy", Style::default().fg(Color::Yellow)),
             ActivityState::Idle => Span::styled("idle", Style::default().fg(Color::DarkGray)),
         };
 
@@ -54,10 +52,8 @@ pub fn render(f: &mut Frame, app: &mut App, area: Rect) {
         Constraint::Min(10),
     ];
 
-    let block = Block::default()
-        .borders(Borders::ALL)
-        .border_type(BorderType::Rounded)
-        .title(" Agents ");
+    let block =
+        Block::default().borders(Borders::ALL).border_type(BorderType::Rounded).title(" Agents ");
 
     let table = Table::new(rows, widths)
         .header(header)

--- a/crates/tui/src/control/views/config.rs
+++ b/crates/tui/src/control/views/config.rs
@@ -60,11 +60,7 @@ pub fn render(f: &mut Frame, app: &mut App, area: Rect) {
     kv(&mut lines, "port", cfg.services.hook.port.to_string());
     kv(&mut lines, "history_size", cfg.services.hook.history_size.to_string());
     kv(&mut lines, "notify_on_failure", cfg.services.hook.notify_on_failure.to_string());
-    kv(
-        &mut lines,
-        "notify_on_long_running",
-        cfg.services.hook.notify_on_long_running.to_string(),
-    );
+    kv(&mut lines, "notify_on_long_running", cfg.services.hook.notify_on_long_running.to_string());
     kv(
         &mut lines,
         "long_running_threshold_ms",

--- a/crates/tui/src/control/views/memories.rs
+++ b/crates/tui/src/control/views/memories.rs
@@ -44,10 +44,8 @@ fn render_list(f: &mut Frame, app: &mut App, area: Rect) {
         } else {
             "No memories found.  r refresh  s search  t filter by tags"
         };
-        let block = Block::default()
-            .borders(Borders::ALL)
-            .border_type(BorderType::Rounded)
-            .title(title);
+        let block =
+            Block::default().borders(Borders::ALL).border_type(BorderType::Rounded).title(title);
         f.render_widget(
             Paragraph::new(Span::styled(msg, Style::default().fg(Color::DarkGray))).block(block),
             area,
@@ -63,11 +61,8 @@ fn render_list(f: &mut Frame, app: &mut App, area: Rect) {
     let rows = app.memories.iter().map(|m| {
         let (badge, badge_style) = type_badge_style(&m.memory_type);
 
-        let tags = if m.tags.is_empty() {
-            "-".to_string()
-        } else {
-            truncate(&m.tags.join(", "), 26)
-        };
+        let tags =
+            if m.tags.is_empty() { "-".to_string() } else { truncate(&m.tags.join(", "), 26) };
 
         let created_by = truncate(&m.created_by, 16);
         let date = format_date_short(m.created_at);
@@ -91,10 +86,8 @@ fn render_list(f: &mut Frame, app: &mut App, area: Rect) {
         Constraint::Min(20),
     ];
 
-    let block = Block::default()
-        .borders(Borders::ALL)
-        .border_type(BorderType::Rounded)
-        .title(title);
+    let block =
+        Block::default().borders(Borders::ALL).border_type(BorderType::Rounded).title(title);
 
     let table = Table::new(rows, widths)
         .header(header)
@@ -189,10 +182,7 @@ fn render_search_dialog(f: &mut Frame, app: &App, area: Rect) {
 
     let lines = vec![
         Line::from(""),
-        Line::from(Span::styled(
-            format!("  > {}_", input),
-            Style::default().fg(Color::White),
-        )),
+        Line::from(Span::styled(format!("  > {}_", input), Style::default().fg(Color::White))),
         Line::from(""),
         Line::from(vec![
             Span::raw("  "),

--- a/crates/tui/src/control/views/workflow_detail.rs
+++ b/crates/tui/src/control/views/workflow_detail.rs
@@ -46,28 +46,16 @@ fn render_info(f: &mut Frame, app: &App, area: Rect) {
     };
 
     let lbl = |s: &str| -> Span<'static> {
-        Span::styled(
-            format!("{s:<16}"),
-            Style::default().fg(Color::DarkGray),
-        )
+        Span::styled(format!("{s:<16}"), Style::default().fg(Color::DarkGray))
     };
 
     let lines = vec![
         Line::from(vec![lbl("name"), Span::raw(wf.name.clone())]),
         Line::from(vec![lbl("id"), Span::raw(wf.id.to_string())]),
         Line::from(vec![lbl("agent"), Span::raw(agent_name)]),
-        Line::from(vec![
-            lbl("trigger"),
-            Span::raw(wf.trigger_config.trigger_type()),
-        ]),
-        Line::from(vec![
-            lbl("poll interval"),
-            Span::raw(format!("{}s", wf.poll_interval_secs)),
-        ]),
-        Line::from(vec![
-            lbl("enabled"),
-            Span::styled(enabled_text, enabled_style),
-        ]),
+        Line::from(vec![lbl("trigger"), Span::raw(wf.trigger_config.trigger_type())]),
+        Line::from(vec![lbl("poll interval"), Span::raw(format!("{}s", wf.poll_interval_secs))]),
+        Line::from(vec![lbl("enabled"), Span::styled(enabled_text, enabled_style)]),
         Line::from(vec![
             lbl("created"),
             Span::raw(wf.created_at.format("%Y-%m-%d %H:%M UTC").to_string()),
@@ -100,15 +88,9 @@ fn render_template(f: &mut Frame, app: &mut App, area: Rect) {
     app.workflow_template_scroll = app.workflow_template_scroll.min(max_scroll);
 
     let (border_style, title) = if focused {
-        (
-            Style::default().fg(Color::Cyan),
-            " Prompt Template (↑/↓ scroll  t unfocus) ",
-        )
+        (Style::default().fg(Color::Cyan), " Prompt Template (↑/↓ scroll  t unfocus) ")
     } else {
-        (
-            Style::default(),
-            " Prompt Template (t to focus) ",
-        )
+        (Style::default(), " Prompt Template (t to focus) ")
     };
 
     let block = Block::default()
@@ -129,15 +111,9 @@ fn render_dispatches(f: &mut Frame, app: &mut App, area: Rect) {
     let focused = app.workflow_focus == WorkflowFocus::Dispatches;
 
     let (border_style, title) = if focused {
-        (
-            Style::default().fg(Color::Cyan),
-            " Dispatch History (↑/↓ scroll  d unfocus) ",
-        )
+        (Style::default().fg(Color::Cyan), " Dispatch History (↑/↓ scroll  d unfocus) ")
     } else {
-        (
-            Style::default(),
-            " Dispatch History (d to focus) ",
-        )
+        (Style::default(), " Dispatch History (d to focus) ")
     };
 
     let block = Block::default()
@@ -165,9 +141,10 @@ fn render_dispatches(f: &mut Frame, app: &mut App, area: Rect) {
     app.workflow_dispatch_scroll = (app.workflow_dispatch_scroll as usize).min(max_scroll) as u16;
     let offset = app.workflow_dispatch_scroll as usize;
 
-    let header = Row::new(["Source", "Status", "Dispatched", "Duration"].map(|h| {
-        Cell::from(h).style(Style::default().add_modifier(Modifier::BOLD))
-    }))
+    let header = Row::new(
+        ["Source", "Status", "Dispatched", "Duration"]
+            .map(|h| Cell::from(h).style(Style::default().add_modifier(Modifier::BOLD))),
+    )
     .height(1)
     .bottom_margin(1);
 

--- a/crates/tui/src/input.rs
+++ b/crates/tui/src/input.rs
@@ -51,11 +51,8 @@ pub fn cursor_visual_pos(buffer: &str, cursor: usize, inner_width: usize) -> (u1
     let row_within = (col_in_logical / line_w) as u16;
     visual_row = visual_row.saturating_add(row_within);
     let col_in_row = col_in_logical % line_w;
-    let col = if logical_idx == 0 && row_within == 0 {
-        col_in_row + PREFIX_LEN
-    } else {
-        col_in_row
-    };
+    let col =
+        if logical_idx == 0 && row_within == 0 { col_in_row + PREFIX_LEN } else { col_in_row };
 
     (visual_row, col as u16)
 }
@@ -83,11 +80,8 @@ pub fn visual_pos_to_byte(
             let col_in_logical =
                 col_logical_start + (target_col as usize).saturating_sub(prefix_here);
             let char_idx = col_in_logical.min(char_count);
-            let byte_in_line = lline
-                .char_indices()
-                .nth(char_idx)
-                .map(|(b, _)| b)
-                .unwrap_or(lline.len());
+            let byte_in_line =
+                lline.char_indices().nth(char_idx).map(|(b, _)| b).unwrap_or(lline.len());
             return byte_start + byte_in_line;
         }
 
@@ -100,12 +94,7 @@ pub fn visual_pos_to_byte(
 
 /// Moves the byte cursor up (`delta < 0`) or down (`delta > 0`) by visual rows.
 /// Returns the new byte offset. If already at the first/last row, returns unchanged.
-pub fn cursor_move_vertical(
-    buffer: &str,
-    cursor: usize,
-    delta: i16,
-    inner_width: usize,
-) -> usize {
+pub fn cursor_move_vertical(buffer: &str, cursor: usize, delta: i16, inner_width: usize) -> usize {
     let (row, col) = cursor_visual_pos(buffer, cursor, inner_width);
     let max_row = compute_input_rows(buffer, inner_width).saturating_sub(1);
     let target_row = ((row as i16 + delta).max(0) as u16).min(max_row);
@@ -135,11 +124,7 @@ pub fn build_input_display_lines(
     let mut display_row = 0u16;
 
     for (li, lline) in buffer.split('\n').enumerate() {
-        let (w, row_prefix) = if li == 0 {
-            (first_w, PREFIX)
-        } else {
-            (inner_width.max(1), "")
-        };
+        let (w, row_prefix) = if li == 0 { (first_w, PREFIX) } else { (inner_width.max(1), "") };
         let chars: Vec<char> = lline.chars().collect();
         let total = chars.len();
         let mut pos = 0usize;
@@ -148,8 +133,7 @@ pub fn build_input_display_lines(
             let end = (pos + w).min(total);
             let chunk: &[char] = &chars[pos..end];
             let prefix_for_row = if pos == 0 { row_prefix } else { "" };
-            let row_str: String =
-                format!("{}{}", prefix_for_row, chunk.iter().collect::<String>());
+            let row_str: String = format!("{}{}", prefix_for_row, chunk.iter().collect::<String>());
 
             let line = match cursor_pos {
                 Some((crow, ccol)) if crow == display_row => {

--- a/crates/tui/src/input.rs
+++ b/crates/tui/src/input.rs
@@ -41,9 +41,9 @@ pub fn cursor_visual_pos(buffer: &str, cursor: usize, inner_width: usize) -> (u1
 
     let all_logical: Vec<&str> = buffer.split('\n').collect();
     let mut visual_row = 0u16;
-    for i in 0..logical_idx {
+    for (i, line) in all_logical.iter().enumerate().take(logical_idx) {
         let w = if i == 0 { first_w } else { inner_width.max(1) };
-        let n = all_logical[i].chars().count().max(1);
+        let n = line.chars().count().max(1);
         visual_row = visual_row.saturating_add(n.div_ceil(w) as u16);
     }
 

--- a/crates/tui/src/lib.rs
+++ b/crates/tui/src/lib.rs
@@ -1,8 +1,8 @@
-pub mod control;
-mod manager;
 pub mod config;
+pub mod control;
 pub mod event;
 pub mod input;
+mod manager;
 
 use anyhow::Result;
 use crossterm::{

--- a/crates/tui/src/manager/app.rs
+++ b/crates/tui/src/manager/app.rs
@@ -163,15 +163,16 @@ impl ManagerApp {
     }
 
     pub fn tab_count(&self) -> usize {
-        if self.metrics_available { 4 } else { 3 }
+        if self.metrics_available {
+            4
+        } else {
+            3
+        }
     }
 
     pub fn tab_labels(&self) -> Vec<String> {
-        let mut labels = vec![
-            " Services ".to_string(),
-            " Logs ".to_string(),
-            " Config ".to_string(),
-        ];
+        let mut labels =
+            vec![" Services ".to_string(), " Logs ".to_string(), " Config ".to_string()];
         if self.metrics_available {
             labels.push(" Metrics ".to_string());
         }
@@ -192,7 +193,9 @@ impl ManagerApp {
         match self.view {
             ManagerView::Services => {
                 let len = self.services.len();
-                if len == 0 { return; }
+                if len == 0 {
+                    return;
+                }
                 let next = self.service_table_state.selected().map_or(0, |i| (i + 1).min(len - 1));
                 self.service_table_state.select(Some(next));
             }
@@ -212,7 +215,9 @@ impl ManagerApp {
     fn navigate_up(&mut self) {
         match self.view {
             ManagerView::Services => {
-                if self.services.is_empty() { return; }
+                if self.services.is_empty() {
+                    return;
+                }
                 let prev = self.service_table_state.selected().map_or(0, |i| i.saturating_sub(1));
                 self.service_table_state.select(Some(prev));
             }
@@ -318,14 +323,20 @@ impl ManagerApp {
         if self.view == ManagerView::Config {
             if let Some(ref mut draft) = self.config_edit {
                 match key.code {
-                    KeyCode::Char(c) => { draft.push(c); }
-                    KeyCode::Backspace => { draft.pop(); }
+                    KeyCode::Char(c) => {
+                        draft.push(c);
+                    }
+                    KeyCode::Backspace => {
+                        draft.pop();
+                    }
                     KeyCode::Enter => {
                         let value = draft.clone();
                         self.apply_config_edit(value);
                         self.config_edit = None;
                     }
-                    KeyCode::Esc => { self.config_edit = None; }
+                    KeyCode::Esc => {
+                        self.config_edit = None;
+                    }
                     _ => {}
                 }
                 return false;
@@ -335,8 +346,12 @@ impl ManagerApp {
         // Log source picker
         if let Some(ref mut input) = self.log_source_input {
             match key.code {
-                KeyCode::Char(c) => { input.push(c); }
-                KeyCode::Backspace => { input.pop(); }
+                KeyCode::Char(c) => {
+                    input.push(c);
+                }
+                KeyCode::Backspace => {
+                    input.pop();
+                }
                 KeyCode::Enter => {
                     let path = input.trim().to_string();
                     if path.is_empty() {
@@ -348,7 +363,9 @@ impl ManagerApp {
                     }
                     self.log_source_input = None;
                 }
-                KeyCode::Esc => { self.log_source_input = None; }
+                KeyCode::Esc => {
+                    self.log_source_input = None;
+                }
                 _ => {}
             }
             return false;
@@ -399,14 +416,18 @@ impl ManagerApp {
                     self.execute_metric_query().await;
                     self.metric_input_active = false;
                 }
-                KeyCode::Esc => { self.metric_input_active = false; }
+                KeyCode::Esc => {
+                    self.metric_input_active = false;
+                }
                 _ => {}
             }
             return false;
         }
 
         match key.code {
-            KeyCode::Char('q') => { self.quitting = true; }
+            KeyCode::Char('q') => {
+                self.quitting = true;
+            }
             KeyCode::Tab => self.switch_tab(true),
             KeyCode::BackTab => self.switch_tab(false),
             KeyCode::Char('1') => {
@@ -427,7 +448,9 @@ impl ManagerApp {
             }
             KeyCode::Down | KeyCode::Char('j') => self.navigate_down(),
             KeyCode::Up | KeyCode::Char('k') => self.navigate_up(),
-            KeyCode::Char('r') => { self.refresh().await; }
+            KeyCode::Char('r') => {
+                self.refresh().await;
+            }
             // Config: start editing selected field
             KeyCode::Char('e') if self.view == ManagerView::Config => {
                 if let Some((_, ref val)) = self.config_fields.get(self.config_selected).cloned() {
@@ -464,9 +487,7 @@ impl ManagerApp {
     }
 
     pub fn secs_until_refresh(&self) -> u64 {
-        self.refresh_interval
-            .saturating_sub(self.last_refresh.elapsed())
-            .as_secs()
+        self.refresh_interval.saturating_sub(self.last_refresh.elapsed()).as_secs()
     }
 }
 
@@ -489,10 +510,7 @@ fn build_config_fields(config: &TuiConfig) -> Vec<(String, String)> {
 }
 
 async fn check_prometheus(url: &str) -> bool {
-    let client = match reqwest::Client::builder()
-        .timeout(Duration::from_secs(2))
-        .build()
-    {
+    let client = match reqwest::Client::builder().timeout(Duration::from_secs(2)).build() {
         Ok(c) => c,
         Err(_) => return false,
     };
@@ -505,9 +523,7 @@ async fn check_prometheus(url: &str) -> bool {
 }
 
 async fn query_prometheus(url: &str, query: &str) -> anyhow::Result<Vec<MetricSample>> {
-    let client = reqwest::Client::builder()
-        .timeout(Duration::from_secs(5))
-        .build()?;
+    let client = reqwest::Client::builder().timeout(Duration::from_secs(5)).build()?;
     let resp = client.get(url).query(&[("query", query)]).send().await?;
     let json: serde_json::Value = resp.json().await?;
 
@@ -518,9 +534,7 @@ async fn query_prometheus(url: &str, query: &str) -> anyhow::Result<Vec<MetricSa
             let metric_labels: Vec<String> = r["metric"]
                 .as_object()
                 .map(|m| {
-                    m.iter()
-                        .map(|(k, v)| format!("{k}={}", v.as_str().unwrap_or("")))
-                        .collect()
+                    m.iter().map(|(k, v)| format!("{k}={}", v.as_str().unwrap_or(""))).collect()
                 })
                 .unwrap_or_default();
             let metric = if metric_labels.is_empty() {
@@ -545,14 +559,14 @@ async fn query_prometheus(url: &str, query: &str) -> anyhow::Result<Vec<MetricSa
 
 const SERVICE_DEFS: &[(&str, &str, &str)] = &[
     ("orchestrator", "AGENTD_ORCHESTRATOR_SERVICE_URL", "http://localhost:17006"),
-    ("notify",       "AGENTD_NOTIFY_SERVICE_URL",       "http://localhost:17004"),
-    ("ask",          "AGENTD_ASK_SERVICE_URL",           "http://localhost:17001"),
-    ("wrap",         "AGENTD_WRAP_SERVICE_URL",          "http://localhost:17005"),
-    ("hook",         "AGENTD_HOOK_SERVICE_URL",          "http://localhost:17002"),
-    ("monitor",      "AGENTD_MONITOR_SERVICE_URL",       "http://localhost:17003"),
-    ("memory",       "AGENTD_MEMORY_SERVICE_URL",        "http://localhost:17008"),
-    ("core",         "AGENTD_CORE_SERVICE_URL",          "http://localhost:17000"),
-    ("communicate",  "AGENTD_COMMUNICATE_SERVICE_URL",   "http://localhost:17010"),
+    ("notify", "AGENTD_NOTIFY_SERVICE_URL", "http://localhost:17004"),
+    ("ask", "AGENTD_ASK_SERVICE_URL", "http://localhost:17001"),
+    ("wrap", "AGENTD_WRAP_SERVICE_URL", "http://localhost:17005"),
+    ("hook", "AGENTD_HOOK_SERVICE_URL", "http://localhost:17002"),
+    ("monitor", "AGENTD_MONITOR_SERVICE_URL", "http://localhost:17003"),
+    ("memory", "AGENTD_MEMORY_SERVICE_URL", "http://localhost:17008"),
+    ("core", "AGENTD_CORE_SERVICE_URL", "http://localhost:17000"),
+    ("communicate", "AGENTD_COMMUNICATE_SERVICE_URL", "http://localhost:17010"),
 ];
 
 async fn probe_services(config: &TuiConfig) -> Vec<ServiceStatus> {
@@ -579,10 +593,7 @@ async fn probe_services(config: &TuiConfig) -> Vec<ServiceStatus> {
         })
         .collect();
 
-    let client = match reqwest::Client::builder()
-        .timeout(Duration::from_secs(2))
-        .build()
-    {
+    let client = match reqwest::Client::builder().timeout(Duration::from_secs(2)).build() {
         Ok(c) => c,
         Err(_) => {
             return urls

--- a/crates/tui/src/manager/ui.rs
+++ b/crates/tui/src/manager/ui.rs
@@ -48,10 +48,7 @@ fn render_header(f: &mut Frame, app: &ManagerApp, area: Rect) {
         Span::styled(format!(" {text}  "), Style::default().fg(Color::Red))
     } else {
         let secs = app.secs_until_refresh();
-        Span::styled(
-            format!(" refresh in {secs}s  "),
-            Style::default().fg(Color::DarkGray),
-        )
+        Span::styled(format!(" refresh in {secs}s  "), Style::default().fg(Color::DarkGray))
     };
 
     f.render_widget(Paragraph::new(right).alignment(Alignment::Right), cols[1]);
@@ -61,11 +58,7 @@ fn render_tabs(f: &mut Frame, app: &ManagerApp, area: Rect) {
     let labels: Vec<Line> = app.tab_labels().into_iter().map(Line::from).collect();
 
     let tabs = Tabs::new(labels)
-        .block(
-            Block::default()
-                .borders(Borders::ALL)
-                .border_type(BorderType::Rounded),
-        )
+        .block(Block::default().borders(Borders::ALL).border_type(BorderType::Rounded))
         .select(app.active_tab)
         .style(Style::default().fg(Color::DarkGray))
         .highlight_style(Style::default().fg(Color::White).add_modifier(Modifier::BOLD));

--- a/crates/tui/src/manager/views/config.rs
+++ b/crates/tui/src/manager/views/config.rs
@@ -26,11 +26,7 @@ pub fn render(f: &mut Frame, app: &ManagerApp, area: Rect) {
         })
         .collect();
 
-    let table = Table::new(
-        rows,
-        [Constraint::Length(24), Constraint::Min(20)],
-    )
-    .block(
+    let table = Table::new(rows, [Constraint::Length(24), Constraint::Min(20)]).block(
         Block::default()
             .borders(Borders::ALL)
             .border_type(BorderType::Rounded)

--- a/crates/tui/src/manager/views/logs.rs
+++ b/crates/tui/src/manager/views/logs.rs
@@ -10,10 +10,7 @@ use ratatui::{
 pub fn render(f: &mut Frame, app: &ManagerApp, area: Rect) {
     let source_label = match &app.log_source {
         LogSource::None => Span::styled(" no source set", Style::default().fg(Color::DarkGray)),
-        LogSource::File(p) => Span::styled(
-            format!(" {p}"),
-            Style::default().fg(Color::Cyan),
-        ),
+        LogSource::File(p) => Span::styled(format!(" {p}"), Style::default().fg(Color::Cyan)),
     };
 
     let chunks = Layout::default()
@@ -29,11 +26,7 @@ pub fn render(f: &mut Frame, app: &ManagerApp, area: Rect) {
     );
     f.render_widget(source_block, chunks[0]);
 
-    let lines: Vec<Line> = app
-        .log_lines
-        .iter()
-        .map(|l| Line::from(Span::raw(l.clone())))
-        .collect();
+    let lines: Vec<Line> = app.log_lines.iter().map(|l| Line::from(Span::raw(l.clone()))).collect();
 
     let total = lines.len() as u16;
     let height = chunks[1].height.saturating_sub(2);
@@ -46,10 +39,7 @@ pub fn render(f: &mut Frame, app: &ManagerApp, area: Rect) {
 
     let log_block = Paragraph::new(lines)
         .block(
-            Block::default()
-                .borders(Borders::ALL)
-                .border_type(BorderType::Rounded)
-                .title(" Logs "),
+            Block::default().borders(Borders::ALL).border_type(BorderType::Rounded).title(" Logs "),
         )
         .wrap(Wrap { trim: false })
         .scroll((scroll, 0));
@@ -91,10 +81,7 @@ fn render_source_input(f: &mut Frame, input: &str, area: Rect) {
         inner[0],
     );
     f.render_widget(
-        Paragraph::new(Span::styled(
-            input,
-            Style::default().fg(Color::White),
-        )),
+        Paragraph::new(Span::styled(input, Style::default().fg(Color::White))),
         inner[1],
     );
 }

--- a/crates/tui/src/manager/views/metrics.rs
+++ b/crates/tui/src/manager/views/metrics.rs
@@ -24,15 +24,9 @@ pub fn render(f: &mut Frame, app: &ManagerApp, area: Rect) {
 
 fn render_query_bar(f: &mut Frame, app: &ManagerApp, area: Rect) {
     let (query_style, border_style) = if app.metric_input_active {
-        (
-            Style::default().fg(Color::White),
-            Style::default().fg(Color::Yellow),
-        )
+        (Style::default().fg(Color::White), Style::default().fg(Color::Yellow))
     } else {
-        (
-            Style::default().fg(Color::DarkGray),
-            Style::default().fg(Color::DarkGray),
-        )
+        (Style::default().fg(Color::DarkGray), Style::default().fg(Color::DarkGray))
     };
 
     let mut spans = vec![
@@ -99,25 +93,20 @@ fn render_results(f: &mut Frame, app: &ManagerApp, area: Rect) {
                     s.value.clone(),
                     Style::default().fg(Color::White).add_modifier(Modifier::BOLD),
                 )),
-                Cell::from(Span::styled(
-                    s.timestamp.clone(),
-                    Style::default().fg(Color::DarkGray),
-                )),
+                Cell::from(Span::styled(s.timestamp.clone(), Style::default().fg(Color::DarkGray))),
             ])
         })
         .collect();
 
-    let table = Table::new(
-        rows,
-        [Constraint::Min(30), Constraint::Length(16), Constraint::Length(14)],
-    )
-    .header(header)
-    .block(
-        Block::default()
-            .borders(Borders::ALL)
-            .border_type(BorderType::Rounded)
-            .title(format!(" Results ({}) ", app.metric_results.len())),
-    );
+    let table =
+        Table::new(rows, [Constraint::Min(30), Constraint::Length(16), Constraint::Length(14)])
+            .header(header)
+            .block(
+                Block::default()
+                    .borders(Borders::ALL)
+                    .border_type(BorderType::Rounded)
+                    .title(format!(" Results ({}) ", app.metric_results.len())),
+            );
 
     f.render_widget(table, area);
 }
@@ -155,21 +144,17 @@ fn render_query_picker(f: &mut Frame, app: &ManagerApp, area: Rect) {
 
     // Filter row
     let filter_prefix = if picker.filter_active {
-        Span::styled(
-            "Filter: ",
-            Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD),
-        )
+        Span::styled("Filter: ", Style::default().fg(Color::Yellow).add_modifier(Modifier::BOLD))
     } else {
         Span::styled("Filter: ", Style::default().fg(Color::DarkGray))
     };
-    let mut filter_spans = vec![filter_prefix, Span::styled(&picker.filter, Style::default().fg(Color::White))];
+    let mut filter_spans =
+        vec![filter_prefix, Span::styled(&picker.filter, Style::default().fg(Color::White))];
     if picker.filter_active {
         filter_spans.push(Span::styled("█", Style::default().fg(Color::Yellow)));
     } else if picker.filter.is_empty() {
-        filter_spans.push(Span::styled(
-            "(press / to filter)",
-            Style::default().fg(Color::DarkGray),
-        ));
+        filter_spans
+            .push(Span::styled("(press / to filter)", Style::default().fg(Color::DarkGray)));
     }
     f.render_widget(Paragraph::new(Line::from(filter_spans)), inner[0]);
 
@@ -202,14 +187,8 @@ fn render_query_picker(f: &mut Frame, app: &ManagerApp, area: Rect) {
         })
         .collect();
 
-    let table = Table::new(
-        rows,
-        [
-            Constraint::Length(14),
-            Constraint::Length(32),
-            Constraint::Min(20),
-        ],
-    );
+    let table =
+        Table::new(rows, [Constraint::Length(14), Constraint::Length(32), Constraint::Min(20)]);
     f.render_widget(table, inner[1]);
 
     // Hint row

--- a/crates/tui/src/manager/views/services.rs
+++ b/crates/tui/src/manager/views/services.rs
@@ -29,17 +29,11 @@ pub fn render(f: &mut Frame, app: &mut ManagerApp, area: Rect) {
                     } else {
                         reason.clone()
                     };
-                    (
-                        "down",
-                        Style::default().fg(Color::Red).add_modifier(Modifier::BOLD),
-                        reason,
-                    )
+                    ("down", Style::default().fg(Color::Red).add_modifier(Modifier::BOLD), reason)
                 }
-                ServiceState::Unknown => (
-                    "unknown",
-                    Style::default().fg(Color::DarkGray),
-                    String::new(),
-                ),
+                ServiceState::Unknown => {
+                    ("unknown", Style::default().fg(Color::DarkGray), String::new())
+                }
             };
 
             Row::new(vec![
@@ -62,10 +56,7 @@ pub fn render(f: &mut Frame, app: &mut ManagerApp, area: Rect) {
     )
     .header(header)
     .block(
-        Block::default()
-            .borders(Borders::ALL)
-            .border_type(BorderType::Rounded)
-            .title(" Services "),
+        Block::default().borders(Borders::ALL).border_type(BorderType::Rounded).title(" Services "),
     )
     .row_highlight_style(Style::default().add_modifier(Modifier::REVERSED));
 

--- a/crates/xtask/src/install_config.rs
+++ b/crates/xtask/src/install_config.rs
@@ -49,17 +49,11 @@ fn build_install_defaults(services: &[ServiceInfo]) -> toml::Value {
     use toml::map::Map;
     use toml::Value;
 
-    let orchestrator_port = services
-        .iter()
-        .find(|s| s.name == "orchestrator")
-        .map(|s| s.port)
-        .unwrap_or(7006);
+    let orchestrator_port =
+        services.iter().find(|s| s.name == "orchestrator").map(|s| s.port).unwrap_or(7006);
 
-    let communicate_port = services
-        .iter()
-        .find(|s| s.name == "communicate")
-        .map(|s| s.port)
-        .unwrap_or(7010);
+    let communicate_port =
+        services.iter().find(|s| s.name == "communicate").map(|s| s.port).unwrap_or(7010);
 
     let mut services_map = Map::new();
 
@@ -125,9 +119,24 @@ mod tests {
 
     fn test_services() -> Vec<ServiceInfo> {
         vec![
-            ServiceInfo { name: "ask", binary: "agentd-ask", port: 7001, port_env: "AGENTD_ASK_PORT" },
-            ServiceInfo { name: "notify", binary: "agentd-notify", port: 7004, port_env: "AGENTD_NOTIFY_PORT" },
-            ServiceInfo { name: "wrap", binary: "agentd-wrap", port: 7005, port_env: "AGENTD_WRAP_PORT" },
+            ServiceInfo {
+                name: "ask",
+                binary: "agentd-ask",
+                port: 7001,
+                port_env: "AGENTD_ASK_PORT",
+            },
+            ServiceInfo {
+                name: "notify",
+                binary: "agentd-notify",
+                port: 7004,
+                port_env: "AGENTD_NOTIFY_PORT",
+            },
+            ServiceInfo {
+                name: "wrap",
+                binary: "agentd-wrap",
+                port: 7005,
+                port_env: "AGENTD_WRAP_PORT",
+            },
             ServiceInfo {
                 name: "orchestrator",
                 binary: "agentd-orchestrator",
@@ -180,21 +189,21 @@ mod tests {
         let svcs = test_services();
         let defaults = build_install_defaults(&svcs);
         let services = defaults["services"].as_table().unwrap();
-        assert_eq!(
-            services["ask"]["orchestrator_url"].as_str(),
-            Some("http://localhost:7006")
-        );
+        assert_eq!(services["ask"]["orchestrator_url"].as_str(), Some("http://localhost:7006"));
     }
 
     #[test]
     fn test_merge_fills_gaps() {
-        let mut base: toml::Value = toml::from_str(r#"
+        let mut base: toml::Value = toml::from_str(
+            r#"
             [services.wrap]
             backend = "docker"
-        "#)
+        "#,
+        )
         .unwrap();
 
-        let defaults: toml::Value = toml::from_str(r#"
+        let defaults: toml::Value = toml::from_str(
+            r#"
             [services.wrap]
             port = 7005
             backend = "subprocess"
@@ -202,7 +211,8 @@ mod tests {
             [services.orchestrator]
             port = 7006
             backend = "subprocess"
-        "#)
+        "#,
+        )
         .unwrap();
 
         merge_toml_defaults(&mut base, defaults);
@@ -219,14 +229,15 @@ mod tests {
 
     #[test]
     fn test_merge_preserves_unrelated_sections() {
-        let mut base: toml::Value = toml::from_str(r#"
+        let mut base: toml::Value = toml::from_str(
+            r#"
             [linear]
             api_key = "lin_api_secret"
-        "#)
+        "#,
+        )
         .unwrap();
 
-        let defaults: toml::Value =
-            toml::from_str("[services.wrap]\nport = 7005\n").unwrap();
+        let defaults: toml::Value = toml::from_str("[services.wrap]\nport = 7005\n").unwrap();
 
         merge_toml_defaults(&mut base, defaults);
 

--- a/crates/xtask/src/platform/mod.rs
+++ b/crates/xtask/src/platform/mod.rs
@@ -20,6 +20,7 @@ pub struct ServiceInfo {
     /// Production port number.
     pub port: u16,
     /// Environment variable name used to override the port (e.g. "AGENTD_NOTIFY_PORT").
+    #[allow(dead_code)]
     pub port_env: &'static str,
 }
 


### PR DESCRIPTION
When an agent fails and its workflow runners time out waiting for it to reconnect (the 60-second startup window in `resume_workflows`), no runner is ever started for those workflows. If the agent is later restarted via the API, UI, or reconciliation, the workflows remain dead -- no polling, no dispatches.

## Changes

- **`scheduler/events.rs`**: Add `AgentRestarted { agent_id }` to `SystemEvent`. Published by `restart_agent` after the new process is launched and the DB record is updated.
- **`manager.rs`**: Publish `SystemEvent::AgentRestarted` at the end of `restart_agent` (via `self.registry.event_bus()`). This covers all restart paths: API, reconcile, bootstrap, and `clear_context`.
- **`scheduler/mod.rs`**: Add `Scheduler::restart_workflows_for_agent` which lists all enabled workflows for the agent, skips any with active runners (idempotent), and calls `start_workflow` for the dead ones.
- **`main.rs`**: Subscribe to `AgentRestarted` events in a background task that calls `restart_workflows_for_agent` reactively.
- **`config.rs`**: Fix two `OrchestratorConfig` test initializers that were missing the `backend` field, causing the test binary to fail to compile.

## How it works

1. Agent fails → 60s timeout → runner exits → `runners` map has no entry for the workflow
2. Agent is restarted via `POST /agents/{id}/restart`
3. `restart_agent` succeeds → publishes `AgentRestarted { agent_id }`
4. Event subscriber calls `restart_workflows_for_agent(agent_id)`
5. Method finds the enabled workflow with no active runner → calls `start_workflow`
6. Runner starts and begins polling its task source; dispatches once the agent connects

Closes #1103