### PR TITLE
feat(orchestrator): persist task variables on dispatch records

### DIFF
--- a/crates/cli/src/commands/orchestrator.rs
+++ b/crates/cli/src/commands/orchestrator.rs
@@ -2720,6 +2720,9 @@ async fn trigger_workflow_cmd(
     let request = TriggerWorkflowRequest {
         title: title.map(|s| s.to_string()),
         body: body.map(|s| s.to_string()),
+        url: None,
+        labels: None,
+        assignee: None,
         metadata: std::collections::HashMap::new(),
     };
 
@@ -3124,6 +3127,7 @@ mod tests {
             status: DispatchStatus::Completed,
             dispatched_at: Utc::now(),
             completed_at: Some(Utc::now()),
+            task: None,
         };
         // Should not panic
         display_dispatch(&dispatch);

--- a/crates/orchestrator/src/entity/dispatch.rs
+++ b/crates/orchestrator/src/entity/dispatch.rs
@@ -18,6 +18,9 @@ pub struct Model {
     pub status: String,
     pub dispatched_at: String,
     pub completed_at: Option<String>,
+    /// JSON-serialized `Task` whose variables were rendered into `prompt_sent`.
+    /// NULL for records created before task persistence was added.
+    pub task_json: Option<String>,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/crates/orchestrator/src/migration/m20260610_000019_add_task_json_to_dispatch_log.rs
+++ b/crates/orchestrator/src/migration/m20260610_000019_add_task_json_to_dispatch_log.rs
@@ -1,0 +1,35 @@
+//! Migration: add `task_json` column to the `dispatch_log` table.
+//!
+//! Adds one column:
+//! - `task_json` (TEXT NULLABLE): JSON-serialized `Task` whose variables were
+//!   rendered into `prompt_sent`. Enables re-triggering a dispatch from the UI
+//!   with the original input values prefilled. NULL for records created before
+//!   this migration. Note this duplicates some source-derived content already
+//!   present in `prompt_sent`; growth impact is marginal.
+
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let db = manager.get_connection();
+
+        let stmt = "ALTER TABLE dispatch_log ADD COLUMN task_json TEXT";
+        if let Err(e) = db.execute_unprepared(stmt).await {
+            // Idempotent: ignore if column already exists (e.g., re-run).
+            if !e.to_string().contains("duplicate column name") {
+                return Err(e);
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn down(&self, _manager: &SchemaManager) -> Result<(), DbErr> {
+        // SQLite < 3.35.0 does not support DROP COLUMN.
+        Ok(())
+    }
+}

--- a/crates/orchestrator/src/migration/mod.rs
+++ b/crates/orchestrator/src/migration/mod.rs
@@ -29,6 +29,7 @@ mod m20260417_000015_add_project_id_to_agents_workflows;
 mod m20260417_000016_add_conversation_events;
 mod m20260513_000017_add_skills_to_agents;
 mod m20260525_000018_add_conversation_event_seq;
+mod m20260610_000019_add_task_json_to_dispatch_log;
 
 /// The migration runner — applies all known migrations in order.
 pub struct Migrator;
@@ -55,6 +56,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20260417_000016_add_conversation_events::Migration),
             Box::new(m20260513_000017_add_skills_to_agents::Migration),
             Box::new(m20260525_000018_add_conversation_event_seq::Migration),
+            Box::new(m20260610_000019_add_task_json_to_dispatch_log::Migration),
         ]
     }
 }

--- a/crates/orchestrator/src/scheduler/api.rs
+++ b/crates/orchestrator/src/scheduler/api.rs
@@ -390,7 +390,8 @@ async fn dispatch_history(
 ///
 /// Accepts an optional JSON body:
 /// ```json
-/// { "title": "...", "body": "...", "metadata": { "key": "value" } }
+/// { "title": "...", "body": "...", "url": "...", "labels": ["..."],
+///   "assignee": "...", "metadata": { "key": "value" } }
 /// ```
 ///
 /// Returns:
@@ -415,9 +416,9 @@ async fn trigger_workflow(
         source_id,
         title: req.title.unwrap_or_else(|| "Manual trigger".to_string()),
         body: req.body.unwrap_or_default(),
-        url: String::new(),
-        labels: vec![],
-        assignee: None,
+        url: req.url.unwrap_or_default(),
+        labels: req.labels.unwrap_or_default(),
+        assignee: req.assignee,
         metadata: req.metadata,
     };
 

--- a/crates/orchestrator/src/scheduler/mod.rs
+++ b/crates/orchestrator/src/scheduler/mod.rs
@@ -328,6 +328,7 @@ impl Scheduler {
                         status: DispatchStatus::Pending,
                         dispatched_at: chrono::Utc::now(),
                         completed_at: None,
+                        task: Some(task.clone()),
                     };
                     self.storage.add_dispatch(&record).await?;
 
@@ -359,6 +360,7 @@ impl Scheduler {
             status: DispatchStatus::Dispatched,
             dispatched_at: chrono::Utc::now(),
             completed_at: None,
+            task: Some(task.clone()),
         };
         self.storage.add_dispatch(&record).await?;
 

--- a/crates/orchestrator/src/scheduler/runner.rs
+++ b/crates/orchestrator/src/scheduler/runner.rs
@@ -192,6 +192,7 @@ impl WorkflowRunner {
                 status: DispatchStatus::Dispatched,
                 dispatched_at: Utc::now(),
                 completed_at: None,
+                task: Some(task.clone()),
             };
             self.storage.add_dispatch(&record).await?;
 

--- a/crates/orchestrator/src/scheduler/storage.rs
+++ b/crates/orchestrator/src/scheduler/storage.rs
@@ -166,6 +166,7 @@ impl SchedulerStorage {
             status: Set(record.status.to_string()),
             dispatched_at: Set(record.dispatched_at.to_rfc3339()),
             completed_at: Set(record.completed_at.map(|dt| dt.to_rfc3339())),
+            task_json: Set(record.task.as_ref().and_then(|t| serde_json::to_string(t).ok())),
         };
 
         dispatch_entity::Entity::insert(model).exec(&self.db).await?;
@@ -539,6 +540,9 @@ fn model_to_dispatch(model: dispatch_entity::Model) -> Result<DispatchRecord> {
             .completed_at
             .map(|s| DateTime::parse_from_rfc3339(&s).map(|dt| dt.with_timezone(&Utc)))
             .transpose()?,
+        // Lenient decode: a corrupt or legacy `task_json` value must not fail
+        // the whole dispatch listing — fall back to `None`.
+        task: model.task_json.as_deref().and_then(|s| serde_json::from_str(s).ok()),
     })
 }
 
@@ -549,7 +553,7 @@ fn model_to_dispatch(model: dispatch_entity::Model) -> Result<DispatchRecord> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::scheduler::types::TriggerConfig;
+    use crate::scheduler::types::{Task, TriggerConfig};
     use crate::storage::AgentStorage;
     use tempfile::TempDir;
 
