### PR TITLE
feat(ui): runtime service configuration via /config.json

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7496,6 +7496,8 @@ dependencies = [
  "axum",
  "http-body-util",
  "reqwest",
+ "serde",
+ "serde_json",
  "tokio",
  "tower",
  "tower-http",

--- a/crates/common/src/config.rs
+++ b/crates/common/src/config.rs
@@ -388,11 +388,29 @@ pub struct UiConfig {
     ///
     /// Defaults to `"./ui/dist"`.
     pub ui_dir: String,
+    /// Explicit browser-facing URL overrides per service, served to the SPA
+    /// via `GET /config.json`.
+    ///
+    /// By default the SPA reaches each service at
+    /// `<page protocol>//<page hostname>:<service port>`, which is correct
+    /// when the service ports are reachable from the browser. Deployments
+    /// that front services with a reverse proxy or TLS can override the full
+    /// URL per service instead:
+    ///
+    /// ```toml
+    /// [services.ui.public_urls]
+    /// orchestrator = "https://agentd.example.com/orchestrator"
+    /// ```
+    pub public_urls: std::collections::BTreeMap<String, String>,
 }
 
 impl Default for UiConfig {
     fn default() -> Self {
-        Self { port: 17009, ui_dir: "./ui/dist".to_string() }
+        Self {
+            port: 17009,
+            ui_dir: "./ui/dist".to_string(),
+            public_urls: std::collections::BTreeMap::new(),
+        }
     }
 }
 
@@ -922,6 +940,11 @@ fn merge(base: AgentdConfig, file: AgentdConfig) -> AgentdConfig {
                     &file.services.ui.ui_dir,
                     &d.services.ui.ui_dir,
                 ),
+                public_urls: if file.services.ui.public_urls.is_empty() {
+                    base.services.ui.public_urls.clone()
+                } else {
+                    file.services.ui.public_urls.clone()
+                },
             },
         },
     }

--- a/crates/ui/Cargo.toml
+++ b/crates/ui/Cargo.toml
@@ -21,8 +21,10 @@ anyhow = { workspace = true }
 axum = { workspace = true }
 tower-http = { workspace = true, features = ["cors", "fs"] }
 reqwest = { workspace = true, features = ["json"] }
+serde = { workspace = true }
 agentd-common = { path = "../common" }
 
 [dev-dependencies]
 tower = { version = "0.5", features = ["util"] }
 http-body-util = "0.1"
+serde_json = { workspace = true }

--- a/crates/ui/src/config.rs
+++ b/crates/ui/src/config.rs
@@ -14,6 +14,9 @@ pub struct UiConfig {
     pub notify_service_url: String,
     /// URL of the orchestrator service.
     pub orchestrator_service_url: String,
+    /// Runtime configuration document served to the SPA at `/config.json`,
+    /// built from the same shared config this struct was loaded from.
+    pub runtime_config: crate::runtime_config::RuntimeConfig,
 }
 
 impl UiConfig {
@@ -32,9 +35,11 @@ impl UiConfig {
             tracing::warn!("failed to load config file, using compiled defaults: {e:#}");
             agentd_common::config::AgentdConfig::default()
         });
