### PR TITLE
feat(install): release tarballs, checksums, and curl|sh installer (phase 2)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,8 +9,31 @@ env:
   CARGO_TERM_COLOR: always
 
 jobs:
+  build-ui:
+    name: Build UI
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Install bun
+        uses: oven-sh/setup-bun@v2
+
+      - name: Build UI
+        working-directory: ui
+        run: |
+          bun install --frozen-lockfile
+          bun run build
+
+      - name: Upload UI assets
+        uses: actions/upload-artifact@v4
+        with:
+          name: ui-dist
+          path: ui/dist
+          if-no-files-found: error
+
   build:
     name: Build (${{ matrix.target }})
+    needs: build-ui
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
@@ -18,6 +41,9 @@ jobs:
         include:
           - target: x86_64-unknown-linux-musl
             os: ubuntu-latest
+          # GitHub-hosted arm64 runners are free for public repositories only.
+          - target: aarch64-unknown-linux-musl
+            os: ubuntu-24.04-arm
           - target: x86_64-apple-darwin
             os: macos-15-intel
           - target: aarch64-apple-darwin
@@ -47,35 +73,51 @@ jobs:
       - name: Build release binaries
         run: cargo build --release --workspace --bins --target ${{ matrix.target }}
 
-      - name: Package binaries
+      - name: Download UI assets
+        uses: actions/download-artifact@v4
+        with:
+          name: ui-dist
+          path: stage/ui
+
+      # The tarball is created here in the build job (not the release job)
+      # because artifact upload/download strips executable bits; a tarball
+      # preserves the modes recorded inside it. `agent install` expects bare
+      # binary names (`agent`, `agentd-*`) in --bin-src, so the archive root
+      # holds exactly that layout plus the `ui/` assets.
+      - name: Package tarball
         shell: bash
         run: |
+          set -euo pipefail
           TARGET="${{ matrix.target }}"
+          VERSION="${{ github.ref_name }}"
           BINS=(
-            cli
             agentd-ask
             agentd-communicate
             agentd-core
+            agentd-hook
             agentd-memory
+            agentd-monitor
             agentd-notify
             agentd-orchestrator
+            agentd-ui
             agentd-wrap
           )
-          mkdir -p dist
+          # A missing binary must fail the release rather than ship an
+          # incomplete tarball, so no existence guards here.
           for bin in "${BINS[@]}"; do
-            src="target/${TARGET}/release/${bin}"
-            if [ -f "$src" ]; then
-              # Rename the user-facing CLI binary: cli -> agent
-              dest_name="${bin/cli/agent}"
-              cp "$src" "dist/${dest_name}-${TARGET}"
-            fi
+            cp "target/${TARGET}/release/${bin}" "stage/${bin}"
           done
+          # Rename the user-facing CLI binary: cli -> agent
+          cp "target/${TARGET}/release/cli" "stage/agent"
+          chmod 755 stage/agent stage/agentd-*
+          mkdir -p dist
+          tar -czf "dist/agentd-${VERSION}-${TARGET}.tar.gz" -C stage .
 
       - name: Upload artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: binaries-${{ matrix.target }}