@@ -622,6 +626,18 @@ mod tests {
         let workflow = test_workflow();
         storage.add_workflow(&workflow).await.unwrap();
 
+        let task = Task {
+            source_id: "42".to_string(),
+            title: "Login bug".to_string(),
+            body: "Fix the login bug".to_string(),
+            url: "https://example.com/issues/42".to_string(),
+            labels: vec!["bug".to_string()],
+            assignee: Some("geoff".to_string()),
+            metadata: std::collections::HashMap::from([(
+                "priority".to_string(),
+                "high".to_string(),
+            )]),
+        };
         let record = DispatchRecord {
             id: Uuid::new_v4(),
             workflow_id: workflow.id,
@@ -631,6 +647,7 @@ mod tests {
             status: DispatchStatus::Dispatched,
             dispatched_at: Utc::now(),
             completed_at: None,
+            task: Some(task),
         };
 
         // Add dispatch
@@ -658,6 +675,15 @@ mod tests {
         let history = storage.list_dispatches(&workflow.id).await.unwrap();
         assert_eq!(history.len(), 1);
         assert_eq!(history[0].status, DispatchStatus::Completed);
+
+        // The originating task round-trips through `task_json`.
+        let stored_task = history[0].task.as_ref().expect("task should be persisted");
+        assert_eq!(stored_task.title, "Login bug");
+        assert_eq!(stored_task.body, "Fix the login bug");
+        assert_eq!(stored_task.url, "https://example.com/issues/42");
+        assert_eq!(stored_task.labels, vec!["bug".to_string()]);
+        assert_eq!(stored_task.assignee.as_deref(), Some("geoff"));
+        assert_eq!(stored_task.metadata.get("priority").map(String::as_str), Some("high"));
     }
 
     #[tokio::test]
@@ -675,6 +701,7 @@ mod tests {
             status: DispatchStatus::Dispatched,
             dispatched_at: Utc::now(),
             completed_at: None,
+            task: None,
         };
         storage.add_dispatch(&record).await.unwrap();
 
@@ -683,6 +710,34 @@ mod tests {
 
         let updated = storage.list_dispatches(&workflow.id).await.unwrap();
         assert_eq!(updated[0].status, DispatchStatus::Failed);
+        // Records created without a task round-trip as `None` (legacy rows).
+        assert!(updated[0].task.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_dispatch_task_json_lenient_decode() {
+        // A corrupt `task_json` value must not fail the listing — it decodes
+        // leniently to `None`.
+        let (storage, _tmp) = create_test_storage().await;
+        let workflow = test_workflow();
+        storage.add_workflow(&workflow).await.unwrap();
+
+        let model = dispatch_entity::ActiveModel {
+            id: Set(Uuid::new_v4().to_string()),
+            workflow_id: Set(workflow.id.to_string()),
+            source_id: Set("corrupt".to_string()),
+            agent_id: Set(workflow.agent_id.to_string()),
+            prompt_sent: Set("test".to_string()),
+            status: Set("completed".to_string()),
+            dispatched_at: Set(Utc::now().to_rfc3339()),
+            completed_at: Set(None),
+            task_json: Set(Some("not valid json".to_string())),
+        };
+        dispatch_entity::Entity::insert(model).exec(&storage.db).await.unwrap();
+
+        let history = storage.list_dispatches(&workflow.id).await.unwrap();
+        assert_eq!(history.len(), 1);
+        assert!(history[0].task.is_none());
     }
 
     // -----------------------------------------------------------------------

--- a/crates/orchestrator/src/scheduler/types.rs
+++ b/crates/orchestrator/src/scheduler/types.rs
@@ -379,6 +379,10 @@ pub struct DispatchRecord {
     pub status: DispatchStatus,
     pub dispatched_at: DateTime<Utc>,
     pub completed_at: Option<DateTime<Utc>>,
+    /// The task whose variables were rendered into `prompt_sent`.
+    /// `None` for records created before task persistence was added.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub task: Option<Task>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -430,6 +434,13 @@ pub struct TriggerWorkflowRequest {
     pub title: Option<String>,
     /// Task body / description.
     pub body: Option<String>,
+    /// Task URL (defaults to empty). Lets retries of source-derived
+    /// dispatches reproduce `{{url}}` faithfully.
+    pub url: Option<String>,
+    /// Task labels (defaults to none).
+    pub labels: Option<Vec<String>>,
+    /// Task assignee (defaults to none).
+    pub assignee: Option<String>,
     /// Arbitrary metadata key-value pairs.
     #[serde(default)]
     pub metadata: HashMap<String, String>,
@@ -507,6 +518,9 @@ pub struct DispatchResponse {
     pub status: DispatchStatus,
     pub dispatched_at: DateTime<Utc>,
     pub completed_at: Option<DateTime<Utc>>,
+    /// The task whose variables were rendered into `prompt_sent`, when recorded.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub task: Option<Task>,
 }
 
 impl From<DispatchRecord> for DispatchResponse {
@@ -520,6 +534,7 @@ impl From<DispatchRecord> for DispatchResponse {
             status: d.status,
             dispatched_at: d.dispatched_at,
             completed_at: d.completed_at,
+            task: d.task,
         }
     }
 }
@@ -559,6 +574,52 @@ mod tests {
         } else {
             panic!("Expected AgentIdle variant");
         }
+    }
+
+    #[test]
+    fn test_dispatch_record_deserializes_without_task_field() {
+        // Records serialized before task persistence was added (no `task` key)
+        // must still deserialize, with `task` defaulting to `None`.
+        let json = format!(
+            r#"{{
+                "id": "{}",
+                "workflow_id": "{}",
+                "source_id": "42",
+                "agent_id": "{}",
+                "prompt_sent": "do the thing",
+                "status": "completed",
+                "dispatched_at": "2026-06-10T00:00:00Z",
+                "completed_at": null
+            }}"#,
+            Uuid::new_v4(),
+            Uuid::new_v4(),
+            Uuid::new_v4()
+        );
+        let record: DispatchRecord = serde_json::from_str(&json).unwrap();
+        assert!(record.task.is_none());
+    }
+
+    #[test]
+    fn test_trigger_workflow_request_accepts_full_task_fields() {
+        // url/labels/assignee passthrough for faithful re-triggers.
+        let json = r#"{
+            "title": "Re-run",
+            "body": "details",
+            "url": "https://example.com/issues/7",
+            "labels": ["bug"],
+            "assignee": "geoff",
+            "metadata": {"retry_of": "abc"}
+        }"#;
+        let req: TriggerWorkflowRequest = serde_json::from_str(json).unwrap();
+        assert_eq!(req.url.as_deref(), Some("https://example.com/issues/7"));
+        assert_eq!(req.labels, Some(vec!["bug".to_string()]));
+        assert_eq!(req.assignee.as_deref(), Some("geoff"));
+
+        // Old minimal payloads still deserialize.
+        let req: TriggerWorkflowRequest = serde_json::from_str(r#"{"title": "x"}"#).unwrap();
+        assert!(req.url.is_none());
+        assert!(req.labels.is_none());
+        assert!(req.assignee.is_none());
     }
 
     #[test]

--- a/crates/orchestrator/tests/scheduler_integration.rs
+++ b/crates/orchestrator/tests/scheduler_integration.rs
@@ -163,6 +163,50 @@ async fn non_manual_workflow_trigger_creates_dispatched_record() {
     assert_eq!(dispatches[0].status, DispatchStatus::Dispatched);
 }
 
+/// The originating task (including url/labels/assignee/metadata) is persisted
+/// on the dispatch record so the UI can prefill a re-trigger with the same
+/// variables.
+#[tokio::test]
+async fn trigger_workflow_persists_task_for_retry() {
+    let (storage, _tmp) = create_test_storage().await;
+    let registry = ConnectionRegistry::new();
+    let agent_id = Uuid::new_v4();
+    let _agent_rx = register_mock_agent(&registry, agent_id).await;
+
+    let trigger = TriggerConfig::GithubIssues {
+        owner: "org".to_string(),
+        repo: "repo".to_string(),
+        labels: vec![],
+        state: "open".to_string(),
+        assignee: None,
+    };
+    let workflow = make_workflow(agent_id, trigger);
+    storage.add_workflow(&workflow).await.unwrap();
+
+    let scheduler = Arc::new(Scheduler::new(storage.clone(), registry));
+
+    let mut task = make_task("issue-77");
+    task.body = "Fix the flaky test".to_string();
+    task.url = "https://github.com/org/repo/issues/77".to_string();
+    task.labels = vec!["bug".to_string(), "ci".to_string()];
+    task.assignee = Some("geoff".to_string());
+    task.metadata.insert("retry_of".to_string(), "some-dispatch-id".to_string());
+
+    let record = scheduler.trigger_workflow(&workflow.id, task).await.unwrap();
+    let returned = record.task.as_ref().expect("returned record should carry the task");
+    assert_eq!(returned.url, "https://github.com/org/repo/issues/77");
+
+    // The task round-trips through persistence with all fields intact.
+    let dispatches = storage.list_dispatches(&workflow.id).await.unwrap();
+    let stored = dispatches[0].task.as_ref().expect("task should be persisted");
+    assert_eq!(stored.title, "Task issue-77");
+    assert_eq!(stored.body, "Fix the flaky test");
+    assert_eq!(stored.url, "https://github.com/org/repo/issues/77");
+    assert_eq!(stored.labels, vec!["bug".to_string(), "ci".to_string()]);
+    assert_eq!(stored.assignee.as_deref(), Some("geoff"));
+    assert_eq!(stored.metadata.get("retry_of").map(String::as_str), Some("some-dispatch-id"));
+}
+
 // ---------------------------------------------------------------------------
 // trigger_workflow() requires the agent to be connected (direct path)
 // ---------------------------------------------------------------------------

--- a/ui/src/components/workflows/DispatchHistory.tsx
+++ b/ui/src/components/workflows/DispatchHistory.tsx
@@ -5,12 +5,17 @@
  * Supports filtering by status and pagination.
  */
 
-import { ChevronDown, ChevronUp } from "lucide-react";
+import { ChevronDown, ChevronUp, RotateCcw } from "lucide-react";
 import { useState } from "react";
 import { ListItemSkeleton } from "@/components/common/LoadingSkeleton";
 import { Pagination } from "@/components/common/Pagination";
+import { RetryDispatchModal } from "@/components/workflows/RetryDispatchModal";
 import { useDispatchHistory } from "@/hooks/useWorkflows";
-import type { DispatchRecord, DispatchStatus } from "@/types/orchestrator";
+import type {
+	DispatchRecord,
+	DispatchStatus,
+	Workflow,
+} from "@/types/orchestrator";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -18,6 +23,11 @@ import type { DispatchRecord, DispatchStatus } from "@/types/orchestrator";
 
 export interface DispatchHistoryProps {
 	workflowId: string;
+	/**
+	 * The full workflow. When provided, dispatch rows become clickable and
+	 * open the re-trigger modal (which needs the prompt template).
+	 */
+	workflow?: Workflow;
 	pageSize?: number;
 }
 
@@ -64,12 +74,25 @@ const STATUS_OPTIONS: Array<{ value: DispatchStatus | "all"; label: string }> =
 // Row component
 // ---------------------------------------------------------------------------
 
-function DispatchRow({ record }: { record: DispatchRecord }) {
+function DispatchRow({
+	record,
+	onRetry,
+}: {
+	record: DispatchRecord;
+	onRetry?: (record: DispatchRecord) => void;
+}) {
 	const [expanded, setExpanded] = useState(false);
+	const colCount = onRetry ? 6 : 5;
 
 	return (
 		<>
-			<tr className="border-t border-th-border-subtle hover:bg-th-surface-hover">
+			<tr
+				className={[
+					"border-t border-th-border-subtle hover:bg-th-surface-hover",
+					onRetry ? "cursor-pointer" : "",
+				].join(" ")}
+				onClick={onRetry ? () => onRetry(record) : undefined}
+			>
 				<td className="py-2 px-4 font-mono text-xs text-th-text-muted">
 					{record.source_id}
 				</td>
@@ -81,7 +104,10 @@ function DispatchRow({ record }: { record: DispatchRecord }) {
 						{record.prompt_sent.length > 80 && (
 							<button
 								type="button"
-								onClick={() => setExpanded((v) => !v)}
+								onClick={(e) => {
+									e.stopPropagation();
+									setExpanded((v) => !v);
+								}}
 								className="flex-shrink-0 text-th-text-link hover:text-th-text-link focus-visible:outline-none"
 								aria-label={expanded ? "Collapse prompt" : "Expand prompt"}
 							>
@@ -103,11 +129,27 @@ function DispatchRow({ record }: { record: DispatchRecord }) {
 				<td className="py-2 px-4 text-xs text-th-text-faint whitespace-nowrap">
 					{record.completed_at ? formatDate(record.completed_at) : "—"}
 				</td>
+				{onRetry && (
+					<td className="py-2 px-4">
+						<button
+							type="button"
+							onClick={(e) => {
+								e.stopPropagation();
+								onRetry(record);
+							}}
+							className="rounded p-1 text-th-text-muted hover:text-th-text-link focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-th-focus-ring"
+							aria-label="Re-trigger this dispatch"
+							title="Re-trigger this dispatch"
+						>
+							<RotateCcw size={14} />
+						</button>
+					</td>
+				)}
 			</tr>
 
 			{expanded && (
 				<tr className="bg-th-surface-sunken">
-					<td colSpan={5} className="px-4 py-2">
+					<td colSpan={colCount} className="px-4 py-2">
 						<pre className="text-xs font-mono text-th-text-secondary whitespace-pre-wrap">
 							{record.prompt_sent}
 						</pre>
@@ -124,19 +166,30 @@ function DispatchRow({ record }: { record: DispatchRecord }) {
 
 export function DispatchHistory({
 	workflowId,
+	workflow,
 	pageSize = 20,
 }: DispatchHistoryProps) {
 	const [page, setPage] = useState(1);
 	const [statusFilter, setStatusFilter] = useState<DispatchStatus | "all">(
 		"all",
 	);
+	const [retryTarget, setRetryTarget] = useState<DispatchRecord | null>(null);
 
-	const { dispatches, total, loading, error } = useDispatchHistory({
+	const { dispatches, total, loading, error, refetch } = useDispatchHistory({
 		workflowId,
 		page,
 		pageSize,
 		status: statusFilter === "all" ? undefined : statusFilter,
 	});
+
+	const colCount = workflow ? 6 : 5;
+
+	function handleRetried() {
+		// Reset to the unfiltered first page so the new dispatch is visible.
+		setStatusFilter("all");
+		setPage(1);
+		refetch();
+	}
 
 	return (
 		<div className="space-y-3">
@@ -185,13 +238,18 @@ export function DispatchHistory({
 							<th className="py-2 px-4 text-left text-xs font-medium text-th-text-muted uppercase tracking-wide">
 								Completed
 							</th>
+							{workflow && (
+								<th className="py-2 px-4 text-left text-xs font-medium text-th-text-muted uppercase tracking-wide">
+									<span className="sr-only">Actions</span>
+								</th>
+							)}
 						</tr>
 					</thead>
 					<tbody>
 						{loading ? (
 							Array.from({ length: 3 }).map((_, i) => (
 								<tr key={i} className="border-t border-th-border-subtle">
-									<td colSpan={5} className="p-2">
+									<td colSpan={colCount} className="p-2">
 										<ListItemSkeleton />
 									</td>
 								</tr>
@@ -199,7 +257,7 @@ export function DispatchHistory({
 						) : error ? (
 							<tr>
 								<td
-									colSpan={5}
+									colSpan={colCount}
 									className="py-8 text-center text-sm text-th-status-error-text"
 								>
 									{error}
@@ -208,7 +266,7 @@ export function DispatchHistory({
 						) : dispatches.length === 0 ? (
 							<tr>
 								<td
-									colSpan={5}
+									colSpan={colCount}
 									className="py-8 text-center text-sm text-th-text-faint"
 								>
 									No dispatches found.
@@ -216,7 +274,11 @@ export function DispatchHistory({
 							</tr>
 						) : (
 							dispatches.map((record) => (
-								<DispatchRow key={record.id} record={record} />
+								<DispatchRow
+									key={record.id}
+									record={record}
+									onRetry={workflow ? setRetryTarget : undefined}
+								/>
 							))
 						)}
 					</tbody>
@@ -231,6 +293,17 @@ export function DispatchHistory({
 					totalItems={total}
 					pageSize={pageSize}
 					onPageChange={setPage}
+				/>
+			)}
+
+			{/* Re-trigger modal */}
+			{workflow && (
+				<RetryDispatchModal
+					open={retryTarget !== null}
+					workflow={workflow}
+					dispatch={retryTarget}
+					onClose={() => setRetryTarget(null)}
+					onRetried={handleRetried}
 				/>
 			)}
 		</div>

--- a/ui/src/components/workflows/RetryDispatchModal.tsx
+++ b/ui/src/components/workflows/RetryDispatchModal.tsx
@@ -1,0 +1,506 @@
+/**
+ * RetryDispatchModal — re-trigger a workflow dispatch with editable variables.
+ *
+ * Opened by clicking a dispatch entry in the dispatch history table. Renders
+ * one input per {{variable}} found in the workflow's prompt template,
+ * prefilled from the task persisted on the dispatch being retried (when
+ * available), plus a live preview of the rendered prompt.
+ */
+
+import { X } from "lucide-react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import { orchestratorClient } from "@/services/orchestrator";
+import { toastStore } from "@/stores/toastStore";
+import { ApiError } from "@/types/common";
+import type {
+	DispatchRecord,
+	Task,
+	TriggerWorkflowRequest,
+	Workflow,
+} from "@/types/orchestrator";
+import {
+	extractTemplateVariables,
+	renderTemplatePreview,
+} from "@/utils/templateVariables";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface RetryDispatchModalProps {
+	open: boolean;
+	workflow: Workflow;
+	dispatch: DispatchRecord | null;
+	onClose: () => void;
+	/** Called with the newly created dispatch after a successful re-trigger. */
+	onRetried: (dispatch: DispatchRecord) => void;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Metadata keys injected by the retry flow itself; excluded from prefill. */
+const INTERNAL_METADATA_KEYS = new Set(["retry_of"]);
+
+function errorMessage(err: unknown): string {
+	if (err instanceof ApiError) {
+		switch (err.status) {
+			case 400:
+				return "Workflow is disabled — enable it before re-triggering.";
+			case 409:
+				return "Agent is busy with another task. Try again when the current dispatch completes.";
+			case 503:
+				return "Agent is not connected. Start the agent and try again.";
+			default:
+				return err.message;
+		}
+	}
+	return err instanceof Error ? err.message : "Failed to trigger workflow";
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function RetryDispatchModal({
+	open,
+	workflow,
+	dispatch,
+	onClose,
+	onRetried,
+}: RetryDispatchModalProps) {
+	const firstFieldRef = useRef<HTMLInputElement | HTMLTextAreaElement>(null);
+
+	// Form state — top-level task fields plus named metadata variables.
+	const [title, setTitle] = useState("");
+	const [body, setBody] = useState("");
+	const [url, setUrl] = useState("");
+	const [labelsRaw, setLabelsRaw] = useState("");
+	const [assignee, setAssignee] = useState("");
+	const [metadataValues, setMetadataValues] = useState<
+		Record<string, string>
+	>({});
+	const [newMetaKey, setNewMetaKey] = useState("");
+	const [newMetaValue, setNewMetaValue] = useState("");
+	const [submitting, setSubmitting] = useState(false);
+	const [submitError, setSubmitError] = useState<string | undefined>();
+
+	const variables = useMemo(
+		() => extractTemplateVariables(workflow.prompt_template),
+		[workflow.prompt_template],
+	);
+	const hasVariable = (name: string) =>
+		variables.some((v) => v.name === name);
+	const metadataVariables = variables.filter((v) => v.kind === "metadata");
+	const usesMetadataMap = variables.some((v) => v.kind === "metadata-map");
+
+	const originalTask = dispatch?.task ?? null;
+
+	// Prefill from the dispatch being retried whenever the modal opens.
+	useEffect(() => {
+		if (!open) return;
+		setTitle(originalTask?.title ?? "");
+		setBody(originalTask?.body ?? "");
+		setUrl(originalTask?.url ?? "");
+		setLabelsRaw((originalTask?.labels ?? []).join(", "));
+		setAssignee(originalTask?.assignee ?? "");
+		setMetadataValues(
+			Object.fromEntries(
+				Object.entries(originalTask?.metadata ?? {}).filter(
+					([key]) => !INTERNAL_METADATA_KEYS.has(key),
+				),
+			),
+		);
+		setNewMetaKey("");
+		setNewMetaValue("");
+		setSubmitError(undefined);
+		setSubmitting(false);
+		setTimeout(() => firstFieldRef.current?.focus(), 50);
+	}, [open, originalTask]);
+
+	// Close on Escape
+	useEffect(() => {
+		if (!open) return;
+		function handleKeyDown(e: KeyboardEvent) {
+			if (e.key === "Escape") onClose();
+		}
+		document.addEventListener("keydown", handleKeyDown);
+		return () => document.removeEventListener("keydown", handleKeyDown);
+	}, [open, onClose]);
+
+	if (!open || !dispatch) return null;
+
+	const labels = labelsRaw
+		.split(",")
+		.map((l) => l.trim())
+		.filter(Boolean);
+
+	// Live preview of the rendered prompt using the current form values.
+	const previewTask: Task = {
+		source_id: "manual:<generated>",
+		title: title || "Manual trigger",
+		body,
+		url,
+		labels,
+		assignee: assignee || undefined,
+		metadata: metadataValues,
+	};
+	const preview = renderTemplatePreview(
+		workflow.prompt_template,
+		previewTask,
+	);
+
+	async function handleSubmit() {
+		setSubmitting(true);
+		setSubmitError(undefined);
+		try {
+			const request: TriggerWorkflowRequest = {
+				...(title.trim() ? { title: title.trim() } : {}),
+				...(body ? { body } : {}),
+				...(url.trim() ? { url: url.trim() } : {}),
+				...(labels.length > 0 ? { labels } : {}),
+				...(assignee.trim() ? { assignee: assignee.trim() } : {}),
+				metadata: {
+					...metadataValues,
+					retry_of: dispatch!.id,
+				},
+			};
+			const created = await orchestratorClient.triggerWorkflow(
+				workflow.id,
+				request,
+			);
+			toastStore.success("Workflow re-triggered", {
+				message: `Dispatch ${created.source_id} created`,
+			});
+			onRetried(created);
+			onClose();
+		} catch (err) {
+			setSubmitError(errorMessage(err));
+		} finally {
+			setSubmitting(false);
+		}
+	}
+
+	const editableCount =
+		Number(hasVariable("title")) +
+		Number(hasVariable("body")) +
+		Number(hasVariable("url")) +
+		Number(hasVariable("labels")) +
+		Number(hasVariable("assignee")) +
+		metadataVariables.length +
+		Number(usesMetadataMap);
+
+	return (
+		<div
+			className="fixed inset-0 z-50 flex items-center justify-center p-4"
+			role="dialog"
+			aria-modal="true"
+			aria-labelledby="retry-dispatch-title"
+		>
+			{/* Backdrop */}
+			<div
+				className="absolute inset-0 bg-th-overlay"
+				onClick={onClose}
+				aria-hidden="true"
+			/>
+
+			{/* Panel */}
+			<div className="relative z-10 w-full max-w-2xl max-h-[90vh] overflow-y-auto rounded-xl bg-th-surface shadow-xl">
+				{/* Header */}
+				<div className="sticky top-0 z-10 flex items-center justify-between border-b border-th-border bg-th-surface px-6 py-4">
+					<h2
+						id="retry-dispatch-title"
+						className="text-lg font-semibold text-th-text"
+					>
+						Re-trigger Workflow
+					</h2>
+					<button
+						type="button"
+						onClick={onClose}
+						className="rounded p-1 text-th-text-muted hover:text-th-text-secondary focus-visible:outline-none focus-visible:ring-2 focus:ring-th-focus-ring"
+						aria-label="Close dialog"
+					>
+						<X size={18} />
+					</button>
+				</div>
+
+				{/* Body */}
+				<div className="px-6 py-5 space-y-5">
+					<p className="text-sm text-th-text-muted">
+						Re-runs <span className="font-medium">{workflow.name}</span>{" "}
+						as a new manual dispatch. Original dispatch:{" "}
+						<span className="font-mono text-xs">{dispatch.source_id}</span>
+					</p>
+
+					{submitError && (
+						<p className="rounded-md bg-th-status-error-bg px-3 py-2 text-sm text-th-status-error-text">
+							{submitError}
+						</p>
+					)}
+
+					{!originalTask && (
+						<p className="rounded-md bg-th-status-warning-bg px-3 py-2 text-sm text-th-status-warning-text">
+							Original input values were not recorded for this dispatch.
+							Fill in the variables below to re-run it.
+						</p>
+					)}
+
+					{editableCount === 0 && (
+						<p className="text-sm text-th-text-faint">
+							This workflow's prompt has no editable variables — it will
+							be re-run as-is.
+						</p>
+					)}
+
+					{/* Title */}
+					{hasVariable("title") && (
+						<div>
+							<label className="block text-sm font-medium text-th-text-secondary mb-1">
+								Title{" "}
+								<span className="font-mono text-xs text-th-text-faint">
+									{"{{title}}"}
+								</span>
+							</label>
+							<input
+								ref={firstFieldRef as React.RefObject<HTMLInputElement>}
+								type="text"
+								value={title}
+								onChange={(e) => setTitle(e.target.value)}
+								placeholder="Manual trigger"
+								className={fieldClass()}
+							/>
+						</div>
+					)}
+
+					{/* Body */}
+					{hasVariable("body") && (
+						<div>
+							<label className="block text-sm font-medium text-th-text-secondary mb-1">
+								Body{" "}
+								<span className="font-mono text-xs text-th-text-faint">
+									{"{{body}}"}
+								</span>
+							</label>
+							<textarea
+								value={body}
+								onChange={(e) => setBody(e.target.value)}
+								rows={4}
+								className={fieldClass("", "font-mono text-xs leading-relaxed")}
+							/>
+						</div>
+					)}
+
+					{/* URL */}
+					{hasVariable("url") && (
+						<div>
+							<label className="block text-sm font-medium text-th-text-secondary mb-1">
+								URL{" "}
+								<span className="font-mono text-xs text-th-text-faint">
+									{"{{url}}"}
+								</span>
+							</label>
+							<input
+								type="text"
+								value={url}
+								onChange={(e) => setUrl(e.target.value)}
+								className={fieldClass()}
+							/>
+						</div>
+					)}
+
+					{/* Labels */}
+					{hasVariable("labels") && (
+						<div>
+							<label className="block text-sm font-medium text-th-text-secondary mb-1">
+								Labels{" "}
+								<span className="font-mono text-xs text-th-text-faint">
+									{"{{labels}}"}
+								</span>
+							</label>
+							<input
+								type="text"
+								value={labelsRaw}
+								onChange={(e) => setLabelsRaw(e.target.value)}
+								placeholder="bug, urgent (comma-separated)"
+								className={fieldClass()}
+							/>
+						</div>
+					)}
+
+					{/* Assignee */}
+					{hasVariable("assignee") && (
+						<div>
+							<label className="block text-sm font-medium text-th-text-secondary mb-1">
+								Assignee{" "}
+								<span className="font-mono text-xs text-th-text-faint">
+									{"{{assignee}}"}
+								</span>
+							</label>
+							<input
+								type="text"
+								value={assignee}
+								onChange={(e) => setAssignee(e.target.value)}
+								className={fieldClass()}
+							/>
+						</div>
+					)}
+
+					{/* Named metadata variables */}
+					{metadataVariables.map((variable) => (
+						<div key={variable.name}>
+							<label className="block text-sm font-medium text-th-text-secondary mb-1">
+								{variable.name}{" "}
+								<span className="font-mono text-xs text-th-text-faint">
+									{`{{${variable.name}}}`}
+								</span>
+							</label>
+							<input
+								type="text"
+								value={metadataValues[variable.name] ?? ""}
+								onChange={(e) =>
+									setMetadataValues((prev) => ({
+										...prev,
+										[variable.name]: e.target.value,
+									}))
+								}
+								className={fieldClass()}
+							/>
+						</div>
+					))}
+
+					{/* Free-form metadata editor (template uses the whole {{metadata}} map) */}
+					{usesMetadataMap && (
+						<fieldset className="rounded-lg border border-th-border p-4 space-y-3">
+							<legend className="text-sm font-medium text-th-text-secondary px-1">
+								Metadata{" "}
+								<span className="font-mono text-xs text-th-text-faint">
+									{"{{metadata}}"}
+								</span>
+							</legend>
+							{Object.entries(metadataValues)
+								.filter(
+									([key]) =>
+										!metadataVariables.some((v) => v.name === key),
+								)
+								.map(([key, value]) => (
+									<div key={key} className="flex items-center gap-2">
+										<span className="w-1/3 truncate font-mono text-xs text-th-text-muted">
+											{key}
+										</span>
+										<input
+											type="text"
+											value={value}
+											onChange={(e) =>
+												setMetadataValues((prev) => ({
+													...prev,
+													[key]: e.target.value,
+												}))
+											}
+											className={fieldClass()}
+										/>
+										<button
+											type="button"
+											onClick={() =>
+												setMetadataValues((prev) => {
+													const next = { ...prev };
+													delete next[key];
+													return next;
+												})
+											}
+											className="rounded p-1 text-th-text-muted hover:text-th-status-error-text"
+											aria-label={`Remove metadata key ${key}`}
+										>
+											<X size={14} />
+										</button>
+									</div>
+								))}
+							<div className="flex items-center gap-2">
+								<input
+									type="text"
+									value={newMetaKey}
+									onChange={(e) => setNewMetaKey(e.target.value)}
+									placeholder="key"
+									className={fieldClass("", "w-1/3")}
+								/>
+								<input
+									type="text"
+									value={newMetaValue}
+									onChange={(e) => setNewMetaValue(e.target.value)}
+									placeholder="value"
+									className={fieldClass()}
+								/>
+								<button
+									type="button"
+									onClick={() => {
+										const key = newMetaKey.trim();
+										if (!key) return;
+										setMetadataValues((prev) => ({
+											...prev,
+											[key]: newMetaValue,
+										}));
+										setNewMetaKey("");
+										setNewMetaValue("");
+									}}
+									className="rounded-md border border-th-border-strong px-2 py-1 text-xs font-medium text-th-text-secondary hover:bg-th-surface-hover"
+								>
+									Add
+								</button>
+							</div>
+						</fieldset>
+					)}
+
+					{/* Prompt preview */}
+					<div>
+						<label className="block text-sm font-medium text-th-text-secondary mb-1">
+							Prompt preview
+						</label>
+						<pre className="max-h-48 overflow-y-auto rounded-md border border-th-border bg-th-surface-sunken px-3 py-2 text-xs font-mono text-th-text-secondary whitespace-pre-wrap">
+							{preview}
+						</pre>
+					</div>
+				</div>
+
+				{/* Footer */}
+				<div className="sticky bottom-0 flex items-center justify-end gap-3 border-t border-th-border bg-th-surface px-6 py-4">
+					<button
+						type="button"
+						onClick={onClose}
+						disabled={submitting}
+						className="rounded-md border border-th-border-strong bg-th-surface px-4 py-2 text-sm font-medium text-th-text-secondary hover:bg-th-surface-hover transition-colors disabled:opacity-50"
+					>
+						Cancel
+					</button>
+					<button
+						type="button"
+						onClick={handleSubmit}
+						disabled={submitting}
+						className="rounded-md bg-th-accent px-4 py-2 text-sm font-medium text-th-accent-text hover:bg-th-accent-hover transition-colors disabled:opacity-50"
+					>
+						{submitting ? "Triggering…" : "Re-trigger"}
+					</button>
+				</div>
+			</div>
+		</div>
+	);
+}
+
+// ---------------------------------------------------------------------------
+// Style helpers
+// ---------------------------------------------------------------------------
+
+function fieldClass(error?: string, extra = ""): string {
+	return [
+		"w-full rounded-md border px-3 py-2 text-sm",
+		"bg-th-input",
+		"text-th-text",
+		"focus:outline-none focus:ring-2 focus:ring-th-focus-ring",
+		"disabled:cursor-not-allowed disabled:opacity-50",
+		error ? "border-th-status-error-border" : "border-th-border-input",
+		extra,
+	]
+		.filter(Boolean)
+		.join(" ");
+}
+
+export default RetryDispatchModal;

--- a/ui/src/components/workflows/index.ts
+++ b/ui/src/components/workflows/index.ts
@@ -2,6 +2,8 @@ export type { DispatchHistoryProps } from "./DispatchHistory";
 export { DispatchHistory } from "./DispatchHistory";
 export type { PromptTemplateEditorProps } from "./PromptTemplateEditor";
 export { PromptTemplateEditor } from "./PromptTemplateEditor";
+export type { RetryDispatchModalProps } from "./RetryDispatchModal";
+export { RetryDispatchModal } from "./RetryDispatchModal";
 export type { WorkflowFormProps } from "./WorkflowForm";
 export { WorkflowForm } from "./WorkflowForm";
 export type { WorkflowTableProps } from "./WorkflowTable";

--- a/ui/src/pages/workflows/WorkflowDetail.tsx
+++ b/ui/src/pages/workflows/WorkflowDetail.tsx
@@ -245,7 +245,7 @@ export function WorkflowDetail() {
 				<h2 className="text-base font-semibold text-th-text mb-4">
 					Dispatch history
 				</h2>
-				<DispatchHistory workflowId={workflow.id} />
+				<DispatchHistory workflowId={workflow.id} workflow={workflow} />
 			</div>
 
 			{/* Edit dialog */}

--- a/ui/src/services/orchestrator.ts
+++ b/ui/src/services/orchestrator.ts
@@ -27,6 +27,7 @@ import type {
 	SendMessageResponse,
 	SetModelRequest,
 	ToolPolicy,
+	TriggerWorkflowRequest,
 	UpdatePolicyRequest,
 	UpdateWorkflowRequest,
 	Workflow,
@@ -224,6 +225,18 @@ export class OrchestratorClient extends ApiClient {
 			`/workflows/${id}/history`,
 			params as Record<string, string>,
 		);
+	}
+
+	/**
+	 * Manually trigger a workflow, bypassing its normal trigger strategy.
+	 * Used by the dispatch retry modal to re-run a dispatch with
+	 * (optionally edited) variables.
+	 */
+	triggerWorkflow(
+		id: string,
+		request?: TriggerWorkflowRequest,
+	): Promise<DispatchRecord> {
+		return this.post<DispatchRecord>(`/workflows/${id}/trigger`, request ?? {});
 	}
 
 	// -------------------------------------------------------------------------

--- a/ui/src/test/components/workflows/RetryDispatchModal.test.tsx
+++ b/ui/src/test/components/workflows/RetryDispatchModal.test.tsx
@@ -1,0 +1,178 @@
+/**
+ * RetryDispatchModal tests.
+ *
+ * Covers: prefill from the dispatch's persisted task, the missing-task
+ * banner for legacy records, error mapping (409 busy), and the submit
+ * payload shape sent to triggerWorkflow.
+ */
+
+import { fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { RetryDispatchModal } from "@/components/workflows/RetryDispatchModal";
+import { orchestratorClient } from "@/services/orchestrator";
+import { ApiError } from "@/types/common";
+import type { DispatchRecord, Workflow } from "@/types/orchestrator";
+
+vi.mock("@/services/orchestrator", () => ({
+	orchestratorClient: {
+		triggerWorkflow: vi.fn(),
+	},
+}));
+
+const triggerWorkflow = vi.mocked(orchestratorClient.triggerWorkflow);
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const workflow: Workflow = {
+	id: "wf-1",
+	name: "Fix Issues",
+	agent_id: "agent-1",
+	source_config: {
+		type: "github_issues",
+		owner: "geoffjay",
+		repo: "agentd",
+		labels: [],
+		state: "open",
+	},
+	prompt_template: "Fix {{title}} at {{url}}: {{body}} ({{priority}})",
+	poll_interval_secs: 900,
+	enabled: true,
+	tool_policy: { mode: "allow_all" },
+	created_at: new Date().toISOString(),
+	updated_at: new Date().toISOString(),
+};
+
+const dispatchWithTask: DispatchRecord = {
+	id: "dispatch-1",
+	workflow_id: "wf-1",
+	source_id: "issue-42",
+	agent_id: "agent-1",
+	prompt_sent: "Fix Login bug at https://example.com/42: Broken (high)",
+	status: "failed",
+	dispatched_at: new Date().toISOString(),
+	task: {
+		source_id: "issue-42",
+		title: "Login bug",
+		body: "Broken",
+		url: "https://example.com/42",
+		labels: ["bug"],
+		assignee: "geoff",
+		metadata: { priority: "high", retry_of: "older-dispatch" },
+	},
+};
+
+const dispatchWithoutTask: DispatchRecord = {
+	...dispatchWithTask,
+	id: "dispatch-2",
+	task: undefined,
+};
+
+function renderModal(dispatch: DispatchRecord) {
+	const onClose = vi.fn();
+	const onRetried = vi.fn();
+	render(
+		<RetryDispatchModal
+			open={true}
+			workflow={workflow}
+			dispatch={dispatch}
+			onClose={onClose}
+			onRetried={onRetried}
+		/>,
+	);
+	return { onClose, onRetried };
+}
+
+beforeEach(() => {
+	triggerWorkflow.mockReset();
+});
+
+// ---------------------------------------------------------------------------
+// Prefill
+// ---------------------------------------------------------------------------
+
+describe("RetryDispatchModal prefill", () => {
+	it("prefills inputs from the dispatch's persisted task", () => {
+		renderModal(dispatchWithTask);
+
+		expect(screen.getByDisplayValue("Login bug")).toBeInTheDocument();
+		expect(screen.getByDisplayValue("Broken")).toBeInTheDocument();
+		expect(
+			screen.getByDisplayValue("https://example.com/42"),
+		).toBeInTheDocument();
+		// Named metadata variable from the template
+		expect(screen.getByDisplayValue("high")).toBeInTheDocument();
+	});
+
+	it("strips internal retry_of metadata from prefill", () => {
+		renderModal(dispatchWithTask);
+		expect(
+			screen.queryByDisplayValue("older-dispatch"),
+		).not.toBeInTheDocument();
+	});
+
+	it("only renders inputs for variables in the template", () => {
+		renderModal(dispatchWithTask);
+		// {{labels}} and {{assignee}} are not in the template
+		expect(screen.queryByText(/\{\{labels\}\}/)).not.toBeInTheDocument();
+		expect(screen.queryByText(/\{\{assignee\}\}/)).not.toBeInTheDocument();
+	});
+
+	it("shows a banner when the original task was not recorded", () => {
+		renderModal(dispatchWithoutTask);
+		expect(
+			screen.getByText(/Original input values were not recorded/),
+		).toBeInTheDocument();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Submit
+// ---------------------------------------------------------------------------
+
+describe("RetryDispatchModal submit", () => {
+	it("sends prefilled values with retry_of metadata and reports success", async () => {
+		triggerWorkflow.mockResolvedValue({
+			...dispatchWithTask,
+			id: "dispatch-new",
+			source_id: "manual:abc",
+			status: "dispatched",
+		});
+		const { onClose, onRetried } = renderModal(dispatchWithTask);
+
+		fireEvent.click(screen.getByRole("button", { name: "Re-trigger" }));
+
+		await waitFor(() => expect(triggerWorkflow).toHaveBeenCalledOnce());
+		// All original task fields are forwarded (even those not in the
+		// template) so the new dispatch's persisted task stays complete.
+		expect(triggerWorkflow).toHaveBeenCalledWith("wf-1", {
+			title: "Login bug",
+			body: "Broken",
+			url: "https://example.com/42",
+			labels: ["bug"],
+			assignee: "geoff",
+			metadata: {
+				priority: "high",
+				retry_of: "dispatch-1",
+			},
+		});
+		await waitFor(() => expect(onRetried).toHaveBeenCalledOnce());
+		expect(onClose).toHaveBeenCalledOnce();
+	});
+
+	it("shows a busy message on 409 and keeps the modal open", async () => {
+		triggerWorkflow.mockRejectedValue(new ApiError(409, "Conflict"));
+		const { onClose, onRetried } = renderModal(dispatchWithTask);
+
+		fireEvent.click(screen.getByRole("button", { name: "Re-trigger" }));
+
+		await waitFor(() =>
+			expect(
+				screen.getByText(/Agent is busy with another task/),
+			).toBeInTheDocument(),
+		);
+		expect(onRetried).not.toHaveBeenCalled();
+		expect(onClose).not.toHaveBeenCalled();
+	});
+});

--- a/ui/src/test/utils/templateVariables.test.ts
+++ b/ui/src/test/utils/templateVariables.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Tests for template variable extraction and preview rendering.
+ */
+
+import { describe, expect, it } from "vitest";
+import type { Task } from "@/types/orchestrator";
+import {
+	classifyVariable,
+	extractTemplateVariables,
+	renderTemplatePreview,
+} from "@/utils/templateVariables";
+
+// ---------------------------------------------------------------------------
+// extractTemplateVariables
+// ---------------------------------------------------------------------------
+
+describe("extractTemplateVariables", () => {
+	it("extracts variables in order of first appearance", () => {
+		const vars = extractTemplateVariables(
+			"Fix {{title}} at {{url}}: {{body}}",
+		);
+		expect(vars.map((v) => v.name)).toEqual(["title", "url", "body"]);
+	});
+
+	it("deduplicates repeated variables", () => {
+		const vars = extractTemplateVariables("{{title}} and {{title}} again");
+		expect(vars).toHaveLength(1);
+		expect(vars[0].name).toBe("title");
+	});
+
+	it("tolerates whitespace inside braces", () => {
+		const vars = extractTemplateVariables("Handle {{ title }}");
+		expect(vars.map((v) => v.name)).toEqual(["title"]);
+	});
+
+	it("ignores unclosed placeholders", () => {
+		const vars = extractTemplateVariables("Broken {{title");
+		expect(vars).toHaveLength(0);
+	});
+
+	it("returns empty for a template without variables", () => {
+		expect(extractTemplateVariables("static prompt")).toEqual([]);
+	});
+
+	it("classifies variables by how they are supplied", () => {
+		const vars = extractTemplateVariables(
+			"{{title}} {{body}} {{url}} {{assignee}} {{labels}} {{metadata}} {{source_id}} {{fire_time}}",
+		);
+		const kinds = Object.fromEntries(vars.map((v) => [v.name, v.kind]));
+		expect(kinds).toEqual({
+			title: "field",
+			body: "field",
+			url: "field",
+			assignee: "field",
+			labels: "labels",
+			metadata: "metadata-map",
+			source_id: "readonly",
+			fire_time: "metadata",
+		});
+	});
+});
+
+// ---------------------------------------------------------------------------
+// classifyVariable
+// ---------------------------------------------------------------------------
+
+describe("classifyVariable", () => {
+	it("treats unknown names as metadata-backed", () => {
+		expect(classifyVariable("custom_thing")).toBe("metadata");
+	});
+});
+
+// ---------------------------------------------------------------------------
+// renderTemplatePreview
+// ---------------------------------------------------------------------------
+
+describe("renderTemplatePreview", () => {
+	const task: Task = {
+		source_id: "manual:abc",
+		title: "Login bug",
+		body: "Fix it",
+		url: "https://example.com/42",
+		labels: ["bug", "p1"],
+		assignee: "geoff",
+		metadata: { fire_time: "2026-06-10T00:00:00Z" },
+	};
+
+	it("replaces top-level fields and metadata variables", () => {
+		const result = renderTemplatePreview(
+			"{{title}} ({{labels}}) by {{assignee}} at {{fire_time}}",
+			task,
+		);
+		expect(result).toBe(
+			"Login bug (bug, p1) by geoff at 2026-06-10T00:00:00Z",
+		);
+	});
+
+	it("renders the whole metadata map for {{metadata}}", () => {
+		const result = renderTemplatePreview("Meta:\n{{metadata}}", task);
+		expect(result).toBe("Meta:\nfire_time: 2026-06-10T00:00:00Z");
+	});
+
+	it("preserves unknown variables as literal placeholders", () => {
+		const result = renderTemplatePreview("Value: {{unknown_var}}", task);
+		expect(result).toBe("Value: {{unknown_var}}");
+	});
+
+	it("renders missing assignee as empty", () => {
+		const result = renderTemplatePreview("By: {{assignee}}", {
+			...task,
+			assignee: undefined,
+		});
+		expect(result).toBe("By: ");
+	});
+});

--- a/ui/src/types/orchestrator.ts
+++ b/ui/src/types/orchestrator.ts
@@ -215,6 +215,11 @@ export interface DispatchRecord {
 	status: DispatchStatus;
 	dispatched_at: string;
 	completed_at?: string;
+	/**
+	 * The task whose variables were rendered into prompt_sent.
+	 * Absent for records created before task persistence was added.
+	 */
+	task?: Task | null;
 }
 
 /**
@@ -229,6 +234,19 @@ export interface Task {
 	labels: string[];
 	assignee?: string;
 	metadata: Record<string, string>;
+}
+
+/**
+ * Request body for manually triggering a workflow.
+ * Mirrors the Rust TriggerWorkflowRequest type.
+ */
+export interface TriggerWorkflowRequest {
+	title?: string;
+	body?: string;
+	url?: string;
+	labels?: string[];
+	assignee?: string;
+	metadata?: Record<string, string>;
 }
 
 /** Request body for creating a workflow */

--- a/ui/src/utils/templateVariables.ts
+++ b/ui/src/utils/templateVariables.ts
@@ -1,0 +1,95 @@
+/**
+ * Utilities for working with workflow prompt template variables.
+ *
+ * Mirrors the backend's template semantics (crates/orchestrator/src/scheduler/template.rs):
+ * top-level task fields ({{title}}, {{body}}, {{url}}, {{labels}}, {{assignee}},
+ * {{source_id}}, {{metadata}}) are replaced first, then any remaining
+ * {{variable}} placeholders are resolved from task metadata. Unknown variables
+ * are preserved as-is in the rendered prompt.
+ */
+
+import type { Task } from "@/types/orchestrator";
+
+/** How a template variable is supplied when manually triggering a workflow. */
+export type VariableKind =
+	/** Maps to a top-level field of TriggerWorkflowRequest (title, body, url, assignee). */
+	| "field"
+	/** Comma-separated list mapping to TriggerWorkflowRequest.labels. */
+	| "labels"
+	/** The special {{metadata}} variable rendering the whole metadata map. */
+	| "metadata-map"
+	/** Assigned by the server on trigger; cannot be set manually. */
+	| "readonly"
+	/** Resolved from the metadata map by name. */
+	| "metadata";
+
+export interface TemplateVariable {
+	name: string;
+	kind: VariableKind;
+}
+
+const FIELD_VARIABLES = new Set(["title", "body", "url", "assignee"]);
+
+/** Classify a single variable name into how it must be supplied. */
+export function classifyVariable(name: string): VariableKind {
+	if (FIELD_VARIABLES.has(name)) return "field";
+	if (name === "labels") return "labels";
+	if (name === "metadata") return "metadata-map";
+	if (name === "source_id") return "readonly";
+	return "metadata";
+}
+
+/**
+ * Extract {{variable}} placeholders from a prompt template, deduplicated and
+ * in order of first appearance. Whitespace inside braces is tolerated
+ * ({{ title }} === {{title}}), matching the backend's `.trim()`.
+ */
+export function extractTemplateVariables(template: string): TemplateVariable[] {
+	const seen = new Set<string>();
+	const variables: TemplateVariable[] = [];
+	const pattern = /\{\{\s*([A-Za-z_][A-Za-z0-9_]*)\s*\}\}/g;
+
+	for (const match of template.matchAll(pattern)) {
+		const name = match[1];
+		if (seen.has(name)) continue;
+		seen.add(name);
+		variables.push({ name, kind: classifyVariable(name) });
+	}
+
+	return variables;
+}
+
+/**
+ * Client-side mirror of the backend's render_template, used for live previews.
+ * Unknown variables are preserved as literal {{placeholders}}, matching the
+ * backend behavior.
+ */
+export function renderTemplatePreview(template: string, task: Task): string {
+	const metadataBlock = Object.entries(task.metadata)
+		.map(([k, v]) => `${k}: ${v}`)
+		.join("\n");
+
+	return template.replace(
+		/\{\{\s*([A-Za-z_][A-Za-z0-9_]*)\s*\}\}/g,
+		(placeholder, name: string) => {
+			switch (name) {
+				case "title":
+					return task.title;
+				case "body":
+					return task.body;
+				case "url":
+					return task.url;
+				case "labels":
+					return task.labels.join(", ");
+				case "assignee":
+					return task.assignee ?? "";
+				case "source_id":
+					return task.source_id;
+				case "metadata":
+					return metadataBlock;
+				default:
+					return task.metadata[name] ?? placeholder;
+			}
+		},
+	);
+}


### PR DESCRIPTION
feat(orchestrator): persist task variables on dispatch records

Adds a nullable task_json column to dispatch_log storing the JSON-serialized
Task whose variables were rendered into prompt_sent, so the UI can prefill a
re-trigger with the original input values. Also extends TriggerWorkflowRequest
with optional url/labels/assignee so manual re-triggers of source-derived
dispatches reproduce the original prompt faithfully.

- Migration m20260610_000019 adds dispatch_log.task_json (TEXT NULL)
- DispatchRecord/DispatchResponse carry task: Option<Task> (serde default,
  lenient decode so corrupt/legacy rows never fail listings)
- All three dispatch-creation sites persist the originating task
- CLI initializers updated for the new fields

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

feat(ui): re-trigger workflow dispatches from the dispatch history

Clicking a dispatch row (or its retry icon) opens a modal with one input
per {{variable}} in the workflow's prompt template, prefilled from the
task persisted on the dispatch being retried, plus a live prompt preview.
Submitting re-runs the workflow via POST /workflows/{id}/trigger with a
retry_of metadata entry for traceability.

- New RetryDispatchModal following the WorkflowForm modal pattern
- templateVariables util mirrors backend template semantics
- DispatchHistory rows clickable when the workflow is provided; legacy
  dispatches without a recorded task show an informational banner

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>