+        let runtime_config = crate::runtime_config::build(&shared);
         let base = shared.services.ui;
 
         Self {
+            runtime_config,
             port: std::env::var("AGENTD_UI_PORT")
                 .or_else(|_| std::env::var("AGENTD_PORT"))
                 .ok()
@@ -80,27 +85,24 @@ mod tests {
         assert!(config.validate().is_ok());
     }
 
-    #[test]
-    fn test_validate_zero_port_fails() {
-        let config = UiConfig {
-            port: 0,
-            ui_dir: "./ui/dist".to_string(),
+    fn test_config(port: u16, ui_dir: &str) -> UiConfig {
+        UiConfig {
+            port,
+            ui_dir: ui_dir.to_string(),
             ask_service_url: "http://localhost:7001".to_string(),
             notify_service_url: "http://localhost:7004".to_string(),
             orchestrator_service_url: "http://localhost:7006".to_string(),
-        };
-        assert!(config.validate().is_err());
+            runtime_config: crate::runtime_config::build(&Default::default()),
+        }
+    }
+
+    #[test]
+    fn test_validate_zero_port_fails() {
+        assert!(test_config(0, "./ui/dist").validate().is_err());
     }
 
     #[test]
     fn test_validate_empty_ui_dir_fails() {
-        let config = UiConfig {
-            port: 17009,
-            ui_dir: "".to_string(),
-            ask_service_url: "http://localhost:7001".to_string(),
-            notify_service_url: "http://localhost:7004".to_string(),
-            orchestrator_service_url: "http://localhost:7006".to_string(),
-        };
-        assert!(config.validate().is_err());
+        assert!(test_config(17009, "").validate().is_err());
     }
 }

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -26,10 +26,11 @@
 
 pub mod config;
 pub mod proxy;
+pub mod runtime_config;
 
 use anyhow::Result;
 use axum::routing::{any, get};
-use axum::Router;
+use axum::{Json, Router};
 use proxy::ProxyState;
 use std::path::Path;
 use tower_http::services::{ServeDir, ServeFile};
@@ -58,8 +59,13 @@ pub async fn run(config: config::UiConfig) -> Result<()> {
     let index_path = ui_path.join("index.html");
     let serve_dir = ServeDir::new(&ui_dir).fallback(ServeFile::new(&index_path));
 
+    // Runtime configuration for the SPA: built once at startup, immutable
+    // for the lifetime of the process.
+    let runtime_config = config.runtime_config.clone();
+
     let router = Router::new()
         .route("/health", get(|| async { "ok" }))
+        .route("/config.json", get(move || async move { Json(runtime_config.clone()) }))
         // API proxy routes — use `any` to support all HTTP methods
         .route("/api/ask/{*path}", any(proxy::proxy_ask))
         .route("/api/notify/{*path}", any(proxy::proxy_notify))

--- a/crates/ui/src/runtime_config.rs
+++ b/crates/ui/src/runtime_config.rs
@@ -1,0 +1,102 @@
+//! Runtime configuration served to the SPA at `GET /config.json`.
+//!
+//! The prebuilt frontend cannot know per-host service locations at build
+//! time, so it fetches this document at startup. For each browser-facing
+//! service the document carries the configured port; the SPA combines it
+//! with the page's own protocol and hostname unless an explicit `url`
+//! override is present (`[services.ui.public_urls]` in `config.toml`).
+
+use serde::Serialize;
+use std::collections::BTreeMap;
+
+/// Document returned by `GET /config.json`.
+#[derive(Debug, Clone, Serialize)]
+pub struct RuntimeConfig {
+    /// Version of the agentd-ui service that produced the document.
+    pub version: &'static str,
+    /// Browser-facing services keyed by short service name.
+    pub services: BTreeMap<&'static str, ServiceEntry>,
+}
+
+/// Location of a single service as exposed to the browser.
+#[derive(Debug, Clone, Serialize)]
+pub struct ServiceEntry {
+    /// Listen port of the service.
+    pub port: u16,
+    /// Explicit browser-facing URL override; when present it takes
+    /// precedence over host + port derivation in the SPA.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+}
+
+/// Services the SPA talks to directly. `hook`, `wrap`, and `core` are
+/// backend-only and intentionally not exposed.
+const BROWSER_SERVICES: &[&str] =
+    &["ask", "notify", "orchestrator", "memory", "monitor", "communicate"];
+
+/// Build the runtime configuration from the shared agentd config.
+pub fn build(shared: &agentd_common::config::AgentdConfig) -> RuntimeConfig {
+    let s = &shared.services;
+    let overrides = &s.ui.public_urls;
+
+    let mut services = BTreeMap::new();
+    for &name in BROWSER_SERVICES {
+        let port = match name {
+            "ask" => s.ask.port,
+            "notify" => s.notify.port,
+            "orchestrator" => s.orchestrator.port,
+            "memory" => s.memory.port,
+            "monitor" => s.monitor.port,
+            "communicate" => s.communicate.port,
+            _ => unreachable!("unknown browser service {name}"),
+        };
+        services.insert(name, ServiceEntry { port, url: overrides.get(name).cloned() });
+    }
+
+    RuntimeConfig { version: env!("CARGO_PKG_VERSION"), services }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use agentd_common::config::AgentdConfig;
+
+    #[test]
+    fn test_build_default_ports() {
+        let cfg = AgentdConfig::default();
+        let runtime = build(&cfg);
+
+        assert_eq!(runtime.services.len(), BROWSER_SERVICES.len());
+        assert_eq!(runtime.services["ask"].port, 17001);
+        assert_eq!(runtime.services["orchestrator"].port, 17006);
+        assert_eq!(runtime.services["communicate"].port, 17010);
+        assert!(runtime.services.values().all(|s| s.url.is_none()));
+    }
+
+    #[test]
+    fn test_build_with_public_url_override() {
+        let mut cfg = AgentdConfig::default();
+        cfg.services
+            .ui
+            .public_urls
+            .insert("orchestrator".to_string(), "https://agentd.example.com/orch".to_string());
+        let runtime = build(&cfg);
+
+        assert_eq!(
+            runtime.services["orchestrator"].url.as_deref(),
+            Some("https://agentd.example.com/orch")
+        );
+        assert!(runtime.services["ask"].url.is_none());
+    }
+
+    #[test]
+    fn test_serialization_shape() {
+        let cfg = AgentdConfig::default();
+        let json = serde_json::to_value(build(&cfg)).unwrap();
+
+        assert!(json["version"].is_string());
+        assert_eq!(json["services"]["notify"]["port"], 17004);
+        // `url` is omitted entirely when not overridden.
+        assert!(json["services"]["notify"].get("url").is_none());
+    }
+}

--- a/docs/planning/installation-method.md
+++ b/docs/planning/installation-method.md
@@ -77,6 +77,11 @@ Delivered as a hand-rolled workflow + POSIX installer rather than cargo-dist
 - Release tags containing a `-` (e.g. `v0.5.0-rc.1`) publish as pre-releases,
   so installer/pipeline changes can be tested end-to-end without affecting
   `releases/latest`.
+- The web UI in the tarball is host-agnostic: instead of baking `VITE_*` env
+  values at build time (which a prebuilt artifact cannot carry per host), the
+  SPA fetches `/config.json` from `agentd-ui` at startup. The endpoint derives
+  service ports from the shared `config.toml`, with optional full-URL
+  overrides in `[services.ui.public_urls]` for reverse-proxy/TLS deployments.
 
 ### Why not cargo-dist
 

--- a/docs/public/install.md
+++ b/docs/public/install.md
@@ -58,6 +58,24 @@ agent service start
 agent service status
 ```
 
+#### Web UI service discovery
+
+The installed web UI needs no build-time configuration: at startup the SPA
+fetches `/config.json` from the `agentd-ui` service, which derives the
+browser-facing service locations from the agentd config file (the same
+`config.toml` the installer gap-fills with production ports). By default each
+service is reached at the page's own hostname with the service's configured
+port, which works for direct access to the host.
+
+Deployments that front services with a reverse proxy or TLS can override the
+full URL per service:
+
+```toml
+[services.ui.public_urls]
+orchestrator = "https://agentd.example.com/orchestrator"
+notify = "https://agentd.example.com/notify"
+```
+
 ### Option 2: cargo xtask (from source)
 
 ```bash

--- a/ui/.env.example
+++ b/ui/.env.example
@@ -1,4 +1,10 @@
 # Copy this file to .env.local and customize as needed
+#
+# These build-time variables only apply in development (vite dev server) or
+# custom local builds. A UI served by the agentd-ui service ignores them:
+# it fetches /config.json at startup and resolves service locations from the
+# agentd config.toml instead (see [services.ui.public_urls] for overrides).
+#
 # Service URLs for agentd backend services
 VITE_AGENTD_ASK_SERVICE_URL=http://localhost:7001
 VITE_AGENTD_HOOK_SERVICE_URL=http://localhost:7002

--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -1,10 +1,19 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
 import "./index.css";
-import App from "./App.tsx";
+import { loadRuntimeConfig, setRuntimeConfig } from "./runtime-config";
 
-createRoot(document.getElementById("root")!).render(
-	<StrictMode>
-		<App />
-	</StrictMode>,
-);
+// Resolve runtime service configuration before the application module graph
+// loads: API clients capture their base URLs at module evaluation time, so
+// `App` must be imported only after the config is in place.
+loadRuntimeConfig().then(async (config) => {
+	setRuntimeConfig(config);
+	const { default: App } = await import("./App.tsx");
+	const root = document.getElementById("root");
+	if (!root) throw new Error("missing #root element");
+	createRoot(root).render(
+		<StrictMode>
+			<App />
+		</StrictMode>,
+	);
+});

--- a/ui/src/runtime-config.ts
+++ b/ui/src/runtime-config.ts
@@ -1,0 +1,77 @@
+/**
+ * Runtime service configuration fetched from the hosting agentd-ui service.
+ *
+ * The prebuilt SPA cannot know per-host service locations at build time, so
+ * `main.tsx` fetches `/config.json` (served by agentd-ui from the shared
+ * agentd config file) before the application module graph loads. Service
+ * URLs resolve as: explicit `url` override from the config file, otherwise
+ * the page's own protocol and hostname combined with the service's port.
+ *
+ * When the endpoint is unavailable (e.g. the Vite dev server) the app falls
+ * back to the build-time `VITE_*` env defaults in `services/config.ts`.
+ */
+
+export interface RuntimeServiceEntry {
+	port: number;
+	url?: string;
+}
+
+export interface RuntimeConfig {
+	version: string;
+	services: Record<string, RuntimeServiceEntry>;
+}
+
+let runtimeConfig: RuntimeConfig | null = null;
+
+export function setRuntimeConfig(config: RuntimeConfig | null): void {
+	runtimeConfig = config;
+}
+
+export function getRuntimeConfig(): RuntimeConfig | null {
+	return runtimeConfig;
+}
+
+function isRuntimeConfig(value: unknown): value is RuntimeConfig {
+	if (typeof value !== "object" || value === null) return false;
+	const services = (value as { services?: unknown }).services;
+	if (typeof services !== "object" || services === null) return false;
+	return Object.values(services).every(
+		(entry) =>
+			typeof entry === "object" &&
+			entry !== null &&
+			typeof (entry as RuntimeServiceEntry).port === "number",
+	);
+}
+
+/**
+ * Fetch `/config.json` from the origin serving the SPA.
+ *
+ * Returns `null` when the endpoint is missing, returns non-JSON (an SPA
+ * index.html fallback), or fails validation — callers treat that as "no
+ * runtime config" and build-time defaults apply.
+ */
+export async function loadRuntimeConfig(): Promise<RuntimeConfig | null> {
+	try {
+		const response = await fetch("/config.json", {
+			headers: { accept: "application/json" },
+		});
+		if (!response.ok) return null;
+		const contentType = response.headers.get("content-type") ?? "";
+		if (!contentType.includes("application/json")) return null;
+		const data: unknown = await response.json();
+		return isRuntimeConfig(data) ? data : null;
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Resolve the browser-facing URL for a service from the runtime config, or
+ * `undefined` when no runtime config is loaded or the service is unknown.
+ */
+export function runtimeServiceUrl(name: string): string | undefined {
+	const entry = runtimeConfig?.services[name];
+	if (!entry) return undefined;
+	if (entry.url) return entry.url;
+	return `${window.location.protocol}//${window.location.hostname}:${entry.port}`;
+}

--- a/ui/src/services/config.ts
+++ b/ui/src/services/config.ts
@@ -1,19 +1,38 @@
 /**
- * Service configuration with environment variable defaults
+ * Service configuration.
+ *
+ * Resolution order per service:
+ * 1. Runtime config fetched from the hosting agentd-ui service
+ *    (`/config.json`, see `../runtime-config.ts`) — set before this module
+ *    evaluates via the `main.tsx` bootstrap.
+ * 2. Build-time `VITE_*` env vars (local development).
+ * 3. Compiled dev-port defaults.
  */
+import { runtimeServiceUrl } from "../runtime-config";
+
 export const serviceConfig = {
 	askServiceUrl:
-		import.meta.env.VITE_AGENTD_ASK_SERVICE_URL ?? "http://localhost:17001",
+		runtimeServiceUrl("ask") ??
+		import.meta.env.VITE_AGENTD_ASK_SERVICE_URL ??
+		"http://localhost:17001",
 	notifyServiceUrl:
-		import.meta.env.VITE_AGENTD_NOTIFY_SERVICE_URL ?? "http://localhost:17004",
+		runtimeServiceUrl("notify") ??
+		import.meta.env.VITE_AGENTD_NOTIFY_SERVICE_URL ??
+		"http://localhost:17004",
 	orchestratorServiceUrl:
+		runtimeServiceUrl("orchestrator") ??
 		import.meta.env.VITE_AGENTD_ORCHESTRATOR_SERVICE_URL ??
 		"http://localhost:17006",
 	memoryServiceUrl:
-		import.meta.env.VITE_AGENTD_MEMORY_SERVICE_URL ?? "http://localhost:17008",
+		runtimeServiceUrl("memory") ??
+		import.meta.env.VITE_AGENTD_MEMORY_SERVICE_URL ??
+		"http://localhost:17008",
 	monitorServiceUrl:
-		import.meta.env.VITE_AGENTD_MONITOR_SERVICE_URL ?? "http://localhost:17003",
+		runtimeServiceUrl("monitor") ??
+		import.meta.env.VITE_AGENTD_MONITOR_SERVICE_URL ??
+		"http://localhost:17003",
 	communicateServiceUrl:
+		runtimeServiceUrl("communicate") ??
 		import.meta.env.VITE_AGENTD_COMMUNICATE_SERVICE_URL ??
 		"http://localhost:17010",
 } as const;

--- a/ui/src/test/runtime-config.test.ts
+++ b/ui/src/test/runtime-config.test.ts
@@ -1,0 +1,78 @@
+import { HttpResponse, http } from "msw";
+import { afterEach, describe, expect, it } from "vitest";
+import {
+	loadRuntimeConfig,
+	runtimeServiceUrl,
+	setRuntimeConfig,
+} from "../runtime-config";
+import { server } from "./mocks/server";
+
+const CONFIG = {
+	version: "0.4.3",
+	services: {
+		ask: { port: 7001 },
+		orchestrator: { port: 7006, url: "https://agentd.example.com/orch" },
+	},
+};
+
+afterEach(() => setRuntimeConfig(null));
+
+describe("loadRuntimeConfig", () => {
+	it("returns the parsed config when /config.json serves JSON", async () => {
+		server.use(http.get("*/config.json", () => HttpResponse.json(CONFIG)));
+		expect(await loadRuntimeConfig()).toEqual(CONFIG);
+	});
+
+	it("returns null when the endpoint is missing", async () => {
+		server.use(
+			http.get("*/config.json", () => new HttpResponse(null, { status: 404 })),
+		);
+		expect(await loadRuntimeConfig()).toBeNull();
+	});
+
+	it("returns null when an SPA fallback serves HTML", async () => {
+		server.use(
+			http.get(
+				"*/config.json",
+				() =>
+					new HttpResponse("<!doctype html><html></html>", {
+						headers: { "content-type": "text/html" },
+					}),
+			),
+		);
+		expect(await loadRuntimeConfig()).toBeNull();
+	});
+
+	it("returns null when the payload fails validation", async () => {
+		server.use(
+			http.get("*/config.json", () =>
+				HttpResponse.json({ services: { ask: { port: "7001" } } }),
+			),
+		);
+		expect(await loadRuntimeConfig()).toBeNull();
+	});
+});
+
+describe("runtimeServiceUrl", () => {
+	it("returns undefined when no runtime config is loaded", () => {
+		expect(runtimeServiceUrl("ask")).toBeUndefined();
+	});
+
+	it("derives the URL from the page protocol and hostname plus the port", () => {
+		setRuntimeConfig(CONFIG);
+		const { protocol, hostname } = window.location;
+		expect(runtimeServiceUrl("ask")).toBe(`${protocol}//${hostname}:7001`);
+	});
+
+	it("prefers an explicit url override", () => {
+		setRuntimeConfig(CONFIG);
+		expect(runtimeServiceUrl("orchestrator")).toBe(
+			"https://agentd.example.com/orch",
+		);
+	});
+
+	it("returns undefined for an unknown service", () => {
+		setRuntimeConfig(CONFIG);
+		expect(runtimeServiceUrl("hook")).toBeUndefined();
+	});
+});


### PR DESCRIPTION
The prebuilt SPA shipped in release tarballs baked VITE_* service URLs at
build time, and the CI build has no .env.production, so installed UIs fell
back to dev-port localhost URLs and could not reach any service. A prebuilt
artifact cannot carry per-host values at all, so service discovery moves to
runtime:

- agentd-ui serves GET /config.json, built once at startup from the shared
  config.toml: per-service ports for the browser-facing services (ask,
  notify, orchestrator, memory, monitor, communicate) plus the service
  version.
- New optional [services.ui.public_urls] table in the shared config supplies
  explicit full-URL overrides per service for reverse-proxy/TLS deployments.
- The SPA fetches /config.json before the application module graph loads
  (API clients capture base URLs at module evaluation), resolving each
  service as: explicit override, else page protocol + hostname + configured
  port. When the endpoint is unavailable (vite dev server) the existing
  VITE_* env defaults apply unchanged.

ui/.env.production is no longer needed for production installs.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>