-          path: dist/*
+          name: tarball-${{ matrix.target }}
+          path: dist/*.tar.gz
           if-no-files-found: error
 
   release:
@@ -100,9 +142,17 @@ jobs:
       - name: Download all artifacts
         uses: actions/download-artifact@v4
         with:
-          pattern: binaries-*
+          pattern: tarball-*
           path: dist
           merge-multiple: true
+
+      - name: Generate checksums and stage installer
+        run: |
+          cd dist
+          sha256sum *.tar.gz > SHA256SUMS
+          # Uploaded under the basename `install.sh` so that
+          # `releases/latest/download/install.sh` resolves.
+          cp ../contrib/scripts/install.sh install.sh
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
@@ -110,3 +160,6 @@ jobs:
           body_path: RELEASE_NOTES.md
           files: dist/*
           fail_on_unmatched_files: true
+          # Tags like v0.5.0-rc.1 publish as pre-releases and never become
+          # the `latest` release the installer resolves by default.
+          prerelease: ${{ contains(github.ref_name, '-') }}

--- a/README.md
+++ b/README.md
@@ -152,23 +152,38 @@ full guide including manual setup, dashboard descriptions, and troubleshooting.
 ### Prerequisites
 
 - macOS 14+ (tested) or Linux
-- Rust 1.75+ ([Install Rust](https://rustup.rs/))
-- Git
 - tmux (for agent session management with tmux backend)
 - Docker Engine 20.10+ or Docker Desktop (optional, for Docker backend)
+- Rust 1.75+ ([Install Rust](https://rustup.rs/)) - only for installing from source
 
-### Install
+### Install from a release (recommended)
+
+```bash
+curl -fsSL https://github.com/geoffjay/agentd/releases/latest/download/install.sh | sh
+```
+
+The installer detects your platform (Linux x86_64/aarch64, macOS Intel/Apple
+Silicon), downloads the release tarball, verifies its checksum, and runs
+`agent install` to set up binaries, services (launchd/systemd), configuration,
+and database migrations.
+
+```bash
+# Pin a specific version
+AGENTD_VERSION=v0.5.0 sh -c "$(curl -fsSL https://github.com/geoffjay/agentd/releases/latest/download/install.sh)"
+
+# Override the install prefix (default: /usr/local on macOS or as root, ~/.local otherwise)
+PREFIX=$HOME/.local sh -c "$(curl -fsSL https://github.com/geoffjay/agentd/releases/latest/download/install.sh)"
+```
+
+### Install from source
 
 ```bash
 # Using cargo xtask (creates Agent.app bundle + shell completions)
 cargo xtask install-user
 cargo xtask start-services
-
-# Or use the interactive script
-./contrib/scripts/install.sh
 ```
 
-For detailed installation instructions, see [INSTALL.md](INSTALL.md). Once installed, follow the **[Getting Started Guide](docs/public/getting-started.md)** to learn the full workflow.
+For detailed installation instructions, see [docs/public/install.md](docs/public/install.md). Once installed, follow the **[Getting Started Guide](docs/public/getting-started.md)** to learn the full workflow.
 
 ## Usage
 

--- a/contrib/README.md
+++ b/contrib/README.md
@@ -53,49 +53,47 @@ Installation and utility scripts for agentd.
 
 #### install.sh
 
-Interactive installation script for end users.
-
-**Features:**
-- Guided installation process
-- Colored terminal output
-- Service auto-start option
-- Comprehensive status checks
+POSIX `sh` installer for prebuilt release binaries. Uploaded to every GitHub
+Release so it can be piped straight from `releases/latest/download/install.sh`.
 
 **Usage:**
 ```bash
-./contrib/scripts/install.sh
+curl -fsSL https://github.com/geoffjay/agentd/releases/latest/download/install.sh | sh
 ```
 
 **What it does:**
-1. Checks prerequisites (macOS, Rust/Cargo)
-2. Verifies project directory
-3. Builds release binaries
-4. Installs binaries to `/usr/local/bin/`
-5. Installs plist files to `~/Library/LaunchAgents/`
-6. Optionally starts services
-7. Displays next steps
+1. Detects the platform (Linux x86_64/aarch64 musl, macOS Intel/Apple Silicon)
+2. Resolves the latest release tag (or `AGENTD_VERSION` to pin a version)
+3. Downloads the release tarball and `SHA256SUMS`, and verifies the checksum
+4. Extracts to a temporary directory
+5. Runs `agent install` for the platform-specific setup (binaries, launchd/systemd services, config, web UI, database migrations)
+
+No Rust toolchain or source tree is required; all installation logic lives in
+the `agentd-install` crate, this script only fetches and verifies artifacts.
+`PREFIX` overrides the install prefix.
 
 ## Installation Methods
 
-### cargo xtask (Recommended)
+### Release installer (Recommended)
+```bash
+curl -fsSL https://github.com/geoffjay/agentd/releases/latest/download/install.sh | sh
+```
+
+Prebuilt binaries from GitHub Releases, verified via `SHA256SUMS`.
+
+### cargo xtask (from source)
 ```bash
 cargo xtask install-user
 cargo xtask start-services
 ```
 
-Type-safe Rust-based installer with better error handling.
-
-### Interactive Script
-```bash
-./contrib/scripts/install.sh
-```
-
-Guided installation with prompts and colored output.
+Builds binaries and the UI locally, then performs the same platform setup.
 
 ## See Also
 
-- [INSTALL.md](../INSTALL.md) - Detailed installation guide
-- [xtask/](../xtask/) - Rust-based installer implementation
+- [docs/public/install.md](../docs/public/install.md) - Detailed installation guide
+- [crates/install/](../crates/install/) - Rust installation library
+- [crates/xtask/](../crates/xtask/) - Dev-only build + install front-end
 
 ## Contributing
 

--- a/contrib/scripts/install.sh
+++ b/contrib/scripts/install.sh
@@ -1,192 +1,149 @@
-#!/usr/bin/env bash
-# Installation script for agentd
-# This script provides an interactive installation experience
+#!/bin/sh
+# agentd installer
+#
+# Downloads the agentd release tarball for this platform from GitHub Releases,
+# verifies its checksum, and runs `agent install` to perform the
+# platform-specific setup (binaries, launchd/systemd services, config,
+# database migrations). All installation logic lives in the Rust `agent`
+# binary; this script only fetches and verifies the artifacts.
+#
+# Usage:
+#   curl -fsSL https://github.com/geoffjay/agentd/releases/latest/download/install.sh | sh
+#
+# Environment variables:
+#   AGENTD_VERSION  Install a specific version (e.g. "v0.5.0" or "0.5.0")
+#                   instead of the latest release.
+#   PREFIX          Install prefix honoured by `agent install`
+#                   (default: /usr/local on macOS or as root, ~/.local otherwise).
+#
+# The script is non-interactive and safe to pipe to sh: `agent install` reads
+# nothing from stdin.
 
-set -e
+set -eu
 
-# Colors
-BLUE='\033[0;34m'
-GREEN='\033[0;32m'
-YELLOW='\033[0;33m'
-RED='\033[0;31m'
-NC='\033[0m' # No Color
+REPO="geoffjay/agentd"
 
-# Configuration
-PREFIX="${PREFIX:-/usr/local}"
-BINDIR="$PREFIX/bin"
-LOGDIR="$PREFIX/var/log"
-PLIST_DIR_USER="$HOME/Library/LaunchAgents"
+info() { printf '\033[0;34m==>\033[0m %s\n' "$1"; }
+error() { printf '\033[0;31merror:\033[0m %s\n' "$1" >&2; exit 1; }
 
-echo -e "${BLUE}╔════════════════════════════════════════╗${NC}"
-echo -e "${BLUE}║     agentd Installation Script         ║${NC}"
-echo -e "${BLUE}╚════════════════════════════════════════╝${NC}"
-echo ""
+# Map uname output to a release target triple.
+detect_target() {
+    os=$(uname -s)
+    arch=$(uname -m)
+    case "$os/$arch" in
+        Linux/x86_64) echo "x86_64-unknown-linux-musl" ;;
+        Linux/aarch64 | Linux/arm64) echo "aarch64-unknown-linux-musl" ;;
+        Darwin/x86_64) echo "x86_64-apple-darwin" ;;
+        Darwin/arm64) echo "aarch64-apple-darwin" ;;
+        *)
+            error "unsupported platform: $os/$arch
+Supported platforms:
+  Linux   x86_64, aarch64 (static musl binaries)
+  macOS   x86_64 (Intel), arm64 (Apple Silicon)"
+            ;;
+    esac
+}
 
-# Check if running on macOS
-if [[ "$OSTYPE" != "darwin"* ]]; then
-    echo -e "${RED}Error: This script is for macOS only${NC}"
-    exit 1
-fi
-
-# Check for Rust
-if ! command -v cargo &> /dev/null; then
-    echo -e "${RED}Error: Rust/Cargo not found${NC}"
-    echo "Please install Rust from https://rustup.rs/"
-    exit 1
-fi
-
-echo -e "${GREEN}✓ Rust found: $(cargo --version)${NC}"
-
-# Check if we're in the right directory
-if [[ ! -f "Cargo.toml" ]] || [[ ! -d "crates" ]]; then
-    echo -e "${RED}Error: Must be run from the agentd project root${NC}"
-    exit 1
-fi
-
-echo -e "${GREEN}✓ Project directory verified${NC}"
-echo ""
-
-# Ask user for installation type
-echo -e "${YELLOW}Choose installation type:${NC}"
-echo "  1) User installation (recommended, no sudo needed)"
-echo "  2) System installation (requires sudo)"
-echo ""
-read -p "Enter choice [1]: " install_type
-install_type="${install_type:-1}"
-
-echo ""
-echo -e "${BLUE}Building binaries (this may take a few minutes)...${NC}"
-if cargo build --release; then
-    echo -e "${GREEN}✓ Build successful${NC}"
-else
-    echo -e "${RED}✗ Build failed${NC}"
-    exit 1
-fi
-
-echo ""
-echo -e "${BLUE}Installing binaries to $BINDIR...${NC}"
-
-# Create directories
-mkdir -p "$LOGDIR" 2>/dev/null || sudo mkdir -p "$LOGDIR"
-
-# Install binaries
-binaries=(
-    "agent:target/release/agent"
-    "agentd-notify:target/release/agentd-notify"
-    "agentd-ask:target/release/agentd-ask"
-    "agentd-hook:target/release/agentd-hook"
-    "agentd-monitor:target/release/agentd-monitor"
-    "Agent:target/release/Agent"
-)
-
-for binary_pair in "${binaries[@]}"; do
-    name="${binary_pair%%:*}"
-    path="${binary_pair##*:}"
-
-    if [[ -f "$path" ]]; then
-        echo "  Installing $name..."
-        if install -m 755 "$path" "$BINDIR/$name" 2>/dev/null || \
-           sudo install -m 755 "$path" "$BINDIR/$name"; then
-            echo -e "    ${GREEN}✓${NC} $name installed"
-        else
-            echo -e "    ${RED}✗${NC} Failed to install $name"
-            exit 1
-        fi
+# Download $1 to $2 using curl or wget.
+download() {
+    url=$1
+    dest=$2
+    if command -v curl >/dev/null 2>&1; then
+        curl -fsSL -o "$dest" "$url" || error "download failed: $url"
+    elif command -v wget >/dev/null 2>&1; then
+        wget -q -O "$dest" "$url" || error "download failed: $url"
     else
-        echo -e "    ${YELLOW}⚠${NC} $name not found (may not be built yet)"
+        error "neither curl nor wget is available"
     fi
-done
+}
 
-echo ""
-echo -e "${BLUE}Installing service plist files...${NC}"
-
-# Create plist directory
-mkdir -p "$PLIST_DIR_USER"
-
-# Install plist files
-services=(
-    "agentd-notify"
-    "agentd-ask"
-    "agentd-hook"
-    "agentd-monitor"
-)
-
-for service in "${services[@]}"; do
-    plist_file="contrib/plists/com.geoffjay.$service.plist"
-
-    if [[ -f "$plist_file" ]]; then
-        echo "  Installing $service..."
-        cp "$plist_file" "$PLIST_DIR_USER/"
-        echo -e "    ${GREEN}✓${NC} $service plist installed"
+# Resolve the release tag: $AGENTD_VERSION if set, otherwise the tag the
+# `releases/latest` redirect points at (avoids the GitHub API and its rate
+# limits on the happy path).
+resolve_version() {
+    if [ -n "${AGENTD_VERSION:-}" ]; then
+        case "$AGENTD_VERSION" in
+            v*) echo "$AGENTD_VERSION" ;;
+            *) echo "v$AGENTD_VERSION" ;;
+        esac
+        return
+    fi
+    latest_url="https://github.com/$REPO/releases/latest"
+    if command -v curl >/dev/null 2>&1; then
+        effective=$(curl -fsSLI -o /dev/null -w '%{url_effective}' "$latest_url") ||
+            error "failed to resolve the latest release from $latest_url"
+    elif command -v wget >/dev/null 2>&1; then
+        effective=$(wget -q -S --max-redirect=0 -O /dev/null "$latest_url" 2>&1 |
+            sed -n 's/^ *[Ll]ocation: *//p' | tr -d '\r' | head -n 1) ||
+            true
+        [ -n "$effective" ] || error "failed to resolve the latest release from $latest_url"
     else
