### PR TITLE
feat(ui): overhaul dashboard with theme-aware charts, auto-refresh, and system metrics

### DIFF
--- a/docs/instrumentation.md
+++ b/docs/instrumentation.md
@@ -1,0 +1,268 @@
+# Instrumentation and API Exposure Gaps
+
+This document tracks areas of the service APIs that would benefit from additional
+tracking, aggregation, or exposure. It was produced during a review of the service
+crate APIs (`crates/*`) against the needs of the dashboard UI (`ui/`). Each item
+lists the gap, a proposed change, and the dashboard or operational capability it
+would unlock.
+
+Related: the Prometheus/Grafana stack documented in
+[`docs/observability/`](observability/README.md) already scrapes the services'
+Prometheus metrics. This document focuses on what the *APIs* expose, since the
+web dashboard consumes JSON endpoints directly rather than PromQL.
+
+The dashboard currently works around several of these gaps by fetching full list
+endpoints and aggregating client-side (counting statuses, bucketing `created_at`
+timestamps by hour). That works at today's data volumes but does not scale: it
+transfers full rows to compute a single number, and it is capped by pagination
+limits (`limit` max 200), so counts silently saturate once a list exceeds one page.
+
+## Cross-cutting
+
+### 1. Aggregate stats endpoints
+
+Only `notify` (`GET /notifications/count`) and orchestrator queues
+(`GET /queues/{name}/stats`) expose aggregate counts. Every other "how many X by
+status" question requires listing and counting client-side.
+
+**Proposed:** a `GET /stats` (or `/counts`) endpoint per service returning counts
+grouped by status:
+
+- orchestrator: agents by status, approvals by status, workflows enabled/disabled,
+  dispatches by outcome (last 24h / 7d)
+- ask: questions by status (`pending`, `answered`, `dismissed`)
+- communicate: rooms, participants, messages totals
+- memory: memories by type and visibility
+
+**Unlocks:** accurate overview stat cards with one cheap request per service, no
+pagination saturation.
+
+### 2. Time-bucketed activity endpoints
+
+All major entities carry `created_at`/`updated_at`, but no service can return
+counts bucketed over time. The dashboard's activity-over-time chart buckets
+client-side from list responses, which is both expensive and truncated to the
+first page of results.
+
+**Proposed:** `GET /stats/activity?bucket=hour&since=<rfc3339>` per service
+returning `[{ bucket: "2026-06-10T14:00:00Z", count: n }]`. Highest value in:
+
+- notify (notifications created)
+- ask (questions created / answered)
+- orchestrator (dispatches started / completed, agent state transitions)
+- communicate (messages sent)
+- hook (commands run, failures)
+
+**Unlocks:** correct, cheap time-series charts of system activity at any volume.
+
+### 2b. Unified event / audit feed
+
+Related but distinct from bucketed counts: the dashboard's "recent activity" feed
+is synthesized client-side from four list endpoints (notifications, questions,
+agents, and notification history). Beyond the request overhead, this only sees the
+*latest* state of each row - an agent that transitioned twice within a poll
+interval appears once, and past transitions are invisible.
+
+**Proposed:** a `GET /events?since=<rfc3339>&limit=` feed (orchestrator is the
+natural home) recording state *transitions* as append-only events: agent status
+changes, dispatch start/finish, approval created/resolved, notification created.
+
+**Unlocks:** an accurate activity feed from one request instead of four polls;
+no missed transitions.
+
+### 3. Uptime / started_at in health responses
+
+`HealthResponse` has a `details` map but no service reports its start time or
+uptime, so the UI cannot show "restarted 2 min ago" or flag crash loops.
+
+**Proposed:** include `started_at` (RFC3339) and `uptime_secs` in every service's
+`/health` details.
+
+**Unlocks:** uptime column in the service health grid; restart detection.
+
+### 4. Mirror key Prometheus gauges in JSON
+
+Services register rich metrics with the `metrics` crate (counters like
+`agents_created_total`, gauges like `approvals_pending`), and Prometheus scrapes
+them (see [`docs/observability/`](observability/README.md)). However, the web
+dashboard does not consume Prometheus format, so none of those values are
+reachable from the UI. The most useful gauges should also be surfaced through
+plain JSON endpoints (see item 1) so both consumers see the same numbers.
+
+## orchestrator
+
+### 5. Dispatch / workflow outcome aggregates
+
+`GET /workflows/{id}/history` returns paginated dispatches per workflow, but there
+is no aggregate view: no success/failure rate, no average runtime, no global
+"dispatches in the last 24h" across workflows.
+
+**Proposed:**
+
+- `GET /dispatches?since=&status=` - global dispatch list (currently reachable
+  only per-workflow)
+- `GET /dispatches/stats` - counts by outcome, average/percentile duration,
+  bucketed by hour
+- metrics: `dispatches_total{outcome}`, `dispatch_duration_seconds` histogram
+
+**Unlocks:** a workflow pipeline health panel (success rate, throughput, slowest
+workflows) - currently impossible without N+1 history requests.
+
+### 6. Agent failure tracking
+
+Agent status is a point-in-time value. There is no counter of failures, restarts
+per agent, or last-error reason exposed via the API (`agents_restarted_total`
+exists as a metric but is not queryable per agent).
+
+**Proposed:** per-agent `failure_count`, `restart_count`, `last_error`,
+`last_state_change_at` fields on `AgentResponse` (or a `GET /agents/{id}/stats`),
+plus `agents_failed_total{agent}` counter.
+
+**Unlocks:** "which agents are flapping" on the dashboard; alerting on crash loops.
+
+### 7. Approval latency
+
+Approvals expose `created_at` but not resolution time, so approval SLA (how long
+requests wait for a human) cannot be charted.
+
+**Proposed:** add `resolved_at` to `PendingApproval`; metric
+`approval_resolution_seconds` histogram; include average pending age in
+`GET /approvals` responses or a stats endpoint.
+
+**Unlocks:** "approvals waiting > 1h" alerts and a latency trend chart.
+
+### 8. Per-agent usage history and aggregate usage
+
+`GET /agents/{id}/usage` returns lifetime totals (tokens, cost). There is no
+history, so cost over time and cost per day cannot be charted. There is also no
+cross-agent aggregate: the dashboard's "total cost" stat issues one usage request
+per agent on every poll (up to 200 requests every 30 seconds at the pagination
+cap).
+
+**Proposed:** persist usage snapshots (or deltas per session) and expose
+`GET /agents/{id}/usage/history?bucket=day`; aggregate cross-agent endpoint
+`GET /usage/stats`.
+
+**Unlocks:** cost trend chart, per-agent cost ranking, budget alerting.
+
+## monitor
+
+### 9. History durability and query parameters
+
+`GET /history` returns the in-memory ring buffer: it is lost on restart, has a
+fixed size (120 snapshots, about one hour at the 30s collection interval), and
+supports no `since`/`limit`/downsampling parameters. The dashboard charts
+whatever happens to be in the buffer; a true 24h system-metrics chart is not
+possible today.
+
+**Proposed:** `since`, `limit`, and `step` (downsample) query params; optionally
+persist snapshots to SQLite like the other services so history survives restarts.
+
+**Unlocks:** stable 24h system charts regardless of service restarts; cheap
+long-range queries.
+
+### 10. Per-service process metrics
+
+Monitor reports host-level CPU/memory/disk only. There is no per-service (or
+per-agent-process) resource usage, so a runaway agent cannot be identified from
+the dashboard.
+
+**Proposed:** collect per-process metrics for the agentd services (and optionally
+wrapped agent sessions) keyed by service name: `process_cpu_percent{service}`,
+`process_memory_bytes{service}`; expose in `/metrics` JSON.
+
+**Unlocks:** per-service resource breakdown chart; identifying which component is
+consuming resources.
+
+## notify
+
+### 11. Time-bucketed notification counts
+
+`GET /notifications/count` gives status distribution; combined with item 2's
+activity buckets this service is otherwise well covered. Two smaller gaps:
+
+- the count endpoint reports by status only - no priority breakdown, so the
+  dashboard's priority chart lists actionable notifications and counts
+  client-side
+- `/notifications/history` and `/notifications/actionable` accept no time-range
+  filter (`created_after`), so the 24h activity chart fetches the first page and
+  hopes it covers the window
+
+## ask
+
+### 12. Question stats and answer latency
+
+`GET /questions` supports filters but there is no count endpoint and no exposed
+answer latency, even though `created_at` and `answered_at` both exist. The
+dashboard's pending-questions stat currently requests the list with `limit=1`
+purely to read the `total` field.
+
+**Proposed:** `GET /questions/count` (by status); include
+`answer_latency_secs` derived field or a stats endpoint with average/median time
+to answer.
+
+**Unlocks:** pending question stat without listing; "how long do agents wait on
+humans" trend.
+
+## hook
+
+### 13. Event aggregates
+
+`GET /events` returns recent raw events (shell/git, `exit_code`, `duration_ms`)
+with a 500-row cap and no filters.
+
+**Proposed:** `kind`, `since`, and `failed_only` query params; a
+`GET /events/stats` with command counts, failure rate, and long-running command
+count bucketed by hour.
+
+**Unlocks:** a useful "Hooks" dashboard panel (failure-rate trend, slow commands)
+instead of the current placeholder.
+
+## communicate
+
+### 14. Message rate exposure
+
+Message counts exist only as per-room Prometheus metrics. There is no API to ask
+"messages in the last hour across rooms" without paging every room's messages.
+
+**Proposed:** `GET /stats` with total rooms/participants/messages and messages
+bucketed by hour (item 2).
+
+**Unlocks:** inter-agent communication activity on the dashboard activity chart
+without N requests.
+
+## wrap
+
+### 15. Session lifecycle history
+
+`GET /sessions` lists live sessions only; once a session ends it disappears, with
+no record of when it started or stopped.
+
+**Proposed:** include `started_at` in `SessionInfo`; keep a short ring buffer of
+ended sessions (`GET /sessions/history`); metric `sessions_total{backend}`.
+
+**Unlocks:** session churn visibility; correlating agent failures with session
+restarts.
+
+## memory
+
+### 16. Store size and growth
+
+Health reports backend status but not store size. No count endpoint exists.
+
+**Proposed:** include memory count and store size in `/health` details or a
+`GET /stats` (count by type/visibility, growth per day).
+
+**Unlocks:** memory growth trend; spotting runaway memory creation by an agent.
+
+## Suggested priority order
+
+| Priority | Item | Rationale |
+|----------|------|-----------|
+| 1 | Aggregate stats endpoints (1) | Removes the dashboard's biggest workaround; cheap to add per service |
+| 2 | Time-bucketed activity (2) | Powers every time-series chart correctly at scale |
+| 3 | Dispatch aggregates (5) | Workflow health is currently a blind spot |
+| 4 | Monitor history params/persistence (9) | System chart stability |
+| 5 | Agent failure tracking (6) | Operational visibility into flapping agents |
+| 6 | Approval latency (7) | Human-in-the-loop SLA |
+| 7 | Remaining per-service items | Incremental |

--- a/ui/src/components/dashboard/ActivityChart.tsx
+++ b/ui/src/components/dashboard/ActivityChart.tsx
@@ -1,0 +1,145 @@
+/**
+ * ActivityChart — stacked bar chart of activity counts per hour over the
+ * last 24 hours, split by type (notifications, questions, agent updates).
+ *
+ * Uses the muted theme palette so the chart sits quietly on the page;
+ * full-strength colors appear only in the small inline legend dots.
+ */
+
+import { ResponsiveBar } from "@nivo/bar";
+import { BarChart2 } from "lucide-react";
+import { ChartSkeleton } from "@/components/common/LoadingSkeleton";
+import type { ActivityBucket } from "@/hooks/useActivityFeed";
+import { useChartPalette } from "@/hooks/useChartPalette";
+import { useNivoTheme } from "@/hooks/useNivoTheme";
+
+/** Alpha used for bar fills */
+const FILL_ALPHA = 0.7;
+
+const KEYS = ["notifications", "questions", "agents"] as const;
+
+const KEY_LABELS: Record<(typeof KEYS)[number], string> = {
+	notifications: "Notifications",
+	questions: "Questions",
+	agents: "Agents",
+};
+
+interface ActivityChartProps {
+	buckets: ActivityBucket[];
+	loading?: boolean;
+	error?: string;
+}
+
+export function ActivityChart({ buckets, loading, error }: ActivityChartProps) {
+	const palette = useChartPalette();
+	const nivoTheme = useNivoTheme();
+
+	// Full-strength colors per series (legend); fills are muted below
+	const keyColors: Record<(typeof KEYS)[number], string> = {
+		notifications: palette.info,
+		questions: palette.warning,
+		agents: palette.accent,
+	};
+
+	const hasData = buckets.some(
+		(b) => b.notifications + b.questions + b.agents > 0,
+	);
+
+	// Only label every 4th hour to keep the axis quiet
+	const tickValues = buckets.flatMap((b, i) => (i % 4 === 0 ? [b.hour] : []));
+
+	return (
+		<section
+			aria-labelledby="activity-chart-heading"
+			className="rounded-lg border border-th-border bg-th-surface p-5"
+		>
+			{/* Header + inline legend */}
+			<div className="flex flex-wrap items-center justify-between gap-2">
+				<h2
+					id="activity-chart-heading"
+					className="text-base font-semibold text-th-text"
+				>
+					Activity (24h)
+				</h2>
+				<div className="flex items-center gap-3">
+					{KEYS.map((key) => (
+						<span
+							key={key}
+							className="flex items-center gap-1 text-xs text-th-text-muted"
+						>
+							<span
+								aria-hidden="true"
+								className="h-2 w-2 rounded-full"
+								style={{ background: keyColors[key] }}
+							/>
+							{KEY_LABELS[key]}
+						</span>
+					))}
+				</div>
+			</div>
+
+			{/* Error */}
+			{error && (
+				<p className="mt-3 text-sm text-th-status-error-text">{error}</p>
+			)}
+
+			{/* Loading */}
+			{loading && !error && (
+				<div className="mt-4">
+					<ChartSkeleton height={192} />
+				</div>
+			)}
+
+			{/* Empty state */}
+			{!loading && !error && !hasData && (
+				<div className="mt-4 flex h-48 flex-col items-center justify-center gap-2 text-center">
+					<BarChart2 size={24} className="text-th-text-faint" />
+					<p className="text-sm text-th-text-muted">
+						No activity in the last 24 hours.
+					</p>
+				</div>
+			)}
+
+			{/* Chart */}
+			{!loading && !error && hasData && (
+				<div className="mt-4 h-48" data-testid="activity-chart">
+					<ResponsiveBar
+						data={buckets as unknown as Record<string, number | string>[]}
+						keys={[...KEYS]}
+						indexBy="hour"
+						groupMode="stacked"
+						theme={nivoTheme}
+						colors={({ id }) =>
+							palette.withAlpha(
+								keyColors[id as (typeof KEYS)[number]] ?? palette.neutral,
+								FILL_ALPHA,
+							)
+						}
+						enableLabel={false}
+						borderRadius={2}
+						padding={0.35}
+						axisLeft={{
+							tickSize: 0,
+							tickPadding: 6,
+							tickValues: 4,
+						}}
+						axisBottom={{
+							tickSize: 0,
+							tickPadding: 8,
+							tickValues,
+						}}
+						margin={{ top: 8, right: 8, bottom: 28, left: 28 }}
+						tooltip={({ id, indexValue, value }) => (
+							<div className="rounded bg-th-surface-raised px-2 py-1 text-xs text-th-text shadow">
+								{KEY_LABELS[id as (typeof KEYS)[number]] ?? id} at {indexValue}:{" "}
+								{value}
+							</div>
+						)}
+					/>
+				</div>
+			)}
+		</section>
+	);
+}
+
+export default ActivityChart;

