### PR TITLE
ci: cross-compile x86_64-apple-darwin on the arm64 macOS runner

### DIFF
--- a/.github/workflows/cache-warm.yml
+++ b/.github/workflows/cache-warm.yml
@@ -43,7 +43,7 @@ jobs:
           - target: aarch64-unknown-linux-musl
             os: ubuntu-24.04-arm
           - target: x86_64-apple-darwin
-            os: macos-15-intel
+            os: macos-latest
           - target: aarch64-apple-darwin
             os: macos-latest
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,8 +44,11 @@ jobs:
           # GitHub-hosted arm64 runners are free for public repositories only.
           - target: aarch64-unknown-linux-musl
             os: ubuntu-24.04-arm
+          # Cross-compiled from the arm64 runner: the same Xcode SDK serves
+          # both darwin architectures, and the Intel runners are slow enough
+          # (1h+ builds) that cross-compiling beats building natively.
           - target: x86_64-apple-darwin
-            os: macos-15-intel
+            os: macos-latest
           - target: aarch64-apple-darwin
             os: macos-latest
     steps:


### PR DESCRIPTION
The macos-15-intel runner is the slowest job in the release matrix (1h+
builds). macOS cross-compiles between architectures with the same Xcode
SDK, so build the x86_64 darwin target on macos-latest (arm64) instead
and drop the Intel runner entirely.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>