-        echo -e "    ${RED}✗${NC} Plist file not found: $plist_file"
+        error "neither curl nor wget is available"
     fi
-done
+    version=${effective##*/tag/}
+    case "$version" in
+        v*) echo "$version" ;;
+        *) error "could not determine the latest release tag (got '$effective')" ;;
+    esac
+}
 
-echo ""
-echo -e "${GREEN}✓ Installation complete!${NC}"
-echo ""
-
-# Ask if user wants to start services
-read -p "Start services now? [Y/n]: " start_services
-start_services="${start_services:-Y}"
-
-if [[ "$start_services" =~ ^[Yy] ]]; then
-    echo ""
-    echo -e "${BLUE}Starting services...${NC}"
-
-    for service in "${services[@]}"; do
-        plist_path="$PLIST_DIR_USER/com.geoffjay.$service.plist"
-
-        if [[ -f "$plist_path" ]]; then
-            echo "  Starting $service..."
-            if launchctl load "$plist_path" 2>/dev/null; then
-                echo -e "    ${GREEN}✓${NC} $service started"
-            else
-                echo -e "    ${YELLOW}⚠${NC} $service may already be running or failed to start"
-            fi
-        fi
-    done
-
-    echo ""
-    echo -e "${BLUE}Checking service status...${NC}"
-    sleep 2
-
-    for service in "${services[@]}"; do
-        if launchctl list | grep -q "com.geoffjay.$service"; then
-            echo -e "  $service: ${GREEN}running${NC}"
+verify_checksum() {
+    dir=$1
+    asset=$2
+    (
+        cd "$dir"
+        grep " ${asset}\$" SHA256SUMS > checksum.txt ||
+            error "no checksum entry for $asset in SHA256SUMS"
+        if command -v sha256sum >/dev/null 2>&1; then
+            sha256sum -c checksum.txt >/dev/null 2>&1 ||
+                error "checksum verification failed for $asset"
+        elif command -v shasum >/dev/null 2>&1; then
+            shasum -a 256 -c checksum.txt >/dev/null 2>&1 ||
+                error "checksum verification failed for $asset"
         else
-            echo -e "  $service: ${RED}stopped${NC}"
+            error "neither sha256sum nor shasum is available"
         fi
-    done
-fi
+    )
+}
 