--- a/ui/src/components/dashboard/AgentSummary.tsx
+++ b/ui/src/components/dashboard/AgentSummary.tsx
@@ -12,18 +12,11 @@ import {
 } from "@/components/common/LoadingSkeleton";
 import { StatusBadge } from "@/components/common/StatusBadge";
 import type { UseAgentSummaryResult } from "@/hooks/useAgentSummary";
+import { useChartPalette } from "@/hooks/useChartPalette";
 import type { Agent } from "@/types/orchestrator";
 
-// ---------------------------------------------------------------------------
-// Pie chart colour map
-// ---------------------------------------------------------------------------
-
-const STATUS_COLORS: Record<string, string> = {
-	running: "#8ac926",
-	pending: "#ffca3a",
-	stopped: "#94a3b8",
-	failed: "#ff595e",
-};
+/** Alpha used for chart fills — muted so arcs don't overpower the page */
+const FILL_ALPHA = 0.7;
 
 // ---------------------------------------------------------------------------
 // Sub-components
@@ -70,30 +63,40 @@ export function AgentSummary({
 	error,
 	onCreateAgent,
 }: AgentSummaryProps) {
+	const palette = useChartPalette();
+
+	// Theme-aware status colors (full strength — for legend dots only)
+	const statusColors: Record<string, string> = {
+		running: palette.success,
+		pending: palette.warning,
+		stopped: palette.neutral,
+		failed: palette.error,
+	};
+
 	const pieData = [
 		{
 			id: "Running",
 			label: "Running",
 			value: counts.running,
-			color: STATUS_COLORS.running,
+			color: statusColors.running,
 		},
 		{
 			id: "Pending",
 			label: "Pending",
 			value: counts.pending,
-			color: STATUS_COLORS.pending,
+			color: statusColors.pending,
 		},
 		{
 			id: "Stopped",
 			label: "Stopped",
 			value: counts.stopped,
-			color: STATUS_COLORS.stopped,
+			color: statusColors.stopped,
 		},
 		{
 			id: "Failed",
 			label: "Failed",
 			value: counts.failed,
-			color: STATUS_COLORS.failed,
+			color: statusColors.failed,
 		},
 	].filter((d) => d.value > 0);
 
@@ -154,10 +157,12 @@ export function AgentSummary({
 						<div className="relative mt-4 h-40 w-full">
 							<ResponsivePie
 								data={pieData}
-								colors={{ datum: "data.color" }}
+								colors={(d) => palette.withAlpha(d.data.color, FILL_ALPHA)}
 								innerRadius={0.6}
 								padAngle={2}
 								cornerRadius={3}
+								borderWidth={1}
+								borderColor={palette.surface}
 								enableArcLabels={false}
 								enableArcLinkLabels={false}
 								tooltip={({ datum }) => (
@@ -165,20 +170,7 @@ export function AgentSummary({
 										{datum.label}: {datum.value}
 									</div>
 								)}
-								legends={[
-									{
-										anchor: "right",
-										direction: "column",
-										itemWidth: 80,
-										itemHeight: 16,
-										itemsSpacing: 4,
-										symbolSize: 10,
-										symbolShape: "circle",
-										itemTextColor: "#94a3b8",
-										translateX: 90,
-									},
-								]}
-								margin={{ top: 8, right: 100, bottom: 8, left: 8 }}
+								margin={{ top: 8, right: 8, bottom: 8, left: 8 }}
 							/>
 						</div>
 					) : (
@@ -196,7 +188,7 @@ export function AgentSummary({
 									>
 										<span
 											className="h-2 w-2 rounded-full"
-											style={{ background: STATUS_COLORS[status] }}
+											style={{ background: statusColors[status] }}
 										/>
 										{count} {status}
 									</span>

--- a/ui/src/components/dashboard/NotificationSummary.tsx
+++ b/ui/src/components/dashboard/NotificationSummary.tsx
@@ -6,14 +6,12 @@ import { ResponsiveBar } from "@nivo/bar";
 import { Bell, ExternalLink } from "lucide-react";
 import { Link } from "react-router-dom";
 import { ChartSkeleton } from "@/components/common/LoadingSkeleton";
+import { useChartPalette } from "@/hooks/useChartPalette";
+import { useNivoTheme } from "@/hooks/useNivoTheme";
 import type { UseNotificationSummaryResult } from "@/hooks/useNotificationSummary";
 
-const PRIORITY_COLORS: Record<string, string> = {
-	low: "#94a3b8",
-	normal: "#60a5fa",
-	high: "#f59e0b",
-	urgent: "#ef4444",
-};
+/** Alpha used for bar fills — muted so bars don't overpower the page */
+const FILL_ALPHA = 0.7;
 
 type NotificationSummaryProps = UseNotificationSummaryResult;
 
@@ -25,23 +23,22 @@ export function NotificationSummary({
 	loading,
 	error,
 }: NotificationSummaryProps) {
+	const palette = useChartPalette();
+	const nivoTheme = useNivoTheme();
+
+	// Theme-aware priority colors (full strength — mute with withAlpha for fills)
+	const priorityColors: Record<string, string> = {
+		low: palette.neutral,
+		normal: palette.info,
+		high: palette.warning,
+		urgent: palette.error,
+	};
+
 	const barData = [
-		{ priority: "low", count: priorityCounts.low, color: PRIORITY_COLORS.low },
-		{
-			priority: "normal",
-			count: priorityCounts.normal,
-			color: PRIORITY_COLORS.normal,
-		},
-		{
-			priority: "high",
-			count: priorityCounts.high,
-			color: PRIORITY_COLORS.high,
-		},
-		{
-			priority: "urgent",
-			count: priorityCounts.urgent,
-			color: PRIORITY_COLORS.urgent,
-		},
+		{ priority: "low", count: priorityCounts.low },
+		{ priority: "normal", count: priorityCounts.normal },
+		{ priority: "high", count: priorityCounts.high },
+		{ priority: "urgent", count: priorityCounts.urgent },
 	];
 
 	const hasData = total > 0;
@@ -118,7 +115,11 @@ export function NotificationSummary({
 									keys={["count"]}
 									indexBy="priority"
 									colors={({ data }) =>
-										PRIORITY_COLORS[data.priority as string] ?? "#94a3b8"
+										palette.withAlpha(
+											priorityColors[data.priority as string] ??
+												palette.neutral,
+											FILL_ALPHA,
+										)
 									}
 									enableLabel={false}
 									axisLeft={null}
@@ -134,13 +135,7 @@ export function NotificationSummary({
 											{indexValue}: {value}
 										</div>
 									)}
-									theme={{
-										axis: {
-											ticks: {
-												text: { fill: "#94a3b8", fontSize: 11 },
-											},
-										},
-									}}
+									theme={nivoTheme}
 								/>
 							</div>
 						</div>

--- a/ui/src/components/dashboard/OverviewStats.tsx
+++ b/ui/src/components/dashboard/OverviewStats.tsx
@@ -1,0 +1,126 @@
+/**
+ * OverviewStats — compact stat-card row at the top of the dashboard.
+ *
+ * Each stat shows "—" when its backing service is unreachable (null value)
+ * so a single dead service never breaks the rest of the row.
+ */
+
+import {
+	Bell,
+	DollarSign,
+	HelpCircle,
+	Play,
+	ShieldCheck,
+	Workflow,
+} from "lucide-react";
+import { Skeleton } from "@/components/common/LoadingSkeleton";
+
+export interface OverviewStatsProps {
+	runningAgents: number | null;
+	pendingApprovals: number | null;
+	pendingNotifications: number | null;
+	pendingQuestions: number | null;
+	workflows: number | null;
+	totalCostUsd: number | null;
+	loading?: boolean;
+}
+
+// ---------------------------------------------------------------------------
+// Formatting helpers
+// ---------------------------------------------------------------------------
+
+function formatCount(value: number | null): string {
+	return value === null ? "—" : String(value);
+}
+
+function formatCost(value: number | null): string {
+	if (value === null) return "—";
+	if (value > 0 && value < 0.01) return "<$0.01";
+	return `$${value.toFixed(2)}`;
+}
+
+// ---------------------------------------------------------------------------
+// Stat card
+// ---------------------------------------------------------------------------
+
+interface StatCardProps {
+	icon: React.ReactNode;
+	label: string;
+	value: string;
+	loading?: boolean;
+}
+
+function StatCard({ icon, label, value, loading }: StatCardProps) {
+	return (
+		<div className="rounded-lg border border-th-border bg-th-surface px-4 py-3">
+			<div className="flex items-center gap-1.5 text-xs text-th-text-faint">
+				{icon}
+				{label}
+			</div>
+			{loading ? (
+				<Skeleton className="mt-1.5 h-7 w-12" />
+			) : (
+				<p className="mt-1 text-2xl font-semibold text-th-text">{value}</p>
+			)}
+		</div>
+	);
+}
+
+// ---------------------------------------------------------------------------
+// OverviewStats
+// ---------------------------------------------------------------------------
+
+export function OverviewStats({
+	runningAgents,
+	pendingApprovals,
+	pendingNotifications,
+	pendingQuestions,
+	workflows,
+	totalCostUsd,
+	loading = false,
+}: OverviewStatsProps) {
+	const stats: StatCardProps[] = [
+		{
+			icon: <Play size={12} />,
+			label: "Running Agents",
+			value: formatCount(runningAgents),
+		},
+		{
+			icon: <ShieldCheck size={12} />,
+			label: "Pending Approvals",
+			value: formatCount(pendingApprovals),
+		},
+		{
+			icon: <Bell size={12} />,
+			label: "Pending Notifications",
+			value: formatCount(pendingNotifications),
+		},
+		{
+			icon: <HelpCircle size={12} />,
+			label: "Pending Questions",
+			value: formatCount(pendingQuestions),
+		},
+		{
+			icon: <Workflow size={12} />,
+			label: "Workflows",
+			value: formatCount(workflows),
+		},
+		{
+			icon: <DollarSign size={12} />,
+			label: "Total Cost",
+			value: formatCost(totalCostUsd),
+		},
+	];
+
+	return (
+		<section aria-label="Overview statistics">
+			<div className="grid grid-cols-2 gap-3 sm:grid-cols-3 xl:grid-cols-6">
+				{stats.map((stat) => (
+					<StatCard key={stat.label} {...stat} loading={loading} />
+				))}
+			</div>
+		</section>
+	);
+}
+
+export default OverviewStats;

--- a/ui/src/components/dashboard/ServiceHealthCard.tsx
+++ b/ui/src/components/dashboard/ServiceHealthCard.tsx
@@ -14,6 +14,7 @@ const SERVICE_ROUTES: Record<string, string> = {
 	ask: "/questions",
 	memory: "/memories",
 	communicate: "/communicate",
+	monitor: "/monitoring",
 };
 
 interface ServiceHealthCardProps {

--- a/ui/src/components/dashboard/SystemMetricsChart.tsx
+++ b/ui/src/components/dashboard/SystemMetricsChart.tsx
@@ -1,0 +1,192 @@
+/**
+ * SystemMetricsChart — CPU and memory usage over time from the monitor
+ * service, rendered as a muted two-series line chart with latest-value
+ * readouts above it.
+ *
+ * Renders a quiet empty state when the monitor service is unreachable or
+ * has not collected any metrics yet — it never crashes the dashboard.
+ */
+
+import { ResponsiveLine } from "@nivo/line";
+import { Activity, Cpu, ExternalLink, MemoryStick } from "lucide-react";
+import { Link } from "react-router-dom";
+import { ChartSkeleton } from "@/components/common/LoadingSkeleton";
+import { useChartPalette } from "@/hooks/useChartPalette";
+import { useNivoTheme } from "@/hooks/useNivoTheme";
+import type { UseSystemMetricsResult } from "@/hooks/useSystemMetrics";
+
+/** Alpha used for area fills under the lines */
+const AREA_ALPHA = 0.12;
+
+type SystemMetricsChartProps = UseSystemMetricsResult;
+
+interface StatReadoutProps {
+	icon: React.ReactNode;
+	label: string;
+	value: string;
+	color: string;
+}
+
+function StatReadout({ icon, label, value, color }: StatReadoutProps) {
+	return (
+		<div className="flex items-center gap-1.5 text-xs text-th-text-muted">
+			<span
+				aria-hidden="true"
+				className="h-2 w-2 rounded-full"
+				style={{ background: color }}
+			/>
+			{icon}
+			<span>{label}</span>
+			<span className="font-semibold text-th-text">{value}</span>
+		</div>
+	);
+}
+
+export function SystemMetricsChart({
+	history,
+	latest,
+	alerts,
+	available,
+	loading,
+}: SystemMetricsChartProps) {
+	const palette = useChartPalette();
+	const nivoTheme = useNivoTheme();
+
+	const cpuColor = palette.series[0];
+	const memColor = palette.series[1];
+
+	const lineData = [
+		{
+			id: "CPU",
+			color: cpuColor,
+			data: history.map((m) => ({
+				x: new Date(m.collected_at),
+				y: m.cpu.usage_percent,
+			})),
+		},
+		{
+			id: "Memory",
+			color: memColor,
+			data: history.map((m) => ({
+				x: new Date(m.collected_at),
+				y: m.memory.usage_percent,
+			})),
+		},
+	];
+
+	const hasData = available && history.length > 0;
+
+	return (
+		<section
+			aria-labelledby="system-metrics-heading"
+			className="rounded-lg border border-th-border bg-th-surface p-5"
+		>
+			{/* Header */}
+			<div className="flex items-center justify-between">
+				<h2
+					id="system-metrics-heading"
+					className="text-base font-semibold text-th-text"
+				>
+					System Metrics
+				</h2>
+				<Link
+					to="/monitoring"
+					className="flex items-center gap-1 text-xs font-medium text-th-text-link hover:opacity-80"
+				>
+					Monitoring <ExternalLink size={12} />
+				</Link>
+			</div>
+
+			{/* Loading */}
+			{loading && (
+				<div className="mt-4">
+					<ChartSkeleton height={192} />
+				</div>
+			)}
+
+			{/* Empty / unavailable state */}
+			{!loading && !hasData && (
+				<div className="mt-4 flex h-48 flex-col items-center justify-center gap-2 text-center">
+					<Activity size={24} className="text-th-text-faint" />
+					<p className="text-sm text-th-text-muted">
+						{available
+							? "No metrics collected yet."
+							: "Monitor service unavailable"}
+					</p>
+				</div>
+			)}
+
+			{/* Content */}
+			{!loading && hasData && (
+				<>
+					{/* Latest readouts (double as the chart legend) */}
+					<div className="mt-3 flex flex-wrap items-center gap-4">
+						<StatReadout
+							icon={<Cpu size={12} />}
+							label="CPU"
+							value={latest ? `${latest.cpu.usage_percent.toFixed(0)}%` : "—"}
+							color={cpuColor}
+						/>
+						<StatReadout
+							icon={<MemoryStick size={12} />}
+							label="Memory"
+							value={
+								latest ? `${latest.memory.usage_percent.toFixed(0)}%` : "—"
+							}
+							color={memColor}
+						/>
+						{latest && (
+							<span className="text-xs text-th-text-faint">
+								load {latest.load_average.one.toFixed(2)}
+							</span>
+						)}
+						{alerts.length > 0 && (
+							<span className="rounded-full bg-th-status-warning-bg px-2 py-0.5 text-xs font-medium text-th-status-warning-text">
+								{alerts.length} alert{alerts.length === 1 ? "" : "s"}
+							</span>
+						)}
+					</div>
+
+					{/* Time-series chart */}
+					<div className="mt-3 h-48" data-testid="system-metrics-chart">
+						<ResponsiveLine
+							data={lineData}
+							theme={nivoTheme}
+							colors={(serie: { color: string }) => serie.color}
+							xScale={{ type: "time", format: "native", precision: "minute" }}
+							yScale={{ type: "linear", min: 0, max: 100 }}
+							axisBottom={{
+								format: "%H:%M",
+								tickValues: 4,
+								tickSize: 0,
+								tickPadding: 8,
+							}}
+							axisLeft={{
+								tickValues: [0, 50, 100],
+								tickSize: 0,
+								tickPadding: 6,
+								format: (v: number) => `${v}%`,
+							}}
+							gridYValues={[0, 25, 50, 75, 100]}
+							enableGridX={false}
+							lineWidth={2}
+							enablePoints={false}
+							enableArea
+							areaOpacity={AREA_ALPHA}
+							curve="monotoneX"
+							useMesh
+							margin={{ top: 8, right: 8, bottom: 28, left: 36 }}
+							tooltip={({ point }) => (
+								<div className="rounded bg-th-surface-raised px-2 py-1 text-xs text-th-text shadow">
+									{String(point.seriesId)}: {Number(point.data.y).toFixed(1)}%
+								</div>
+							)}
+						/>
+					</div>
+				</>
+			)}
+		</section>
+	);
+}
+
+export default SystemMetricsChart;

--- a/ui/src/components/dashboard/index.ts
+++ b/ui/src/components/dashboard/index.ts
@@ -1,8 +1,12 @@
+export { ActivityChart } from "./ActivityChart";
 export type { ActivityEvent, ActivityEventType } from "./ActivityTimeline";
 export { ActivityTimeline } from "./ActivityTimeline";
 export { AgentSummary } from "./AgentSummary";
 export { NotificationSummary } from "./NotificationSummary";
+export type { OverviewStatsProps } from "./OverviewStats";
+export { OverviewStats } from "./OverviewStats";
 export {
 	ServiceHealthCard,
 	ServiceHealthCardSkeleton,
 } from "./ServiceHealthCard";
+export { SystemMetricsChart } from "./SystemMetricsChart";

--- a/ui/src/hooks/index.ts
+++ b/ui/src/hooks/index.ts
@@ -1,4 +1,9 @@
 export type {
+	ActivityBucket,
+	UseActivityFeedResult,
+} from "./useActivityFeed";
+export { useActivityFeed } from "./useActivityFeed";
+export type {
 	UseAgentDetailOptions,
 	UseAgentDetailResult,
 } from "./useAgentDetail";
@@ -33,6 +38,15 @@ export type { UseAllAgentsStreamResult } from "./useAllAgentsStream";
 export { useAllAgentsStream } from "./useAllAgentsStream";
 export type { UseApprovalsOptions, UseApprovalsResult } from "./useApprovals";
 export { useApprovals } from "./useApprovals";
+export type { ChartPalette } from "./useChartPalette";
+export {
+	buildChartPalette,
+	useChartPalette,
+	useThemeTokens,
+	withAlpha,
+} from "./useChartPalette";
+export type { UseDashboardStatsResult } from "./useDashboardStats";
+export { useDashboardStats } from "./useDashboardStats";
 export type {
 	MemoryFilters,
 	MemorySortDir,
@@ -53,6 +67,7 @@ export type {
 	UseNotificationSummaryResult,
 } from "./useNotificationSummary";
 export { useNotificationSummary } from "./useNotificationSummary";
+export { DEFAULT_POLL_INTERVAL_MS, usePolling } from "./usePolling";
 export type {
 	GroupedSearchResults,
 	SearchCategory,
@@ -62,6 +77,8 @@ export type {
 export { useSearch } from "./useSearch";
 export type { ServiceHealth, UseServiceHealthResult } from "./useServiceHealth";
 export { useServiceHealth } from "./useServiceHealth";
+export type { UseSystemMetricsResult } from "./useSystemMetrics";
+export { useSystemMetrics } from "./useSystemMetrics";
 export type { ThemeContextValue } from "./useTheme";
 export { ThemeProvider, useTheme } from "./useTheme";
 export type {

--- a/ui/src/hooks/useActivityFeed.ts
+++ b/ui/src/hooks/useActivityFeed.ts
@@ -1,0 +1,197 @@
+/**
+ * useActivityFeed — fetches notifications, questions, and agents once per
+ * poll tick and derives two views from the same data:
+ *
+ * 1. `events` — merged recent-activity list for the ActivityTimeline
+ *    (sorted newest-first, capped at 12 entries).
+ * 2. `buckets` — hourly activity counts for the last 24 hours, stacked by
+ *    type, for the ActivityChart.
+ *
+ * Sources are fetched with Promise.allSettled so a single dead service
+ * degrades gracefully instead of blanking the whole feed.
+ */
+
+import { useCallback, useRef, useState } from "react";
+import type { ActivityEvent } from "@/components/dashboard/ActivityTimeline";
+import { askClient } from "@/services/ask";
+import { notifyClient } from "@/services/notify";
+import { orchestratorClient } from "@/services/orchestrator";
+import type { Question } from "@/types/ask";
+import type { Notification } from "@/types/notify";
+import type { Agent } from "@/types/orchestrator";
+import { usePolling } from "./usePolling";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+/** Activity counts for a single hour bucket */
+export interface ActivityBucket {
+	/** Hour label, e.g. "13:00" */
+	hour: string;
+	notifications: number;
+	questions: number;
+	agents: number;
+}
+
+export interface UseActivityFeedResult {
+	/** Merged recent events, newest first, capped at 12 */
+	events: ActivityEvent[];
+	/** Hourly activity buckets covering the last 24 hours, oldest first */
+	buckets: ActivityBucket[];
+	/** True only during the very first load */
+	loading: boolean;
+	error?: string;
+	refetch: () => void;
+}
+
+const MAX_EVENTS = 12;
+const BUCKET_COUNT = 24;
+const HOUR_MS = 60 * 60 * 1000;
+
+// ---------------------------------------------------------------------------
+// Derivation helpers
+// ---------------------------------------------------------------------------
+
+function buildEvents(
+	notifications: Notification[],
+	questions: Question[],
+	agents: Agent[],
+): ActivityEvent[] {
+	const events: ActivityEvent[] = [];
+
+	for (const n of notifications) {
+		events.push({
+			id: `notification-${n.id}`,
+			type: "notification",
+			description: n.message ? `${n.title} — ${n.message}` : n.title,
+			timestamp: new Date(n.created_at),
+		});
+	}
+
+	for (const q of questions) {
+		events.push({
+			id: `question-${q.id}`,
+			type: "question",
+			description: `Question ${q.status.toLowerCase()}: ${q.question}`,
+			timestamp: new Date(q.asked_at),
+		});
+	}
+
+	for (const a of agents) {
+		events.push({
+			id: `agent-${a.id}`,
+			type: "agent",
+			description: `Agent "${a.name}" is ${a.status.toLowerCase()}`,
+			timestamp: new Date(a.updated_at),
+		});
+	}
+
+	return events
+		.filter((e) => !Number.isNaN(e.timestamp.getTime()))
+		.sort((a, b) => b.timestamp.getTime() - a.timestamp.getTime())
+		.slice(0, MAX_EVENTS);
+}
+
+function buildBuckets(
+	notifications: Notification[],
+	questions: Question[],
+	agents: Agent[],
+	now: Date = new Date(),
+): ActivityBucket[] {
+	// Bucket 0 starts 23 hours before the start of the current hour.
+	const currentHourStart = new Date(now);
+	currentHourStart.setMinutes(0, 0, 0);
+	const windowStart = currentHourStart.getTime() - (BUCKET_COUNT - 1) * HOUR_MS;
+
+	const buckets: ActivityBucket[] = Array.from(
+		{ length: BUCKET_COUNT },
+		(_, i) => {
+			const start = new Date(windowStart + i * HOUR_MS);
+			return {
+				hour: `${String(start.getHours()).padStart(2, "0")}:00`,
+				notifications: 0,
+				questions: 0,
+				agents: 0,
+			};
+		},
+	);
+
+	const add = (
+		timestamp: string,
+		key: "notifications" | "questions" | "agents",
+	) => {
+		const time = new Date(timestamp).getTime();
+		if (Number.isNaN(time)) return;
+		const index = Math.floor((time - windowStart) / HOUR_MS);
+		if (index >= 0 && index < BUCKET_COUNT) buckets[index][key]++;
+	};
+
+	for (const n of notifications) add(n.created_at, "notifications");
+	for (const q of questions) add(q.asked_at, "questions");
+	for (const a of agents) add(a.updated_at, "agents");
+
+	return buckets;
+}
+
+export const activityFeedInternals = { buildEvents, buildBuckets };
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+export function useActivityFeed(): UseActivityFeedResult {
+	const [events, setEvents] = useState<ActivityEvent[]>([]);
+	const [buckets, setBuckets] = useState<ActivityBucket[]>([]);
+	const [loading, setLoading] = useState(true);
+	const [error, setError] = useState<string | undefined>();
+	const hasLoadedRef = useRef(false);
+
+	const fetch = useCallback(async () => {
+		if (!hasLoadedRef.current) setLoading(true);
+		const [actionableRes, historyRes, questionsRes, agentsRes] =
+			await Promise.allSettled([
+				notifyClient.listActionable({ limit: 100 }),
+				notifyClient.listHistory({ limit: 100 }),
+				askClient.listQuestions({ limit: 100 }),
+				orchestratorClient.listAgents({ limit: 200 }),
+			]);
+
+		// Merge actionable + history notifications, de-duplicated by ID.
+		// Guard against unexpected payload shapes — never crash the dashboard.
+		const notificationsById = new Map<string, Notification>();
+		for (const res of [actionableRes, historyRes]) {
+			if (res.status === "fulfilled") {
+				for (const n of res.value.items ?? []) notificationsById.set(n.id, n);
+			}
+		}
+		const notifications = [...notificationsById.values()];
+		const questions =
+			questionsRes.status === "fulfilled"
+				? (questionsRes.value.items ?? [])
+				: [];
+		const agents =
+			agentsRes.status === "fulfilled" ? (agentsRes.value.items ?? []) : [];
+
+		const allFailed = [
+			actionableRes,
+			historyRes,
+			questionsRes,
+			agentsRes,
+		].every((r) => r.status === "rejected");
+
+		setError(allFailed ? "Failed to load recent activity" : undefined);
+		setEvents(buildEvents(notifications, questions, agents));
+		setBuckets(buildBuckets(notifications, questions, agents));
+		hasLoadedRef.current = true;
+		setLoading(false);
+	}, []);
+
+	usePolling(fetch);
+
+	const refetch = useCallback(() => {
+		void fetch();
+	}, [fetch]);
+
+	return { events, buckets, loading, error, refetch };
+}

--- a/ui/src/hooks/useAgentSummary.ts
+++ b/ui/src/hooks/useAgentSummary.ts
@@ -3,9 +3,10 @@
  * updated agents.
  */
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 import { orchestratorClient } from "@/services/orchestrator";
 import type { Agent, AgentStatus, AgentUsageStats } from "@/types/orchestrator";
+import { usePolling } from "./usePolling";
 
 export interface AgentStatusCounts {
 	running: number;
@@ -72,9 +73,12 @@ export function useAgentSummary(): UseAgentSummaryResult {
 		useState<AggregateUsageSummary | null>(null);
 	const [loading, setLoading] = useState(true);
 	const [error, setError] = useState<string | undefined>();
+	const hasLoadedRef = useRef(false);
 
 	const fetch = useCallback(async () => {
-		setLoading(true);
+		// Only flash the loading skeleton on the very first load — subsequent
+		// polls refresh in the background (stale-while-revalidate).
+		if (!hasLoadedRef.current) setLoading(true);
 		setError(undefined);
 		try {
 			// Fetch all agents (up to 200 for summary purposes)
@@ -116,13 +120,12 @@ export function useAgentSummary(): UseAgentSummaryResult {
 		} catch (err) {
 			setError(err instanceof Error ? err.message : "Failed to load agents");
 		} finally {
+			hasLoadedRef.current = true;
 			setLoading(false);
 		}
 	}, []);
 
-	useEffect(() => {
-		void fetch();
-	}, [fetch]);
+	usePolling(fetch);
 
 	return {
 		counts,

--- a/ui/src/hooks/useChartPalette.ts
+++ b/ui/src/hooks/useChartPalette.ts
@@ -1,0 +1,124 @@
+/**
+ * useChartPalette -- theme-aware chart colors derived from ThemeTokens.
+ *
+ * Charts should use muted (alpha-blended) fills via `withAlpha` so they sit
+ * quietly on the page; full-strength token colors are reserved for legend
+ * dots, small text accents, and thin (1px) arc/series borders.
+ *
+ * Falls back to the default theme tokens when rendered outside a
+ * <ThemeProvider> (e.g. isolated component tests) instead of throwing.
+ */
+
+import { useContext, useMemo } from "react";
+import { ThemeContext } from "@/hooks/useTheme";
+import { getTheme } from "@/stores/themeStore";
+import type { ThemeTokens } from "@/styles/theme-tokens";
+import { DEFAULT_THEME_ID } from "@/styles/themes/index";
+
+// ---------------------------------------------------------------------------
+// withAlpha
+// ---------------------------------------------------------------------------
+
+/**
+ * Apply an alpha channel to a CSS color, returning an `rgba()` string.
+ *
+ * Supported inputs: `#rgb`, `#rgba`, `#rrggbb`, `#rrggbbaa`,
+ * `rgb(r, g, b)`, `rgba(r, g, b, a)` (comma or space separated).
+ * Unparseable values are returned unchanged.
+ */
+export function withAlpha(color: string, alpha: number): string {
+	const a = Math.min(1, Math.max(0, alpha));
+	const trimmed = color.trim();
+
+	// Hex forms
+	const hexMatch = trimmed.match(/^#([0-9a-f]{3,8})$/i);
+	if (hexMatch) {
+		const hex = hexMatch[1];
+		let r: number;
+		let g: number;
+		let b: number;
+		if (hex.length === 3 || hex.length === 4) {
+			r = Number.parseInt(hex[0] + hex[0], 16);
+			g = Number.parseInt(hex[1] + hex[1], 16);
+			b = Number.parseInt(hex[2] + hex[2], 16);
+		} else if (hex.length === 6 || hex.length === 8) {
+			r = Number.parseInt(hex.slice(0, 2), 16);
+			g = Number.parseInt(hex.slice(2, 4), 16);
+			b = Number.parseInt(hex.slice(4, 6), 16);
+		} else {
+			return color;
+		}
+		return `rgba(${r}, ${g}, ${b}, ${a})`;
+	}
+
+	// rgb(...) / rgba(...) forms -- comma, space, or slash separated
+	const rgbMatch = trimmed.match(
+		/^rgba?\(\s*([\d.]+%?)\s*[, ]\s*([\d.]+%?)\s*[, ]\s*([\d.]+%?)\s*(?:[,/]\s*[\d.%]+\s*)?\)$/i,
+	);
+	if (rgbMatch) {
+		return `rgba(${rgbMatch[1]}, ${rgbMatch[2]}, ${rgbMatch[3]}, ${a})`;
+	}
+
+	return color;
+}
+
+// ---------------------------------------------------------------------------
+// Palette
+// ---------------------------------------------------------------------------
+
+export interface ChartPalette {
+	/** Semantic colors (full strength -- mute with withAlpha for fills) */
+	success: string;
+	warning: string;
+	error: string;
+	info: string;
+	neutral: string;
+	accent: string;
+	/** Surface color, used for subtle arc/segment borders */
+	surface: string;
+	/** Categorical series colors derived from theme tokens */
+	series: string[];
+	/** Helper re-exported for convenience in chart components */
+	withAlpha: typeof withAlpha;
+}
+
+/** Build a chart palette from a full token set. */
+export function buildChartPalette(t: ThemeTokens): ChartPalette {
+	return {
+		success: t.statusSuccessDot,
+		warning: t.statusWarningDot,
+		error: t.statusErrorDot,
+		info: t.statusInfoDot,
+		neutral: t.textMuted,
+		accent: t.accent,
+		surface: t.surface,
+		series: [
+			t.accent,
+			t.statusInfoDot,
+			t.statusSuccessDot,
+			t.statusWarningDot,
+			t.accentSecondary,
+			t.statusErrorDot,
+		],
+		withAlpha,
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Hooks
+// ---------------------------------------------------------------------------
+
+/**
+ * Read the current ThemeTokens, falling back to the default theme when no
+ * ThemeProvider is mounted (keeps chart components safe in isolation).
+ */
+export function useThemeTokens(): ThemeTokens {
+	const ctx = useContext(ThemeContext);
+	return ctx?.theme ?? getTheme(DEFAULT_THEME_ID);
+}
+
+/** Theme-aware chart palette for the active theme. */
+export function useChartPalette(): ChartPalette {
+	const tokens = useThemeTokens();
+	return useMemo(() => buildChartPalette(tokens), [tokens]);
+}

--- a/ui/src/hooks/useDashboardStats.ts
+++ b/ui/src/hooks/useDashboardStats.ts
@@ -1,0 +1,68 @@
+/**
+ * useDashboardStats — fetches the overview stat counts that are not already
+ * provided by useAgentSummary / useNotificationSummary:
+ *
+ * - Pending tool-use approvals (orchestrator)
+ * - Workflows (orchestrator)
+ * - Pending questions (ask)
+ *
+ * Each source is fetched with Promise.allSettled, so a dead service nulls
+ * out only its own stat (rendered as "—") without breaking the others.
+ */
+
+import { useCallback, useRef, useState } from "react";
+import { askClient } from "@/services/ask";
+import { orchestratorClient } from "@/services/orchestrator";
+import { usePolling } from "./usePolling";
+
+export interface UseDashboardStatsResult {
+	/** Pending approvals count (null when the orchestrator is unreachable) */
+	pendingApprovals: number | null;
+	/** Total workflow count (null when the orchestrator is unreachable) */
+	workflows: number | null;
+	/** Pending questions count (null when the ask service is unreachable) */
+	pendingQuestions: number | null;
+	/** True only during the very first load */
+	loading: boolean;
+	refetch: () => void;
+}
+
+export function useDashboardStats(): UseDashboardStatsResult {
+	const [pendingApprovals, setPendingApprovals] = useState<number | null>(null);
+	const [workflows, setWorkflows] = useState<number | null>(null);
+	const [pendingQuestions, setPendingQuestions] = useState<number | null>(null);
+	const [loading, setLoading] = useState(true);
+	const hasLoadedRef = useRef(false);
+
+	const fetch = useCallback(async () => {
+		if (!hasLoadedRef.current) setLoading(true);
+		const [approvalsRes, workflowsRes, questionsRes] = await Promise.allSettled(
+			[
+				orchestratorClient.listApprovals({ status: "pending", limit: 1 }),
+				orchestratorClient.listWorkflows({ limit: 1 }),
+				askClient.listQuestions({ status: "Pending", limit: 1 }),
+			],
+		);
+
+		setPendingApprovals(
+			approvalsRes.status === "fulfilled" ? approvalsRes.value.total : null,
+		);
+		setWorkflows(
+			workflowsRes.status === "fulfilled" ? workflowsRes.value.total : null,
+		);
+		setPendingQuestions(
+			questionsRes.status === "fulfilled" ? questionsRes.value.total : null,
+		);
+
+		hasLoadedRef.current = true;
+		setLoading(false);
+	}, []);
+
+	usePolling(fetch);
+
+	const refetch = useCallback(() => {
+		void fetch();
+	}, [fetch]);
+
+	return { pendingApprovals, workflows, pendingQuestions, loading, refetch };
+}

--- a/ui/src/hooks/useNivoTheme.ts
+++ b/ui/src/hooks/useNivoTheme.ts
@@ -1,6 +1,9 @@
 /**
  * useNivoTheme -- derives a Nivo chart theme from the active ThemeTokens.
  *
+ * Grid lines and axis tick lines are softened (50% alpha) so chart chrome
+ * recedes behind the data instead of competing with it.
+ *
  * Usage:
  *   const nivoTheme = useNivoTheme()
  *   <ResponsiveLine theme={nivoTheme} ... />
@@ -9,10 +12,11 @@
 import type { PartialTheme as NivoTheme } from "@nivo/theming";
 import { useMemo } from "react";
 import type { ThemeTokens } from "@/styles/theme-tokens";
-import { useTheme } from "./useTheme";
+import { useThemeTokens, withAlpha } from "./useChartPalette";
 
 /** Build a Nivo chart theme from ThemeTokens. */
 export function buildNivoTheme(t: ThemeTokens): NivoTheme {
+	const softLine = withAlpha(t.border, 0.5);
 	return {
 		background: t.surface,
 		axis: {
@@ -20,7 +24,7 @@ export function buildNivoTheme(t: ThemeTokens): NivoTheme {
 				line: { stroke: t.borderStrong, strokeWidth: 1 },
 			},
 			ticks: {
-				line: { stroke: t.border, strokeWidth: 1 },
+				line: { stroke: softLine, strokeWidth: 1 },
 				text: { fill: t.textMuted, fontSize: 11 },
 			},
 			legend: {
@@ -28,7 +32,7 @@ export function buildNivoTheme(t: ThemeTokens): NivoTheme {
 			},
 		},
 		grid: {
-			line: { stroke: t.border, strokeWidth: 1 },
+			line: { stroke: softLine, strokeWidth: 1 },
 		},
 		legends: {
 			text: { fill: t.textSecondary, fontSize: 12 },
@@ -50,6 +54,6 @@ export function buildNivoTheme(t: ThemeTokens): NivoTheme {
 }
 
 export function useNivoTheme(): NivoTheme {
-	const { theme } = useTheme();
-	return useMemo(() => buildNivoTheme(theme), [theme]);
+	const tokens = useThemeTokens();
+	return useMemo(() => buildNivoTheme(tokens), [tokens]);
 }

--- a/ui/src/hooks/useNotificationSummary.ts
+++ b/ui/src/hooks/useNotificationSummary.ts
@@ -2,9 +2,10 @@
  * useNotificationSummary — fetches notification count and priority breakdown.
  */
 
-import { useCallback, useEffect, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 import { notifyClient } from "@/services/notify";
 import type { NotificationPriority } from "@/types/notify";
+import { usePolling } from "./usePolling";
 
 export interface NotificationPriorityCounts {
 	low: number;
@@ -20,6 +21,7 @@ export interface UseNotificationSummaryResult {
 	priorityCounts: NotificationPriorityCounts;
 	loading: boolean;
 	error?: string;
+	refetch: () => void;
 }
 
 const EMPTY_PRIORITY: NotificationPriorityCounts = {
@@ -37,9 +39,12 @@ export function useNotificationSummary(): UseNotificationSummaryResult {
 		useState<NotificationPriorityCounts>(EMPTY_PRIORITY);
 	const [loading, setLoading] = useState(true);
 	const [error, setError] = useState<string | undefined>();
+	const hasLoadedRef = useRef(false);
 
 	const fetch = useCallback(async () => {
-		setLoading(true);
+		// Only flash the loading skeleton on the very first load — subsequent
+		// polls refresh in the background (stale-while-revalidate).
+		if (!hasLoadedRef.current) setLoading(true);
 		setError(undefined);
 		try {
 			const [actionable, countData] = await Promise.all([
@@ -77,13 +82,20 @@ export function useNotificationSummary(): UseNotificationSummaryResult {
 				err instanceof Error ? err.message : "Failed to load notifications",
 			);
 		} finally {
+			hasLoadedRef.current = true;
 			setLoading(false);
 		}
 	}, []);
 
-	useEffect(() => {
-		void fetch();
-	}, [fetch]);
+	usePolling(fetch);
 
-	return { pending, unread, total, priorityCounts, loading, error };
+	return {
+		pending,
+		unread,
+		total,
+		priorityCounts,
+		loading,
+		error,
+		refetch: fetch,
+	};
 }

--- a/ui/src/hooks/usePolling.ts
+++ b/ui/src/hooks/usePolling.ts
@@ -1,0 +1,63 @@
+/**
+ * usePolling -- shared interval polling helper for dashboard data hooks.
+ *
+ * - Fires the callback immediately on mount.
+ * - Re-fires every `intervalMs` (default 30s).
+ * - Pauses while the document is hidden and resumes (with an immediate
+ *   fire) when it becomes visible again.
+ * - Cleans up the interval and visibility listener on unmount.
+ */
+
+import { useEffect, useRef } from "react";
+
+export const DEFAULT_POLL_INTERVAL_MS = 30_000;
+
+export function usePolling(
+	callback: () => void | Promise<void>,
+	intervalMs: number = DEFAULT_POLL_INTERVAL_MS,
+): void {
+	const callbackRef = useRef(callback);
+
+	useEffect(() => {
+		callbackRef.current = callback;
+	}, [callback]);
+
+	useEffect(() => {
+		let intervalId: ReturnType<typeof setInterval> | null = null;
+
+		const tick = () => {
+			void callbackRef.current();
+		};
+
+		const start = () => {
+			if (intervalId === null) {
+				intervalId = setInterval(tick, intervalMs);
+			}
+		};
+
+		const stop = () => {
+			if (intervalId !== null) {
+				clearInterval(intervalId);
+				intervalId = null;
+			}
+		};
+
+		const handleVisibilityChange = () => {
+			if (document.hidden) {
+				stop();
+			} else {
+				tick();
+				start();
+			}
+		};
+
+		tick();
+		if (!document.hidden) start();
+		document.addEventListener("visibilitychange", handleVisibilityChange);
+
+		return () => {
+			stop();
+			document.removeEventListener("visibilitychange", handleVisibilityChange);
+		};
+	}, [intervalMs]);
+}

--- a/ui/src/hooks/useServiceHealth.ts
+++ b/ui/src/hooks/useServiceHealth.ts
@@ -1,22 +1,25 @@
 /**
- * useServiceHealth — polls all three service health endpoints in parallel.
+ * useServiceHealth — polls all service health endpoints in parallel.
  *
  * Uses a stale-while-revalidate pattern: returns the last known data
- * immediately while refreshing in the background every 30 seconds.
+ * immediately while refreshing in the background every 30 seconds
+ * (paused while the tab is hidden, via the shared usePolling helper).
  */
 
-import { useCallback, useEffect, useRef, useState } from "react";
+import { useCallback, useState } from "react";
 import type { ServiceStatus } from "@/components/common/StatusBadge";
 import { askClient } from "@/services/ask";
 import { communicateClient } from "@/services/communicate";
 import { memoryClient } from "@/services/memory";
+import { monitorClient } from "@/services/monitor";
 import { notifyClient } from "@/services/notify";
 import { orchestratorClient } from "@/services/orchestrator";
 import type { HealthResponse } from "@/types/common";
+import { usePolling } from "./usePolling";
 
 export interface ServiceHealth {
 	name: string;
-	key: "orchestrator" | "notify" | "ask" | "memory" | "communicate";
+	key: "orchestrator" | "notify" | "ask" | "memory" | "communicate" | "monitor";
 	port: number;
 	status: ServiceStatus;
 	version?: string;
@@ -31,8 +34,6 @@ export interface UseServiceHealthResult {
 	initializing: boolean;
 	refresh: () => void;
 }
-
-const REFRESH_INTERVAL_MS = 30_000;
 
 async function fetchHealth(
 	key: ServiceHealth["key"],
@@ -69,7 +70,6 @@ export function useServiceHealth(): UseServiceHealthResult {
 	const [services, setServices] = useState<ServiceHealth[]>([]);
 	const [loading, setLoading] = useState(false);
 	const [initializing, setInitializing] = useState(true);
-	const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
 	const fetch = useCallback(async () => {
 		setLoading(true);
@@ -79,24 +79,17 @@ export function useServiceHealth(): UseServiceHealthResult {
 			fetchHealth("ask", () => askClient.getHealth(), 17001),
 			fetchHealth("memory", () => memoryClient.getHealth(), 17008),
 			fetchHealth("communicate", () => communicateClient.getHealth(), 17010),
+			fetchHealth("monitor", () => monitorClient.getHealth(), 17003),
 		]);
 		setServices(results);
 		setLoading(false);
 		setInitializing(false);
 	}, []);
 
+	usePolling(fetch);
+
 	const refresh = useCallback(() => {
 		void fetch();
-	}, [fetch]);
-
-	useEffect(() => {
-		void fetch();
-		intervalRef.current = setInterval(() => {
-			void fetch();
-		}, REFRESH_INTERVAL_MS);
-		return () => {
-			if (intervalRef.current) clearInterval(intervalRef.current);
-		};
 	}, [fetch]);
 
 	return { services, loading, initializing, refresh };

--- a/ui/src/hooks/useSystemMetrics.ts
+++ b/ui/src/hooks/useSystemMetrics.ts
@@ -1,0 +1,95 @@
+/**
+ * useSystemMetrics — polls the monitor service for the system metrics
+ * history (time-series) and the current threshold-based health status.
+ *
+ * Resilient to the monitor service being down: `available` flips to false
+ * and the dashboard renders a quiet empty state instead of crashing.
+ */
+
+import { useCallback, useRef, useState } from "react";
+import { monitorClient } from "@/services/monitor";
+import type {
+	MonitorAlert,
+	SystemHealthStatus,
+	SystemMetrics,
+} from "@/types/monitor";
+import { usePolling } from "./usePolling";
+
+export interface UseSystemMetricsResult {
+	/** Retained metrics snapshots, oldest first */
+	history: SystemMetrics[];
+	/** Most recent snapshot (null when none collected yet) */
+	latest: SystemMetrics | null;
+	/** Active threshold alerts */
+	alerts: MonitorAlert[];
+	/** Overall health assessment (null when unavailable) */
+	status: SystemHealthStatus | null;
+	/** False when the monitor service is unreachable */
+	available: boolean;
+	/** True only during the very first load */
+	loading: boolean;
+	error?: string;
+	refetch: () => void;
+}
+
+export function useSystemMetrics(): UseSystemMetricsResult {
+	const [history, setHistory] = useState<SystemMetrics[]>([]);
+	const [latest, setLatest] = useState<SystemMetrics | null>(null);
+	const [alerts, setAlerts] = useState<MonitorAlert[]>([]);
+	const [status, setStatus] = useState<SystemHealthStatus | null>(null);
+	const [available, setAvailable] = useState(true);
+	const [loading, setLoading] = useState(true);
+	const [error, setError] = useState<string | undefined>();
+	const hasLoadedRef = useRef(false);
+
+	const fetch = useCallback(async () => {
+		if (!hasLoadedRef.current) setLoading(true);
+		const [historyRes, statusRes] = await Promise.allSettled([
+			monitorClient.getHistory(),
+			monitorClient.getStatus(),
+		]);
+
+		if (historyRes.status === "rejected" && statusRes.status === "rejected") {
+			setAvailable(false);
+			setError("Monitor service unavailable");
+			setHistory([]);
+			setLatest(null);
+			setAlerts([]);
+			setStatus(null);
+		} else {
+			const newHistory =
+				historyRes.status === "fulfilled" ? historyRes.value : [];
+			const newStatus =
+				statusRes.status === "fulfilled" ? statusRes.value : null;
+
+			setAvailable(true);
+			setError(undefined);
+			setHistory(newHistory);
+			setLatest(
+				newStatus?.metrics ?? newHistory[newHistory.length - 1] ?? null,
+			);
+			setAlerts(newStatus?.alerts ?? []);
+			setStatus(newStatus?.status ?? null);
+		}
+
+		hasLoadedRef.current = true;
+		setLoading(false);
+	}, []);
+
+	usePolling(fetch);
+
+	const refetch = useCallback(() => {
+		void fetch();
+	}, [fetch]);
+
+	return {
+		history,
+		latest,
+		alerts,
+		status,
+		available,
+		loading,
+		error,
+		refetch,
+	};
+}

--- a/ui/src/pages/DashboardPage.tsx
+++ b/ui/src/pages/DashboardPage.tsx
@@ -1,45 +1,40 @@
 /**
- * DashboardPage — landing page with service health, agent summary,
- * notification summary, activity timeline, and stub sections.
+ * DashboardPage — landing page with overview stats, system metrics,
+ * activity charts, agent/notification summaries, service health, and a
+ * recent activity feed.
  */
 
-import { BarChart2, RefreshCw, Webhook } from "lucide-react";
+import { RefreshCw } from "lucide-react";
 import { useMemo, useState } from "react";
-import type { ActivityEvent } from "@/components/dashboard/ActivityTimeline";
+import { ActivityChart } from "@/components/dashboard/ActivityChart";
 import { ActivityTimeline } from "@/components/dashboard/ActivityTimeline";
 import { AgentSummary } from "@/components/dashboard/AgentSummary";
 import { NotificationSummary } from "@/components/dashboard/NotificationSummary";
+import { OverviewStats } from "@/components/dashboard/OverviewStats";
 import {
 	ServiceHealthCard,
 	ServiceHealthCardSkeleton,
 } from "@/components/dashboard/ServiceHealthCard";
+import { SystemMetricsChart } from "@/components/dashboard/SystemMetricsChart";
+import { useActivityFeed } from "@/hooks/useActivityFeed";
 import { useAgentSummary } from "@/hooks/useAgentSummary";
+import { useDashboardStats } from "@/hooks/useDashboardStats";
 import { useNotificationSummary } from "@/hooks/useNotificationSummary";
 import { useServiceHealth } from "@/hooks/useServiceHealth";
+import { useSystemMetrics } from "@/hooks/useSystemMetrics";
 import { CreateAgentDialog } from "@/pages/agents/CreateAgentDialog";
 import { orchestratorClient } from "@/services/orchestrator";
 
 // ---------------------------------------------------------------------------
-// Stub "Coming Soon" card
+// Helpers
 // ---------------------------------------------------------------------------
 
-interface ComingSoonCardProps {
-	title: string;
-	icon: React.ReactNode;
-}
-
-function ComingSoonCard({ title, icon }: ComingSoonCardProps) {
-	return (
-		<div className="flex flex-col items-center justify-center gap-3 rounded-lg border border-dashed border-th-border-strong bg-th-surface p-8 text-center">
-			<div className="flex h-12 w-12 items-center justify-center rounded-full bg-th-surface-sunken">
-				{icon}
-			</div>
-			<div>
-				<p className="font-medium text-th-text-secondary">{title}</p>
-				<p className="mt-1 text-sm text-th-text-faint">Coming Soon</p>
-			</div>
-		</div>
-	);
+function formatRelativeTime(date: Date): string {
+	const diffSec = Math.floor((Date.now() - date.getTime()) / 1000);
+	if (diffSec < 60) return "just now";
+	const diffMin = Math.floor(diffSec / 60);
+	if (diffMin < 60) return `${diffMin}m ago`;
+	return `${Math.floor(diffMin / 60)}h ago`;
 }
 
 // ---------------------------------------------------------------------------
@@ -55,27 +50,31 @@ export function DashboardPage() {
 	} = useServiceHealth();
 	const agentSummary = useAgentSummary();
 	const notifSummary = useNotificationSummary();
+	const systemMetrics = useSystemMetrics();
+	const dashboardStats = useDashboardStats();
+	const activityFeed = useActivityFeed();
 	const [createOpen, setCreateOpen] = useState(false);
 
-	// Build a synthetic activity feed from available data
-	const activityEvents: ActivityEvent[] = useMemo(() => {
-		const events: ActivityEvent[] = [];
-
-		// Derive events from recently-updated agents
-		for (const agent of agentSummary.recentAgents) {
-			events.push({
-				id: `agent-${agent.id}`,
-				type: "agent",
-				description: `Agent "${agent.name}" is ${agent.status.toLowerCase()}`,
-				timestamp: new Date(agent.updated_at),
-			});
+	// Most recent successful health check — doubles as the "Updated" stamp
+	// since service health refreshes on the same cadence as everything else.
+	const lastUpdated = useMemo(() => {
+		let latest: Date | null = null;
+		for (const svc of services) {
+			if (svc.lastChecked && (!latest || svc.lastChecked > latest)) {
+				latest = svc.lastChecked;
+			}
 		}
+		return latest;
+	}, [services]);
 
-		// Sort by timestamp descending
-		return events
-			.sort((a, b) => b.timestamp.getTime() - a.timestamp.getTime())
-			.slice(0, 10);
-	}, [agentSummary.recentAgents]);
+	function refreshAll() {
+		refresh();
+		agentSummary.refetch();
+		notifSummary.refetch();
+		systemMetrics.refetch();
+		dashboardStats.refetch();
+		activityFeed.refetch();
+	}
 
 	return (
 		<div className="space-y-6">
@@ -87,19 +86,58 @@ export function DashboardPage() {
 						System overview and service health
 					</p>
 				</div>
-				<button
-					type="button"
-					onClick={refresh}
-					disabled={healthLoading}
-					aria-label="Refresh service health"
-					className="flex items-center gap-1.5 rounded-md border border-th-border-strong bg-th-surface px-3 py-2 text-sm text-th-text-secondary hover:bg-th-surface-hover disabled:opacity-50"
-				>
-					<RefreshCw
-						size={14}
-						className={healthLoading ? "animate-spin" : ""}
-					/>
-					Refresh
-				</button>
+				<div className="flex items-center gap-3">
+					{lastUpdated && (
+						<span className="text-xs text-th-text-faint">
+							Updated {formatRelativeTime(lastUpdated)}
+						</span>
+					)}
+					<button
+						type="button"
+						onClick={refreshAll}
+						disabled={healthLoading}
+						aria-label="Refresh dashboard"
+						className="flex items-center gap-1.5 rounded-md border border-th-border-strong bg-th-surface px-3 py-2 text-sm text-th-text-secondary hover:bg-th-surface-hover disabled:opacity-50"
+					>
+						<RefreshCw
+							size={14}
+							className={healthLoading ? "animate-spin" : ""}
+						/>
+						Refresh
+					</button>
+				</div>
+			</div>
+
+			{/* Overview stat row */}
+			<OverviewStats
+				runningAgents={agentSummary.error ? null : agentSummary.counts.running}
+				pendingApprovals={dashboardStats.pendingApprovals}
+				pendingNotifications={notifSummary.error ? null : notifSummary.pending}
+				pendingQuestions={dashboardStats.pendingQuestions}
+				workflows={dashboardStats.workflows}
+				totalCostUsd={agentSummary.aggregateUsage?.totalCostUsd ?? null}
+				loading={
+					agentSummary.loading || notifSummary.loading || dashboardStats.loading
+				}
+			/>
+
+			{/* Time-series charts */}
+			<div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+				<SystemMetricsChart {...systemMetrics} />
+				<ActivityChart
+					buckets={activityFeed.buckets}
+					loading={activityFeed.loading}
+					error={activityFeed.error}
+				/>
+			</div>
+
+			{/* Main grid: agents + notifications */}
+			<div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
+				<AgentSummary
+					{...agentSummary}
+					onCreateAgent={() => setCreateOpen(true)}
+				/>
+				<NotificationSummary {...notifSummary} />
 			</div>
 
 			{/* Service health cards */}
@@ -121,33 +159,12 @@ export function DashboardPage() {
 				</div>
 			</section>
 
-			{/* Main grid: agents + notifications */}
-			<div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
-				<AgentSummary
-					{...agentSummary}
-					onCreateAgent={() => setCreateOpen(true)}
-				/>
-				<NotificationSummary {...notifSummary} />
-			</div>
-
 			{/* Activity timeline */}
 			<ActivityTimeline
-				events={activityEvents}
-				loading={agentSummary.loading}
-				error={agentSummary.error}
+				events={activityFeed.events}
+				loading={activityFeed.loading}
+				error={activityFeed.error}
 			/>
-
-			{/* Stub sections */}
-			<div className="grid grid-cols-1 gap-6 lg:grid-cols-2">
-				<ComingSoonCard
-					title="Monitoring"
-					icon={<BarChart2 size={24} className="text-th-text-muted" />}
-				/>
-				<ComingSoonCard
-					title="Hooks"
-					icon={<Webhook size={24} className="text-th-text-muted" />}
-				/>
-			</div>
 
 			{/* Create agent dialog */}
 			<CreateAgentDialog

--- a/ui/src/services/config.ts
+++ b/ui/src/services/config.ts
@@ -11,6 +11,8 @@ export const serviceConfig = {
 		"http://localhost:17006",
 	memoryServiceUrl:
 		import.meta.env.VITE_AGENTD_MEMORY_SERVICE_URL ?? "http://localhost:17008",
+	monitorServiceUrl:
+		import.meta.env.VITE_AGENTD_MONITOR_SERVICE_URL ?? "http://localhost:17003",
 	communicateServiceUrl:
 		import.meta.env.VITE_AGENTD_COMMUNICATE_SERVICE_URL ??
 		"http://localhost:17010",

--- a/ui/src/services/index.ts
+++ b/ui/src/services/index.ts
@@ -4,5 +4,6 @@ export { ApiClient } from "./base";
 export { CommunicateClient, communicateClient } from "./communicate";
 export { serviceConfig } from "./config";
 export { MemoryClient, memoryClient } from "./memory";
+export { MonitorClient, monitorClient } from "./monitor";
 export { NotifyClient, notifyClient } from "./notify";
 export { OrchestratorClient, orchestratorClient } from "./orchestrator";

--- a/ui/src/services/monitor.ts
+++ b/ui/src/services/monitor.ts
@@ -1,0 +1,58 @@
+/**
+ * Client for the Monitor service (default port 17003).
+ *
+ * Exposes system metrics (CPU, memory, disk, load average), the retained
+ * metrics history ring buffer, and threshold-based health assessment.
+ */
+
+import type { HealthResponse } from "@/types/common";
+import type {
+	CollectResponse,
+	SystemMetrics,
+	SystemStatus,
+} from "@/types/monitor";
+import { ApiClient } from "./base";
+import { serviceConfig } from "./config";
+
+export class MonitorClient extends ApiClient {
+	// -------------------------------------------------------------------------
+	// Health
+	// -------------------------------------------------------------------------
+
+	getHealth(): Promise<HealthResponse> {
+		return this.get<HealthResponse>("/health");
+	}
+
+	// -------------------------------------------------------------------------
+	// Metrics
+	// -------------------------------------------------------------------------
+
+	/** `GET /metrics` — latest system metrics snapshot (503 if none yet). */
+	getMetrics(): Promise<SystemMetrics> {
+		return this.get<SystemMetrics>("/metrics");
+	}
+
+	/** `GET /history` — all retained metrics snapshots (ring buffer). */
+	getHistory(): Promise<SystemMetrics[]> {
+		return this.get<SystemMetrics[]>("/history");
+	}
+
+	/** `POST /collect` — trigger an immediate metrics collection. */
+	collect(): Promise<CollectResponse> {
+		return this.post<CollectResponse>("/collect");
+	}
+
+	// -------------------------------------------------------------------------
+	// Status
+	// -------------------------------------------------------------------------
+
+	/** `GET /status` — current health assessment against thresholds. */
+	getStatus(): Promise<SystemStatus> {
+		return this.get<SystemStatus>("/status");
+	}
+}
+
+/** Singleton client instance using the configured service URL */
+export const monitorClient = new MonitorClient({
+	baseUrl: serviceConfig.monitorServiceUrl,
+});

--- a/ui/src/test/components/dashboard/OverviewStats.test.tsx
+++ b/ui/src/test/components/dashboard/OverviewStats.test.tsx
@@ -1,0 +1,78 @@
+/**
+ * OverviewStats -- rendering tests, including the "—" fallback for
+ * unavailable (null) data sources.
+ */
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import type { OverviewStatsProps } from "@/components/dashboard/OverviewStats";
+import { OverviewStats } from "@/components/dashboard/OverviewStats";
+
+const baseProps: OverviewStatsProps = {
+	runningAgents: 3,
+	pendingApprovals: 2,
+	pendingNotifications: 5,
+	pendingQuestions: 1,
+	workflows: 4,
+	totalCostUsd: 1.23,
+	loading: false,
+};
+
+describe("OverviewStats", () => {
+	it("renders all six stat labels", () => {
+		render(<OverviewStats {...baseProps} />);
+		expect(screen.getByText("Running Agents")).toBeInTheDocument();
+		expect(screen.getByText("Pending Approvals")).toBeInTheDocument();
+		expect(screen.getByText("Pending Notifications")).toBeInTheDocument();
+		expect(screen.getByText("Pending Questions")).toBeInTheDocument();
+		expect(screen.getByText("Workflows")).toBeInTheDocument();
+		expect(screen.getByText("Total Cost")).toBeInTheDocument();
+	});
+
+	it("renders numeric values", () => {
+		render(<OverviewStats {...baseProps} />);
+		expect(screen.getByText("3")).toBeInTheDocument();
+		expect(screen.getByText("5")).toBeInTheDocument();
+	});
+
+	it("formats the total cost as dollars", () => {
+		render(<OverviewStats {...baseProps} />);
+		expect(screen.getByText("$1.23")).toBeInTheDocument();
+	});
+
+	it("formats tiny non-zero costs as <$0.01", () => {
+		render(<OverviewStats {...baseProps} totalCostUsd={0.001} />);
+		expect(screen.getByText("<$0.01")).toBeInTheDocument();
+	});
+
+	it('renders "—" when a source is unavailable (null)', () => {
+		render(
+			<OverviewStats
+				{...baseProps}
+				pendingApprovals={null}
+				totalCostUsd={null}
+			/>,
+		);
+		expect(screen.getAllByText("—")).toHaveLength(2);
+	});
+
+	it('renders "—" for every stat when all sources are unavailable', () => {
+		render(
+			<OverviewStats
+				runningAgents={null}
+				pendingApprovals={null}
+				pendingNotifications={null}
+				pendingQuestions={null}
+				workflows={null}
+				totalCostUsd={null}
+			/>,
+		);
+		expect(screen.getAllByText("—")).toHaveLength(6);
+	});
+
+	it("renders skeletons instead of values while loading", () => {
+		render(<OverviewStats {...baseProps} loading />);
+		expect(screen.queryByText("3")).not.toBeInTheDocument();
+		expect(screen.queryByText("$1.23")).not.toBeInTheDocument();
+	});
+});

--- a/ui/src/test/hooks/useActivityFeed.test.ts
+++ b/ui/src/test/hooks/useActivityFeed.test.ts
@@ -1,0 +1,111 @@
+/**
+ * useActivityFeed -- derivation unit tests (events + hourly buckets) and an
+ * MSW integration smoke test.
+ */
+
+import { renderHook, waitFor } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import {
+	activityFeedInternals,
+	useActivityFeed,
+} from "@/hooks/useActivityFeed";
+import {
+	makeAgent,
+	makeNotification,
+	makeQuestion,
+} from "@/test/mocks/factories";
+
+const { buildEvents, buildBuckets } = activityFeedInternals;
+
+const NOW = new Date("2024-06-15T12:30:00Z");
+
+describe("buildEvents", () => {
+	it("merges notifications, questions, and agents sorted newest first", () => {
+		const events = buildEvents(
+			[makeNotification({ id: "n1", created_at: "2024-06-15T10:00:00Z" })],
+			[makeQuestion({ id: "q1", asked_at: "2024-06-15T12:00:00Z" })],
+			[makeAgent({ id: "a1", updated_at: "2024-06-15T11:00:00Z" })],
+		);
+
+		expect(events.map((e) => e.type)).toEqual([
+			"question",
+			"agent",
+			"notification",
+		]);
+	});
+
+	it("caps the merged feed at 12 events", () => {
+		const notifications = Array.from({ length: 20 }, (_, i) =>
+			makeNotification({ id: `n${i}`, created_at: "2024-06-15T10:00:00Z" }),
+		);
+		expect(buildEvents(notifications, [], [])).toHaveLength(12);
+	});
+
+	it("includes title and message in notification descriptions", () => {
+		const [event] = buildEvents(
+			[makeNotification({ title: "Build failed", message: "exit code 1" })],
+			[],
+			[],
+		);
+		expect(event.description).toContain("Build failed");
+		expect(event.description).toContain("exit code 1");
+	});
+
+	it("drops events with invalid timestamps", () => {
+		const events = buildEvents(
+			[makeNotification({ created_at: "not-a-date" })],
+			[],
+			[],
+		);
+		expect(events).toHaveLength(0);
+	});
+});
+
+describe("buildBuckets", () => {
+	it("returns 24 hourly buckets", () => {
+		const buckets = buildBuckets([], [], [], NOW);
+		expect(buckets).toHaveLength(24);
+		expect(buckets.every((b) => /^\d{2}:00$/.test(b.hour))).toBe(true);
+	});
+
+	it("counts items into the correct hour bucket by type", () => {
+		const oneHourAgo = new Date(NOW.getTime() - 60 * 60 * 1000).toISOString();
+		const buckets = buildBuckets(
+			[makeNotification({ created_at: oneHourAgo })],
+			[makeQuestion({ asked_at: oneHourAgo })],
+			[makeAgent({ updated_at: NOW.toISOString() })],
+			NOW,
+		);
+
+		// Second-to-last bucket = previous hour; last bucket = current hour
+		expect(buckets[22].notifications).toBe(1);
+		expect(buckets[22].questions).toBe(1);
+		expect(buckets[23].agents).toBe(1);
+	});
+
+	it("ignores items outside the 24h window", () => {
+		const twoDaysAgo = new Date(
+			NOW.getTime() - 48 * 60 * 60 * 1000,
+		).toISOString();
+		const buckets = buildBuckets(
+			[makeNotification({ created_at: twoDaysAgo })],
+			[],
+			[],
+			NOW,
+		);
+		expect(buckets.every((b) => b.notifications === 0)).toBe(true);
+	});
+});
+
+describe("useActivityFeed (MSW integration)", () => {
+	it("loads events from the default handlers without errors", async () => {
+		const { result } = renderHook(() => useActivityFeed());
+
+		await waitFor(() => expect(result.current.loading).toBe(false));
+
+		expect(result.current.error).toBeUndefined();
+		expect(result.current.buckets).toHaveLength(24);
+		// Default handlers provide notifications, questions, and agents
+		expect(result.current.events.length).toBeGreaterThan(0);
+	});
+});

--- a/ui/src/test/hooks/useChartPalette.test.ts
+++ b/ui/src/test/hooks/useChartPalette.test.ts
@@ -1,0 +1,86 @@
+/**
+ * useChartPalette / withAlpha -- unit tests.
+ */
+
+import { renderHook } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import {
+	buildChartPalette,
+	useChartPalette,
+	withAlpha,
+} from "@/hooks/useChartPalette";
+import { getTheme } from "@/stores/themeStore";
+import { DEFAULT_THEME_ID } from "@/styles/themes/index";
+
+describe("withAlpha", () => {
+	it("converts #rrggbb hex to rgba", () => {
+		expect(withAlpha("#8ac926", 0.7)).toBe("rgba(138, 201, 38, 0.7)");
+	});
+
+	it("converts #rgb shorthand hex to rgba", () => {
+		expect(withAlpha("#fff", 0.5)).toBe("rgba(255, 255, 255, 0.5)");
+	});
+
+	it("converts #rrggbbaa hex to rgba (ignoring the original alpha)", () => {
+		expect(withAlpha("#ff595e80", 0.25)).toBe("rgba(255, 89, 94, 0.25)");
+	});
+
+	it("converts rgb(...) to rgba", () => {
+		expect(withAlpha("rgb(10, 20, 30)", 0.25)).toBe("rgba(10, 20, 30, 0.25)");
+	});
+
+	it("replaces the alpha of an existing rgba(...) value", () => {
+		expect(withAlpha("rgba(126, 156, 216, 0.15)", 0.4)).toBe(
+			"rgba(126, 156, 216, 0.4)",
+		);
+	});
+
+	it("handles surrounding whitespace", () => {
+		expect(withAlpha("  #333  ", 0.5)).toBe("rgba(51, 51, 51, 0.5)");
+	});
+
+	it("clamps alpha into the [0, 1] range", () => {
+		expect(withAlpha("#000", 2)).toBe("rgba(0, 0, 0, 1)");
+		expect(withAlpha("#000", -1)).toBe("rgba(0, 0, 0, 0)");
+	});
+
+	it("returns unparseable values unchanged", () => {
+		expect(withAlpha("var(--th-accent)", 0.5)).toBe("var(--th-accent)");
+		expect(withAlpha("not-a-color", 0.5)).toBe("not-a-color");
+	});
+});
+
+describe("buildChartPalette", () => {
+	const tokens = getTheme(DEFAULT_THEME_ID);
+	const palette = buildChartPalette(tokens);
+
+	it("maps semantic colors from status dot tokens", () => {
+		expect(palette.success).toBe(tokens.statusSuccessDot);
+		expect(palette.warning).toBe(tokens.statusWarningDot);
+		expect(palette.error).toBe(tokens.statusErrorDot);
+		expect(palette.info).toBe(tokens.statusInfoDot);
+	});
+
+	it("maps neutral from textMuted and accent from accent", () => {
+		expect(palette.neutral).toBe(tokens.textMuted);
+		expect(palette.accent).toBe(tokens.accent);
+	});
+
+	it("derives a categorical series array from theme tokens", () => {
+		expect(palette.series.length).toBeGreaterThanOrEqual(5);
+		expect(palette.series[0]).toBe(tokens.accent);
+	});
+
+	it("exposes the withAlpha helper", () => {
+		expect(palette.withAlpha("#fff", 0.5)).toBe("rgba(255, 255, 255, 0.5)");
+	});
+});
+
+describe("useChartPalette", () => {
+	it("falls back to the default theme outside a ThemeProvider", () => {
+		const { result } = renderHook(() => useChartPalette());
+		const tokens = getTheme(DEFAULT_THEME_ID);
+		expect(result.current.accent).toBe(tokens.accent);
+		expect(result.current.surface).toBe(tokens.surface);
+	});
+});

--- a/ui/src/test/hooks/useNivoTheme.test.ts
+++ b/ui/src/test/hooks/useNivoTheme.test.ts
@@ -51,9 +51,15 @@ describe("buildNivoTheme", () => {
 		expect(theme.axis?.ticks?.text?.fill).toBe("#888");
 	});
 
-	it("uses border for grid lines", () => {
+	it("uses softened (50% alpha) border for grid lines", () => {
 		const theme = buildNivoTheme(MOCK_TOKENS);
-		expect(theme.grid?.line?.stroke).toBe("#333");
+		// border "#333" → rgba at half strength so grids recede behind data
+		expect(theme.grid?.line?.stroke).toBe("rgba(51, 51, 51, 0.5)");
+	});
+
+	it("uses softened (50% alpha) border for axis tick lines", () => {
+		const theme = buildNivoTheme(MOCK_TOKENS);
+		expect(theme.axis?.ticks?.line?.stroke).toBe("rgba(51, 51, 51, 0.5)");
 	});
 
 	it("uses surfaceRaised for tooltip background", () => {

--- a/ui/src/test/hooks/usePolling.test.ts
+++ b/ui/src/test/hooks/usePolling.test.ts
@@ -1,0 +1,103 @@
+/**
+ * usePolling -- unit tests (fake timers + visibility pause/resume).
+ */
+
+import { renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { usePolling } from "@/hooks/usePolling";
+
+/** Override document.hidden and fire a visibilitychange event */
+function setDocumentHidden(hidden: boolean) {
+	Object.defineProperty(document, "hidden", {
+		configurable: true,
+		get: () => hidden,
+	});
+	document.dispatchEvent(new Event("visibilitychange"));
+}
+
+describe("usePolling", () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+	});
+
+	afterEach(() => {
+		setDocumentHidden(false);
+		vi.useRealTimers();
+	});
+
+	it("fires the callback immediately on mount", () => {
+		const callback = vi.fn();
+		renderHook(() => usePolling(callback, 30_000));
+		expect(callback).toHaveBeenCalledTimes(1);
+	});
+
+	it("fires on each interval tick", () => {
+		const callback = vi.fn();
+		renderHook(() => usePolling(callback, 30_000));
+
+		vi.advanceTimersByTime(30_000);
+		expect(callback).toHaveBeenCalledTimes(2);
+
+		vi.advanceTimersByTime(60_000);
+		expect(callback).toHaveBeenCalledTimes(4);
+	});
+
+	it("respects a custom interval", () => {
+		const callback = vi.fn();
+		renderHook(() => usePolling(callback, 5_000));
+
+		vi.advanceTimersByTime(4_999);
+		expect(callback).toHaveBeenCalledTimes(1);
+		vi.advanceTimersByTime(1);
+		expect(callback).toHaveBeenCalledTimes(2);
+	});
+
+	it("pauses while the document is hidden", () => {
+		const callback = vi.fn();
+		renderHook(() => usePolling(callback, 30_000));
+		expect(callback).toHaveBeenCalledTimes(1);
+
+		setDocumentHidden(true);
+		vi.advanceTimersByTime(120_000);
+		expect(callback).toHaveBeenCalledTimes(1);
+	});
+
+	it("resumes and fires immediately when the document becomes visible", () => {
+		const callback = vi.fn();
+		renderHook(() => usePolling(callback, 30_000));
+
+		setDocumentHidden(true);
+		vi.advanceTimersByTime(120_000);
+		expect(callback).toHaveBeenCalledTimes(1);
+
+		setDocumentHidden(false);
+		// Immediate fire on visibility
+		expect(callback).toHaveBeenCalledTimes(2);
+		// ...and the interval resumes
+		vi.advanceTimersByTime(30_000);
+		expect(callback).toHaveBeenCalledTimes(3);
+	});
+
+	it("stops polling after unmount", () => {
+		const callback = vi.fn();
+		const { unmount } = renderHook(() => usePolling(callback, 30_000));
+
+		unmount();
+		vi.advanceTimersByTime(120_000);
+		expect(callback).toHaveBeenCalledTimes(1);
+	});
+
+	it("always invokes the latest callback", () => {
+		const first = vi.fn();
+		const second = vi.fn();
+		const { rerender } = renderHook(({ cb }) => usePolling(cb, 30_000), {
+			initialProps: { cb: first },
+		});
+
+		rerender({ cb: second });
+		vi.advanceTimersByTime(30_000);
+
+		expect(first).toHaveBeenCalledTimes(1); // mount fire only
+		expect(second).toHaveBeenCalledTimes(1); // interval fire
+	});
+});

--- a/ui/src/test/hooks/useSystemMetrics.test.ts
+++ b/ui/src/test/hooks/useSystemMetrics.test.ts
@@ -1,0 +1,88 @@
+/**
+ * useSystemMetrics -- MSW integration tests.
+ *
+ * Note: the ApiClient retries on 5xx errors, so the service-down tests use
+ * 4xx responses to avoid slow retries (matching serviceHealth.test.tsx).
+ */
+
+import { renderHook, waitFor } from "@testing-library/react";
+import { HttpResponse, http } from "msw";
+import { describe, expect, it } from "vitest";
+import { useSystemMetrics } from "@/hooks/useSystemMetrics";
+import { makeMonitorAlert, makeSystemStatus } from "@/test/mocks/factories";
+import { server } from "@/test/mocks/server";
+
+const BASE = "http://localhost:17003";
+
+describe("useSystemMetrics (MSW integration)", () => {
+	it("loads history and status on the happy path", async () => {
+		const { result } = renderHook(() => useSystemMetrics());
+
+		await waitFor(() => expect(result.current.loading).toBe(false));
+
+		expect(result.current.available).toBe(true);
+		expect(result.current.error).toBeUndefined();
+		expect(result.current.history).toHaveLength(12);
+		expect(result.current.latest).not.toBeNull();
+		expect(result.current.latest?.cpu.usage_percent).toBeCloseTo(42.5);
+		expect(result.current.latest?.memory.usage_percent).toBeCloseTo(50.0);
+		expect(result.current.status).toBe("healthy");
+		expect(result.current.alerts).toHaveLength(0);
+	});
+
+	it("surfaces threshold alerts from the status endpoint", async () => {
+		server.use(
+			http.get(`${BASE}/status`, () =>
+				HttpResponse.json(
+					makeSystemStatus({
+						status: "degraded",
+						alerts: [makeMonitorAlert()],
+					}),
+				),
+			),
+		);
+
+		const { result } = renderHook(() => useSystemMetrics());
+		await waitFor(() => expect(result.current.loading).toBe(false));
+
+		expect(result.current.status).toBe("degraded");
+		expect(result.current.alerts).toHaveLength(1);
+		expect(result.current.alerts[0].metric).toBe("cpu");
+	});
+
+	it("marks the service unavailable when all endpoints fail", async () => {
+		server.use(
+			http.get(`${BASE}/history`, () =>
+				HttpResponse.json({ error: "Not found" }, { status: 404 }),
+			),
+			http.get(`${BASE}/status`, () =>
+				HttpResponse.json({ error: "Not found" }, { status: 404 }),
+			),
+		);
+
+		const { result } = renderHook(() => useSystemMetrics());
+		await waitFor(() => expect(result.current.loading).toBe(false));
+
+		expect(result.current.available).toBe(false);
+		expect(result.current.error).toBe("Monitor service unavailable");
+		expect(result.current.history).toHaveLength(0);
+		expect(result.current.latest).toBeNull();
+	});
+
+	it("still returns history when only the status endpoint fails", async () => {
+		server.use(
+			http.get(`${BASE}/status`, () =>
+				HttpResponse.json({ error: "Not found" }, { status: 404 }),
+			),
+		);
+
+		const { result } = renderHook(() => useSystemMetrics());
+		await waitFor(() => expect(result.current.loading).toBe(false));
+
+		expect(result.current.available).toBe(true);
+		expect(result.current.history).toHaveLength(12);
+		// Falls back to the newest history entry for `latest`
+		expect(result.current.latest).not.toBeNull();
+		expect(result.current.status).toBeNull();
+	});
+});

--- a/ui/src/test/integration/serviceHealth.test.tsx
+++ b/ui/src/test/integration/serviceHealth.test.tsx
@@ -2,7 +2,7 @@
  * Integration test for useServiceHealth hook.
  *
  * Uses MSW to intercept real fetch calls and verifies that the hook
- * correctly parses health responses from all five services.
+ * correctly parses health responses from all six services.
  *
  * Note: the ApiClient retries on 5xx errors. We use 4xx errors in tests
  * to avoid slow retries; the catch block in fetchHealth() treats any error
@@ -16,17 +16,17 @@ import { useServiceHealth } from "@/hooks/useServiceHealth";
 import { server } from "@/test/mocks/server";
 
 describe("useServiceHealth (MSW integration)", () => {
-	it("fetches health from all five services and marks them healthy", async () => {
+	it("fetches health from all six services and marks them healthy", async () => {
 		const { result } = renderHook(() => useServiceHealth());
 
 		await waitFor(() => expect(result.current.initializing).toBe(false));
 
-		expect(result.current.services).toHaveLength(5);
+		expect(result.current.services).toHaveLength(6);
 		const statuses = result.current.services.map((s) => s.status);
 		expect(statuses.every((s) => s === "healthy")).toBe(true);
 	});
 
-	it("includes service names Orchestrator, Notify, Ask, Memory, Communicate", async () => {
+	it("includes service names Orchestrator, Notify, Ask, Memory, Communicate, Monitor", async () => {
 		const { result } = renderHook(() => useServiceHealth());
 		await waitFor(() => expect(result.current.initializing).toBe(false));
 
@@ -36,6 +36,16 @@ describe("useServiceHealth (MSW integration)", () => {
 		expect(names).toContain("Ask");
 		expect(names).toContain("Memory");
 		expect(names).toContain("Communicate");
+		expect(names).toContain("Monitor");
+	});
+
+	it("reports the monitor service on port 17003", async () => {
+		const { result } = renderHook(() => useServiceHealth());
+		await waitFor(() => expect(result.current.initializing).toBe(false));
+
+		const monitor = result.current.services.find((s) => s.key === "monitor");
+		expect(monitor?.port).toBe(17003);
+		expect(monitor?.status).toBe("healthy");
 	});
 
 	it("marks orchestrator as down on 4xx response (no retry)", async () => {

--- a/ui/src/test/mocks/factories/index.ts
+++ b/ui/src/test/mocks/factories/index.ts
@@ -33,6 +33,12 @@ export {
 	resetMemorySeq,
 } from "./memory";
 export {
+	makeMonitorAlert,
+	makeSystemMetrics,
+	makeSystemMetricsHistory,
+	makeSystemStatus,
+} from "./monitor";
+export {
 	makeCountResponse,
 	makeNotification,
 	makeNotificationList,

--- a/ui/src/test/mocks/factories/monitor.ts
+++ b/ui/src/test/mocks/factories/monitor.ts
@@ -1,0 +1,94 @@
+/**
+ * Test data factory for Monitor service types.
+ *
+ * Usage:
+ *   const metrics = makeSystemMetrics()
+ *   const history = makeSystemMetricsHistory(12)
+ *   const status = makeSystemStatus({ status: 'degraded' })
+ */
+
+import type {
+	MonitorAlert,
+	SystemMetrics,
+	SystemStatus,
+} from "@/types/monitor";
+
+/** Base timestamp used for deterministic snapshot times */
+const BASE_TIME_MS = Date.parse("2024-01-01T00:00:00Z");
+
+// ---------------------------------------------------------------------------
+// SystemMetrics factory
+// ---------------------------------------------------------------------------
+
+export function makeSystemMetrics(
+	overrides?: Partial<SystemMetrics>,
+): SystemMetrics {
+	return {
+		collected_at: "2024-01-01T00:00:00Z",
+		cpu: {
+			usage_percent: 42.5,
+			core_count: 8,
+			per_core: [40.0, 45.0, 41.0, 44.0, 42.0, 43.0, 40.5, 44.5],
+		},
+		memory: {
+			total_bytes: 16_000_000_000,
+			used_bytes: 8_000_000_000,
+			available_bytes: 8_000_000_000,
+			usage_percent: 50.0,
+		},
+		disks: [
+			{
+				name: "disk0",
+				mount_point: "/",
+				total_bytes: 500_000_000_000,
+				available_bytes: 200_000_000_000,
+				used_bytes: 300_000_000_000,
+				usage_percent: 60.0,
+			},
+		],
+		load_average: { one: 1.5, five: 1.2, fifteen: 0.9 },
+		...overrides,
+	};
+}
+
+/** Create a history of N snapshots spaced 30 seconds apart, oldest first */
+export function makeSystemMetricsHistory(
+	count: number,
+	overrides?: Partial<SystemMetrics>,
+): SystemMetrics[] {
+	return Array.from({ length: count }, (_, i) =>
+		makeSystemMetrics({
+			collected_at: new Date(BASE_TIME_MS + i * 30_000).toISOString(),
+			...overrides,
+		}),
+	);
+}
+
+// ---------------------------------------------------------------------------
+// Alert / status factories
+// ---------------------------------------------------------------------------
+
+export function makeMonitorAlert(
+	overrides?: Partial<MonitorAlert>,
+): MonitorAlert {
+	return {
+		metric: "cpu",
+		current_value: 95.0,
+		threshold: 90.0,
+		message: "CPU usage is critical: 95.0% (threshold: 90.0%)",
+		raised_at: "2024-01-01T00:00:00Z",
+		...overrides,
+	};
+}
+
+export function makeSystemStatus(
+	overrides?: Partial<SystemStatus>,
+): SystemStatus {
+	return {
+		status: "healthy",
+		metrics: makeSystemMetrics(),
+		alerts: [],
+		last_collected_at: "2024-01-01T00:00:00Z",
+		...overrides,
+	};
+}

--- a/ui/src/test/mocks/handlers/index.ts
+++ b/ui/src/test/mocks/handlers/index.ts
@@ -14,6 +14,7 @@
 import { askHandlers } from "./ask";
 import { communicateHandlers } from "./communicate";
 import { memoryHandlers } from "./memory";
+import { monitorHandlers } from "./monitor";
 import { notifyHandlers } from "./notify";
 import { orchestratorHandlers } from "./orchestrator";
 
@@ -23,12 +24,14 @@ export const handlers = [
 	...askHandlers,
 	...memoryHandlers,
 	...communicateHandlers,
+	...monitorHandlers,
 ];
 
 export {
 	askHandlers,
 	communicateHandlers,
 	memoryHandlers,
+	monitorHandlers,
 	notifyHandlers,
 	orchestratorHandlers,
 };

--- a/ui/src/test/mocks/handlers/monitor.ts
+++ b/ui/src/test/mocks/handlers/monitor.ts
@@ -1,0 +1,57 @@
+/**
+ * MSW request handlers for the Monitor service (port 17003).
+ *
+ * Provides default responses for all Monitor API endpoints.
+ * Override per test with server.use().
+ */
+
+import { HttpResponse, http } from "msw";
+import {
+	makeSystemMetrics,
+	makeSystemMetricsHistory,
+	makeSystemStatus,
+} from "../factories";
+
+const BASE = "http://localhost:17003";
+
+const DEFAULT_HISTORY = makeSystemMetricsHistory(12);
+const DEFAULT_LATEST = DEFAULT_HISTORY[DEFAULT_HISTORY.length - 1];
+
+export const monitorHandlers = [
+	// -------------------------------------------------------------------------
+	// Health
+	// -------------------------------------------------------------------------
+
+	http.get(`${BASE}/health`, () =>
+		HttpResponse.json({
+			status: "ok",
+			service: "agentd-monitor",
+			version: "0.2.0",
+		}),
+	),
+
+	// -------------------------------------------------------------------------
+	// Metrics
+	// -------------------------------------------------------------------------
+
+	http.get(`${BASE}/metrics`, () => HttpResponse.json(DEFAULT_LATEST)),
+
+	http.get(`${BASE}/history`, () => HttpResponse.json(DEFAULT_HISTORY)),
+
+	http.post(`${BASE}/collect`, () =>
+		HttpResponse.json({ metrics: makeSystemMetrics(), alerts: [] }),
+	),
+
+	// -------------------------------------------------------------------------
+	// Status
+	// -------------------------------------------------------------------------
+
+	http.get(`${BASE}/status`, () =>
+		HttpResponse.json(
+			makeSystemStatus({
+				metrics: DEFAULT_LATEST,
+				last_collected_at: DEFAULT_LATEST.collected_at,
+			}),
+		),
+	),
+];

--- a/ui/src/test/mocks/handlers/notify.ts
+++ b/ui/src/test/mocks/handlers/notify.ts
@@ -47,6 +47,35 @@ export const notifyHandlers = [
 		return HttpResponse.json(notif, { status: 201 });
 	}),
 
+	// -------------------------------------------------------------------------
+	// Filtered views + count
+	//
+	// NOTE: these MUST be registered before the `/notifications/:id` routes —
+	// MSW matches handlers in order, and `:id` would otherwise swallow
+	// `actionable`, `history`, and `count` as path parameters.
+	// -------------------------------------------------------------------------
+
+	http.get(`${BASE}/notifications/actionable`, () =>
+		HttpResponse.json(paginated<Notification>(DEFAULT_PENDING)),
+	),
+
+	http.get(`${BASE}/notifications/history`, () =>
+		HttpResponse.json(paginated<Notification>([])),
+	),
+
+	http.get(`${BASE}/notifications/count`, () =>
+		HttpResponse.json(
+			makeCountResponse(DEFAULT_NOTIFICATIONS.length, {
+				Pending: 2,
+				Viewed: 1,
+			}),
+		),
+	),
+
+	// -------------------------------------------------------------------------
+	// Single-notification routes
+	// -------------------------------------------------------------------------
+
 	http.get(`${BASE}/notifications/:id`, ({ params }) => {
 		const notif =
 			DEFAULT_NOTIFICATIONS.find((n) => n.id === params.id) ??
@@ -65,30 +94,5 @@ export const notifyHandlers = [
 	http.delete(
 		`${BASE}/notifications/:id`,
 		() => new HttpResponse(null, { status: 204 }),
-	),
-
-	// -------------------------------------------------------------------------
-	// Filtered views
-	// -------------------------------------------------------------------------
-
-	http.get(`${BASE}/notifications/actionable`, () =>
-		HttpResponse.json(paginated<Notification>(DEFAULT_PENDING)),
-	),
-
-	http.get(`${BASE}/notifications/history`, () =>
-		HttpResponse.json(paginated<Notification>([])),
-	),
-
-	// -------------------------------------------------------------------------
-	// Count
-	// -------------------------------------------------------------------------
-
-	http.get(`${BASE}/notifications/count`, () =>
-		HttpResponse.json(
-			makeCountResponse(DEFAULT_NOTIFICATIONS.length, {
-				Pending: 2,
-				Viewed: 1,
-			}),
-		),
 	),
 ];

--- a/ui/src/test/mocks/handlers/orchestrator.ts
+++ b/ui/src/test/mocks/handlers/orchestrator.ts
@@ -7,7 +7,7 @@
 
 import { HttpResponse, http, ws } from "msw";
 import type { PaginatedResponse } from "@/types/common";
-import type { Agent, PendingApproval } from "@/types/orchestrator";
+import type { Agent, PendingApproval, Workflow } from "@/types/orchestrator";
 import { makeAgent, makeAgentList, makeApprovalList } from "../factories";
 
 const BASE = "http://localhost:17006";
@@ -192,6 +192,14 @@ export const orchestratorHandlers = [
 
 	http.post(`${BASE}/approvals/:id/deny`, ({ params }) =>
 		HttpResponse.json({ id: params.id, status: "Denied" }),
+	),
+
+	// -------------------------------------------------------------------------
+	// Workflows
+	// -------------------------------------------------------------------------
+
+	http.get(`${BASE}/workflows`, () =>
+		HttpResponse.json(paginated<Workflow>([])),
 	),
 
 	// -------------------------------------------------------------------------

--- a/ui/src/test/pages/DashboardPage.test.tsx
+++ b/ui/src/test/pages/DashboardPage.test.tsx
@@ -36,6 +36,7 @@ vi.mock("@/hooks/useNotificationSummary", () => ({
 		priorityCounts: { low: 0, normal: 0, high: 0, urgent: 0 },
 		loading: false,
 		error: undefined,
+		refetch: vi.fn(),
 	}),
 }));
 
@@ -48,9 +49,48 @@ vi.mock("@/hooks/useServiceHealth", () => ({
 	}),
 }));
 
+vi.mock("@/hooks/useSystemMetrics", () => ({
+	useSystemMetrics: () => ({
+		history: [],
+		latest: null,
+		alerts: [],
+		status: null,
+		available: false,
+		loading: false,
+		error: "Monitor service unavailable",
+		refetch: vi.fn(),
+	}),
+}));
+
+vi.mock("@/hooks/useDashboardStats", () => ({
+	useDashboardStats: () => ({
+		pendingApprovals: 0,
+		workflows: 0,
+		pendingQuestions: 0,
+		loading: false,
+		refetch: vi.fn(),
+	}),
+}));
+
+vi.mock("@/hooks/useActivityFeed", () => ({
+	useActivityFeed: () => ({
+		events: [],
+		buckets: [],
+		loading: false,
+		error: undefined,
+		refetch: vi.fn(),
+	}),
+}));
+
 // Mock nivo so it doesn't complain about missing ResizeObserver in jsdom
 vi.mock("@nivo/pie", () => ({
 	ResponsivePie: () => <div data-testid="mock-pie" />,
+}));
+vi.mock("@nivo/bar", () => ({
+	ResponsiveBar: () => <div data-testid="mock-bar" />,
+}));
+vi.mock("@nivo/line", () => ({
+	ResponsiveLine: () => <div data-testid="mock-line" />,
 }));
 
 // ---------------------------------------------------------------------------

--- a/ui/src/types/env.d.ts
+++ b/ui/src/types/env.d.ts
@@ -2,6 +2,7 @@
 
 interface ImportMetaEnv {
 	readonly VITE_AGENTD_ASK_SERVICE_URL: string;
+	readonly VITE_AGENTD_MONITOR_SERVICE_URL: string;
 	readonly VITE_AGENTD_NOTIFY_SERVICE_URL: string;
 	readonly VITE_AGENTD_ORCHESTRATOR_SERVICE_URL: string;
 }

--- a/ui/src/types/index.ts
+++ b/ui/src/types/index.ts
@@ -1,5 +1,6 @@
 export * from "./ask";
 export * from "./common";
 export * from "./memory";
+export * from "./monitor";
 export * from "./notify";
 export * from "./orchestrator";

--- a/ui/src/types/monitor.ts
+++ b/ui/src/types/monitor.ts
@@ -1,0 +1,89 @@
+/**
+ * TypeScript types for the Monitor service.
+ * Mirrors the Rust types in crates/monitor/src/types.rs.
+ */
+
+// ---------------------------------------------------------------------------
+// Metrics
+// ---------------------------------------------------------------------------
+
+/** CPU utilisation metrics */
+export interface CpuMetrics {
+	/** Global CPU usage as a percentage (0.0-100.0) */
+	usage_percent: number;
+	/** Number of logical CPU cores */
+	core_count: number;
+	/** Per-core usage percentages */
+	per_core: number[];
+}
+
+/** Memory usage metrics */
+export interface MemoryMetrics {
+	total_bytes: number;
+	used_bytes: number;
+	available_bytes: number;
+	/** Memory usage as a percentage (0.0-100.0) */
+	usage_percent: number;
+}
+
+/** Disk usage metrics for a single mount point */
+export interface DiskMetrics {
+	name: string;
+	mount_point: string;
+	total_bytes: number;
+	available_bytes: number;
+	used_bytes: number;
+	/** Usage as a percentage (0.0-100.0) */
+	usage_percent: number;
+}
+
+/** System load averages over 1, 5, and 15 minute windows */
+export interface LoadAverage {
+	one: number;
+	five: number;
+	fifteen: number;
+}
+
+/** A complete snapshot of system metrics at a point in time */
+export interface SystemMetrics {
+	/** When these metrics were collected (ISO 8601) */
+	collected_at: string;
+	cpu: CpuMetrics;
+	memory: MemoryMetrics;
+	disks: DiskMetrics[];
+	load_average: LoadAverage;
+}
+
+// ---------------------------------------------------------------------------
+// Status / alerts
+// ---------------------------------------------------------------------------
+
+/** Overall system health status derived from threshold checks */
+export type SystemHealthStatus = "healthy" | "degraded" | "critical";
+
+/** An alert triggered by a threshold breach */
+export interface MonitorAlert {
+	/** Metric that triggered the alert (e.g. "cpu", "memory", "disk:/") */
+	metric: string;
+	current_value: number;
+	threshold: number;
+	message: string;
+	/** When the alert was raised (ISO 8601) */
+	raised_at: string;
+}
+
+/** Health assessment response from GET /status */
+export interface SystemStatus {
+	status: SystemHealthStatus;
+	/** Latest metrics snapshot (null if no collection has occurred) */
+	metrics: SystemMetrics | null;
+	alerts: MonitorAlert[];
+	/** Timestamp of the last successful collection (ISO 8601) */
+	last_collected_at: string | null;
+}
+
+/** Response from POST /collect */
+export interface CollectResponse {
+	metrics: SystemMetrics;
+	alerts: MonitorAlert[];
+}


### PR DESCRIPTION
- Replace hardcoded chart hexes with a theme-derived palette (useChartPalette):
  muted alpha fills, full-strength colors only for legends/readouts, softened
  grid and tick lines so charts match the active theme
- Add shared usePolling (30s, pauses on hidden tab) and apply to all dashboard
  data hooks; Refresh button now refreshes every source with an updated-at stamp
- Add MonitorClient and a CPU/memory time-series chart fed by monitor /history;
  monitor joins the service health grid (6 services)
- Add OverviewStats row (agents, approvals, notifications, questions, workflows,
  cost) with graceful degradation per source
- Add stacked 24h ActivityChart and make the recent-activity feed show real
  notifications, questions, and agent state changes via useActivityFeed
- Fix MSW handler ordering bug (/notifications/:id shadowing count/actionable/history)
- Document API instrumentation gaps in docs/instrumentation.md

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>