-echo ""
-echo -e "${GREEN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
-echo -e "${GREEN}Installation Summary${NC}"
-echo -e "${GREEN}━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━${NC}"
-echo ""
-echo -e "  ${GREEN}✓${NC} Binaries installed to: $BINDIR"
-echo -e "  ${GREEN}✓${NC} Services installed to: $PLIST_DIR_USER"
-echo -e "  ${GREEN}✓${NC} Logs will be written to: $LOGDIR"
-echo ""
-echo -e "${YELLOW}Next steps:${NC}"
-echo ""
-echo -e "  Test the CLI:"
-echo -e "    ${BLUE}agent notify create --title \"Test\" --message \"Hello\"${NC}"
-echo -e "    ${BLUE}agent notify list${NC}"
-echo ""
-echo -e "  Check service health:"
-echo -e "    ${BLUE}curl http://localhost:4000/health${NC}"
-echo -e "    ${BLUE}curl http://localhost:7001/health${NC}"
-echo ""
-echo -e "  View logs:"
-echo -e "    ${BLUE}tail -f $LOGDIR/agentd-notify.log${NC}"
-echo ""
-echo -e "  Manage services:"
-echo -e "    ${BLUE}make services-status${NC}  # Check status"
-echo -e "    ${BLUE}make services-stop${NC}    # Stop all services"
-echo -e "    ${BLUE}make services-start${NC}   # Start all services"
-echo ""
-echo -e "For more information, see: ${BLUE}INSTALL.md${NC}"
-echo ""
+main() {
+    target=$(detect_target)
+    version=$(resolve_version)
+    asset="agentd-${version}-${target}.tar.gz"
+    base="https://github.com/$REPO/releases/download/$version"
+
+    # Explicit template: unlike `mktemp -d` bare, this honours $TMPDIR on
+    # macOS as well as Linux.
+    tmpdir=$(mktemp -d "${TMPDIR:-/tmp}/agentd-install.XXXXXX")
+    trap 'rm -rf "$tmpdir"' EXIT INT TERM
+
+    info "Installing agentd $version for $target"
+
+    info "Downloading $asset"
+    download "$base/$asset" "$tmpdir/$asset"
+    download "$base/SHA256SUMS" "$tmpdir/SHA256SUMS"
+
+    info "Verifying checksum"
+    verify_checksum "$tmpdir" "$asset"
+
+    info "Extracting"
+    stage="$tmpdir/stage"
+    mkdir "$stage"
+    tar -xzf "$tmpdir/$asset" -C "$stage"
+    # curl/wget downloads carry no quarantine attribute, but clear it
+    # defensively for copies fetched via a browser on macOS.
+    if command -v xattr >/dev/null 2>&1; then
+        xattr -dr com.apple.quarantine "$stage" 2>/dev/null || true
+    fi
+
+    info "Running agent install"
+    "$stage/agent" install --bin-src "$stage" --ui-dir "$stage/ui"
+
+    info "Done. Next steps:"
+    echo "  - ensure the install bin directory is on your PATH" \
+        "(/usr/local/bin, or ~/.local/bin for a Linux user install)"
+    echo "  - start the services: agent service start"
+    echo "  - check status:       agent service status"
+}
+
+main

--- a/docs/planning/installation-method.md
+++ b/docs/planning/installation-method.md
@@ -23,7 +23,7 @@ and then runs `agent install` to do the platform-specific setup. The
 platform-specific logic stays in Rust (one source of truth) rather than being
 reimplemented in shell.
 
-## Phase 1 — `agentd-install` crate + `agent install` (this change)
+## Phase 1 — `agentd-install` crate + `agent install` (done)
 
 Relocate the install/service/migration logic out of the dev-only `xtask` crate
 into a reusable `agentd-install` library that the shipped `agent` binary can
@@ -47,17 +47,51 @@ call with no source tree and no `cargo`/`bun`.
   `agentd-install`. `release` and `generate-entities` (which needs
   `sea-orm-cli`) remain dev-only in `xtask`.
 
-## Phase 2 — cargo-dist + installer + release pipeline (future)
+## Phase 2 — installer + release pipeline (done)
 
-- Adopt [`cargo-dist`](https://opensource.axo.dev/cargo-dist/) to generate the
-  `curl … | sh` installer, per-target tarballs, `SHA256SUMS`, and a release
-  manifest from the existing tag-triggered workflow.
-- The installer downloads + verifies + extracts binaries into a `bin` dir, then
-  runs `agent install` for the platform/service/migration setup.
-- Add `aarch64-unknown-linux-gnu` (or musl) to the release matrix — currently
-  there is no Linux arm64 artifact.
-- Optionally publish a Homebrew tap formula and `cargo-binstall` metadata
-  (cargo-dist can emit both).
+Delivered as a hand-rolled workflow + POSIX installer rather than cargo-dist
+(see "Why not cargo-dist" below).
 
-cargo-dist will not perform the launchd/systemd/migration setup — that stays in
-`agent install`, which is exactly why Phase 1 is the prerequisite.
+- The tag-triggered release workflow now produces per-target tarballs
+  (`agentd-<tag>-<target>.tar.gz`) containing all service binaries with bare
+  names (`agent`, `agentd-*` - the layout `agent install --bin-src` expects)
+  plus the built web UI under `ui/`, alongside a `SHA256SUMS` file and the
+  installer script itself. The loose per-binary `<bin>-<target>` assets were
+  dropped: their target-suffixed names were never discoverable by
+  `install_binaries()`, and nothing consumed them.
+- `contrib/scripts/install.sh` is a POSIX `sh` installer uploaded to every
+  release, so the canonical install command is:
+
+  ```sh
+  curl -fsSL https://github.com/geoffjay/agentd/releases/latest/download/install.sh | sh
+  ```
+
+  It detects the platform, resolves the latest tag via the `releases/latest`
+  redirect (`AGENTD_VERSION` pins a version), downloads and sha256-verifies the
+  tarball, extracts to a temp dir, and runs
+  `agent install --bin-src <stage> --ui-dir <stage>/ui` - the
+  platform/service/migration setup stays in Rust.
+- `aarch64-unknown-linux-musl` was added to the release matrix on the
+  `ubuntu-24.04-arm` runner (native arm64; `musl-tools` provides the native
+  musl-gcc), closing the Linux arm64 gap.
+- Release tags containing a `-` (e.g. `v0.5.0-rc.1`) publish as pre-releases,
+  so installer/pipeline changes can be tested end-to-end without affecting
+  `releases/latest`.
+
+### Why not cargo-dist
+
+cargo-dist (actively maintained again as of 2025/2026) models each workspace
+package as its own "app": every package gets its own tarball and its own
+installer. It cannot bundle binaries from multiple workspace crates
+(`agent` + nine `agentd-*` services) into a single tarball or a single
+`curl … | sh` installer, and its generated installer has no post-install hook
+to run `agent install`. Working around that would have meant either ~10
+separate installers or restructuring every service crate behind thin bin
+wrappers in one package. The hand-rolled workflow is small and achieves the
+same end state.
+
+`cargo-binstall` metadata and a Homebrew tap were descoped: binstall requires
+publishing the CLI crate to crates.io (it is currently the unpublished `cli`
+package) and would only place the bare binary on `PATH`, skipping the service
+and migration setup that `agent install` performs. Revisit if a crates.io
+publishing effort ever happens.

--- a/docs/public/install.md
+++ b/docs/public/install.md
@@ -16,20 +16,49 @@ The agentd system consists of:
 
 ## Prerequisites
 
-- macOS (tested on macOS 14+)
-- Rust toolchain (1.75+)
-- Git
+- macOS (tested on macOS 14+) or Linux
+- Rust toolchain (1.75+) and Git - only for installing from source
 
 ## Installation Methods
 
 Choose one of two installation methods:
 
-1. **cargo xtask** - Type-safe Rust installer (recommended)
-2. **Bash script** - Interactive installer
+1. **Release installer** - Downloads prebuilt binaries from GitHub Releases (recommended)
+2. **cargo xtask** - Builds and installs from source
 
 ## Quick Start
 
-### Option 1: cargo xtask (Recommended)
+### Option 1: Release installer (Recommended)
+
+```bash
+curl -fsSL https://github.com/geoffjay/agentd/releases/latest/download/install.sh | sh
+```
+
+No Rust toolchain or source tree required. The script:
+
+1. Detects your platform (Linux x86_64/aarch64 via static musl binaries, macOS Intel/Apple Silicon)
+2. Downloads the release tarball and `SHA256SUMS`, and verifies the checksum
+3. Extracts to a temporary directory
+4. Runs `agent install` to install binaries, service definitions (launchd/systemd), configuration, the web UI, and database migrations
+
+Environment variables:
+
+```bash
+# Pin a specific version instead of the latest release
+AGENTD_VERSION=v0.5.0 sh -c "$(curl -fsSL https://github.com/geoffjay/agentd/releases/latest/download/install.sh)"
+
+# Override the install prefix (default: /usr/local on macOS or as root, ~/.local otherwise)
+PREFIX=$HOME/.local sh -c "$(curl -fsSL https://github.com/geoffjay/agentd/releases/latest/download/install.sh)"
+```
+
+After installation:
+
+```bash
+agent service start
+agent service status
+```
+
+### Option 2: cargo xtask (from source)
 
 ```bash
 # Clone the repository
@@ -56,14 +85,6 @@ export PATH="$HOME/.local/bin:$PATH"
 # Start services
 cargo xtask start-services
 ```
-
-### Option 2: Interactive Bash Script
-
-```bash
-./contrib/scripts/install.sh
-```
-
-The script will guide you through the installation process.
 
 ## Detailed Installation with cargo xtask
 


### PR DESCRIPTION
Implements Phase 2 of docs/planning/installation-method.md as a hand-rolled
release pipeline rather than cargo-dist (which models each workspace package
as its own app and cannot bundle the multi-crate binary suite into a single
installer; rationale recorded in the planning doc).

Release workflow:
- build the web UI once with bun and include it in every tarball under ui/
- package per-target tarballs (agentd-<tag>-<target>.tar.gz) with bare-named
  binaries (agent, agentd-*) so `agent install --bin-src` can discover them
- add all 10 service binaries (agentd-hook/monitor/ui were missing) and fail
  the release on a missing binary instead of silently skipping
- add aarch64-unknown-linux-musl on the ubuntu-24.04-arm runner
- generate SHA256SUMS and upload it plus the installer as release assets
- publish tags containing '-' (e.g. v0.5.0-rc.1) as pre-releases
- drop the loose <bin>-<target> assets (target-suffixed names were never
  discoverable by `agent install` and nothing consumed them)

Installer (contrib/scripts/install.sh, replaces the legacy interactive
build-from-source script): POSIX sh, detects the platform, resolves the
latest tag via the releases/latest redirect (AGENTD_VERSION pins a version),
downloads with curl or wget, verifies the tarball against SHA256SUMS,
extracts to a temp dir, and runs `agent install` so the platform/service/
migration logic stays in Rust. cargo-binstall and Homebrew are descoped.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>