### PR TITLE
docs(planning): system agents expansion tracking document

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,6 +86,7 @@ dependencies = [
  "axum",
  "chrono",
  "futures",
+ "orchestrator",
  "reqwest",
  "rmcp",
  "schemars 0.8.22",

--- a/crates/cli/src/commands/apply.rs
+++ b/crates/cli/src/commands/apply.rs
@@ -87,6 +87,11 @@ pub struct AgentTemplate {
     /// Rooms are created (if missing) during `agent apply` before agents start.
     #[serde(default)]
     pub rooms: Vec<AgentRoomConfig>,
+    /// MCP servers for the agent's Claude session, keyed by server name.
+    /// Forwarded verbatim to the orchestrator, which writes the map to a
+    /// per-agent config file and launches claude with `--mcp-config`.
+    #[serde(default)]
+    pub mcp_servers: Option<HashMap<String, orchestrator::types::McpServerConfig>>,
 }
 
 fn default_working_dir() -> String {
@@ -1227,6 +1232,7 @@ async fn apply_agent(
         resource_limits: tmpl.resource_limits.clone(),
         additional_dirs,
         rooms: tmpl.rooms.iter().map(|r| r.name().to_string()).collect(),
+        mcp_servers: tmpl.mcp_servers.clone(),
     };
 
     let agent = client.create_agent(&request).await?;
@@ -1998,5 +2004,32 @@ repo: myproject
             }
             other => panic!("Expected GitlabMergeRequests, got {:?}", other),
         }
+    }
+
+    #[test]
+    fn test_agent_template_with_mcp_servers() {
+        let yaml = r#"
+name: diagnostician
+model: sonnet
+mcp_servers:
+  agentd:
+    command: agent
+    args: [mcp]
+    env:
+      AGENTD_ORCHESTRATOR_URL: http://localhost:17006
+"#;
+        let tmpl: AgentTemplate = serde_yaml::from_str(yaml).unwrap();
+        let servers = tmpl.mcp_servers.expect("mcp_servers parsed");
+        let agentd = &servers["agentd"];
+        assert_eq!(agentd.command, "agent");
+        assert_eq!(agentd.args, vec!["mcp"]);
+        assert_eq!(agentd.env["AGENTD_ORCHESTRATOR_URL"], "http://localhost:17006");
+    }
+
+    #[test]
+    fn test_agent_template_without_mcp_servers_defaults_none() {
+        let yaml = "name: plain\n";
+        let tmpl: AgentTemplate = serde_yaml::from_str(yaml).unwrap();
+        assert!(tmpl.mcp_servers.is_none());
     }
 }

--- a/crates/cli/src/commands/orchestrator.rs
+++ b/crates/cli/src/commands/orchestrator.rs
@@ -192,6 +192,16 @@ pub enum OrchestratorCommand {
         #[arg(long)]
         tool_policy: Option<String>,
 
+        /// MCP servers for the agent's Claude session, as a path to a JSON
+        /// file or inline JSON.
+        ///
+        /// Accepts either a bare server map or a full {"mcpServers": {...}}
+        /// wrapper:
+        ///   --mcp-config ./mcp.json
+        ///   --mcp-config '{"agentd":{"command":"agent","args":["mcp"]}}'
+        #[arg(long = "mcp-config", value_name = "PATH_OR_JSON")]
+        mcp_config: Option<String>,
+
         /// Environment variables to set for the agent (KEY=VALUE format).
         ///
         /// Can be specified multiple times for multiple variables.
@@ -907,6 +917,7 @@ impl OrchestratorCommand {
                 attach,
                 model,
                 tool_policy,
+                mcp_config,
                 env_vars,
                 auto_clear_threshold,
                 network_policy,
@@ -931,6 +942,7 @@ impl OrchestratorCommand {
                     *attach,
                     model.as_deref(),
                     tool_policy.as_deref(),
+                    mcp_config.as_deref(),
                     env_vars,
                     *auto_clear_threshold,
                     network_policy.as_deref(),
@@ -1184,6 +1196,34 @@ fn parse_mount_flags(raw: &[String]) -> Result<Vec<orchestrator::types::VolumeMo
     Ok(mounts)
 }
 
+/// Parse a `--mcp-config` value: a path to a JSON file or inline JSON.
+///
+/// Accepts either a bare server map (`{"agentd": {...}}`) or a full
+/// `{"mcpServers": {...}}` wrapper, matching Claude Code's config format.
+fn parse_mcp_config(
+    raw: &str,
+) -> Result<std::collections::HashMap<String, orchestrator::types::McpServerConfig>> {
+    let content = if std::path::Path::new(raw).is_file() {
+        std::fs::read_to_string(raw).with_context(|| format!("Failed to read {raw}"))?
+    } else {
+        raw.to_string()
+    };
+
+    let value: serde_json::Value = serde_json::from_str(&content).context(
+        "Invalid --mcp-config: expected a JSON file path or inline JSON. \
+         Example: '{\"agentd\":{\"command\":\"agent\",\"args\":[\"mcp\"]}}'",
+    )?;
+
+    // Unwrap a {"mcpServers": {...}} wrapper if present.
+    let map = match value.get("mcpServers") {
+        Some(inner) => inner.clone(),
+        None => value,
+    };
+
+    serde_json::from_value(map)
+        .context("Invalid --mcp-config server map: each entry needs at least a \"command\"")
+}
+
 #[allow(clippy::too_many_arguments)]
 async fn create_agent(
     client: &OrchestratorClient,
@@ -1200,6 +1240,7 @@ async fn create_agent(
     attach: bool,
     model: Option<&str>,
     tool_policy_json: Option<&str>,
+    mcp_config: Option<&str>,
     env_vars: &[String],
     auto_clear_threshold: Option<u64>,
     network_policy: Option<&str>,
@@ -1221,6 +1262,9 @@ async fn create_agent(
         Some(s) => serde_json::from_str(s).context("Invalid tool policy JSON. Example: '{\"mode\":\"allow_list\",\"tools\":[\"Read\",\"Grep\"]}'")?,
         None => Default::default(),
     };
+
+    // Parse --mcp-config from a file path or inline JSON.
+    let mcp_servers = mcp_config.map(parse_mcp_config).transpose()?;
 
     // Parse --env KEY=VALUE pairs into a HashMap.
     // Values containing '=' are handled correctly: only the first '=' is the delimiter.
@@ -1264,6 +1308,7 @@ async fn create_agent(
         resource_limits,
         additional_dirs: add_dirs.to_vec(),
         rooms: vec![],
+        mcp_servers,
     };
 
     let agent = client.create_agent(&request).await.context("Failed to create agent")?;
@@ -3076,6 +3121,7 @@ mod tests {
                 resource_limits: None,
                 additional_dirs: vec![],
                 rooms: vec![],
+                mcp_servers: None,
             },
             session_id: Some("agentd-orch-abc123".to_string()),
             backend_type: Some("tmux".to_string()),
@@ -3938,6 +3984,7 @@ mod tests {
                 }),
                 additional_dirs: vec![],
                 rooms: vec![],
+                mcp_servers: None,
             },
             session_id: Some("abc123container".to_string()),
             backend_type: Some("docker".to_string()),

--- a/crates/mcp/Cargo.toml
+++ b/crates/mcp/Cargo.toml
@@ -40,3 +40,5 @@ chrono = { version = "0.4", features = ["serde"] }
 tokio-test = "0.4"
 axum = { workspace = true }
 tokio = { workspace = true, features = ["net"] }
+# Round-trip tests locking JSON shapes against the real orchestrator types.
+orchestrator = { path = "../orchestrator" }

--- a/crates/mcp/src/client.rs
+++ b/crates/mcp/src/client.rs
@@ -78,4 +78,14 @@ impl AgentdClient {
         let resp = self.inner.post(url).json(body).send().await?.error_for_status()?;
         Ok(resp.json::<T>().await?)
     }
+
+    /// Perform a PUT request with a JSON body and deserialize the JSON response.
+    pub async fn put<B: serde::Serialize, T: serde::de::DeserializeOwned>(
+        &self,
+        url: &str,
+        body: &B,
+    ) -> Result<T> {
+        let resp = self.inner.put(url).json(body).send().await?.error_for_status()?;
+        Ok(resp.json::<T>().await?)
+    }
 }

--- a/crates/mcp/src/server.rs
+++ b/crates/mcp/src/server.rs
@@ -7,8 +7,8 @@
 use crate::client::AgentdClient;
 use crate::config::AgentdMcpConfig;
 use crate::tools::{
-    agents, approvals, communicate, creation, diagnostic, health, lifecycle, memory, notifications,
-    orchestrator_debug, remediation, workflows,
+    agents, approvals, communicate, creation, diagnostic, health, lifecycle, memory, metrics,
+    notifications, orchestrator_debug, remediation, workflows,
 };
 use rmcp::{
     model::{ServerCapabilities, ServerInfo},
@@ -963,6 +963,33 @@ impl AgentdMcp {
         service: Option<String>,
     ) -> String {
         health::run_get_prometheus_metrics(&self.client, service.as_deref()).await
+    }
+
+    /// Run a curated PromQL query via the monitor service.
+    #[tool(
+        description = "Run a curated PromQL query against the agentd Prometheus stack via the monitor service. Call without a name to list the catalog (dispatch-success-rate, dispatch-throughput, agent-restart-rate, http-error-rate, http-p95-latency, session-cost, approvals-backlog, host-saturation, ...). window is like 15m/1h/24h; range=true returns a six-hour trend summarized per series instead of an instant value. Falls back gracefully when Prometheus is down (use get_prometheus_metrics for direct scraping)."
+    )]
+    async fn query_metrics(
+        &self,
+        #[tool(param)]
+        #[schemars(description = "Catalog query name; omit to list the catalog")]
+        name: Option<String>,
+        #[tool(param)]
+        #[schemars(description = "Time window for rate/increase queries, e.g. 15m, 1h, 24h")]
+        window: Option<String>,
+        #[tool(param)]
+        #[schemars(
+            description = "true for a range query (trend over the last 6h) instead of an instant value"
+        )]
+        range: Option<bool>,
+    ) -> String {
+        metrics::run_query_metrics(
+            &self.client,
+            name.as_deref(),
+            window.as_deref(),
+            range.unwrap_or(false),
+        )
+        .await
     }
 }
 

--- a/crates/mcp/src/server.rs
+++ b/crates/mcp/src/server.rs
@@ -7,7 +7,7 @@
 use crate::client::AgentdClient;
 use crate::config::AgentdMcpConfig;
 use crate::tools::{
-    agents, approvals, communicate, diagnostic, health, lifecycle, memory, notifications,
+    agents, approvals, communicate, creation, diagnostic, health, lifecycle, memory, notifications,
     orchestrator_debug, remediation, workflows,
 };
 use rmcp::{
@@ -227,6 +227,238 @@ impl AgentdMcp {
         limit: Option<u32>,
     ) -> String {
         workflows::run_get_failed_dispatches(&self.client, limit).await
+    }
+
+    // ── Agent and workflow creation ─────────────────────────────────────
+
+    /// Create a new agent.
+    #[tool(
+        description = "Create a new agent. Exposes the safe subset of agent configuration: name, working_dir, model, system_prompt, initial prompt, tool policy, and rooms. Env vars and Docker settings are deliberately NOT exposed (secrets must not transit MCP) — use the CLI for those. Returns the new agent ID."
+    )]
+    #[allow(clippy::too_many_arguments)]
+    async fn create_agent(
+        &self,
+        #[tool(param)]
+        #[schemars(description = "Unique agent name")]
+        name: String,
+        #[tool(param)]
+        #[schemars(description = "Absolute working directory for the agent process")]
+        working_dir: String,
+        #[tool(param)]
+        #[schemars(
+            description = "Model alias or full name (e.g. sonnet, opus, claude-sonnet-4-6). Omit for the default."
+        )]
+        model: Option<String>,
+        #[tool(param)]
+        #[schemars(description = "System prompt for the agent's Claude session")]
+        system_prompt: Option<String>,
+        #[tool(param)]
+        #[schemars(
+            description = "If true, the system prompt is appended to Claude's default prompt instead of replacing it"
+        )]
+        append_system_prompt: Option<bool>,
+        #[tool(param)]
+        #[schemars(description = "Initial prompt delivered once the agent connects")]
+        prompt: Option<String>,
+        #[tool(param)]
+        #[schemars(
+            description = "Tool policy mode: allow_all | deny_all | require_approval | allow_list | deny_list. Omit for allow_all."
+        )]
+        tool_policy_mode: Option<String>,
+        #[tool(param)]
+        #[schemars(description = "Tool names/patterns for allow_list or deny_list modes")]
+        tool_policy_tools: Option<Vec<String>>,
+        #[tool(param)]
+        #[schemars(description = "Communicate room names the agent auto-joins on connect")]
+        rooms: Option<Vec<String>>,
+    ) -> String {
+        creation::run_create_agent(
+            &self.client,
+            &name,
+            &working_dir,
+            model.as_deref(),
+            system_prompt.as_deref(),
+            append_system_prompt.unwrap_or(false),
+            prompt.as_deref(),
+            tool_policy_mode.as_deref(),
+            tool_policy_tools,
+            rooms,
+        )
+        .await
+    }
+
+    /// Create a new workflow.
+    #[tool(
+        description = "Create a new workflow that dispatches prompts to an agent when its trigger fires. trigger_config is a JSON object with a `type` field, e.g. {\"type\":\"cron\",\"expression\":\"0 9 * * MON-FRI\"}, {\"type\":\"manual\"}, or {\"type\":\"agent_idle\",\"idle_seconds\":600}. Valid types: github_issues, github_pull_requests, cron, delay, agent_lifecycle, dispatch_result, webhook, manual, agent_idle, linear_issues, composite, queue, ask_response, gitlab_issues, gitlab_merge_requests. Use get_workflow on an existing workflow to copy a working config. prompt_template supports {{placeholder}} substitution and is validated server-side."
+    )]
+    #[allow(clippy::too_many_arguments)]
+    async fn create_workflow(
+        &self,
+        #[tool(param)]
+        #[schemars(description = "Workflow name")]
+        name: String,
+        #[tool(param)]
+        #[schemars(
+            description = "ID (UUID) of the agent that receives dispatched prompts — see list_agents"
+        )]
+        agent_id: String,
+        #[tool(param)]
+        #[schemars(
+            description = "Trigger configuration object with a `type` field (see tool description for examples)"
+        )]
+        trigger_config: serde_json::Value,
+        #[tool(param)]
+        #[schemars(
+            description = "Prompt template dispatched on trigger; {{placeholder}} variables are substituted from the trigger payload"
+        )]
+        prompt_template: String,
+        #[tool(param)]
+        #[schemars(description = "Polling interval in seconds for polling triggers (default: 60)")]
+        poll_interval_secs: Option<u64>,
+        #[tool(param)]
+        #[schemars(description = "Whether the workflow starts enabled (default: true)")]
+        enabled: Option<bool>,
+        #[tool(param)]
+        #[schemars(
+            description = "Tool policy mode applied to dispatched runs: allow_all | deny_all | require_approval | allow_list | deny_list"
+        )]
+        tool_policy_mode: Option<String>,
+        #[tool(param)]
+        #[schemars(description = "Tool names/patterns for allow_list or deny_list modes")]
+        tool_policy_tools: Option<Vec<String>>,
+    ) -> String {
+        creation::run_create_workflow(
+            &self.client,
+            &name,
+            &agent_id,
+            trigger_config,
+            &prompt_template,
+            poll_interval_secs,
+            enabled,
+            tool_policy_mode.as_deref(),
+            tool_policy_tools,
+        )
+        .await
+    }
+
+    /// Update an existing workflow.
+    #[tool(
+        description = "Update an existing workflow. Only the provided fields change (merge semantics): name, agent_id, trigger_config, prompt_template, poll_interval_secs, enabled, tool policy. Use set_workflow_enabled for a plain enable/disable toggle."
+    )]
+    #[allow(clippy::too_many_arguments)]
+    async fn update_workflow(
+        &self,
+        #[tool(param)]
+        #[schemars(description = "The workflow ID (UUID) to update")]
+        workflow_id: String,
+        #[tool(param)]
+        #[schemars(description = "New workflow name")]
+        name: Option<String>,
+        #[tool(param)]
+        #[schemars(description = "Reassign to this agent ID (UUID)")]
+        agent_id: Option<String>,
+        #[tool(param)]
+        #[schemars(description = "Replacement trigger configuration object with a `type` field")]
+        trigger_config: Option<serde_json::Value>,
+        #[tool(param)]
+        #[schemars(description = "Replacement prompt template")]
+        prompt_template: Option<String>,
+        #[tool(param)]
+        #[schemars(description = "New polling interval in seconds")]
+        poll_interval_secs: Option<u64>,
+        #[tool(param)]
+        #[schemars(description = "Enable or disable the workflow")]
+        enabled: Option<bool>,
+        #[tool(param)]
+        #[schemars(
+            description = "Tool policy mode: allow_all | deny_all | require_approval | allow_list | deny_list"
+        )]
+        tool_policy_mode: Option<String>,
+        #[tool(param)]
+        #[schemars(description = "Tool names/patterns for allow_list or deny_list modes")]
+        tool_policy_tools: Option<Vec<String>>,
+    ) -> String {
+        creation::run_update_workflow(
+            &self.client,
+            &workflow_id,
+            name.as_deref(),
+            agent_id.as_deref(),
+            trigger_config,
+            prompt_template.as_deref(),
+            poll_interval_secs,
+            enabled,
+            tool_policy_mode.as_deref(),
+            tool_policy_tools,
+        )
+        .await
+    }
+
+    /// Enable or disable a workflow.
+    #[tool(
+        description = "Enable or disable a workflow. Disabled workflows keep their configuration and history but their trigger no longer fires."
+    )]
+    async fn set_workflow_enabled(
+        &self,
+        #[tool(param)]
+        #[schemars(description = "The workflow ID (UUID)")]
+        workflow_id: String,
+        #[tool(param)]
+        #[schemars(description = "true to enable, false to disable")]
+        enabled: bool,
+    ) -> String {
+        creation::run_set_workflow_enabled(&self.client, &workflow_id, enabled).await
+    }
+
+    /// Manually trigger a workflow.
+    #[tool(
+        description = "Manually trigger a workflow, dispatching its prompt template immediately. Optional title/body/url/labels/metadata populate the {{placeholder}} variables in the template. Ideal for smoke-testing a freshly created workflow."
+    )]
+    async fn trigger_workflow(
+        &self,
+        #[tool(param)]
+        #[schemars(description = "The workflow ID (UUID) to trigger")]
+        workflow_id: String,
+        #[tool(param)]
+        #[schemars(description = "Task title substituted into {{title}}")]
+        title: Option<String>,
+        #[tool(param)]
+        #[schemars(description = "Task body substituted into {{body}}")]
+        body: Option<String>,
+        #[tool(param)]
+        #[schemars(description = "Task URL substituted into {{url}}")]
+        url: Option<String>,
+        #[tool(param)]
+        #[schemars(description = "Labels substituted into {{labels}}")]
+        labels: Option<Vec<String>>,
+        #[tool(param)]
+        #[schemars(
+            description = "Additional string key/value metadata for {{metadata.*}} placeholders"
+        )]
+        metadata: Option<serde_json::Value>,
+    ) -> String {
+        creation::run_trigger_workflow(
+            &self.client,
+            &workflow_id,
+            title.as_deref(),
+            body.as_deref(),
+            url.as_deref(),
+            labels,
+            metadata,
+        )
+        .await
+    }
+
+    /// Delete a workflow.
+    #[tool(
+        description = "⚠️ DESTRUCTIVE: Delete a workflow permanently. Its trigger stops firing and the configuration is removed (dispatch history is retained). Prefer set_workflow_enabled(false) when you may need the workflow again."
+    )]
+    async fn delete_workflow(
+        &self,
+        #[tool(param)]
+        #[schemars(description = "The workflow ID (UUID) to delete")]
+        workflow_id: String,
+    ) -> String {
+        creation::run_delete_workflow(&self.client, &workflow_id).await
     }
 
     // ── Notification management ─────────────────────────────────────────
@@ -744,7 +976,9 @@ impl ServerHandler for AgentdMcp {
                  diagnostic services as MCP tools. \
                  Start with `diagnose_system` or `check_service_health` for a \
                  system overview. Use `diagnose_state_mismatches` to catch \
-                 subtle agent stuckness."
+                 subtle agent stuckness. Provision resources with \
+                 `create_agent` and `create_workflow`; smoke-test new \
+                 workflows with `trigger_workflow`."
                     .into(),
             ),
             capabilities: ServerCapabilities::builder().enable_tools().build(),

--- a/crates/mcp/src/tools/creation.rs
+++ b/crates/mcp/src/tools/creation.rs
@@ -1,0 +1,548 @@
+//! Agent and workflow creation/management tool implementations.
+//!
+//! These tools wrap the orchestrator's `POST /agents` and `/workflows` CRUD
+//! routes so MCP clients (and the agentd-architect built-in agent) can
+//! provision live resources through the API.
+//!
+//! # Deliberately not exposed
+//!
+//! `create_agent` accepts no `env` map: agent env vars commonly carry
+//! `ANTHROPIC_API_KEY`-class secrets, and values passed through an MCP tool
+//! transit model context and transcripts. `get_agent` redacts env values for
+//! the same reason — accepting them here would undo that. Docker fields,
+//! `interactive`, `worktree`, `shell`, and other power-user knobs are also
+//! omitted to keep the tool schema small; use the CLI or API directly.
+
+use crate::client::AgentdClient;
+use crate::tools::policy::build_tool_policy;
+use serde_json::{json, Value};
+
+/// Trigger variant names accepted by `CreateWorkflowRequest.trigger_config`
+/// (the internally-tagged `type` field of the orchestrator's TriggerConfig).
+pub const TRIGGER_TYPES: &[&str] = &[
+    "github_issues",
+    "github_pull_requests",
+    "cron",
+    "delay",
+    "agent_lifecycle",
+    "dispatch_result",
+    "webhook",
+    "manual",
+    "agent_idle",
+    "linear_issues",
+    "composite",
+    "queue",
+    "ask_response",
+    "gitlab_issues",
+    "gitlab_merge_requests",
+];
+
+// ── create_agent ───────────────────────────────────────────────────────────
+
+/// Build the `POST /agents` body, validating the cheap things client-side.
+#[allow(clippy::too_many_arguments)]
+fn build_create_agent_body(
+    name: &str,
+    working_dir: &str,
+    model: Option<&str>,
+    system_prompt: Option<&str>,
+    append_system_prompt: bool,
+    prompt: Option<&str>,
+    tool_policy_mode: Option<&str>,
+    tool_policy_tools: Option<&[String]>,
+    rooms: Option<&[String]>,
+) -> Result<Value, String> {
+    if name.trim().is_empty() {
+        return Err("🔴 `name` must not be empty.".to_string());
+    }
+    if working_dir.trim().is_empty() {
+        return Err("🔴 `working_dir` must not be empty.".to_string());
+    }
+
+    let mut body = json!({
+        "name": name,
+        "working_dir": working_dir,
+    });
+
+    if let Some(model) = model {
+        body["model"] = json!(model);
+    }
+    if let Some(system_prompt) = system_prompt {
+        body["system_prompt"] = json!(system_prompt);
+        body["append_system_prompt"] = json!(append_system_prompt);
+    }
+    if let Some(prompt) = prompt {
+        body["prompt"] = json!(prompt);
+    }
+    if let Some(mode) = tool_policy_mode {
+        body["tool_policy"] = build_tool_policy(mode, tool_policy_tools)?;
+    }
+    if let Some(rooms) = rooms {
+        body["rooms"] = json!(rooms);
+    }
+
+    Ok(body)
+}
+
+/// Create a new agent via `POST /agents`.
+#[allow(clippy::too_many_arguments)]
+pub async fn run_create_agent(
+    client: &AgentdClient,
+    name: &str,
+    working_dir: &str,
+    model: Option<&str>,
+    system_prompt: Option<&str>,
+    append_system_prompt: bool,
+    prompt: Option<&str>,
+    tool_policy_mode: Option<&str>,
+    tool_policy_tools: Option<Vec<String>>,
+    rooms: Option<Vec<String>>,
+) -> String {
+    let body = match build_create_agent_body(
+        name,
+        working_dir,
+        model,
+        system_prompt,
+        append_system_prompt,
+        prompt,
+        tool_policy_mode,
+        tool_policy_tools.as_deref(),
+        rooms.as_deref(),
+    ) {
+        Ok(b) => b,
+        Err(msg) => return msg,
+    };
+
+    let url = format!("{}/agents", client.orchestrator_url());
+    match client.post::<Value, Value>(&url, &body).await {
+        Ok(agent) => {
+            let id = agent["id"].as_str().unwrap_or("unknown");
+            let status = agent["status"].as_str().unwrap_or("unknown");
+            format!(
+                "✅ Agent `{name}` created.\n\
+                 - **ID:** `{id}`\n\
+                 - **Status:** `{status}`\n\
+                 → Use `diagnose_agent({id})` to monitor startup."
+            )
+        }
+        Err(e) => format!(
+            "🔴 Failed to create agent `{name}`: {e}\n\
+             Common causes: duplicate name, working_dir does not exist, \
+             orchestrator unreachable."
+        ),
+    }
+}
+
+// ── create_workflow ────────────────────────────────────────────────────────
+
+/// Validate trigger_config client-side: must be an object whose `type` is a
+/// known variant name. Full structural validation stays server-side.
+fn validate_trigger_config(trigger_config: &Value) -> Result<(), String> {
+    let Some(obj) = trigger_config.as_object() else {
+        return Err(format!(
+            "🔴 `trigger_config` must be a JSON object like \
+             {{\"type\":\"cron\",\"expression\":\"0 9 * * MON-FRI\"}}.\n\
+             Valid types: {}",
+            TRIGGER_TYPES.join(", ")
+        ));
+    };
+    let Some(trigger_type) = obj.get("type").and_then(|t| t.as_str()) else {
+        return Err(format!(
+            "🔴 `trigger_config` is missing the `type` field.\n Valid types: {}",
+            TRIGGER_TYPES.join(", ")
+        ));
+    };
+    if !TRIGGER_TYPES.contains(&trigger_type) {
+        return Err(format!(
+            "🔴 Unknown trigger type `{trigger_type}`.\n Valid types: {}",
+            TRIGGER_TYPES.join(", ")
+        ));
+    }
+    Ok(())
+}
+
+/// Build the `POST /workflows` body.
+#[allow(clippy::too_many_arguments)]
+fn build_create_workflow_body(
+    name: &str,
+    agent_id: &str,
+    trigger_config: &Value,
+    prompt_template: &str,
+    poll_interval_secs: Option<u64>,
+    enabled: Option<bool>,
+    tool_policy_mode: Option<&str>,
+    tool_policy_tools: Option<&[String]>,
+) -> Result<Value, String> {
+    if name.trim().is_empty() {
+        return Err("🔴 `name` must not be empty.".to_string());
+    }
+    if uuid_err(agent_id) {
+        return Err(format!(
+            "🔴 `agent_id` must be a UUID, got `{agent_id}`. \
+             Use `list_agents` to find agent IDs."
+        ));
+    }
+    validate_trigger_config(trigger_config)?;
+    if prompt_template.trim().is_empty() {
+        return Err("🔴 `prompt_template` must not be empty.".to_string());
+    }
+
+    let mut body = json!({
+        "name": name,
+        "agent_id": agent_id,
+        "trigger_config": trigger_config,
+        "prompt_template": prompt_template,
+    });
+    if let Some(secs) = poll_interval_secs {
+        body["poll_interval_secs"] = json!(secs);
+    }
+    if let Some(enabled) = enabled {
+        body["enabled"] = json!(enabled);
+    }
+    if let Some(mode) = tool_policy_mode {
+        body["tool_policy"] = build_tool_policy(mode, tool_policy_tools)?;
+    }
+    Ok(body)
+}
+
+/// Loose UUID check (8-4-4-4-12 hex groups) without a uuid dependency.
+fn uuid_err(s: &str) -> bool {
+    let groups: Vec<&str> = s.split('-').collect();
+    groups.len() != 5
+        || [8usize, 4, 4, 4, 12]
+            .iter()
+            .zip(&groups)
+            .any(|(len, g)| g.len() != *len || !g.chars().all(|c| c.is_ascii_hexdigit()))
+}
+
+/// Create a new workflow via `POST /workflows`.
+#[allow(clippy::too_many_arguments)]
+pub async fn run_create_workflow(
+    client: &AgentdClient,
+    name: &str,
+    agent_id: &str,
+    trigger_config: Value,
+    prompt_template: &str,
+    poll_interval_secs: Option<u64>,
+    enabled: Option<bool>,
+    tool_policy_mode: Option<&str>,
+    tool_policy_tools: Option<Vec<String>>,
+) -> String {
+    let body = match build_create_workflow_body(
+        name,
+        agent_id,
+        &trigger_config,
+        prompt_template,
+        poll_interval_secs,
+        enabled,
+        tool_policy_mode,
+        tool_policy_tools.as_deref(),
+    ) {
+        Ok(b) => b,
+        Err(msg) => return msg,
+    };
+
+    let url = format!("{}/workflows", client.orchestrator_url());
+    match client.post::<Value, Value>(&url, &body).await {
+        Ok(workflow) => {
+            let id = workflow["id"].as_str().unwrap_or("unknown");
+            let enabled = workflow["enabled"].as_bool().unwrap_or(true);
+            format!(
+                "✅ Workflow `{name}` created.\n\
+                 - **ID:** `{id}`\n\
+                 - **Enabled:** `{enabled}`\n\
+                 → Smoke-test it with `trigger_workflow({id})`, then \
+                 `list_dispatches({id})` to follow execution."
+            )
+        }
+        // The orchestrator's 400 body includes prompt-template validation
+        // messages (unknown placeholders, etc.) — surface it verbatim.
+        Err(e) => format!("🔴 Failed to create workflow `{name}`: {e}"),
+    }
+}
+
+// ── update_workflow ────────────────────────────────────────────────────────
+
+/// Build the `PUT /workflows/{id}` body with only the provided fields.
+#[allow(clippy::too_many_arguments)]
+fn build_update_workflow_body(
+    name: Option<&str>,
+    agent_id: Option<&str>,
+    trigger_config: Option<&Value>,
+    prompt_template: Option<&str>,
+    poll_interval_secs: Option<u64>,
+    enabled: Option<bool>,
+    tool_policy_mode: Option<&str>,
+    tool_policy_tools: Option<&[String]>,
+) -> Result<Value, String> {
+    let mut body = json!({});
+    if let Some(name) = name {
+        body["name"] = json!(name);
+    }
+    if let Some(agent_id) = agent_id {
+        if uuid_err(agent_id) {
+            return Err(format!("🔴 `agent_id` must be a UUID, got `{agent_id}`."));
+        }
+        body["agent_id"] = json!(agent_id);
+    }
+    if let Some(tc) = trigger_config {
+        validate_trigger_config(tc)?;
+        body["trigger_config"] = tc.clone();
+    }
+    if let Some(template) = prompt_template {
+        body["prompt_template"] = json!(template);
+    }
+    if let Some(secs) = poll_interval_secs {
+        body["poll_interval_secs"] = json!(secs);
+    }
+    if let Some(enabled) = enabled {
+        body["enabled"] = json!(enabled);
+    }
+    if let Some(mode) = tool_policy_mode {
+        body["tool_policy"] = build_tool_policy(mode, tool_policy_tools)?;
+    }
+    if body.as_object().is_some_and(|o| o.is_empty()) {
+        return Err("🔴 No fields to update — provide at least one parameter.".to_string());
+    }
+    Ok(body)
+}
+
+/// Update a workflow via `PUT /workflows/{id}`. Only provided fields change.
+#[allow(clippy::too_many_arguments)]
+pub async fn run_update_workflow(
+    client: &AgentdClient,
+    workflow_id: &str,
+    name: Option<&str>,
+    agent_id: Option<&str>,
+    trigger_config: Option<Value>,
+    prompt_template: Option<&str>,
+    poll_interval_secs: Option<u64>,
+    enabled: Option<bool>,
+    tool_policy_mode: Option<&str>,
+    tool_policy_tools: Option<Vec<String>>,
+) -> String {
+    let body = match build_update_workflow_body(
+        name,
+        agent_id,
+        trigger_config.as_ref(),
+        prompt_template,
+        poll_interval_secs,
+        enabled,
+        tool_policy_mode,
+        tool_policy_tools.as_deref(),
+    ) {
+        Ok(b) => b,
+        Err(msg) => return msg,
+    };
+
+    let url = format!("{}/workflows/{workflow_id}", client.orchestrator_url());
+    match client.put::<Value, Value>(&url, &body).await {
+        Ok(workflow) => {
+            let name = workflow["name"].as_str().unwrap_or("unknown");
+            format!("✅ Workflow `{name}` (`{workflow_id}`) updated.")
+        }
+        Err(e) => format!("🔴 Failed to update workflow `{workflow_id}`: {e}"),
+    }
+}
+
+// ── set_workflow_enabled ───────────────────────────────────────────────────
+
+/// Enable or disable a workflow (PUT /workflows/{id} with just `enabled`).
+pub async fn run_set_workflow_enabled(
+    client: &AgentdClient,
+    workflow_id: &str,
+    enabled: bool,
+) -> String {
+    let url = format!("{}/workflows/{workflow_id}", client.orchestrator_url());
+    let body = json!({ "enabled": enabled });
+    match client.put::<Value, Value>(&url, &body).await {
+        Ok(workflow) => {
+            let name = workflow["name"].as_str().unwrap_or("unknown");
+            let verb = if enabled { "enabled" } else { "disabled" };
+            format!("✅ Workflow `{name}` (`{workflow_id}`) {verb}.")
+        }
+        Err(e) => format!("🔴 Failed to update workflow `{workflow_id}`: {e}"),
+    }
+}
+
+// ── trigger_workflow ───────────────────────────────────────────────────────
+
+/// Manually trigger a workflow via `POST /workflows/{id}/trigger`.
+pub async fn run_trigger_workflow(
+    client: &AgentdClient,
+    workflow_id: &str,
+    title: Option<&str>,
+    body_text: Option<&str>,
+    url_field: Option<&str>,
+    labels: Option<Vec<String>>,
+    metadata: Option<Value>,
+) -> String {
+    let mut body = json!({});
+    if let Some(title) = title {
+        body["title"] = json!(title);
+    }
+    if let Some(text) = body_text {
+        body["body"] = json!(text);
+    }
+    if let Some(u) = url_field {
+        body["url"] = json!(u);
+    }
+    if let Some(labels) = labels {
+        body["labels"] = json!(labels);
+    }
+    if let Some(metadata) = metadata {
+        if !metadata.is_object() {
+            return "🔴 `metadata` must be a JSON object (string keys/values).".to_string();
+        }
+        body["metadata"] = metadata;
+    }
+
+    let url = format!("{}/workflows/{workflow_id}/trigger", client.orchestrator_url());
+    match client.post::<Value, Value>(&url, &body).await {
+        Ok(resp) => {
+            let dispatch_id = resp["dispatch_id"].as_str().or(resp["id"].as_str()).unwrap_or("?");
+            format!(
+                "✅ Workflow `{workflow_id}` triggered (dispatch `{dispatch_id}`).\n\
+                 → Use `list_dispatches({workflow_id})` to follow execution."
+            )
+        }
+        Err(e) => format!("🔴 Failed to trigger workflow `{workflow_id}`: {e}"),
+    }
+}
+
+// ── delete_workflow ────────────────────────────────────────────────────────
+
+/// Delete a workflow via `DELETE /workflows/{id}`.
+pub async fn run_delete_workflow(client: &AgentdClient, workflow_id: &str) -> String {
+    let url = format!("{}/workflows/{workflow_id}", client.orchestrator_url());
+    match client.inner.delete(&url).send().await.and_then(|r| r.error_for_status()) {
+        Ok(_) => format!(
+            "✅ Workflow `{workflow_id}` deleted. Its trigger no longer fires; \
+             past dispatch history is retained."
+        ),
+        Err(e) => format!("🔴 Failed to delete workflow `{workflow_id}`: {e}"),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn create_agent_body_minimal() {
+        let body =
+            build_create_agent_body("worker", "/tmp", None, None, false, None, None, None, None)
+                .unwrap();
+        assert_eq!(body["name"], "worker");
+        assert_eq!(body["working_dir"], "/tmp");
+        assert!(body.get("model").is_none());
+        assert!(body.get("tool_policy").is_none());
+        assert!(body.get("env").is_none(), "env must never be sent");
+    }
+
+    #[test]
+    fn create_agent_body_full() {
+        let tools = vec!["Read".to_string()];
+        let rooms = vec!["system".to_string()];
+        let body = build_create_agent_body(
+            "worker",
+            "/tmp",
+            Some("sonnet"),
+            Some("be careful"),
+            true,
+            Some("start by listing files"),
+            Some("allow_list"),
+            Some(&tools),
+            Some(&rooms),
+        )
+        .unwrap();
+        assert_eq!(body["model"], "sonnet");
+        assert_eq!(body["system_prompt"], "be careful");
+        assert_eq!(body["append_system_prompt"], true);
+        assert_eq!(body["tool_policy"]["mode"], "allow_list");
+        assert_eq!(body["rooms"][0], "system");
+    }
+
+    #[test]
+    fn create_agent_body_rejects_empty_name() {
+        assert!(build_create_agent_body("  ", "/tmp", None, None, false, None, None, None, None)
+            .is_err());
+    }
+
+    #[test]
+    fn create_workflow_body_rejects_bad_uuid() {
+        let err = build_create_workflow_body(
+            "wf",
+            "not-a-uuid",
+            &serde_json::json!({"type": "manual"}),
+            "do the thing",
+            None,
+            None,
+            None,
+            None,
+        )
+        .unwrap_err();
+        assert!(err.contains("UUID"), "{err}");
+    }
+
+    #[test]
+    fn create_workflow_body_rejects_unknown_trigger_type() {
+        let err = build_create_workflow_body(
+            "wf",
+            "01234567-89ab-cdef-0123-456789abcdef",
+            &serde_json::json!({"type": "carrier_pigeon"}),
+            "do the thing",
+            None,
+            None,
+            None,
+            None,
+        )
+        .unwrap_err();
+        assert!(err.contains("carrier_pigeon"), "{err}");
+        assert!(err.contains("cron"), "error lists valid types: {err}");
+    }
+
+    #[test]
+    fn create_workflow_body_accepts_all_known_trigger_types() {
+        for t in TRIGGER_TYPES {
+            // Only `type` validity is checked client-side; structure is
+            // validated by the orchestrator.
+            assert!(
+                validate_trigger_config(&serde_json::json!({"type": t})).is_ok(),
+                "type {t} should pass the client-side check"
+            );
+        }
+    }
+
+    #[test]
+    fn trigger_types_match_orchestrator_enum() {
+        // Round-trip each variant tag against the real enum where possible:
+        // `manual` and `cron` are structurally complete with minimal fields.
+        use orchestrator::scheduler::types::TriggerConfig;
+        let manual: TriggerConfig =
+            serde_json::from_value(serde_json::json!({"type": "manual"})).unwrap();
+        assert!(matches!(manual, TriggerConfig::Manual {}));
+        let cron: TriggerConfig = serde_json::from_value(
+            serde_json::json!({"type": "cron", "expression": "0 9 * * MON-FRI"}),
+        )
+        .unwrap();
+        assert!(matches!(cron, TriggerConfig::Cron { .. }));
+    }
+
+    #[test]
+    fn update_workflow_body_requires_at_least_one_field() {
+        let err =
+            build_update_workflow_body(None, None, None, None, None, None, None, None).unwrap_err();
+        assert!(err.contains("at least one"), "{err}");
+    }
+
+    #[test]
+    fn update_workflow_body_only_serializes_provided_fields() {
+        let body =
+            build_update_workflow_body(None, None, None, None, None, Some(false), None, None)
+                .unwrap();
+        let obj = body.as_object().unwrap();
+        assert_eq!(obj.len(), 1, "only `enabled` should be present: {body}");
+        assert_eq!(body["enabled"], false);
+    }
+}

--- a/crates/mcp/src/tools/health.rs
+++ b/crates/mcp/src/tools/health.rs
@@ -267,6 +267,19 @@ pub async fn run_get_system_metrics(client: &AgentdClient) -> String {
 
 // ── get_prometheus_metrics ─────────────────────────────────────────────────
 
+/// Path serving Prometheus text-format metrics for a service.
+///
+/// The monitor service serves JSON system metrics at `/metrics` and exposes
+/// Prometheus text format at `/prom-metrics` instead (see the scrape config in
+/// `infra/prometheus/prometheus.yml`). Every other service uses `/metrics`.
+fn prometheus_metrics_path(service: &str) -> &'static str {
+    if service == "monitor" {
+        "/prom-metrics"
+    } else {
+        "/metrics"
+    }
+}
+
 /// Fetch and parse key Prometheus metrics from a service.
 pub async fn run_get_prometheus_metrics(client: &AgentdClient, service: Option<&str>) -> String {
     let svc_input = service.unwrap_or("orchestrator").to_lowercase();
@@ -287,7 +300,8 @@ pub async fn run_get_prometheus_metrics(client: &AgentdClient, service: Option<&
         }
     };
 
-    let url = format!("{base_url}/metrics");
+    let path = prometheus_metrics_path(svc_name);
+    let url = format!("{base_url}{path}");
     match client.inner.get(&url).send().await {
         Ok(resp) if resp.status().is_success() => match resp.text().await {
             Ok(text) => {
@@ -296,7 +310,7 @@ pub async fn run_get_prometheus_metrics(client: &AgentdClient, service: Option<&
             }
             Err(e) => format!("🔴 Failed to read metrics response from {svc_name}: {e}"),
         },
-        Ok(resp) => format!("🔴 {svc_name} /metrics returned HTTP {}.", resp.status().as_u16()),
+        Ok(resp) => format!("🔴 {svc_name} {path} returned HTTP {}.", resp.status().as_u16()),
         Err(e) => format!("🔴 Could not reach {svc_name} for Prometheus metrics: {e}"),
     }
 }
@@ -479,5 +493,19 @@ http_requests_total{method=\"POST\"} 8
             response_ms: None,
         }];
         assert_eq!(overall_summary(&results), "🔴 One or more services are unreachable.");
+    }
+
+    #[test]
+    fn test_prometheus_metrics_path_monitor_uses_prom_metrics() {
+        // Monitor's /metrics endpoint returns JSON; Prometheus text lives at
+        // /prom-metrics (matching infra/prometheus/prometheus.yml).
+        assert_eq!(prometheus_metrics_path("monitor"), "/prom-metrics");
+    }
+
+    #[test]
+    fn test_prometheus_metrics_path_other_services_use_metrics() {
+        for svc in ["orchestrator", "notify", "memory", "communicate", "ask", "wrap", "hook"] {
+            assert_eq!(prometheus_metrics_path(svc), "/metrics", "service {svc}");
+        }
     }
 }

--- a/crates/mcp/src/tools/lifecycle.rs
+++ b/crates/mcp/src/tools/lifecycle.rs
@@ -97,34 +97,17 @@ pub async fn run_update_agent_tool_policy(
     mode: &str,
     tools: Option<Vec<String>>,
 ) -> String {
-    let policy = match mode {
-        "allow_all" => json!("AllowAll"),
-        "deny_all" => json!("DenyAll"),
-        "require_approval" => json!("RequireApproval"),
-        "allow_list" => {
-            let list = tools.clone().unwrap_or_default();
-            if list.is_empty() {
-                return "🔴 `allow_list` mode requires at least one tool name in the `tools` parameter.".to_string();
-            }
-            json!({ "AllowList": { "tools": list } })
-        }
-        "deny_list" => {
-            let list = tools.clone().unwrap_or_default();
-            if list.is_empty() {
-                return "🔴 `deny_list` mode requires at least one tool name in the `tools` parameter.".to_string();
-            }
-            json!({ "DenyList": { "tools": list } })
-        }
-        other => {
-            return format!(
-                "🔴 Unknown policy mode `{other}`.\n\
-                 Valid modes: `allow_all`, `deny_all`, `require_approval`, `allow_list`, `deny_list`"
-            );
-        }
+    // Internally-tagged shape matching the orchestrator's ToolPolicy enum.
+    // The previous externally-tagged construction ({"AllowList": ...}) never
+    // deserialized server-side.
+    let policy = match crate::tools::policy::build_tool_policy(mode, tools.as_deref()) {
+        Ok(p) => p,
+        Err(msg) => return msg,
     };
 
+    // The orchestrator routes this endpoint as PUT (POST returns 405).
     let url = format!("{}/agents/{agent_id}/policy", client.orchestrator_url());
-    match client.post::<Value, Value>(&url, &policy).await {
+    match client.put::<Value, Value>(&url, &policy).await {
         Ok(_) => {
             let tools_note = match mode {
                 "allow_list" | "deny_list" => {
@@ -156,10 +139,11 @@ pub async fn run_terminate_agent(client: &AgentdClient, agent_id: &str) -> Strin
 
 /// Change the model an agent is using.
 pub async fn run_update_agent_model(client: &AgentdClient, agent_id: &str, model: &str) -> String {
+    // The orchestrator routes this endpoint as PUT (POST returns 405).
     let url = format!("{}/agents/{agent_id}/model", client.orchestrator_url());
     // SetModelRequest: { model: Option<String>, restart: bool }
     let body = json!({ "model": model, "restart": false });
-    match client.post::<Value, Value>(&url, &body).await {
+    match client.put::<Value, Value>(&url, &body).await {
         Ok(resp) => {
             let status = resp["status"].as_str().unwrap_or("updated");
             format!("✅ Model for agent `{agent_id}` updated to `{model}`. Status: `{status}`.")

--- a/crates/mcp/src/tools/metrics.rs
+++ b/crates/mcp/src/tools/metrics.rs
@@ -1,0 +1,252 @@
+//! Curated Prometheus metrics queries via the monitor service.
+//!
+//! The monitor service owns the named PromQL catalog (`GET /queries`) and
+//! executes queries against the agentd Prometheus stack. This tool renders
+//! the results for MCP clients — instant vectors as a table, range matrices
+//! as per-series summaries (never raw sample dumps; token discipline).
+//!
+//! `get_prometheus_metrics` remains the direct-scrape path that works even
+//! when Prometheus itself is down; this tool is the aggregated/historical
+//! path.
+
+use crate::client::AgentdClient;
+use serde_json::Value;
+
+/// Run a named metrics query, or render the catalog when no/unknown name.
+pub async fn run_query_metrics(
+    client: &AgentdClient,
+    name: Option<&str>,
+    window: Option<&str>,
+    range: bool,
+) -> String {
+    let monitor = client.monitor_url();
+
+    let Some(name) = name.filter(|n| !n.trim().is_empty()) else {
+        return render_catalog(client).await;
+    };
+
+    let mut url = format!("{monitor}/queries/{name}");
+    let mut params = vec![];
+    if let Some(window) = window {
+        params.push(format!("window={window}"));
+    }
+    if range {
+        params.push("mode=range".to_string());
+    }
+    if !params.is_empty() {
+        url = format!("{url}?{}", params.join("&"));
+    }
+
+    let response = match client.inner.get(&url).send().await {
+        Ok(r) => r,
+        Err(e) => {
+            return format!(
+                "🔴 Monitor service unreachable: {e}\n\
+                 → Check it with `check_single_service(\"monitor\")`."
+            );
+        }
+    };
+
+    let status = response.status();
+    let body = response.text().await.unwrap_or_default();
+
+    if status.as_u16() == 502 {
+        return format!(
+            "🟡 Prometheus is unreachable (monitor returned 502).\n\
+             Is the observability stack running? On macOS: \
+             `launchctl list | grep com.agentd.prometheus`.\n\
+             → Fallback: `get_prometheus_metrics(<service>)` scrapes services \
+             directly without Prometheus.\n\n\
+             Details: {body}"
+        );
+    }
+    if !status.is_success() {
+        // 404 includes the catalog names; 400 explains the bad parameter.
+        return format!("🔴 Query `{name}` failed (HTTP {}): {body}", status.as_u16());
+    }
+
+    match serde_json::from_str::<Value>(&body) {
+        Ok(result) => render_query_result(name, &result),
+        Err(e) => format!("🔴 Failed to parse monitor response for `{name}`: {e}"),
+    }
+}
+
+/// Render the catalog fetched from `GET {monitor}/queries`.
+async fn render_catalog(client: &AgentdClient) -> String {
+    let url = format!("{}/queries", client.monitor_url());
+    let catalog: Value = match client.get(&url).await {
+        Ok(v) => v,
+        Err(e) => {
+            return format!(
+                "🔴 Could not fetch the query catalog from the monitor service: {e}\n\
+                 → Check it with `check_single_service(\"monitor\")`."
+            );
+        }
+    };
+
+    let Some(entries) = catalog.as_array() else {
+        return "🔴 Unexpected catalog shape from the monitor service.".to_string();
+    };
+
+    let mut out = String::from(
+        "## Metrics Query Catalog\n\n\
+         Call `query_metrics(name, window?, range?)` with one of:\n\n\
+         | Name | Unit | Description |\n|---|---|---|\n",
+    );
+    for entry in entries {
+        out.push_str(&format!(
+            "| `{}` | {} | {} |\n",
+            entry["name"].as_str().unwrap_or("?"),
+            entry["unit"].as_str().unwrap_or("?"),
+            entry["description"].as_str().unwrap_or(""),
+        ));
+    }
+    out.push_str(
+        "\nWindows look like `15m`, `1h`, `24h`. Pass `range: true` for a \
+         six-hour trend (per-series min/avg/max/last) instead of an instant value.",
+    );
+    out
+}
+
+/// Render a monitor QueryResult JSON as markdown.
+fn render_query_result(name: &str, result: &Value) -> String {
+    let promql = result["promql"].as_str().unwrap_or("?");
+    let mode = result["mode"].as_str().unwrap_or("instant");
+    let data = &result["data"];
+
+    let mut out = format!("## Query `{name}` ({mode})\n\n`{promql}`\n\n");
+
+    match data["resultType"].as_str() {
+        Some("vector") => {
+            let samples = data["result"].as_array().cloned().unwrap_or_default();
+            if samples.is_empty() {
+                out.push_str("_No data — the underlying series have no samples (yet)._");
+                return out;
+            }
+            out.push_str("| Labels | Value |\n|---|---|\n");
+            for sample in &samples {
+                let labels = render_labels(&sample["metric"]);
+                let value = sample["value"][1].as_str().unwrap_or("?");
+                out.push_str(&format!("| {labels} | {value} |\n"));
+            }
+        }
+        Some("matrix") => {
+            let series = data["result"].as_array().cloned().unwrap_or_default();
+            if series.is_empty() {
+                out.push_str("_No data in the requested range._");
+                return out;
+            }
+            out.push_str("| Labels | Min | Avg | Max | Last |\n|---|---|---|---|---|\n");
+            for s in &series {
+                let labels = render_labels(&s["metric"]);
+                let values: Vec<f64> = s["values"]
+                    .as_array()
+                    .cloned()
+                    .unwrap_or_default()
+                    .iter()
+                    .filter_map(|pair| pair[1].as_str().and_then(|v| v.parse().ok()))
+                    .collect();
+                if values.is_empty() {
+                    continue;
+                }
+                let min = values.iter().cloned().fold(f64::INFINITY, f64::min);
+                let max = values.iter().cloned().fold(f64::NEG_INFINITY, f64::max);
+                let avg = values.iter().sum::<f64>() / values.len() as f64;
+                let last = values.last().copied().unwrap_or(f64::NAN);
+                out.push_str(&format!(
+                    "| {labels} | {min:.4} | {avg:.4} | {max:.4} | {last:.4} |\n"
+                ));
+            }
+        }
+        Some("scalar") => {
+            let value = data["result"][1].as_str().unwrap_or("?");
+            out.push_str(&format!("**Value:** {value}"));
+        }
+        other => {
+            out.push_str(&format!("_Unrecognized result type: {other:?}_"));
+        }
+    }
+
+    out
+}
+
+/// Render a Prometheus label map compactly, skipping `__name__`.
+fn render_labels(metric: &Value) -> String {
+    let Some(map) = metric.as_object() else { return "—".to_string() };
+    let rendered: Vec<String> = map
+        .iter()
+        .filter(|(k, _)| *k != "__name__")
+        .map(|(k, v)| format!("{k}={}", v.as_str().unwrap_or("?")))
+        .collect();
+    if rendered.is_empty() {
+        "—".to_string()
+    } else {
+        rendered.join(", ")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn vector_result_renders_label_value_table() {
+        let result = json!({
+            "name": "agents-active",
+            "promql": "agents_active",
+            "mode": "instant",
+            "data": {
+                "resultType": "vector",
+                "result": [
+                    {"metric": {"__name__": "agents_active", "service": "orchestrator"},
+                     "value": [1718100000.0, "3"]}
+                ]
+            }
+        });
+        let out = render_query_result("agents-active", &result);
+        assert!(out.contains("| service=orchestrator | 3 |"), "{out}");
+        assert!(!out.contains("__name__"), "name label hidden: {out}");
+    }
+
+    #[test]
+    fn matrix_result_renders_summary_not_samples() {
+        let result = json!({
+            "promql": "x",
+            "mode": "range",
+            "data": {
+                "resultType": "matrix",
+                "result": [
+                    {"metric": {"service": "notify"},
+                     "values": [[1.0, "1"], [2.0, "3"], [3.0, "2"]]}
+                ]
+            }
+        });
+        let out = render_query_result("test", &result);
+        assert!(out.contains("| Min | Avg | Max | Last |"), "{out}");
+        assert!(out.contains("1.0000"), "min: {out}");
+        assert!(out.contains("3.0000"), "max: {out}");
+        assert!(out.contains("2.0000"), "last/avg: {out}");
+        assert!(!out.contains("[[1.0"), "no raw sample dumps: {out}");
+    }
+
+    #[test]
+    fn empty_vector_renders_no_data_note() {
+        let result = json!({
+            "promql": "x", "mode": "instant",
+            "data": { "resultType": "vector", "result": [] }
+        });
+        let out = render_query_result("test", &result);
+        assert!(out.contains("No data"), "{out}");
+    }
+
+    #[test]
+    fn scalar_result_renders_value() {
+        let result = json!({
+            "promql": "scalar(1)", "mode": "instant",
+            "data": { "resultType": "scalar", "result": [1718100000.0, "42"] }
+        });
+        let out = render_query_result("test", &result);
+        assert!(out.contains("**Value:** 42"), "{out}");
+    }
+}

--- a/crates/mcp/src/tools/mod.rs
+++ b/crates/mcp/src/tools/mod.rs
@@ -12,6 +12,7 @@
 //! - `health`             — service health probes, system metrics, prometheus
 //! - `lifecycle`          — restart/terminate agents, send messages, update policy/model
 //! - `memory`             — search and list stored memories
+//! - `metrics`            — curated Prometheus queries via the monitor service
 //! - `notifications`      — list/create/dismiss notifications
 //! - `orchestrator_debug` — state-mismatch detection, queue inspection, conversation summary, projects
 //! - `policy`             — shared ToolPolicy JSON construction
@@ -26,6 +27,7 @@ pub mod diagnostic;
 pub mod health;
 pub mod lifecycle;
 pub mod memory;
+pub mod metrics;
 pub mod notifications;
 pub mod orchestrator_debug;
 pub mod policy;

--- a/crates/mcp/src/tools/mod.rs
+++ b/crates/mcp/src/tools/mod.rs
@@ -7,23 +7,27 @@
 //! - `agents`             — list/inspect agents
 //! - `approvals`          — tool approval requests
 //! - `communicate`        — rooms, participants, messages
+//! - `creation`           — create agents and create/manage workflows
 //! - `diagnostic`         — cross-service diagnostics (system, agent, workflow)
 //! - `health`             — service health probes, system metrics, prometheus
 //! - `lifecycle`          — restart/terminate agents, send messages, update policy/model
 //! - `memory`             — search and list stored memories
 //! - `notifications`      — list/create/dismiss notifications
 //! - `orchestrator_debug` — state-mismatch detection, queue inspection, conversation summary, projects
+//! - `policy`             — shared ToolPolicy JSON construction
 //! - `remediation`        — self-healing batch operations
 //! - `workflows`          — list workflows and dispatch history
 
 pub mod agents;
 pub mod approvals;
 pub mod communicate;
+pub mod creation;
 pub mod diagnostic;
 pub mod health;
 pub mod lifecycle;
 pub mod memory;
 pub mod notifications;
 pub mod orchestrator_debug;
+pub mod policy;
 pub mod remediation;
 pub mod workflows;

--- a/crates/mcp/src/tools/policy.rs
+++ b/crates/mcp/src/tools/policy.rs
@@ -1,0 +1,81 @@
+//! Shared ToolPolicy JSON construction for MCP tools.
+//!
+//! The orchestrator's `ToolPolicy` enum is internally tagged
+//! (`#[serde(tag = "mode", rename_all = "snake_case")]`), so the wire shape is
+//! `{"mode": "allow_list", "tools": [...]}`. Centralizing the construction
+//! here keeps every tool that accepts a (mode, tools) pair consistent with
+//! that shape.
+
+use serde_json::{json, Value};
+
+/// All policy modes accepted by the orchestrator.
+pub const POLICY_MODES: &[&str] =
+    &["allow_all", "deny_all", "require_approval", "allow_list", "deny_list"];
+
+/// Build internally-tagged ToolPolicy JSON from a mode string and optional
+/// tool list.
+///
+/// Returns `Err` with a user-facing message for unknown modes or when a
+/// list mode is missing its tools.
+pub fn build_tool_policy(mode: &str, tools: Option<&[String]>) -> Result<Value, String> {
+    match mode {
+        "allow_all" | "deny_all" | "require_approval" => Ok(json!({ "mode": mode })),
+        "allow_list" | "deny_list" => {
+            let list = tools.unwrap_or_default();
+            if list.is_empty() {
+                return Err(format!(
+                    "🔴 `{mode}` mode requires at least one tool name in the `tools` parameter."
+                ));
+            }
+            Ok(json!({ "mode": mode, "tools": list }))
+        }
+        other => Err(format!(
+            "🔴 Unknown policy mode `{other}`.\n Valid modes: {}",
+            POLICY_MODES.iter().map(|m| format!("`{m}`")).collect::<Vec<_>>().join(", ")
+        )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn simple_modes_build_internally_tagged_json() {
+        for mode in ["allow_all", "deny_all", "require_approval"] {
+            let policy = build_tool_policy(mode, None).unwrap();
+            assert_eq!(policy, json!({ "mode": mode }), "mode {mode}");
+        }
+    }
+
+    #[test]
+    fn list_modes_include_tools() {
+        let tools = vec!["Read".to_string(), "Grep".to_string()];
+        let policy = build_tool_policy("allow_list", Some(&tools)).unwrap();
+        assert_eq!(policy, json!({ "mode": "allow_list", "tools": ["Read", "Grep"] }));
+
+        let policy = build_tool_policy("deny_list", Some(&tools)).unwrap();
+        assert_eq!(policy["mode"], "deny_list");
+    }
+
+    #[test]
+    fn list_modes_require_tools() {
+        assert!(build_tool_policy("allow_list", None).is_err());
+        assert!(build_tool_policy("deny_list", Some(&[])).is_err());
+    }
+
+    #[test]
+    fn unknown_mode_lists_valid_modes() {
+        let err = build_tool_policy("bogus", None).unwrap_err();
+        assert!(err.contains("allow_list"), "error should list valid modes: {err}");
+    }
+
+    #[test]
+    fn output_deserializes_as_orchestrator_tool_policy() {
+        // Round-trip against the real enum to lock the wire shape.
+        let tools = vec!["Read".to_string()];
+        let policy = build_tool_policy("allow_list", Some(&tools)).unwrap();
+        let parsed: orchestrator::types::ToolPolicy = serde_json::from_value(policy).unwrap();
+        assert!(matches!(parsed, orchestrator::types::ToolPolicy::AllowList { .. }));
+    }
+}

--- a/crates/mcp/tests/common/mod.rs
+++ b/crates/mcp/tests/common/mod.rs
@@ -182,9 +182,33 @@ pub async fn mock_orchestrator_server() -> MockServer {
                     "limit": 100,
                     "offset": 0
                 }))
+            })
+            .post(create_workflow_handler),
+        )
+        .route(
+            "/workflows/{id}",
+            get(get_workflow_handler).put(update_workflow_handler).delete(
+                |Path(id): Path<String>| async move {
+                    use axum::response::IntoResponse;
+                    if id == "cccccccc-0000-0000-0000-000000000003" {
+                        axum::http::StatusCode::NO_CONTENT.into_response()
+                    } else {
+                        (axum::http::StatusCode::NOT_FOUND, Json(json!({"error": "not found"})))
+                            .into_response()
+                    }
+                },
+            ),
+        )
+        .route(
+            "/workflows/{id}/trigger",
+            post(|Path(id): Path<String>| async move {
+                Json(json!({
+                    "dispatch_id": "99999999-0000-0000-0000-000000000042",
+                    "workflow_id": id,
+                    "status": "dispatched"
+                }))
             }),
         )
-        .route("/workflows/{id}", get(get_workflow_handler))
         .route("/workflows/{id}/history", get(dispatch_history_handler))
         .route(
             "/metrics",
@@ -232,6 +256,40 @@ async fn create_agent_handler() -> (axum::http::StatusCode, Json<Value>) {
             "status": "pending"
         })),
     )
+}
+
+async fn create_workflow_handler(Json(body): Json<Value>) -> (axum::http::StatusCode, Json<Value>) {
+    // Reject like the orchestrator's server-side validation would.
+    if body.get("trigger_config").and_then(|t| t.get("type")).is_none() {
+        return (
+            axum::http::StatusCode::BAD_REQUEST,
+            Json(json!({"error": "trigger_config.type required"})),
+        );
+    }
+    let mut workflow = mock_workflow();
+    workflow["id"] = json!("22222222-0000-0000-0000-000000000077");
+    workflow["name"] = body["name"].clone();
+    workflow["trigger_config"] = body["trigger_config"].clone();
+    (axum::http::StatusCode::CREATED, Json(workflow))
+}
+
+async fn update_workflow_handler(
+    Path(id): Path<String>,
+    Json(body): Json<Value>,
+) -> axum::response::Response {
+    use axum::response::IntoResponse;
+    if id == "cccccccc-0000-0000-0000-000000000003" {
+        let mut workflow = mock_workflow();
+        if let Some(enabled) = body.get("enabled") {
+            workflow["enabled"] = enabled.clone();
+        }
+        if let Some(name) = body.get("name") {
+            workflow["name"] = name.clone();
+        }
+        Json(workflow).into_response()
+    } else {
+        (axum::http::StatusCode::NOT_FOUND, Json(json!({"error": "not found"}))).into_response()
+    }
 }
 
 async fn get_workflow_handler(Path(id): Path<String>) -> axum::response::Response {

--- a/crates/mcp/tests/creation_tools.rs
+++ b/crates/mcp/tests/creation_tools.rs
@@ -1,0 +1,189 @@
+//! Integration tests for agent/workflow creation and management tools.
+
+mod common;
+use common::{mock_orchestrator_server, test_client};
+
+use agentd_mcp::tools::creation;
+use serde_json::json;
+
+// ---------------------------------------------------------------------------
+// create_agent
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_create_agent_success() {
+    let orch = mock_orchestrator_server().await;
+    let client = test_client(&orch.url(), "http://127.0.0.1:1", "http://127.0.0.1:1");
+
+    let result = creation::run_create_agent(
+        &client,
+        "new-agent",
+        "/tmp/work",
+        Some("sonnet"),
+        None,
+        false,
+        None,
+        Some("allow_list"),
+        Some(vec!["Read".to_string()]),
+        Some(vec!["system".to_string()]),
+    )
+    .await;
+
+    assert!(result.contains("✅"), "expected success: {result}");
+    assert!(result.contains("11111111-0000-0000-0000-000000000099"), "new id: {result}");
+    assert!(result.contains("diagnose_agent"), "follow-up hint: {result}");
+}
+
+#[tokio::test]
+async fn test_create_agent_invalid_policy_mode_fails_client_side() {
+    // Service deliberately unreachable: validation must reject before any call.
+    let client = test_client("http://127.0.0.1:1", "http://127.0.0.1:1", "http://127.0.0.1:1");
+
+    let result = creation::run_create_agent(
+        &client,
+        "x",
+        "/tmp",
+        None,
+        None,
+        false,
+        None,
+        Some("bogus_mode"),
+        None,
+        None,
+    )
+    .await;
+
+    assert!(result.contains("Unknown policy mode"), "{result}");
+}
+
+#[tokio::test]
+async fn test_create_agent_service_down() {
+    let client = test_client("http://127.0.0.1:1", "http://127.0.0.1:1", "http://127.0.0.1:1");
+
+    let result =
+        creation::run_create_agent(&client, "x", "/tmp", None, None, false, None, None, None, None)
+            .await;
+
+    assert!(result.contains("🔴"), "expected failure message: {result}");
+}
+
+// ---------------------------------------------------------------------------
+// create_workflow
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_create_workflow_success() {
+    let orch = mock_orchestrator_server().await;
+    let client = test_client(&orch.url(), "http://127.0.0.1:1", "http://127.0.0.1:1");
+
+    let result = creation::run_create_workflow(
+        &client,
+        "nightly-report",
+        "aaaaaaaa-0000-0000-0000-000000000001",
+        json!({"type": "cron", "expression": "0 9 * * MON-FRI"}),
+        "Summarize overnight activity",
+        None,
+        None,
+        None,
+        None,
+    )
+    .await;
+
+    assert!(result.contains("✅"), "expected success: {result}");
+    assert!(result.contains("22222222-0000-0000-0000-000000000077"), "new id: {result}");
+    assert!(result.contains("trigger_workflow"), "smoke-test hint: {result}");
+}
+
+#[tokio::test]
+async fn test_create_workflow_unknown_trigger_rejected_client_side() {
+    let client = test_client("http://127.0.0.1:1", "http://127.0.0.1:1", "http://127.0.0.1:1");
+
+    let result = creation::run_create_workflow(
+        &client,
+        "wf",
+        "aaaaaaaa-0000-0000-0000-000000000001",
+        json!({"type": "carrier_pigeon"}),
+        "template",
+        None,
+        None,
+        None,
+        None,
+    )
+    .await;
+
+    assert!(result.contains("carrier_pigeon"), "{result}");
+    assert!(result.contains("cron"), "lists valid types: {result}");
+}
+
+// ---------------------------------------------------------------------------
+// update / enable / trigger / delete
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_set_workflow_enabled() {
+    let orch = mock_orchestrator_server().await;
+    let client = test_client(&orch.url(), "http://127.0.0.1:1", "http://127.0.0.1:1");
+
+    let result =
+        creation::run_set_workflow_enabled(&client, "cccccccc-0000-0000-0000-000000000003", false)
+            .await;
+
+    assert!(result.contains("disabled"), "{result}");
+}
+
+#[tokio::test]
+async fn test_update_workflow_rename() {
+    let orch = mock_orchestrator_server().await;
+    let client = test_client(&orch.url(), "http://127.0.0.1:1", "http://127.0.0.1:1");
+
+    let result = creation::run_update_workflow(
+        &client,
+        "cccccccc-0000-0000-0000-000000000003",
+        Some("renamed"),
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+    )
+    .await;
+
+    assert!(result.contains("✅"), "{result}");
+    assert!(result.contains("renamed"), "{result}");
+}
+
+#[tokio::test]
+async fn test_trigger_workflow() {
+    let orch = mock_orchestrator_server().await;
+    let client = test_client(&orch.url(), "http://127.0.0.1:1", "http://127.0.0.1:1");
+
+    let result = creation::run_trigger_workflow(
+        &client,
+        "cccccccc-0000-0000-0000-000000000003",
+        Some("manual smoke test"),
+        None,
+        None,
+        None,
+        None,
+    )
+    .await;
+
+    assert!(result.contains("✅"), "{result}");
+    assert!(result.contains("99999999-0000-0000-0000-000000000042"), "dispatch id: {result}");
+}
+
+#[tokio::test]
+async fn test_delete_workflow() {
+    let orch = mock_orchestrator_server().await;
+    let client = test_client(&orch.url(), "http://127.0.0.1:1", "http://127.0.0.1:1");
+
+    let result =
+        creation::run_delete_workflow(&client, "cccccccc-0000-0000-0000-000000000003").await;
+    assert!(result.contains("✅"), "{result}");
+
+    let result =
+        creation::run_delete_workflow(&client, "00000000-0000-0000-0000-000000000000").await;
+    assert!(result.contains("🔴"), "missing workflow should fail: {result}");
+}

--- a/crates/monitor/src/api.rs
+++ b/crates/monitor/src/api.rs
@@ -2,30 +2,39 @@
 //!
 //! Provides the following endpoints:
 //!
-//! - `GET /health`   — standard health check
-//! - `GET /metrics`  — latest system metrics snapshot
-//! - `POST /collect` — trigger an immediate metrics collection
-//! - `GET /history`  — full metrics history (ring buffer)
-//! - `GET /status`   — health assessment against configured thresholds
+//! - `GET /health`            — standard health check
+//! - `GET /metrics`           — latest system metrics snapshot
+//! - `POST /collect`          — trigger an immediate metrics collection
+//! - `GET /history`           — full metrics history (ring buffer)
+//! - `GET /status`            — health assessment against configured thresholds
+//! - `GET /queries`           — the curated named-query catalog
+//! - `GET /queries/{name}`    — execute a named query against Prometheus
+//! - `GET /query`             — raw PromQL passthrough (read-only escape hatch)
 
 use crate::{
     error::ApiError,
     metrics_collector,
+    prometheus::{PromClient, PromData, PromError},
+    queries,
     state::AppState,
     types::{CollectResponse, HealthResponse, SystemStatus},
 };
 use axum::{
-    extract::State,
+    extract::{Path, Query, State},
     response::IntoResponse,
     routing::{get, post},
     Json, Router,
 };
+use chrono::{DateTime, Duration, Utc};
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
 use tracing::info;
 
 /// Shared state passed to every API handler.
 #[derive(Clone)]
 pub struct ApiState {
     pub app_state: AppState,
+    pub prom: Arc<PromClient>,
 }
 
 /// Create the base router (no middleware).
@@ -36,6 +45,9 @@ pub fn create_router(state: ApiState) -> Router {
         .route("/collect", post(collect_metrics))
         .route("/history", get(get_history))
         .route("/status", get(get_status))
+        .route("/queries", get(list_queries))
+        .route("/queries/{name}", get(run_named_query))
+        .route("/query", get(run_raw_query))
         .with_state(state)
 }
 
@@ -86,6 +98,112 @@ async fn get_status(State(state): State<ApiState>) -> Json<SystemStatus> {
     Json(state.app_state.evaluate_status().await)
 }
 
+// ---------------------------------------------------------------------------
+// Prometheus named queries
+// ---------------------------------------------------------------------------
+
+/// Query-string parameters for query execution endpoints.
+#[derive(Debug, Default, Deserialize)]
+struct QueryParams {
+    /// `$__window` substitution (e.g. `15m`, `1h`). Defaults per query.
+    window: Option<String>,
+    /// `instant` (default) or `range`.
+    mode: Option<String>,
+    /// Range mode: how far back from now the range starts (default: 360).
+    range_minutes: Option<u64>,
+    /// Range mode: resolution step in seconds (default: 60).
+    step_secs: Option<u64>,
+    /// Raw passthrough only: the PromQL expression.
+    promql: Option<String>,
+}
+
+/// Response body for query execution endpoints.
+#[derive(Debug, Serialize)]
+struct QueryResult {
+    /// Catalog name, or `"raw"` for the passthrough endpoint.
+    name: String,
+    /// The executed PromQL after window substitution.
+    promql: String,
+    /// `instant` or `range`.
+    mode: String,
+    executed_at: DateTime<Utc>,
+    data: PromData,
+}
+
+fn map_prom_error(e: PromError) -> ApiError {
+    match e {
+        PromError::Query { .. } => ApiError::BadQueryParam(e.to_string()),
+        _ => ApiError::PrometheusUnavailable(e.to_string()),
+    }
+}
+
+/// Execute resolved PromQL in the requested mode.
+async fn execute_query(
+    state: &ApiState,
+    name: &str,
+    promql: String,
+    params: &QueryParams,
+) -> Result<Json<QueryResult>, ApiError> {
+    let mode = params.mode.as_deref().unwrap_or("instant");
+    let data = match mode {
+        "instant" => state.prom.query(&promql).await.map_err(map_prom_error)?,
+        "range" => {
+            let end = Utc::now();
+            let minutes = params.range_minutes.unwrap_or(360).min(7 * 24 * 60);
+            let step = params.step_secs.unwrap_or(60).max(1);
+            let start = end - Duration::minutes(minutes as i64);
+            state.prom.query_range(&promql, start, end, step).await.map_err(map_prom_error)?
+        }
+        other => {
+            return Err(ApiError::BadQueryParam(format!(
+                "invalid mode `{other}` — expected `instant` or `range`"
+            )));
+        }
+    };
+
+    Ok(Json(QueryResult {
+        name: name.to_string(),
+        promql,
+        mode: mode.to_string(),
+        executed_at: Utc::now(),
+        data,
+    }))
+}
+
+/// `GET /queries` — the catalog with descriptions. Always 200; never touches
+/// Prometheus.
+async fn list_queries() -> Json<&'static [queries::NamedQuery]> {
+    Json(queries::QUERY_CATALOG)
+}
+
+/// `GET /queries/{name}?window=1h&mode=instant|range` — run a named query.
+async fn run_named_query(
+    State(state): State<ApiState>,
+    Path(name): Path<String>,
+    Query(params): Query<QueryParams>,
+) -> Result<impl IntoResponse, ApiError> {
+    let query = queries::find(&name).ok_or_else(|| ApiError::UnknownQuery(name.clone()))?;
+    let promql =
+        queries::resolve(query, params.window.as_deref()).map_err(ApiError::BadQueryParam)?;
+    execute_query(&state, &name, promql, &params).await
+}
+
+/// `GET /query?promql=...` — raw PromQL passthrough.
+///
+/// Read-only escape hatch for ad-hoc analysis; Prometheus itself listens on
+/// loopback only. Prefer the named catalog for anything recurring.
+async fn run_raw_query(
+    State(state): State<ApiState>,
+    Query(params): Query<QueryParams>,
+) -> Result<impl IntoResponse, ApiError> {
+    let promql = params
+        .promql
+        .clone()
+        .filter(|p| !p.trim().is_empty())
+        .ok_or_else(|| ApiError::BadQueryParam("missing `promql` parameter".to_string()))?;
+    execute_query(&state, "raw", promql, &params).await
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -96,7 +214,58 @@ mod tests {
     use tower::ServiceExt;
 
     fn make_state() -> ApiState {
-        ApiState { app_state: AppState::new(MonitorConfig::default()) }
+        // Port 1 — connection refused; only the Prometheus-backed endpoints
+        // touch it, and those tests use stub_prometheus() instead.
+        make_state_with_prometheus("http://127.0.0.1:1")
+    }
+
+    fn make_state_with_prometheus(prometheus_url: &str) -> ApiState {
+        ApiState {
+            app_state: AppState::new(MonitorConfig::default()),
+            prom: Arc::new(PromClient::new(prometheus_url.to_string())),
+        }
+    }
+
+    /// Spawn a stub Prometheus answering /api/v1/query and /api/v1/query_range
+    /// with canned vector/matrix envelopes. Returns its base URL.
+    async fn stub_prometheus() -> String {
+        let router = Router::new()
+            .route(
+                "/api/v1/query",
+                get(|| async {
+                    Json(serde_json::json!({
+                        "status": "success",
+                        "data": {
+                            "resultType": "vector",
+                            "result": [
+                                {"metric": {"service": "orchestrator"},
+                                 "value": [1718100000.0, "3"]}
+                            ]
+                        }
+                    }))
+                }),
+            )
+            .route(
+                "/api/v1/query_range",
+                get(|| async {
+                    Json(serde_json::json!({
+                        "status": "success",
+                        "data": {
+                            "resultType": "matrix",
+                            "result": [
+                                {"metric": {"service": "orchestrator"},
+                                 "values": [[1718100000.0, "1"], [1718100060.0, "2"]]}
+                            ]
+                        }
+                    }))
+                }),
+            );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, router).await.unwrap();
+        });
+        format!("http://{addr}")
     }
 
     #[tokio::test]
@@ -171,5 +340,115 @@ mod tests {
         let body = resp.into_body().collect().await.unwrap().to_bytes();
         let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
         assert_eq!(json["status"], "healthy");
+    }
+
+    // -----------------------------------------------------------------------
+    // Named-query endpoints
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_list_queries_returns_catalog_without_prometheus() {
+        // Prometheus deliberately unreachable — the catalog is static.
+        let router = create_router(make_state());
+        let req = Request::builder().uri("/queries").body(Body::empty()).unwrap();
+        let resp = router.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = resp.into_body().collect().await.unwrap().to_bytes();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let entries = json.as_array().unwrap();
+        assert_eq!(entries.len(), crate::queries::QUERY_CATALOG.len());
+        assert!(entries.iter().any(|e| e["name"] == "dispatch-success-rate"));
+    }
+
+    #[tokio::test]
+    async fn test_named_query_instant_happy_path() {
+        let prom_url = stub_prometheus().await;
+        let router = create_router(make_state_with_prometheus(&prom_url));
+        let req = Request::builder()
+            .uri("/queries/dispatch-success-rate?window=15m")
+            .body(Body::empty())
+            .unwrap();
+        let resp = router.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = resp.into_body().collect().await.unwrap().to_bytes();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["name"], "dispatch-success-rate");
+        assert_eq!(json["mode"], "instant");
+        assert!(json["promql"].as_str().unwrap().contains("[15m]"));
+        assert_eq!(json["data"]["resultType"], "vector");
+    }
+
+    #[tokio::test]
+    async fn test_named_query_range_mode() {
+        let prom_url = stub_prometheus().await;
+        let router = create_router(make_state_with_prometheus(&prom_url));
+        let req = Request::builder()
+            .uri("/queries/dispatch-throughput?mode=range&range_minutes=60&step_secs=60")
+            .body(Body::empty())
+            .unwrap();
+        let resp = router.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = resp.into_body().collect().await.unwrap().to_bytes();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["mode"], "range");
+        assert_eq!(json["data"]["resultType"], "matrix");
+    }
+
+    #[tokio::test]
+    async fn test_unknown_query_returns_404_with_catalog() {
+        let router = create_router(make_state());
+        let req = Request::builder().uri("/queries/bogus").body(Body::empty()).unwrap();
+        let resp = router.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+        let body = resp.into_body().collect().await.unwrap().to_bytes();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert!(
+            json["error"].as_str().unwrap().contains("dispatch-success-rate"),
+            "404 should list the catalog: {json}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_bad_window_returns_400() {
+        let router = create_router(make_state());
+        let req = Request::builder()
+            .uri("/queries/dispatch-success-rate?window=1h)%20or%20vector(1)")
+            .body(Body::empty())
+            .unwrap();
+        let resp = router.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn test_prometheus_down_returns_502() {
+        // make_state points the client at a refused port.
+        let router = create_router(make_state());
+        let req = Request::builder().uri("/queries/agents-active").body(Body::empty()).unwrap();
+        let resp = router.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_GATEWAY);
+        let body = resp.into_body().collect().await.unwrap().to_bytes();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert!(json["error"].as_str().unwrap().contains("unreachable"), "{json}");
+    }
+
+    #[tokio::test]
+    async fn test_raw_query_requires_promql() {
+        let router = create_router(make_state());
+        let req = Request::builder().uri("/query").body(Body::empty()).unwrap();
+        let resp = router.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn test_raw_query_passthrough() {
+        let prom_url = stub_prometheus().await;
+        let router = create_router(make_state_with_prometheus(&prom_url));
+        let req = Request::builder().uri("/query?promql=up").body(Body::empty()).unwrap();
+        let resp = router.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = resp.into_body().collect().await.unwrap().to_bytes();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["name"], "raw");
+        assert_eq!(json["promql"], "up");
     }
 }

--- a/crates/monitor/src/client.rs
+++ b/crates/monitor/src/client.rs
@@ -104,6 +104,50 @@ impl MonitorClient {
 
         resp.json::<SystemStatus>().await.context("Failed to parse status response")
     }
+
+    /// `GET /queries` — fetch the named-query catalog as raw JSON.
+    pub async fn list_queries(&self) -> Result<serde_json::Value> {
+        let url = format!("{}/queries", self.base_url);
+        let resp = self.http.get(&url).send().await.with_context(|| format!("GET {url}"))?;
+
+        if !resp.status().is_success() {
+            return Err(anyhow!("GET /queries failed: HTTP {}", resp.status()));
+        }
+
+        resp.json().await.context("Failed to parse queries catalog")
+    }
+
+    /// `GET /queries/{name}` — execute a named query.
+    ///
+    /// `window` substitutes `$__window` (e.g. `"15m"`); `range` switches from
+    /// an instant evaluation to a range query over the last six hours.
+    pub async fn run_query(
+        &self,
+        name: &str,
+        window: Option<&str>,
+        range: bool,
+    ) -> Result<serde_json::Value> {
+        let mut url = format!("{}/queries/{name}", self.base_url);
+        let mut params = vec![];
+        if let Some(window) = window {
+            params.push(format!("window={window}"));
+        }
+        if range {
+            params.push("mode=range".to_string());
+        }
+        if !params.is_empty() {
+            url = format!("{url}?{}", params.join("&"));
+        }
+
+        let resp = self.http.get(&url).send().await.with_context(|| format!("GET {url}"))?;
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let body = resp.text().await.unwrap_or_default();
+            return Err(anyhow!("GET /queries/{name} failed: HTTP {} — {}", status, body));
+        }
+
+        resp.json().await.context("Failed to parse query result")
+    }
 }
 
 #[cfg(test)]

--- a/crates/monitor/src/config.rs
+++ b/crates/monitor/src/config.rs
@@ -33,6 +33,9 @@ pub struct MonitorConfig {
     pub disk_alert_threshold: f32,
     /// Maximum number of metric snapshots to retain in memory (default: 120)
     pub history_size: usize,
+    /// Base URL of the Prometheus server backing the named-query API
+    /// (default: http://127.0.0.1:9090, matching infra/prometheus/).
+    pub prometheus_url: String,
 }
 
 impl MonitorConfig {
@@ -77,6 +80,9 @@ impl MonitorConfig {
                 .ok()
                 .and_then(|v| v.parse().ok())
                 .unwrap_or(120),
+            // TODO(#1201): migrate when shared schema adds prometheus_url
+            prometheus_url: env::var("AGENTD_PROMETHEUS_URL")
+                .unwrap_or_else(|_| "http://127.0.0.1:9090".to_string()),
         }
     }
 
@@ -96,6 +102,7 @@ impl Default for MonitorConfig {
             memory_alert_threshold: 90.0,
             disk_alert_threshold: 90.0,
             history_size: 120,
+            prometheus_url: "http://127.0.0.1:9090".to_string(),
         }
     }
 }
@@ -116,6 +123,14 @@ impl ValidateConfig for MonitorConfig {
             if !(0.0..=100.0).contains(&threshold) {
                 bail!("{name} must be between 0.0 and 100.0, got: {threshold}");
             }
+        }
+        if !self.prometheus_url.starts_with("http://")
+            && !self.prometheus_url.starts_with("https://")
+        {
+            bail!(
+                "monitor.prometheus_url must start with http:// or https://, got: {}",
+                self.prometheus_url
+            );
         }
         Ok(())
     }

--- a/crates/monitor/src/error.rs
+++ b/crates/monitor/src/error.rs
@@ -19,6 +19,19 @@ pub enum ApiError {
     #[error("No metrics available — collection has not run yet")]
     NoMetricsAvailable,
 
+    /// Unknown named query — message lists the catalog.
+    #[error("Unknown query `{0}`")]
+    UnknownQuery(String),
+
+    /// Invalid query parameter (window, step, ...).
+    #[error("Invalid query parameter: {0}")]
+    BadQueryParam(String),
+
+    /// Prometheus itself is unreachable or rejected the query — distinct
+    /// from a monitor failure so callers can tell which layer is down.
+    #[error("Prometheus unavailable: {0}")]
+    PrometheusUnavailable(String),
+
     /// Internal service error
     #[error("Internal error: {0}")]
     Internal(String),
@@ -29,6 +42,14 @@ impl IntoResponse for ApiError {
         let (status, message) = match &self {
             ApiError::CollectionFailed(msg) => (StatusCode::SERVICE_UNAVAILABLE, msg.clone()),
             ApiError::NoMetricsAvailable => (StatusCode::SERVICE_UNAVAILABLE, self.to_string()),
+            ApiError::UnknownQuery(_) => {
+                let names: Vec<&str> =
+                    crate::queries::QUERY_CATALOG.iter().map(|q| q.name).collect();
+                let message = format!("{self}. Known queries: {}", names.join(", "));
+                return (StatusCode::NOT_FOUND, Json(json!({ "error": message }))).into_response();
+            }
+            ApiError::BadQueryParam(msg) => (StatusCode::BAD_REQUEST, msg.clone()),
+            ApiError::PrometheusUnavailable(msg) => (StatusCode::BAD_GATEWAY, msg.clone()),
             ApiError::Internal(msg) => (StatusCode::INTERNAL_SERVER_ERROR, msg.clone()),
         };
 

--- a/crates/monitor/src/lib.rs
+++ b/crates/monitor/src/lib.rs
@@ -62,13 +62,26 @@
 //! - `AGENTD_MEMORY_ALERT_THRESHOLD` - Memory usage % to trigger alert (default: 90.0)
 //! - `AGENTD_DISK_ALERT_THRESHOLD` - Disk usage % to trigger alert (default: 90.0)
 //! - `AGENTD_HISTORY_SIZE` - Number of metric snapshots to retain (default: 120)
+//! - `AGENTD_PROMETHEUS_URL` - Prometheus base URL for the named-query API
+//!   (default: http://127.0.0.1:9090)
 //! - `RUST_LOG` - Logging level (default: info)
+//!
+//! ## GET /queries and GET /queries/{name}
+//!
+//! The curated named-query API: `/queries` returns the catalog (name,
+//! description, unit, promql, default_window); `/queries/{name}` executes one
+//! against Prometheus with optional `window`, `mode=instant|range`,
+//! `range_minutes`, and `step_secs` parameters. `GET /query?promql=...` is a
+//! raw read-only passthrough. Prometheus being down yields HTTP 502 with a
+//! structured error body; the catalog endpoint never touches Prometheus.
 
 pub mod api;
 pub mod client;
 pub mod config;
 pub mod error;
 pub mod metrics_collector;
+pub mod prometheus;
+pub mod queries;
 pub mod state;
 pub mod types;
 
@@ -129,8 +142,10 @@ pub async fn run(config: config::MonitorConfig) -> Result<()> {
 
     let prom_handle = init_metrics();
 
+    let prom_client =
+        std::sync::Arc::new(prometheus::PromClient::new(config.prometheus_url.clone()));
     let app_state = state::AppState::new(config);
-    let api_state = api::ApiState { app_state: app_state.clone() };
+    let api_state = api::ApiState { app_state: app_state.clone(), prom: prom_client };
     let prom_router = axum::Router::new()
         .route("/prom-metrics", get(prom_metrics_handler))
         .with_state(prom_handle);

--- a/crates/monitor/src/prometheus.rs
+++ b/crates/monitor/src/prometheus.rs
@@ -1,0 +1,240 @@
+//! Minimal Prometheus HTTP API client.
+//!
+//! Hand-rolled over `reqwest` rather than pulling in a query-client crate:
+//! only two endpoints are needed (`/api/v1/query` and `/api/v1/query_range`),
+//! and the workspace convention is thin typed reqwest wrappers.
+//!
+//! The agentd observability stack runs Prometheus at `127.0.0.1:9090`
+//! (see `infra/prometheus/` and the launchd plist) scraping every service's
+//! metrics endpoint.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::time::Duration;
+
+/// Errors from the Prometheus HTTP API.
+#[derive(Debug, thiserror::Error)]
+pub enum PromError {
+    /// Prometheus could not be reached at all.
+    #[error("Prometheus unreachable at {url}: {source}")]
+    Unreachable {
+        url: String,
+        #[source]
+        source: reqwest::Error,
+    },
+    /// Prometheus answered with a non-success HTTP status.
+    #[error("Prometheus returned HTTP {status}: {body}")]
+    HttpStatus { status: u16, body: String },
+    /// Prometheus accepted the request but rejected the query.
+    #[error("Prometheus query error ({error_type}): {error}")]
+    Query { error_type: String, error: String },
+    /// The response body did not match the expected envelope.
+    #[error("Failed to parse Prometheus response: {0}")]
+    Parse(String),
+}
+
+/// One instant-vector sample: label set + (timestamp, value) pair.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct VectorSample {
+    /// Label name → value, including `__name__` when present.
+    pub metric: BTreeMap<String, String>,
+    /// `[unix_seconds, "value"]` as returned by Prometheus.
+    pub value: (f64, String),
+}
+
+/// One range-vector series: label set + list of (timestamp, value) pairs.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MatrixSeries {
+    pub metric: BTreeMap<String, String>,
+    /// `[[unix_seconds, "value"], ...]` as returned by Prometheus.
+    pub values: Vec<(f64, String)>,
+}
+
+/// Query result data, tagged by Prometheus's `resultType`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "resultType", content = "result", rename_all = "lowercase")]
+pub enum PromData {
+    Vector(Vec<VectorSample>),
+    Matrix(Vec<MatrixSeries>),
+    Scalar((f64, String)),
+}
+
+/// The standard Prometheus HTTP API response envelope.
+#[derive(Debug, Deserialize)]
+struct PromEnvelope {
+    status: String,
+    #[serde(default)]
+    data: Option<PromData>,
+    #[serde(default, rename = "errorType")]
+    error_type: Option<String>,
+    #[serde(default)]
+    error: Option<String>,
+}
+
+/// Typed client for the Prometheus HTTP API.
+#[derive(Debug, Clone)]
+pub struct PromClient {
+    http: reqwest::Client,
+    base_url: String,
+}
+
+impl PromClient {
+    /// Create a client for `base_url` (e.g. `"http://127.0.0.1:9090"`).
+    pub fn new(base_url: String) -> Self {
+        let http = reqwest::Client::builder()
+            .timeout(Duration::from_secs(5))
+            .build()
+            .expect("Failed to build reqwest Client");
+        Self { http, base_url: base_url.trim_end_matches('/').to_string() }
+    }
+
+    /// The configured Prometheus base URL.
+    pub fn base_url(&self) -> &str {
+        &self.base_url
+    }
+
+    /// `GET /api/v1/query` — evaluate an instant query.
+    pub async fn query(&self, promql: &str) -> Result<PromData, PromError> {
+        let url = format!("{}/api/v1/query", self.base_url);
+        self.execute(self.http.get(&url).query(&[("query", promql)]), &url).await
+    }
+
+    /// `GET /api/v1/query_range` — evaluate a range query.
+    pub async fn query_range(
+        &self,
+        promql: &str,
+        start: DateTime<Utc>,
+        end: DateTime<Utc>,
+        step_secs: u64,
+    ) -> Result<PromData, PromError> {
+        let url = format!("{}/api/v1/query_range", self.base_url);
+        let request = self.http.get(&url).query(&[
+            ("query", promql.to_string()),
+            ("start", start.timestamp().to_string()),
+            ("end", end.timestamp().to_string()),
+            ("step", format!("{step_secs}s")),
+        ]);
+        self.execute(request, &url).await
+    }
+
+    async fn execute(
+        &self,
+        request: reqwest::RequestBuilder,
+        url: &str,
+    ) -> Result<PromData, PromError> {
+        let response = request
+            .send()
+            .await
+            .map_err(|source| PromError::Unreachable { url: url.to_string(), source })?;
+
+        let status = response.status();
+        let body = response
+            .text()
+            .await
+            .map_err(|source| PromError::Unreachable { url: url.to_string(), source })?;
+
+        // Prometheus returns query errors with non-2xx statuses AND a JSON
+        // envelope; prefer the envelope's message when it parses.
+        let envelope: Result<PromEnvelope, _> = serde_json::from_str(&body);
+        match envelope {
+            Ok(env) if env.status == "success" => {
+                env.data.ok_or_else(|| PromError::Parse("missing data field".to_string()))
+            }
+            Ok(env) => Err(PromError::Query {
+                error_type: env.error_type.unwrap_or_else(|| "unknown".to_string()),
+                error: env.error.unwrap_or_else(|| "unknown error".to_string()),
+            }),
+            Err(_) if !status.is_success() => {
+                Err(PromError::HttpStatus { status: status.as_u16(), body })
+            }
+            Err(e) => Err(PromError::Parse(e.to_string())),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn vector_envelope_deserializes() {
+        let body = r#"{
+            "status": "success",
+            "data": {
+                "resultType": "vector",
+                "result": [
+                    {"metric": {"__name__": "agents_active", "service": "orchestrator"},
+                     "value": [1718100000.0, "3"]}
+                ]
+            }
+        }"#;
+        let env: PromEnvelope = serde_json::from_str(body).unwrap();
+        assert_eq!(env.status, "success");
+        match env.data.unwrap() {
+            PromData::Vector(samples) => {
+                assert_eq!(samples.len(), 1);
+                assert_eq!(samples[0].metric["service"], "orchestrator");
+                assert_eq!(samples[0].value.1, "3");
+            }
+            other => panic!("expected vector, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn matrix_envelope_deserializes() {
+        let body = r#"{
+            "status": "success",
+            "data": {
+                "resultType": "matrix",
+                "result": [
+                    {"metric": {"service": "notify"},
+                     "values": [[1718100000.0, "1"], [1718100060.0, "2"]]}
+                ]
+            }
+        }"#;
+        let env: PromEnvelope = serde_json::from_str(body).unwrap();
+        match env.data.unwrap() {
+            PromData::Matrix(series) => {
+                assert_eq!(series[0].values.len(), 2);
+                assert_eq!(series[0].values[1].1, "2");
+            }
+            other => panic!("expected matrix, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn scalar_envelope_deserializes() {
+        let body = r#"{
+            "status": "success",
+            "data": { "resultType": "scalar", "result": [1718100000.0, "42"] }
+        }"#;
+        let env: PromEnvelope = serde_json::from_str(body).unwrap();
+        assert!(matches!(env.data.unwrap(), PromData::Scalar((_, v)) if v == "42"));
+    }
+
+    #[test]
+    fn error_envelope_maps_to_query_error() {
+        let body = r#"{
+            "status": "error",
+            "errorType": "bad_data",
+            "error": "parse error: unexpected character"
+        }"#;
+        let env: PromEnvelope = serde_json::from_str(body).unwrap();
+        assert_eq!(env.status, "error");
+        assert_eq!(env.error_type.as_deref(), Some("bad_data"));
+    }
+
+    #[test]
+    fn base_url_trailing_slash_is_trimmed() {
+        let client = PromClient::new("http://127.0.0.1:9090/".to_string());
+        assert_eq!(client.base_url(), "http://127.0.0.1:9090");
+    }
+
+    #[tokio::test]
+    async fn unreachable_prometheus_yields_unreachable_error() {
+        let client = PromClient::new("http://127.0.0.1:1".to_string());
+        let err = client.query("up").await.unwrap_err();
+        assert!(matches!(err, PromError::Unreachable { .. }), "{err}");
+    }
+}

--- a/crates/monitor/src/queries.rs
+++ b/crates/monitor/src/queries.rs
@@ -1,0 +1,237 @@
+//! Curated named PromQL queries over the agentd metric inventory.
+//!
+//! The catalog is the single version-controlled home for PromQL on the
+//! platform: agents and tools reference queries by name instead of embedding
+//! query text in prompts. Each entry may contain the `$__window` token, which
+//! [`resolve`] substitutes with a validated duration.
+//!
+//! Counter-based queries use `increase()`/`rate()` (reset-safe). Metrics
+//! labeled by unbounded values (e.g. `room_id`) are aggregated or excluded.
+
+/// One catalog entry.
+#[derive(Debug, Clone, Copy, serde::Serialize)]
+pub struct NamedQuery {
+    /// Stable identifier used in API paths and tool calls.
+    pub name: &'static str,
+    /// Human-readable description of what the result means.
+    pub description: &'static str,
+    /// PromQL, possibly containing the `$__window` token.
+    pub promql: &'static str,
+    /// Unit of the resulting values.
+    pub unit: &'static str,
+    /// Default `$__window` substitution when the caller omits one.
+    pub default_window: &'static str,
+}
+
+/// The curated query catalog.
+pub const QUERY_CATALOG: &[NamedQuery] = &[
+    NamedQuery {
+        name: "service-up",
+        description: "Scrape success per agentd service; 0 means Prometheus cannot reach it",
+        promql: r#"up{job=~"agentd-.*"}"#,
+        unit: "boolean",
+        default_window: "",
+    },
+    NamedQuery {
+        name: "dispatch-success-rate",
+        description: "Fraction of finished workflow dispatches that completed successfully",
+        promql: r#"sum(increase(workflow_dispatches_total{status="completed"}[$__window])) / clamp_min(sum(increase(workflow_dispatches_total{status=~"completed|failed"}[$__window])), 1)"#,
+        unit: "ratio",
+        default_window: "1h",
+    },
+    NamedQuery {
+        name: "dispatch-throughput",
+        description: "Workflow dispatch counts by status over the window",
+        promql: r#"sum by (status) (increase(workflow_dispatches_total[$__window]))"#,
+        unit: "count",
+        default_window: "1h",
+    },
+    NamedQuery {
+        name: "agent-restart-rate",
+        description:
+            "Agent restarts over the window; sustained nonzero values suggest crash-looping",
+        promql: r#"sum(increase(agents_restarted_total[$__window]))"#,
+        unit: "count",
+        default_window: "1h",
+    },
+    NamedQuery {
+        name: "agents-active",
+        description: "Currently active agents",
+        promql: "agents_active",
+        unit: "count",
+        default_window: "",
+    },
+    NamedQuery {
+        name: "websocket-connections",
+        description:
+            "Live agent SDK WebSocket connections; compare with agents-active for state mismatches",
+        promql: "websocket_connections_active",
+        unit: "count",
+        default_window: "",
+    },
+    NamedQuery {
+        name: "approvals-backlog",
+        description: "Pending tool approvals; sustained growth means agents are blocked on humans",
+        promql: "approvals_pending",
+        unit: "count",
+        default_window: "",
+    },
+    NamedQuery {
+        name: "approvals-resolution",
+        description: "Tool approvals resolved over the window, by decision (approve/deny)",
+        promql: r#"sum by (decision) (increase(approvals_resolved_total[$__window]))"#,
+        unit: "count",
+        default_window: "1h",
+    },
+    NamedQuery {
+        name: "http-error-rate",
+        description: "HTTP 5xx ratio per service over the window",
+        promql: r#"sum by (service) (rate(http_requests_total{status=~"5.."}[$__window])) / clamp_min(sum by (service) (rate(http_requests_total[$__window])), 1e-9)"#,
+        unit: "ratio",
+        default_window: "15m",
+    },
+    NamedQuery {
+        name: "http-p95-latency",
+        description: "p95 HTTP request latency per service over the window (seconds)",
+        promql: r#"histogram_quantile(0.95, sum by (service, le) (rate(http_request_duration_seconds_bucket[$__window])))"#,
+        unit: "seconds",
+        default_window: "15m",
+    },
+    NamedQuery {
+        name: "session-cost",
+        description: "Claude session spend over the window (USD, gauge delta)",
+        promql: r#"delta(usage_session_cost_usd_total[$__window])"#,
+        unit: "usd",
+        default_window: "24h",
+    },
+    NamedQuery {
+        name: "notifications-backlog",
+        description: "Pending notifications awaiting response or dismissal",
+        promql: "notifications_pending",
+        unit: "count",
+        default_window: "",
+    },
+    NamedQuery {
+        name: "message-drops",
+        description: "Agent-bound messages dropped by the message bridge over the window",
+        promql: r#"sum(increase(messages_dropped[$__window]))"#,
+        unit: "count",
+        default_window: "1h",
+    },
+    NamedQuery {
+        name: "host-saturation",
+        description: "Host CPU %, memory %, worst-disk %, and 1m load in one vector",
+        promql: r#"system_cpu_usage_percent or (100 * system_memory_used_bytes / system_memory_total_bytes) or max by (mountpoint) (system_disk_usage_percent) or system_load_average{period="1m"}"#,
+        unit: "mixed",
+        default_window: "",
+    },
+];
+
+/// Look up a catalog entry by name.
+pub fn find(name: &str) -> Option<&'static NamedQuery> {
+    QUERY_CATALOG.iter().find(|q| q.name == name)
+}
+
+/// Validate a window string: digits followed by one of `s m h d w`.
+///
+/// The window is the only caller-controlled text spliced into PromQL, so
+/// this check doubles as the injection guard.
+pub fn valid_window(window: &str) -> bool {
+    let Some(unit) = window.chars().last() else { return false };
+    if !matches!(unit, 's' | 'm' | 'h' | 'd' | 'w') {
+        return false;
+    }
+    let digits = &window[..window.len() - 1];
+    !digits.is_empty() && digits.chars().all(|c| c.is_ascii_digit())
+}
+
+/// Resolve a named query to executable PromQL, substituting `$__window`.
+///
+/// Returns `Err` with a user-facing message when the window is invalid or
+/// supplied for a windowless (instant gauge) query.
+pub fn resolve(query: &NamedQuery, window: Option<&str>) -> Result<String, String> {
+    if !query.promql.contains("$__window") {
+        return Ok(query.promql.to_string());
+    }
+
+    let window = window.unwrap_or(query.default_window);
+    if !valid_window(window) {
+        return Err(format!(
+            "invalid window `{window}` — expected digits plus a unit (s/m/h/d/w), e.g. 15m, 1h, 24h"
+        ));
+    }
+    Ok(query.promql.replace("$__window", window))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn catalog_names_are_unique() {
+        let mut names: Vec<&str> = QUERY_CATALOG.iter().map(|q| q.name).collect();
+        names.sort_unstable();
+        names.dedup();
+        assert_eq!(names.len(), QUERY_CATALOG.len());
+    }
+
+    #[test]
+    fn windowed_queries_declare_a_default_window() {
+        for q in QUERY_CATALOG {
+            let windowed = q.promql.contains("$__window");
+            assert_eq!(
+                windowed,
+                !q.default_window.is_empty(),
+                "query `{}` must declare a default window iff its promql is windowed",
+                q.name
+            );
+        }
+    }
+
+    #[test]
+    fn valid_windows_accepted() {
+        for w in ["30s", "15m", "1h", "24h", "7d", "2w"] {
+            assert!(valid_window(w), "{w} should be valid");
+        }
+    }
+
+    #[test]
+    fn invalid_windows_rejected() {
+        for w in ["", "1", "h", "1x", "1h)", "'; drop", "1h or vector(1)", "-1h", "1.5h"] {
+            assert!(!valid_window(w), "{w} should be rejected");
+        }
+    }
+
+    #[test]
+    fn resolve_substitutes_window() {
+        let q = find("dispatch-success-rate").unwrap();
+        let promql = resolve(q, Some("15m")).unwrap();
+        assert!(promql.contains("[15m]"));
+        assert!(!promql.contains("$__window"));
+    }
+
+    #[test]
+    fn resolve_uses_default_window() {
+        let q = find("session-cost").unwrap();
+        let promql = resolve(q, None).unwrap();
+        assert!(promql.contains("[24h]"));
+    }
+
+    #[test]
+    fn resolve_rejects_injection() {
+        let q = find("http-error-rate").unwrap();
+        assert!(resolve(q, Some("5m]) or vector(1) #")).is_err());
+    }
+
+    #[test]
+    fn windowless_queries_ignore_window() {
+        let q = find("agents-active").unwrap();
+        assert_eq!(resolve(q, Some("nonsense")).unwrap(), "agents_active");
+    }
+
+    #[test]
+    fn find_hit_and_miss() {
+        assert!(find("host-saturation").is_some());
+        assert!(find("does-not-exist").is_none());
+    }
+}

--- a/crates/orchestrator/src/api.rs
+++ b/crates/orchestrator/src/api.rs
@@ -233,6 +233,16 @@ async fn create_agent(
     // Validate and canonicalize system_prompt_file if provided.
     let system_prompt_file = req.system_prompt_file.map(validate_system_prompt_file).transpose()?;
 
+    if let Some(servers) = &req.mcp_servers {
+        for (name, server) in servers {
+            if server.command.trim().is_empty() {
+                return Err(ApiError::InvalidInput(format!(
+                    "mcp_servers entry '{name}' has an empty command"
+                )));
+            }
+        }
+    }
+
     let config = AgentConfig {
         working_dir: req.working_dir,
         user: req.user,
@@ -253,6 +263,7 @@ async fn create_agent(
         resource_limits: req.resource_limits,
         additional_dirs: req.additional_dirs,
         rooms: req.rooms,
+        mcp_servers: req.mcp_servers,
     };
 
     let agent = state.manager.spawn_agent(req.name, config, false).await?;
@@ -319,6 +330,7 @@ fn launch_affecting_changed(before: &Agent, after: &Agent) -> bool {
         || b.append_system_prompt != a.append_system_prompt
         || b.additional_dirs != a.additional_dirs
         || b.worktree != a.worktree
+        || b.mcp_servers != a.mcp_servers
 }
 
 /// Update an agent's configuration (merge-patch semantics).
@@ -440,6 +452,44 @@ async fn update_agent(
     }
     if let Some(worktree) = req.worktree {
         agent.config.worktree = worktree;
+    }
+
+    // MCP servers: full replacement (empty map clears). Entry env values that
+    // are the redaction sentinel keep the stored value, mirroring `env`.
+    if let Some(servers) = req.mcp_servers {
+        if servers.is_empty() {
+            agent.config.mcp_servers = None;
+        } else {
+            let mut merged = HashMap::with_capacity(servers.len());
+            for (name, mut server) in servers {
+                if server.command.trim().is_empty() {
+                    return Err(ApiError::InvalidInput(format!(
+                        "mcp_servers entry '{name}' has an empty command"
+                    )));
+                }
+                for (key, value) in server.env.iter_mut() {
+                    if value == ENV_REDACTED {
+                        let stored = before
+                            .config
+                            .mcp_servers
+                            .as_ref()
+                            .and_then(|m| m.get(&name))
+                            .and_then(|s| s.env.get(key));
+                        match stored {
+                            Some(stored) => *value = stored.clone(),
+                            None => {
+                                return Err(ApiError::InvalidInput(format!(
+                                    "mcp_servers entry '{name}' env key '{key}' is the redaction \
+                                     placeholder but the key has no stored value"
+                                )));
+                            }
+                        }
+                    }
+                }
+                merged.insert(name, server);
+            }
+            agent.config.mcp_servers = Some(merged);
+        }
     }
 
     agent.updated_at = chrono::Utc::now();

--- a/crates/orchestrator/src/api.rs
+++ b/crates/orchestrator/src/api.rs
@@ -465,7 +465,31 @@ async fn send_message(
     Json(req): Json<SendMessageRequest>,
 ) -> Result<impl IntoResponse, ApiError> {
     // Verify agent exists and is running.
-    let agent = state.manager.get_agent(&id).await?.ok_or(ApiError::NotFound)?;
+    let mut agent = state.manager.get_agent(&id).await?.ok_or(ApiError::NotFound)?;
+
+    // Lazy built-in agents stay dormant until first contact: spawn on
+    // demand, then wait for the session to connect before delivering.
+    if agent.built_in && agent.status != AgentStatus::Running {
+        agent = state
+            .manager
+            .ensure_builtin_running(&id)
+            .await
+            .map_err(|e| ApiError::Internal(e.context("Failed to wake system agent")))?;
+
+        // SDK-mode delivery goes over the WebSocket, which needs the freshly
+        // spawned Claude process to connect back first.  Subprocess stdio
+        // backends register immediately; PTY/interactive agents bypass the
+        // registry entirely.
+        if !agent.config.interactive && !state.registry.is_connected(&id).await {
+            for _ in 0..30 {
+                tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+                if state.registry.is_connected(&id).await {
+                    break;
+                }
+            }
+        }
+    }
+
     if agent.status != AgentStatus::Running {
         return Err(ApiError::Conflict(format!(
             "Agent {} is not running (status: {})",

--- a/crates/orchestrator/src/entity/agent.rs
+++ b/crates/orchestrator/src/entity/agent.rs
@@ -68,6 +68,9 @@ pub struct Model {
     /// System agents are created programmatically and managed by the orchestrator;
     /// user-created agents always have this set to 0.
     pub built_in: i32,
+    /// JSON-serialized `HashMap<String, McpServerConfig>` of MCP servers for
+    /// the agent's Claude session. NULL when no servers are configured.
+    pub mcp_servers: Option<String>,
 }
 
 #[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]

--- a/crates/orchestrator/src/manager.rs
+++ b/crates/orchestrator/src/manager.rs
@@ -311,63 +311,186 @@ impl AgentManager {
 
     /// Bootstrap built-in system agents at orchestrator startup.
     ///
-    /// Called once after [`reconcile`] so that reconciliation has already
-    /// handled any surviving user agents before we insert/restart system agents.
+    /// Called once after [`reconcile`](Self::reconcile) so that reconciliation
+    /// has already handled any surviving user agents before we insert/restart
+    /// system agents.
     ///
-    /// Behaviour:
-    /// 1. Query storage for existing built-in agents.
-    /// 2. If the system agent exists and is `Running` → skip (reconcile handled it).
-    /// 3. If it exists but is `Stopped` or `Failed` → restart it.
-    /// 4. If it doesn't exist → create it via `spawn_agent()` with `built_in: true`.
+    /// For each definition in [`builtin_agent_defs`](crate::system_agents::builtin_agent_defs):
+    /// 1. **Missing** — eager defs are spawned via `spawn_agent()`; lazy defs
+    ///    get a dormant `Pending` record and are spawned on first message
+    ///    (see [`ensure_builtin_running`](Self::ensure_builtin_running)).
+    /// 2. **Config drift** — when the stored config no longer matches the
+    ///    definition (new prompt, policy, model, ... in this release), the
+    ///    stored config is refreshed *before* any restart so a failed restart
+    ///    still retries with the new config on the next boot.  Running agents
+    ///    are restarted to pick the refresh up; dormant agents pick it up on
+    ///    their next spawn.
+    /// 3. **Stopped/failed eager agents** — restarted (lazy agents are left
+    ///    dormant).
+    ///
+    /// Stored built-ins whose name is no longer in the registry are removed
+    /// as orphans — built-ins cannot be deleted via the API, so leaving them
+    /// would create undeletable zombies.
+    ///
+    /// Per-definition errors are logged and never abort the loop.
     pub async fn bootstrap_system_agents(&self) -> anyhow::Result<()> {
-        use crate::system_agents::build_system_agent_config;
-        use crate::system_agents::SYSTEM_AGENT_NAME;
+        use crate::system_agents::{builtin_agent_defs, config_drifted, refreshed_config};
 
+        let defs = builtin_agent_defs();
         let existing = self.storage.list_system_agents().await?;
-        let system_agent = existing.into_iter().find(|a| a.name == SYSTEM_AGENT_NAME);
 
-        match system_agent {
-            Some(agent) if agent.status == AgentStatus::Running => {
-                // Reconciliation already handled it — nothing to do.
-                info!(
-                    agent_id = %agent.id,
-                    "System agent '{}' is already running, skipping bootstrap",
-                    SYSTEM_AGENT_NAME
-                );
-            }
-            Some(agent) => {
-                // Exists but stopped/failed — restart it.
-                info!(
-                    agent_id = %agent.id,
-                    status = %agent.status,
-                    "Restarting system agent '{}'",
-                    SYSTEM_AGENT_NAME
-                );
-                if let Err(e) = self.restart_agent(&agent).await {
-                    error!(
-                        agent_id = %agent.id,
-                        %e,
-                        "Failed to restart system agent '{}'",
-                        SYSTEM_AGENT_NAME
-                    );
-                }
-            }
-            None => {
-                // First run — create the system agent.
-                info!("Bootstrapping system agent '{}'", SYSTEM_AGENT_NAME);
-                let config = build_system_agent_config();
-                match self.spawn_agent(SYSTEM_AGENT_NAME.to_string(), config, true).await {
-                    Ok(agent) => {
-                        info!(agent_id = %agent.id, "System agent '{}' spawned", SYSTEM_AGENT_NAME)
+        for def in &defs {
+            let stored = existing.iter().find(|a| a.name == def.name);
+            let fresh = def.build_config();
+
+            match stored {
+                None if def.lazy => {
+                    info!("Bootstrapping dormant system agent '{}'", def.name);
+                    if let Err(e) = self.create_dormant_agent(def.name.to_string(), fresh).await {
+                        error!(%e, "Failed to create dormant system agent '{}'", def.name);
                     }
-                    Err(e) => {
-                        error!(%e, "Failed to spawn system agent '{}'", SYSTEM_AGENT_NAME)
+                }
+                None => {
+                    info!("Bootstrapping system agent '{}'", def.name);
+                    match self.spawn_agent(def.name.to_string(), fresh, true).await {
+                        Ok(agent) => {
+                            info!(agent_id = %agent.id, "System agent '{}' spawned", def.name)
+                        }
+                        Err(e) => error!(%e, "Failed to spawn system agent '{}'", def.name),
+                    }
+                }
+                Some(agent) => {
+                    let mut agent = agent.clone();
+                    let drifted = config_drifted(&agent.config, &fresh);
+
+                    if drifted {
+                        // Persist the refreshed config BEFORE restarting so a
+                        // failed restart still retries with the new config.
+                        info!(
+                            agent_id = %agent.id,
+                            "System agent '{}' definition drifted, refreshing config",
+                            def.name
+                        );
+                        agent.config = refreshed_config(&agent.config, fresh);
+                        agent.updated_at = Utc::now();
+                        if let Err(e) = self.storage.update(&agent).await {
+                            error!(
+                                agent_id = %agent.id,
+                                %e,
+                                "Failed to persist refreshed config for '{}'",
+                                def.name
+                            );
+                            continue;
+                        }
+                    }
+
+                    let should_restart = if drifted {
+                        // Running agents must restart to pick up the refresh;
+                        // dormant/stopped lazy agents pick it up on next spawn.
+                        agent.status == AgentStatus::Running || !def.lazy
+                    } else {
+                        // No drift: keep eager agents alive (current
+                        // behavior); leave lazy agents dormant.
+                        agent.status != AgentStatus::Running && !def.lazy
+                    };
+
+                    if should_restart {
+                        info!(
+                            agent_id = %agent.id,
+                            status = %agent.status,
+                            drifted,
+                            "Restarting system agent '{}'",
+                            def.name
+                        );
+                        if let Err(e) = self.restart_agent(&agent).await {
+                            error!(
+                                agent_id = %agent.id,
+                                %e,
+                                "Failed to restart system agent '{}'",
+                                def.name
+                            );
+                        }
+                    } else if agent.status == AgentStatus::Running {
+                        info!(
+                            agent_id = %agent.id,
+                            "System agent '{}' is already running, skipping bootstrap",
+                            def.name
+                        );
                     }
                 }
             }
         }
 
+        // Remove orphaned built-ins: rows whose name left the registry.
+        for agent in existing.iter().filter(|a| !defs.iter().any(|d| d.name == a.name)) {
+            info!(
+                agent_id = %agent.id,
+                name = %agent.name,
+                "Removing orphaned built-in agent (no longer in the registry)"
+            );
+            if let Err(e) = self.remove_built_in_agent(agent).await {
+                error!(agent_id = %agent.id, %e, "Failed to remove orphaned built-in agent");
+            }
+        }
+
         Ok(())
+    }
+
+    /// Create a dormant built-in agent: DB record only, no backend session.
+    ///
+    /// The record is created with status `Pending` and `built_in = true`.
+    /// Reconciliation ignores `Pending` agents, so the record stays dormant
+    /// until [`ensure_builtin_running`](Self::ensure_builtin_running) spawns
+    /// it on first message.
+    async fn create_dormant_agent(
+        &self,
+        name: String,
+        config: AgentConfig,
+    ) -> anyhow::Result<Agent> {
+        let mut agent = Agent::new(name, config);
+        agent.built_in = true;
+        self.storage.add(&agent).await?;
+        info!(agent_id = %agent.id, name = %agent.name, "Dormant system agent record created");
+        Ok(agent)
+    }
+
+    /// Remove a built-in agent: kill any session and delete the DB record.
+    ///
+    /// `terminate_agent` deliberately bails on `built_in` agents, so orphan
+    /// cleanup needs this private path.  Only ever called with rows returned
+    /// by `list_system_agents()` (`built_in = true`), never for user agents.
+    async fn remove_built_in_agent(&self, agent: &Agent) -> anyhow::Result<()> {
+        if let Some(ref session) = agent.session_id {
+            if let Err(e) = self.backend.kill_session(session).await {
+                warn!(agent_id = %agent.id, %e, "Failed to kill session for orphaned built-in");
+            }
+        }
+        self.registry.unregister(&agent.id).await;
+        self.storage.delete(&agent.id).await?;
+        Ok(())
+    }
+
+    /// Ensure a built-in agent has a live session, spawning it if dormant.
+    ///
+    /// Used by the message-delivery path to wake lazy system agents on first
+    /// contact.  Returns the (possibly freshly spawned) agent record.  For
+    /// non-built-in agents this returns the record unchanged — waking user
+    /// agents is not this method's business.
+    pub async fn ensure_builtin_running(&self, id: &Uuid) -> anyhow::Result<Agent> {
+        let agent =
+            self.storage.get(id).await?.ok_or_else(|| anyhow::anyhow!("Agent not found"))?;
+
+        if !agent.built_in || agent.status == AgentStatus::Running {
+            return Ok(agent);
+        }
+
+        info!(
+            agent_id = %agent.id,
+            name = %agent.name,
+            status = %agent.status,
+            "Waking dormant system agent"
+        );
+        self.restart_agent(&agent).await
     }
 
     /// Reconcile DB state with actual backend sessions and WebSocket connections on startup.

--- a/crates/orchestrator/src/manager.rs
+++ b/crates/orchestrator/src/manager.rs
@@ -25,6 +25,18 @@ pub struct AgentManager {
     ws_base_url: String,
     /// Conversation event retention policy applied at terminate and on schedule.
     retention_config: Arc<RetentionConfig>,
+    /// Directory holding per-agent MCP config files (`<agent_id>.json`),
+    /// written at spawn/restart for agents with `mcp_servers` configured.
+    mcp_config_dir: std::path::PathBuf,
+}
+
+/// Default directory for per-agent MCP config files: a sibling of the
+/// orchestrator database (survives restarts, respects `AGENTD_ENV`).
+fn default_mcp_config_dir() -> std::path::PathBuf {
+    AgentStorage::get_db_path()
+        .ok()
+        .and_then(|db| db.parent().map(|p| p.join("mcp")))
+        .unwrap_or_else(|| std::env::temp_dir().join("agentd-mcp"))
 }
 
 impl AgentManager {
@@ -53,7 +65,21 @@ impl AgentManager {
         ws_base_url: String,
         retention_config: Arc<RetentionConfig>,
     ) -> Self {
-        Self { storage, backend, registry, ws_base_url, retention_config }
+        Self {
+            storage,
+            backend,
+            registry,
+            ws_base_url,
+            retention_config,
+            mcp_config_dir: default_mcp_config_dir(),
+        }
+    }
+
+    /// Override the MCP config directory (tests pass a `TempDir` path).
+    #[allow(dead_code)]
+    pub fn with_mcp_config_dir(mut self, dir: std::path::PathBuf) -> Self {
+        self.mcp_config_dir = dir;
+        self
     }
 
     pub fn registry(&self) -> &ConnectionRegistry {
@@ -158,8 +184,14 @@ impl AgentManager {
             .backend
             .agent_ws_url(&session_name, Some(&session_config))
             .unwrap_or_else(|| format!("{}/ws/{}", self.ws_base_url, agent.id));
-        let claude_cmd =
-            build_claude_command(&agent.config, &ws_url, effective_interactive, use_stdio);
+        let mcp_config_path = self.write_mcp_config(&agent)?;
+        let claude_cmd = build_claude_command(
+            &agent.config,
+            &ws_url,
+            effective_interactive,
+            use_stdio,
+            mcp_config_path.as_deref(),
+        );
 
         // Persist the launch command so the UI can display it for debugging.
         agent.launch_command = Some(claude_cmd.clone());
@@ -299,6 +331,7 @@ impl AgentManager {
 
         // Remove the record from storage entirely so the name can be reused.
         self.storage.delete(id).await?;
+        self.remove_mcp_config(id);
 
         // Set status on the returned value for callers that inspect it.
         agent.status = AgentStatus::Stopped;
@@ -307,6 +340,53 @@ impl AgentManager {
         info!(agent_id = %id, "Agent terminated and record deleted");
 
         Ok(agent)
+    }
+
+    /// Write the agent's MCP server map to its per-agent config file.
+    ///
+    /// Returns the file path to pass via `--mcp-config`, or `None` when the
+    /// agent has no `mcp_servers` configured. The file is created with mode
+    /// 0600 — MCP server env vars can carry secrets.
+    ///
+    /// Known limitation: the file lives on the orchestrator host, so
+    /// Docker-backed agents cannot see it. We deliberately do not inline the
+    /// JSON into the launch command instead — that would leak the env values
+    /// into the UI-visible `launch_command`.
+    fn write_mcp_config(&self, agent: &Agent) -> anyhow::Result<Option<String>> {
+        let Some(servers) = agent.config.mcp_servers.as_ref().filter(|s| !s.is_empty()) else {
+            // Config removed since last launch — drop any stale file.
+            self.remove_mcp_config(&agent.id);
+            return Ok(None);
+        };
+
+        if agent.config.docker_image.is_some() {
+            warn!(
+                agent_id = %agent.id,
+                "mcp_servers is configured but the agent uses a Docker image; \
+                 the MCP config file is not visible inside containers (tmux-only for now)"
+            );
+        }
+
+        std::fs::create_dir_all(&self.mcp_config_dir)?;
+        let path = self.mcp_config_dir.join(format!("{}.json", agent.id));
+        let body = serde_json::to_vec_pretty(&serde_json::json!({ "mcpServers": servers }))?;
+        std::fs::write(&path, body)?;
+        #[cfg(unix)]
+        {
+            use std::os::unix::fs::PermissionsExt;
+            std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o600))?;
+        }
+        Ok(Some(path.to_string_lossy().into_owned()))
+    }
+
+    /// Best-effort removal of an agent's MCP config file.
+    fn remove_mcp_config(&self, agent_id: &Uuid) {
+        let path = self.mcp_config_dir.join(format!("{agent_id}.json"));
+        if path.exists() {
+            if let Err(e) = std::fs::remove_file(&path) {
+                warn!(%agent_id, %e, "Failed to remove MCP config file");
+            }
+        }
     }
 
     /// Bootstrap built-in system agents at orchestrator startup.
@@ -467,6 +547,7 @@ impl AgentManager {
         }
         self.registry.unregister(&agent.id).await;
         self.storage.delete(&agent.id).await?;
+        self.remove_mcp_config(&agent.id);
         Ok(())
     }
 
@@ -1059,8 +1140,16 @@ impl AgentManager {
             .backend
             .agent_ws_url(&session_name, Some(&session_config))
             .unwrap_or_else(|| format!("{}/ws/{}", self.ws_base_url, agent.id));
-        let claude_cmd =
-            build_claude_command(&agent.config, &ws_url, effective_interactive, use_stdio);
+        // Always rewrite the MCP config — a PATCH may have changed servers
+        // since the last launch.
+        let mcp_config_path = self.write_mcp_config(&agent)?;
+        let claude_cmd = build_claude_command(
+            &agent.config,
+            &ws_url,
+            effective_interactive,
+            use_stdio,
+            mcp_config_path.as_deref(),
+        );
 
         // Persist the launch command so the UI can display it for debugging.
         agent.launch_command = Some(claude_cmd.clone());
@@ -1217,6 +1306,7 @@ fn build_claude_command(
     ws_url: &str,
     interactive: bool,
     use_stdio: bool,
+    mcp_config_path: Option<&str>,
 ) -> String {
     let mut args = vec!["claude".to_string()];
 
@@ -1249,6 +1339,14 @@ fn build_claude_command(
 
     for dir in &config.additional_dirs {
         args.push(format!("--add-dir {}", shell_escape_value(dir)));
+    }
+
+    // MCP servers: point claude at the per-agent config file and ignore any
+    // user-level mcpServers — a policy-managed agent gets exactly the servers
+    // the orchestrator configured.
+    if let Some(path) = mcp_config_path {
+        args.push(format!("--mcp-config {}", shell_escape_value(path)));
+        args.push("--strict-mcp-config".to_string());
     }
 
     // System prompt flags — four combinations based on (file vs inline) × (replace vs append).
@@ -1327,13 +1425,14 @@ mod tests {
             resource_limits: None,
             additional_dirs: vec![],
             rooms: vec![],
+            mcp_servers: None,
         }
     }
 
     #[test]
     fn test_build_claude_command_no_model() {
         let config = base_config();
-        let cmd = build_claude_command(&config, "ws://localhost:7006/ws/abc", false, false);
+        let cmd = build_claude_command(&config, "ws://localhost:7006/ws/abc", false, false, None);
         assert!(!cmd.contains("--model"));
         assert!(cmd.contains("claude"));
         assert!(cmd.contains("--sdk-url"));
@@ -1342,14 +1441,60 @@ mod tests {
     #[test]
     fn test_build_claude_command_with_model_alias() {
         let config = AgentConfig { model: Some("opus".to_string()), ..base_config() };
-        let cmd = build_claude_command(&config, "ws://localhost:7006/ws/abc", false, false);
+        let cmd = build_claude_command(&config, "ws://localhost:7006/ws/abc", false, false, None);
         assert!(cmd.contains("--model opus"));
+    }
+
+    #[test]
+    fn test_build_claude_command_with_mcp_config_path() {
+        let config = base_config();
+        let cmd = build_claude_command(
+            &config,
+            "ws://localhost:7006/ws/abc",
+            false,
+            false,
+            Some("/data/mcp/abc.json"),
+        );
+        assert!(cmd.contains("--mcp-config '/data/mcp/abc.json'"));
+        // Strict mode always accompanies an orchestrator-managed MCP config so
+        // the agent cannot inherit user-level servers.
+        assert!(cmd.contains("--strict-mcp-config"));
+        let mcp_pos = cmd.find("--mcp-config").unwrap();
+        let strict_pos = cmd.find("--strict-mcp-config").unwrap();
+        assert!(mcp_pos < strict_pos);
+    }
+
+    #[test]
+    fn test_build_claude_command_without_mcp_config_path() {
+        let config = base_config();
+        let cmd = build_claude_command(&config, "ws://localhost:7006/ws/abc", false, false, None);
+        assert!(!cmd.contains("--mcp-config"));
+        assert!(!cmd.contains("--strict-mcp-config"));
+    }
+
+    #[test]
+    fn test_build_claude_command_mcp_config_coexists_with_other_flags() {
+        let config = AgentConfig {
+            model: Some("sonnet".to_string()),
+            system_prompt: Some("be helpful".to_string()),
+            ..base_config()
+        };
+        let cmd = build_claude_command(
+            &config,
+            "ws://localhost:7006/ws/abc",
+            false,
+            false,
+            Some("/tmp/mcp.json"),
+        );
+        assert!(cmd.contains("--model sonnet"));
+        assert!(cmd.contains("--system-prompt 'be helpful'"));
+        assert!(cmd.contains("--mcp-config '/tmp/mcp.json'"));
     }
 
     #[test]
     fn test_build_claude_command_with_full_model_name() {
         let config = AgentConfig { model: Some("claude-sonnet-4-6".to_string()), ..base_config() };
-        let cmd = build_claude_command(&config, "ws://localhost:7006/ws/abc", false, false);
+        let cmd = build_claude_command(&config, "ws://localhost:7006/ws/abc", false, false, None);
         assert!(cmd.contains("--model claude-sonnet-4-6"));
     }
 
@@ -1357,7 +1502,7 @@ mod tests {
     fn test_build_claude_command_model_with_interactive() {
         let config =
             AgentConfig { model: Some("haiku".to_string()), interactive: true, ..base_config() };
-        let cmd = build_claude_command(&config, "ws://localhost:7006/ws/abc", true, false);
+        let cmd = build_claude_command(&config, "ws://localhost:7006/ws/abc", true, false, None);
         assert!(cmd.contains("--model haiku"));
         assert!(!cmd.contains("--sdk-url"));
     }
@@ -1369,7 +1514,7 @@ mod tests {
             user: Some("deploy".to_string()),
             ..base_config()
         };
-        let cmd = build_claude_command(&config, "ws://localhost:7006/ws/abc", false, false);
+        let cmd = build_claude_command(&config, "ws://localhost:7006/ws/abc", false, false, None);
         assert!(cmd.starts_with("sudo -u deploy env"));
         assert!(cmd.contains("--model sonnet"));
     }
@@ -1379,7 +1524,7 @@ mod tests {
         // The generated command must always unset SUDO_* variables so that
         // Claude Code's env-var credential detection is not suppressed.
         let config = AgentConfig { user: Some("cap".to_string()), ..base_config() };
-        let cmd = build_claude_command(&config, "ws://localhost:7006/ws/abc", false, false);
+        let cmd = build_claude_command(&config, "ws://localhost:7006/ws/abc", false, false, None);
         assert!(cmd.contains("-u SUDO_USER"), "must unset SUDO_USER: {cmd}");
         assert!(cmd.contains("-u SUDO_UID"), "must unset SUDO_UID: {cmd}");
         assert!(cmd.contains("-u SUDO_GID"), "must unset SUDO_GID: {cmd}");
@@ -1391,7 +1536,7 @@ mod tests {
         let mut env = HashMap::new();
         env.insert("ANTHROPIC_AUTH_TOKEN".to_string(), "tok-123".to_string());
         let config = AgentConfig { user: Some("cap".to_string()), env, ..base_config() };
-        let cmd = build_claude_command(&config, "ws://localhost:7006/ws/abc", false, false);
+        let cmd = build_claude_command(&config, "ws://localhost:7006/ws/abc", false, false, None);
         assert!(cmd.starts_with("sudo -u cap env"));
         assert!(cmd.contains("-u SUDO_USER"));
         assert!(cmd.contains("-u SUDO_UID"));
@@ -1411,7 +1556,7 @@ mod tests {
         let mut env = HashMap::new();
         env.insert("ANTHROPIC_API_KEY".to_string(), "sk-ant-test123".to_string());
         let config = AgentConfig { env, ..base_config() };
-        let cmd = build_claude_command(&config, "ws://localhost:7006/ws/abc", false, false);
+        let cmd = build_claude_command(&config, "ws://localhost:7006/ws/abc", false, false, None);
 
         assert!(cmd.contains("ANTHROPIC_API_KEY='sk-ant-test123'"));
         // Env prefix must come before claude
@@ -1425,7 +1570,7 @@ mod tests {
         let mut env = HashMap::new();
         env.insert("ANTHROPIC_API_KEY".to_string(), "sk-ant-test".to_string());
         let config = AgentConfig { user: Some("deploy".to_string()), env, ..base_config() };
-        let cmd = build_claude_command(&config, "ws://localhost:7006/ws/abc", false, false);
+        let cmd = build_claude_command(&config, "ws://localhost:7006/ws/abc", false, false, None);
 
         // For sudo, env vars are injected via `env` to cross the sudo boundary
         assert!(cmd.starts_with("sudo -u deploy env"));
@@ -1439,7 +1584,7 @@ mod tests {
         // Value contains a single quote — must be properly escaped
         env.insert("MY_VAR".to_string(), "it's a value".to_string());
         let config = AgentConfig { env, ..base_config() };
-        let cmd = build_claude_command(&config, "ws://localhost:7006/ws/abc", false, false);
+        let cmd = build_claude_command(&config, "ws://localhost:7006/ws/abc", false, false, None);
 
         // Single-quote escaping: ' → '\''
         assert!(cmd.contains("MY_VAR='it'\\''s a value'"));
@@ -1453,7 +1598,7 @@ mod tests {
         env.insert("123STARTS_WITH_DIGIT".to_string(), "v".to_string());
         env.insert("GOOD_KEY".to_string(), "ok".to_string());
         let config = AgentConfig { env, ..base_config() };
-        let cmd = build_claude_command(&config, "ws://localhost:7006/ws/abc", false, false);
+        let cmd = build_claude_command(&config, "ws://localhost:7006/ws/abc", false, false, None);
 
         assert!(cmd.contains("GOOD_KEY='ok'"));
         assert!(!cmd.contains("BAD KEY"));
@@ -1464,7 +1609,7 @@ mod tests {
     #[test]
     fn test_build_claude_command_empty_env_no_prefix() {
         let config = base_config(); // env is empty
-        let cmd = build_claude_command(&config, "ws://localhost:7006/ws/abc", false, false);
+        let cmd = build_claude_command(&config, "ws://localhost:7006/ws/abc", false, false, None);
 
         // Must start directly with claude (no env prefix)
         assert!(cmd.starts_with("claude"));
@@ -1475,7 +1620,7 @@ mod tests {
         let mut env = HashMap::new();
         env.insert("ANTHROPIC_BASE_URL".to_string(), "https://custom.api.example.com".to_string());
         let config = AgentConfig { interactive: true, env, ..base_config() };
-        let cmd = build_claude_command(&config, "ws://localhost:7006/ws/abc", true, false);
+        let cmd = build_claude_command(&config, "ws://localhost:7006/ws/abc", true, false, None);
 
         assert!(cmd.contains("ANTHROPIC_BASE_URL='https://custom.api.example.com'"));
         assert!(!cmd.contains("--sdk-url"));
@@ -1489,8 +1634,8 @@ mod tests {
         env.insert("ANTHROPIC_BASE_URL".to_string(), "https://example.com".to_string());
         env.insert("ANTHROPIC_AUTH_TOKEN".to_string(), "tok-123".to_string());
         let config = AgentConfig { env, ..base_config() };
-        let cmd1 = build_claude_command(&config, "ws://localhost:7006/ws/abc", false, false);
-        let cmd2 = build_claude_command(&config, "ws://localhost:7006/ws/abc", false, false);
+        let cmd1 = build_claude_command(&config, "ws://localhost:7006/ws/abc", false, false, None);
+        let cmd2 = build_claude_command(&config, "ws://localhost:7006/ws/abc", false, false, None);
 
         // Output must be deterministic (sorted) across calls
         assert_eq!(cmd1, cmd2);
@@ -1528,7 +1673,7 @@ mod tests {
     #[test]
     fn test_build_claude_command_no_system_prompt_flag_when_absent() {
         let config = base_config();
-        let cmd = build_claude_command(&config, "ws://localhost:7006/ws/abc", false, false);
+        let cmd = build_claude_command(&config, "ws://localhost:7006/ws/abc", false, false, None);
         assert!(!cmd.contains("--system-prompt"), "no system-prompt flag when none configured");
         assert!(!cmd.contains("--append-system-prompt"), "no append flag when none configured");
     }
@@ -1539,7 +1684,7 @@ mod tests {
             system_prompt: Some("You are a Rust expert".to_string()),
             ..base_config()
         };
-        let cmd = build_claude_command(&config, "ws://localhost:7006/ws/abc", false, false);
+        let cmd = build_claude_command(&config, "ws://localhost:7006/ws/abc", false, false, None);
         assert!(cmd.contains("--system-prompt 'You are a Rust expert'"));
         assert!(!cmd.contains("--append-system-prompt"));
         assert!(!cmd.contains("--system-prompt-file"));
@@ -1551,7 +1696,7 @@ mod tests {
             system_prompt_file: Some("./.agentd/agents/expert.md".to_string()),
             ..base_config()
         };
-        let cmd = build_claude_command(&config, "ws://localhost:7006/ws/abc", false, false);
+        let cmd = build_claude_command(&config, "ws://localhost:7006/ws/abc", false, false, None);
         assert!(cmd.contains("--system-prompt-file './.agentd/agents/expert.md'"));
         assert!(!cmd.contains("--system-prompt "));
         assert!(!cmd.contains("--append-system-prompt"));
@@ -1564,7 +1709,7 @@ mod tests {
             append_system_prompt: true,
             ..base_config()
         };
-        let cmd = build_claude_command(&config, "ws://localhost:7006/ws/abc", false, false);
+        let cmd = build_claude_command(&config, "ws://localhost:7006/ws/abc", false, false, None);
         assert!(cmd.contains("--append-system-prompt 'Always use TypeScript'"));
         assert!(!cmd.contains("--system-prompt "));
         assert!(!cmd.contains("--system-prompt-file"));
@@ -1577,7 +1722,7 @@ mod tests {
             append_system_prompt: true,
             ..base_config()
         };
-        let cmd = build_claude_command(&config, "ws://localhost:7006/ws/abc", false, false);
+        let cmd = build_claude_command(&config, "ws://localhost:7006/ws/abc", false, false, None);
         assert!(cmd.contains("--append-system-prompt-file './style-rules.txt'"));
         assert!(!cmd.contains("--system-prompt "));
         assert!(!cmd.contains("--system-prompt-file "));
@@ -1588,7 +1733,7 @@ mod tests {
         // Single quotes in the prompt must be shell-escaped.
         let config =
             AgentConfig { system_prompt: Some("You're an expert".to_string()), ..base_config() };
-        let cmd = build_claude_command(&config, "ws://localhost:7006/ws/abc", false, false);
+        let cmd = build_claude_command(&config, "ws://localhost:7006/ws/abc", false, false, None);
         assert!(cmd.contains("--system-prompt 'You'\\''re an expert'"));
     }
 
@@ -1599,7 +1744,7 @@ mod tests {
             append_system_prompt: true,
             ..base_config()
         };
-        let cmd = build_claude_command(&config, "ws://localhost:7006/ws/abc", false, false);
+        let cmd = build_claude_command(&config, "ws://localhost:7006/ws/abc", false, false, None);
         assert!(cmd.contains("--append-system-prompt 'Don'\\''t skip tests'"));
     }
 
@@ -1611,7 +1756,7 @@ mod tests {
             system_prompt_file: Some("./file.md".to_string()),
             ..base_config()
         };
-        let cmd = build_claude_command(&config, "ws://localhost:7006/ws/abc", false, false);
+        let cmd = build_claude_command(&config, "ws://localhost:7006/ws/abc", false, false, None);
         assert!(cmd.contains("--system-prompt 'inline prompt'"));
         assert!(!cmd.contains("--system-prompt-file"));
     }
@@ -1625,7 +1770,7 @@ mod tests {
             append_system_prompt: true,
             ..base_config()
         };
-        let cmd = build_claude_command(&config, "ws://localhost:7006/ws/abc", false, false);
+        let cmd = build_claude_command(&config, "ws://localhost:7006/ws/abc", false, false, None);
         assert!(cmd.contains("--append-system-prompt 'inline append'"));
         assert!(!cmd.contains("--append-system-prompt-file"));
         assert!(!cmd.contains("--system-prompt-file"));
@@ -1637,7 +1782,7 @@ mod tests {
     #[test]
     fn test_build_claude_command_no_add_dir_when_empty() {
         let config = base_config(); // additional_dirs is empty
-        let cmd = build_claude_command(&config, "ws://localhost:7006/ws/abc", false, false);
+        let cmd = build_claude_command(&config, "ws://localhost:7006/ws/abc", false, false, None);
         assert!(!cmd.contains("--add-dir"), "no --add-dir flag when additional_dirs is empty");
     }
 
@@ -1647,7 +1792,7 @@ mod tests {
             additional_dirs: vec!["/tmp/project".to_string(), "/home/user/data".to_string()],
             ..base_config()
         };
-        let cmd = build_claude_command(&config, "ws://localhost:7006/ws/abc", false, false);
+        let cmd = build_claude_command(&config, "ws://localhost:7006/ws/abc", false, false, None);
         assert!(cmd.contains("--add-dir '/tmp/project'"), "first dir must appear");
         assert!(cmd.contains("--add-dir '/home/user/data'"), "second dir must appear");
     }
@@ -1659,7 +1804,7 @@ mod tests {
             additional_dirs: vec!["/tmp/my project/it's here".to_string()],
             ..base_config()
         };
-        let cmd = build_claude_command(&config, "ws://localhost:7006/ws/abc", false, false);
+        let cmd = build_claude_command(&config, "ws://localhost:7006/ws/abc", false, false, None);
         // Single-quote escaping: ' → '\''
         assert!(
             cmd.contains("--add-dir '/tmp/my project/it'\\''s here'"),
@@ -1671,7 +1816,7 @@ mod tests {
     fn test_build_claude_command_pty_backend_no_sdk_url() {
         // Simulates PTY backend: effective_interactive = true
         let config = base_config();
-        let cmd = build_claude_command(&config, "ws://localhost:7006/ws/abc", true, false);
+        let cmd = build_claude_command(&config, "ws://localhost:7006/ws/abc", true, false, None);
         assert!(!cmd.contains("--sdk-url"), "PTY mode must not include --sdk-url");
         assert!(!cmd.contains("--input-format"), "PTY mode must not include --input-format");
         assert!(!cmd.contains("--output-format"), "PTY mode must not include --output-format");
@@ -1682,7 +1827,7 @@ mod tests {
     fn test_build_claude_command_sdk_mode_has_sdk_url() {
         // Non-PTY backend: effective_interactive = false
         let config = base_config(); // interactive = false
-        let cmd = build_claude_command(&config, "ws://localhost:7006/ws/abc", false, false);
+        let cmd = build_claude_command(&config, "ws://localhost:7006/ws/abc", false, false, None);
         assert!(cmd.contains("--sdk-url"));
         assert!(cmd.contains("--input-format stream-json"));
         assert!(cmd.contains("--output-format stream-json"));

--- a/crates/orchestrator/src/migration/m20260611_000020_add_mcp_servers_to_agents.rs
+++ b/crates/orchestrator/src/migration/m20260611_000020_add_mcp_servers_to_agents.rs
@@ -1,0 +1,35 @@
+//! Migration: add the `mcp_servers` column to the `agents` table.
+//!
+//! Nullable TEXT holding a JSON-serialized `HashMap<String, McpServerConfig>`
+//! (server name → { command, args, env }). `NULL` means the agent has no MCP
+//! servers configured and claude is launched without `--mcp-config`.
+
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        let db = manager.get_connection();
+
+        if let Err(e) = db
+            .execute_unprepared("ALTER TABLE agents ADD COLUMN mcp_servers TEXT DEFAULT NULL")
+            .await
+        {
+            // Idempotent: ignore if column already exists (e.g., re-run).
+            if !e.to_string().contains("duplicate column name") {
+                return Err(e);
+            }
+        }
+
+        Ok(())
+    }
+
+    async fn down(&self, _manager: &SchemaManager) -> Result<(), DbErr> {
+        // SQLite < 3.35.0 does not support DROP COLUMN, so we leave
+        // the column in place on rollback for simplicity.
+        Ok(())
+    }
+}

--- a/crates/orchestrator/src/migration/mod.rs
+++ b/crates/orchestrator/src/migration/mod.rs
@@ -30,6 +30,7 @@ mod m20260417_000016_add_conversation_events;
 mod m20260513_000017_add_skills_to_agents;
 mod m20260525_000018_add_conversation_event_seq;
 mod m20260610_000019_add_task_json_to_dispatch_log;
+mod m20260611_000020_add_mcp_servers_to_agents;
 
 /// The migration runner — applies all known migrations in order.
 pub struct Migrator;
@@ -57,6 +58,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20260513_000017_add_skills_to_agents::Migration),
             Box::new(m20260525_000018_add_conversation_event_seq::Migration),
             Box::new(m20260610_000019_add_task_json_to_dispatch_log::Migration),
+            Box::new(m20260611_000020_add_mcp_servers_to_agents::Migration),
         ]
     }
 }

--- a/crates/orchestrator/src/storage.rs
+++ b/crates/orchestrator/src/storage.rs
@@ -111,6 +111,11 @@ impl AgentStorage {
             pid: Set(agent.pid.map(|p| p as i64)),
             project_id: Set(agent.project_id.map(|id| id.to_string())),
             built_in: Set(if agent.built_in { 1 } else { 0 }),
+            mcp_servers: Set(agent
+                .config
+                .mcp_servers
+                .as_ref()
+                .map(|m| serde_json::to_string(m).unwrap_or_else(|_| "{}".to_string()))),
         };
 
         agent_entity::Entity::insert(model).exec(&self.db).await?;
@@ -217,6 +222,16 @@ impl AgentStorage {
                         .resource_limits
                         .as_ref()
                         .map(|r| serde_json::to_string(r).unwrap_or_else(|_| "{}".to_string())),
+                ),
+            )
+            .col_expr(
+                agent_entity::Column::McpServers,
+                Expr::value(
+                    agent
+                        .config
+                        .mcp_servers
+                        .as_ref()
+                        .map(|m| serde_json::to_string(m).unwrap_or_else(|_| "{}".to_string())),
                 ),
             )
             .col_expr(
@@ -1111,6 +1126,7 @@ fn model_to_agent(model: agent_entity::Model) -> Result<Agent> {
                 .and_then(|s| serde_json::from_str(s).ok()),
             additional_dirs: serde_json::from_str(&model.additional_dirs).unwrap_or_default(),
             rooms: serde_json::from_str(&model.rooms).unwrap_or_default(),
+            mcp_servers: model.mcp_servers.as_deref().and_then(|s| serde_json::from_str(s).ok()),
         },
         session_id: model.session_id,
         backend_type: model.backend_type,
@@ -1218,6 +1234,7 @@ mod tests {
                 resource_limits: None,
                 additional_dirs: vec![],
                 rooms: vec![],
+                mcp_servers: None,
             },
         )
     }

--- a/crates/orchestrator/src/system_agents.rs
+++ b/crates/orchestrator/src/system_agents.rs
@@ -91,6 +91,7 @@ impl SystemAgentDef {
             resource_limits: None,
             additional_dirs: vec![],
             rooms: self.rooms.iter().map(|r| r.to_string()).collect(),
+            mcp_servers: None,
         }
     }
 }

--- a/crates/orchestrator/src/system_agents.rs
+++ b/crates/orchestrator/src/system_agents.rs
@@ -130,13 +130,59 @@ fn system_agent_def() -> SystemAgentDef {
     }
 }
 
-/// Full system prompt for `agentd-system`: version line + embedded body.
+/// Full system prompt for `agentd-system`: version line + rendered body.
 fn system_agent_prompt() -> String {
+    // Ports come from the deployment's actually-loaded configuration so the
+    // prompt is correct per-deployment (env vars / TOML override defaults).
+    // A config change is a drift, so port changes roll out automatically.
+    let services = agentd_common::config::load().map(|c| c.services).unwrap_or_default();
+    system_agent_prompt_with(&services)
+}
+
+/// Render the system prompt against an explicit [`ServicesConfig`].
+///
+/// Split out from [`system_agent_prompt`] so tests can inject non-default
+/// ports and prove the prompt is generated, not hardcoded.
+fn system_agent_prompt_with(services: &agentd_common::config::ServicesConfig) -> String {
     // Include version/build metadata in the prompt so the agent can report
     // it.  The version line also makes every release a config drift, which
     // is how new prompt text reaches existing deployments.
     let version = env!("CARGO_PKG_VERSION");
-    format!("agentd version: {version}\n\n{SYSTEM_AGENT_PROMPT}")
+    let body = SYSTEM_AGENT_PROMPT_TEMPLATE
+        .replace("$SERVICE_TABLE", &render_service_table(services))
+        .replace("$ORCHESTRATOR_PORT", &services.orchestrator.port.to_string())
+        .replace("$WRAP_PORT", &services.wrap.port.to_string());
+    format!("agentd version: {version}\n\n{body}")
+}
+
+/// Render the service-inventory table from the loaded configuration.
+///
+/// Generated rather than hand-written: the previous hardcoded table had
+/// drifted from the real defaults (wrong notify/wrap ports, missing
+/// ask/hook/monitor, core/communicate collision).
+fn render_service_table(services: &agentd_common::config::ServicesConfig) -> String {
+    let rows: [(&str, u16, &str); 10] = [
+        ("core", services.core.port, "Auth gateway, API proxy"),
+        ("ask", services.ask.port, "Approval requests, human-in-the-loop gates"),
+        ("hook", services.hook.port, "Shell-event capture and forwarding"),
+        ("monitor", services.monitor.port, "System health metrics and thresholds"),
+        ("notify", services.notify.port, "Notification routing and delivery"),
+        ("wrap", services.wrap.port, "tmux/Docker execution backend"),
+        ("orchestrator", services.orchestrator.port, "Agent lifecycle, WebSocket SDK, policies"),
+        ("memory", services.memory.port, "Semantic vector memory store"),
+        ("ui", services.ui.port, "Web UI server"),
+        ("communicate", services.communicate.port, "Room-based messaging (WebSocket + REST)"),
+    ];
+
+    let mut table = String::from(
+        "| Service       | Port  | Description                              |\n\
+         |---------------|-------|------------------------------------------|\n",
+    );
+    for (name, port, description) in rows {
+        table.push_str(&format!("| {name:<13} | {port:<5} | {description:<40} |\n"));
+    }
+    table.push_str("| mcp           | —     | MCP server (stdio transport, no port)    |\n");
+    table
 }
 
 /// Carry runtime-derived fields from a stored config over to a freshly built
@@ -208,11 +254,14 @@ fn system_agent_tool_policy() -> ToolPolicy {
     }
 }
 
-/// System prompt for the agentd-system agent.
+/// System prompt template for the agentd-system agent.
 ///
 /// Embedded as a compile-time constant so it is version-controlled with the
-/// code and requires no files on disk.  The version line is prepended
-/// dynamically in [`build_system_agent_config`].
+/// code and requires no files on disk.  Rendered by
+/// [`system_agent_prompt_with`], which substitutes:
+/// - `$SERVICE_TABLE` — the service inventory generated from the loaded
+///   configuration (see [`render_service_table`])
+/// - `$ORCHESTRATOR_PORT` / `$WRAP_PORT` — ports used in example commands
 ///
 /// # Content coverage
 ///
@@ -229,7 +278,7 @@ fn system_agent_tool_policy() -> ToolPolicy {
 ///
 /// Target: under 6 000 tokens (≈ 24 000 characters). The version prefix
 /// adds ~20 tokens.  Review periodically and trim if this grows.
-const SYSTEM_AGENT_PROMPT: &str = "\
+const SYSTEM_AGENT_PROMPT_TEMPLATE: &str = "\
 You are the agentd system agent — a built-in, always-present domain expert
 on the agentd platform.
 
@@ -254,16 +303,9 @@ SERVICE INVENTORY
 
 agentd is a Rust workspace of microservices.  All expose `/health` (GET).
 
-| Service       | Dev Port | Prod Port | Description                              |
-|---------------|----------|-----------|------------------------------------------|
-| orchestrator  | 17006    | 7006      | Agent lifecycle, WebSocket SDK, policies |
-| core          | 17010    | 7010      | Auth gateway, API proxy                  |
-| communicate   | 17010    | 7010      | Room-based messaging (WebSocket + REST)  |
-| memory        | 17008    | 17008     | Semantic vector memory store             |
-| notify        | 17005    | 17005     | Notification routing and delivery        |
-| wrap          | 17007    | 7007      | Docker/tmux execution backend            |
-
-Note: `AGENTD_ENV=development` or `dev` routes to dev ports.
+$SERVICE_TABLE
+Ports reflect this deployment's loaded configuration — AGENTD_*_PORT
+environment variables and the config TOML override the defaults.
 
 ─────────────────────────────────────────────────────────────────────────────
 AGENT LIFECYCLE
@@ -321,9 +363,9 @@ COMMON CLI OPERATIONS
   agent communicate message list <room>   # read room messages
 
 ## Health checks (curl)
-  curl http://localhost:7006/health
-  curl http://localhost:7006/info         # backend type and capabilities
-  curl http://localhost:7006/debug/agents # all agents including built-in
+  curl http://localhost:$ORCHESTRATOR_PORT/health
+  curl http://localhost:$ORCHESTRATOR_PORT/info         # backend type and capabilities
+  curl http://localhost:$ORCHESTRATOR_PORT/debug/agents # all agents including built-in
 
 ─────────────────────────────────────────────────────────────────────────────
 COMMUNICATE ROOM SYSTEM
@@ -371,10 +413,10 @@ DIAGNOSING COMMON ISSUES
 1. Check the launch_command field: agent get <id>
 2. Verify working_dir exists and is accessible.
 3. Ensure ANTHROPIC_API_KEY / ANTHROPIC_AUTH_TOKEN is set in agent env.
-4. Check wrap service health: curl http://localhost:7007/health
+4. Check wrap service health: curl http://localhost:$WRAP_PORT/health
 
 ## WebSocket never connects (agent stays 'pending' or flips to 'failed')
-1. Verify orchestrator is listening: curl http://localhost:7006/health
+1. Verify orchestrator is listening: curl http://localhost:$ORCHESTRATOR_PORT/health
 2. Check that the SDK URL in launch_command matches the listening address.
 3. Review orchestrator logs for WebSocket handshake errors.
 
@@ -386,7 +428,8 @@ DIAGNOSING COMMON ISSUES
 ## Service not reachable
 1. Check if process is running: ps aux | grep agentd
 2. Verify port binding: lsof -i :<port>
-3. Check AGENTD_ENV — dev ports differ from production ports (see table above).
+3. Check for AGENTD_*_PORT env overrides — the listening port may differ
+   from the table above if the service was started with one set.
 
 ─────────────────────────────────────────────────────────────────────────────
 METRICS AND OBSERVABILITY
@@ -401,7 +444,7 @@ Key orchestrator metrics:
   tool_approvals_total           — tool calls evaluated by policy
 
 To check metrics:
-  curl http://localhost:7006/metrics
+  curl http://localhost:$ORCHESTRATOR_PORT/metrics
 
 Logs are written to stderr in structured JSON (production) or human-readable
 format (development, when AGENTD_LOG_FORMAT=pretty).
@@ -505,6 +548,52 @@ mod tests {
         stored.tool_policy = ToolPolicy::AllowList { tools: vec![], sandbox_bypass: vec![] };
         let fresh = def.build_config();
         assert!(config_drifted(&stored, &fresh));
+    }
+
+    #[test]
+    fn service_table_is_generated_from_config_not_hardcoded() {
+        let mut services = agentd_common::config::ServicesConfig::default();
+        services.orchestrator.port = 19999;
+        let table = render_service_table(&services);
+        assert!(table.contains("19999"), "table must reflect the injected port:\n{table}");
+    }
+
+    #[test]
+    fn service_table_defaults_match_common_config() {
+        let services = agentd_common::config::ServicesConfig::default();
+        let table = render_service_table(&services);
+        // Spot-check the rows that were wrong in the hand-written table.
+        assert!(table.contains("| notify        | 17004"), "notify row:\n{table}");
+        assert!(table.contains("| wrap          | 17005"), "wrap row:\n{table}");
+        assert!(table.contains("| ask           | 17001"), "ask row:\n{table}");
+        assert!(table.contains("| monitor       | 17003"), "monitor row:\n{table}");
+        assert!(table.contains("| hook          | 17002"), "hook row:\n{table}");
+    }
+
+    #[test]
+    fn prompt_substitutes_ports_and_leaves_no_tokens() {
+        let services = agentd_common::config::ServicesConfig::default();
+        let prompt = system_agent_prompt_with(&services);
+        assert!(!prompt.contains("$SERVICE_TABLE"));
+        assert!(!prompt.contains("$ORCHESTRATOR_PORT"));
+        assert!(!prompt.contains("$WRAP_PORT"));
+        assert!(prompt.contains("curl http://localhost:17006/health"));
+        assert!(prompt.contains("curl http://localhost:17005/health"));
+        // The known-bad literals from the hand-written table must be gone.
+        assert!(!prompt.contains("17007"), "wrap was never on 17007");
+        assert!(!prompt.contains("localhost:7006"), "no prod-port fiction");
+        assert!(!prompt.contains("localhost:7007"), "no prod-port fiction");
+    }
+
+    #[test]
+    fn prompt_stays_within_token_budget() {
+        let services = agentd_common::config::ServicesConfig::default();
+        let prompt = system_agent_prompt_with(&services);
+        assert!(
+            prompt.len() < 26_000,
+            "prompt grew past the documented ~6k-token budget: {} chars",
+            prompt.len()
+        );
     }
 
     #[test]

--- a/crates/orchestrator/src/system_agents.rs
+++ b/crates/orchestrator/src/system_agents.rs
@@ -31,6 +31,9 @@ pub const DIAGNOSTICIAN_AGENT_NAME: &str = "agentd-diagnostician";
 /// Name of the built-in architect agent (creates agents and workflows).
 pub const ARCHITECT_AGENT_NAME: &str = "agentd-architect";
 
+/// Name of the built-in analyst agent (metrics and health analysis).
+pub const ANALYST_AGENT_NAME: &str = "agentd-analyst";
+
 /// Env var that, when set to `1`/`true`, adds remediation tools to the
 /// diagnostician's allowlist (restart_failed_agents, retry_failed_dispatches,
 /// cleanup_stale_dispatches, resolve_notification_backlog). Default off.
@@ -116,7 +119,7 @@ impl SystemAgentDef {
 /// are refreshed, and stored built-ins whose name is no longer listed here
 /// are removed as orphans.
 pub fn builtin_agent_defs() -> Vec<SystemAgentDef> {
-    vec![system_agent_def(), diagnostician_def(), architect_def()]
+    vec![system_agent_def(), diagnostician_def(), architect_def(), analyst_def()]
 }
 
 /// Definition of the `agentd-system` domain-expert agent.
@@ -514,6 +517,132 @@ DESIGN GUIDANCE
 
 You cannot delete workflows, terminate or restart agents, or approve tool
 requests. For those, give the human the exact command instead.
+";
+
+// ---------------------------------------------------------------------------
+// agentd-analyst
+// ---------------------------------------------------------------------------
+
+/// Definition of the `agentd-analyst` agent.
+///
+/// A lazy built-in that analyzes platform metrics and health: the curated
+/// Prometheus query catalog (via the monitor service's `query_metrics` MCP
+/// tool) plus the orchestrator's read APIs. Strictly read-only except for
+/// posting findings (notifications and room messages).
+fn analyst_def() -> SystemAgentDef {
+    SystemAgentDef {
+        name: ANALYST_AGENT_NAME,
+        model: "sonnet",
+        rooms: &["system"],
+        working_dir: WorkingDirStrategy::CurrentDir,
+        lazy: true,
+        prompt: analyst_prompt,
+        tool_policy: analyst_tool_policy,
+        mcp_servers: agentd_mcp_servers,
+    }
+}
+
+/// Tool policy for the analyst: read/diagnose tool families plus the two
+/// escalation channels (create_notification, send_room_message). No
+/// lifecycle, creation, approval, or remediation tools.
+fn analyst_tool_policy() -> ToolPolicy {
+    ToolPolicy::AllowList {
+        tools: vec![
+            // ── Metrics and diagnostics (read-only families) ──────────────
+            "mcp__agentd__query_metrics".to_string(),
+            "mcp__agentd__diagnose_*".to_string(),
+            "mcp__agentd__check_*".to_string(),
+            "mcp__agentd__get_*".to_string(),
+            "mcp__agentd__list_*".to_string(),
+            "mcp__agentd__search_*".to_string(),
+            "mcp__agentd__inspect_*".to_string(),
+            // ── Escalation channels (exact names) ─────────────────────────
+            "mcp__agentd__create_notification".to_string(),
+            "mcp__agentd__send_room_message".to_string(),
+            // ── Local read-only tools ──────────────────────────────────────
+            "Read".to_string(),
+            "Grep".to_string(),
+            "Glob".to_string(),
+            "Bash(curl *)".to_string(),
+        ],
+        sandbox_bypass: vec![],
+    }
+}
+
+/// System prompt for the analyst.
+fn analyst_prompt() -> String {
+    let version = env!("CARGO_PKG_VERSION");
+    format!("agentd version: {version}\n\n{ANALYST_PROMPT}")
+}
+
+/// # Coverage note
+///
+/// The query-name list must stay in sync with
+/// `monitor::queries::QUERY_CATALOG` (cross-crate, so the unit test pins a
+/// const string list rather than importing the catalog).
+const ANALYST_PROMPT: &str = "\
+You are the agentd analyst — a built-in agent that analyzes platform metrics
+and health trends, surfaces anomalies, and recommends actions. You are
+read-only: you never modify agents, workflows, or configuration.
+
+─────────────────────────────────────────────────────────────────────────────
+METRICS TOOLKIT
+─────────────────────────────────────────────────────────────────────────────
+
+`query_metrics(name, window?, range?)` runs curated PromQL via the monitor
+service. Call it with no name to list the catalog. Key queries and healthy
+baselines:
+
+  service-up              All targets at 1. Any 0 → check_single_service.
+  dispatch-success-rate   ≥ 0.9 over 24h. Lower → get_failed_dispatches,
+                          then diagnose_workflow on the offenders.
+  dispatch-throughput     Know your normal; a sudden drop to zero on an
+                          enabled workflow means its trigger or agent broke.
+  agent-restart-rate      ~0. Sustained nonzero → crash-looping; diagnose
+                          the restarting agents.
+  agents-active vs websocket-connections
+                          Should match. A gap → diagnose_state_mismatches.
+  approvals-backlog       Near 0. Growth → agents are blocked on humans;
+                          notify the operator.
+  http-error-rate         ~0 per service. Spikes → check that service's
+                          health and recent deploys.
+  http-p95-latency        Know your normal (typically ms). Sustained growth
+                          → host-saturation next.
+  session-cost            Watch the 24h delta; a spike → list_agents and
+                          get_conversation_summary to find the hot agent.
+  notifications-backlog, message-drops, host-saturation
+                          Self-explanatory; drops and saturation are 🔴.
+
+Use `range: true` for trends (per-series min/avg/max/last over 6h) when an
+instant value needs context. If Prometheus is down (502), fall back to
+`get_prometheus_metrics(<service>)` direct scrapes and say so in your report.
+
+─────────────────────────────────────────────────────────────────────────────
+PLAYBOOKS
+─────────────────────────────────────────────────────────────────────────────
+
+Cost spike     → session-cost (24h) → list_agents →
+                 get_conversation_summary on busy agents → report the top
+                 spenders and what they were doing.
+Latency        → http-p95-latency per service → host-saturation →
+                 the slow service's health endpoint via curl.
+Failures       → dispatch-success-rate → get_failed_dispatches →
+                 diagnose_workflow → name the failing workflow and the
+                 pattern (always-fails vs intermittent).
+Routine review → service-up, dispatch-success-rate, agent-restart-rate,
+                 approvals-backlog, session-cost, host-saturation — then
+                 report only what deviates.
+
+─────────────────────────────────────────────────────────────────────────────
+REPORTING
+─────────────────────────────────────────────────────────────────────────────
+
+Post findings to the `system` room (send_room_message). For anything needing
+human action, also create_notification with priority matched to impact:
+data-loss or all-agents-blocked → high; degradation → medium; observations →
+low. Every finding needs: metric evidence, time window, suspected cause, and
+a concrete recommended action (you cannot act — name the command or the agent
+that should).
 ";
 
 /// Carry runtime-derived fields from a stored config over to a freshly built
@@ -980,6 +1109,86 @@ mod tests {
         // The hard constraint is stated prominently.
         assert!(prompt.contains(".agentd/*.yml"));
         assert!(prompt.len() < 26_000, "architect prompt budget: {}", prompt.len());
+    }
+
+    #[test]
+    fn analyst_is_lazy_with_agentd_mcp_server() {
+        let def = analyst_def();
+        assert!(def.lazy);
+        let config = def.build_config();
+        assert!(config.mcp_servers.is_some_and(|s| s.contains_key("agentd")));
+    }
+
+    #[test]
+    fn analyst_policy_is_read_only_plus_escalation() {
+        let policy = analyst_tool_policy();
+
+        for allowed in [
+            "mcp__agentd__query_metrics",
+            "mcp__agentd__get_prometheus_metrics",
+            "mcp__agentd__get_system_metrics",
+            "mcp__agentd__diagnose_system",
+            "mcp__agentd__check_service_health",
+            "mcp__agentd__list_agents",
+            "mcp__agentd__get_failed_dispatches",
+            "mcp__agentd__get_conversation_summary",
+            "mcp__agentd__inspect_queue",
+            "mcp__agentd__create_notification",
+            "mcp__agentd__send_room_message",
+            "Read",
+        ] {
+            assert!(policy.evaluate(allowed, None), "must allow {allowed}");
+        }
+
+        for denied in [
+            "mcp__agentd__create_agent",
+            "mcp__agentd__create_workflow",
+            "mcp__agentd__update_workflow",
+            "mcp__agentd__delete_workflow",
+            "mcp__agentd__terminate_agent",
+            "mcp__agentd__restart_agent",
+            "mcp__agentd__restart_failed_agents",
+            "mcp__agentd__send_agent_message",
+            "mcp__agentd__approve_tool_request",
+            "Write",
+            "Edit",
+            "Bash",
+        ] {
+            assert!(!policy.evaluate(denied, None), "must deny {denied}");
+        }
+    }
+
+    #[test]
+    fn analyst_prompt_covers_the_query_catalog() {
+        // Keep in sync with monitor::queries::QUERY_CATALOG (cross-crate, so
+        // pinned here as a const list). A new catalog entry should be added
+        // to the analyst's baseline guidance.
+        const CATALOG_NAMES: &[&str] = &[
+            "service-up",
+            "dispatch-success-rate",
+            "dispatch-throughput",
+            "agent-restart-rate",
+            "agents-active",
+            "websocket-connections",
+            "approvals-backlog",
+            "approvals-resolution",
+            "http-error-rate",
+            "http-p95-latency",
+            "session-cost",
+            "notifications-backlog",
+            "message-drops",
+            "host-saturation",
+        ];
+        let prompt = analyst_prompt();
+        for name in CATALOG_NAMES {
+            // approvals-resolution is covered by the approvals-backlog
+            // guidance; everything else must appear verbatim.
+            if *name == "approvals-resolution" {
+                continue;
+            }
+            assert!(prompt.contains(name), "analyst prompt must mention `{name}`");
+        }
+        assert!(prompt.len() < 26_000, "analyst prompt budget: {}", prompt.len());
     }
 
     #[test]

--- a/crates/orchestrator/src/system_agents.rs
+++ b/crates/orchestrator/src/system_agents.rs
@@ -19,11 +19,20 @@
 //! Rust string literals so that they are version-controlled with the code and
 //! require no files on disk.
 
-use crate::types::{AgentConfig, ToolPolicy};
+use crate::types::{AgentConfig, McpServerConfig, ToolPolicy};
 use std::collections::HashMap;
 
 /// Name of the primary built-in system agent.
 pub const SYSTEM_AGENT_NAME: &str = "agentd-system";
+
+/// Name of the built-in diagnostician agent.
+pub const DIAGNOSTICIAN_AGENT_NAME: &str = "agentd-diagnostician";
+
+/// Env var that, when set to `1`/`true`, adds remediation tools to the
+/// diagnostician's allowlist (restart_failed_agents, retry_failed_dispatches,
+/// cleanup_stale_dispatches, resolve_notification_backlog). Default off.
+/// Flipping it is a config drift, so the policy refreshes on next bootstrap.
+pub const DIAGNOSTICIAN_REMEDIATION_ENV: &str = "AGENTD_DIAGNOSTICIAN_REMEDIATION";
 
 /// How a built-in agent's `working_dir` is derived at bootstrap time.
 #[derive(Debug, Clone, Copy)]
@@ -60,6 +69,8 @@ pub struct SystemAgentDef {
     pub prompt: fn() -> String,
     /// Builds the agent's tool policy.
     pub tool_policy: fn() -> ToolPolicy,
+    /// Builds the MCP server map for the agent's Claude session.
+    pub mcp_servers: fn() -> Option<HashMap<String, McpServerConfig>>,
 }
 
 impl SystemAgentDef {
@@ -91,7 +102,7 @@ impl SystemAgentDef {
             resource_limits: None,
             additional_dirs: vec![],
             rooms: self.rooms.iter().map(|r| r.to_string()).collect(),
-            mcp_servers: None,
+            mcp_servers: (self.mcp_servers)(),
         }
     }
 }
@@ -102,7 +113,7 @@ impl SystemAgentDef {
 /// are refreshed, and stored built-ins whose name is no longer listed here
 /// are removed as orphans.
 pub fn builtin_agent_defs() -> Vec<SystemAgentDef> {
-    vec![system_agent_def()]
+    vec![system_agent_def(), diagnostician_def()]
 }
 
 /// Definition of the `agentd-system` domain-expert agent.
@@ -128,6 +139,7 @@ fn system_agent_def() -> SystemAgentDef {
         lazy: false,
         prompt: system_agent_prompt,
         tool_policy: system_agent_tool_policy,
+        mcp_servers: || None,
     }
 }
 
@@ -185,6 +197,152 @@ fn render_service_table(services: &agentd_common::config::ServicesConfig) -> Str
     table.push_str("| mcp           | —     | MCP server (stdio transport, no port)    |\n");
     table
 }
+
+// ---------------------------------------------------------------------------
+// agentd-diagnostician
+// ---------------------------------------------------------------------------
+
+/// Definition of the `agentd-diagnostician` agent.
+///
+/// A lazy built-in that diagnoses the agentd platform exclusively through the
+/// agentd MCP server (`agent mcp`). MCP-only tooling keeps its capability
+/// story trivially auditable: the allowlist is a handful of read-only verb
+/// prefixes, with remediation tools gated behind
+/// [`DIAGNOSTICIAN_REMEDIATION_ENV`].
+fn diagnostician_def() -> SystemAgentDef {
+    SystemAgentDef {
+        name: DIAGNOSTICIAN_AGENT_NAME,
+        model: "sonnet",
+        rooms: &["system"],
+        working_dir: WorkingDirStrategy::CurrentDir,
+        lazy: true,
+        prompt: diagnostician_prompt,
+        tool_policy: diagnostician_tool_policy,
+        mcp_servers: diagnostician_mcp_servers,
+    }
+}
+
+/// MCP server map for the diagnostician: the agentd MCP server over stdio.
+///
+/// Service URLs are pinned via `AGENTD_*_URL` env vars derived from this
+/// deployment's loaded configuration (the exact vars `agentd-mcp` reads), so
+/// the MCP server talks to the right ports regardless of the tmux shell
+/// environment. Localhost URLs only — no secrets, drift-stable.
+fn diagnostician_mcp_servers() -> Option<HashMap<String, McpServerConfig>> {
+    let services = agentd_common::config::load().map(|c| c.services).unwrap_or_default();
+    let env: HashMap<String, String> = [
+        ("AGENTD_ORCHESTRATOR_URL", services.orchestrator.port),
+        ("AGENTD_COMMUNICATE_URL", services.communicate.port),
+        ("AGENTD_MEMORY_URL", services.memory.port),
+        ("AGENTD_NOTIFY_URL", services.notify.port),
+        ("AGENTD_ASK_URL", services.ask.port),
+        ("AGENTD_WRAP_URL", services.wrap.port),
+        ("AGENTD_MONITOR_URL", services.monitor.port),
+        ("AGENTD_HOOK_URL", services.hook.port),
+    ]
+    .into_iter()
+    .map(|(var, port)| (var.to_string(), format!("http://localhost:{port}")))
+    .collect();
+
+    Some(HashMap::from([(
+        "agentd".to_string(),
+        McpServerConfig { command: agentd_mcp_command(), args: vec!["mcp".to_string()], env },
+    )]))
+}
+
+/// Resolve the command used to launch the agentd MCP server.
+///
+/// Prefers the `agent` binary sitting next to the running orchestrator
+/// executable (installed layouts, where launchd/systemd may provide a minimal
+/// PATH), falling back to PATH resolution (`cargo run` development). The
+/// value participates in drift detection, which is correct: a moved binary is
+/// a real config change, and it is stable within one install.
+fn agentd_mcp_command() -> String {
+    std::env::current_exe()
+        .ok()
+        .and_then(|exe| exe.parent().map(|dir| dir.join("agent")))
+        .filter(|sibling| sibling.is_file())
+        .map(|sibling| sibling.to_string_lossy().into_owned())
+        .unwrap_or_else(|| "agent".to_string())
+}
+
+/// Tool policy for the diagnostician: read-only agentd MCP tool families.
+///
+/// The verb-prefix globs (`diagnose_`, `check_`, `get_`, `list_`, `search_`,
+/// `inspect_`) cover every read-only tool the agentd MCP server exposes and
+/// stay correct as new read tools are added, while excluding all mutating
+/// verbs (`restart_`, `terminate_`, `update_`, `send_`, `create_`,
+/// `approve_`, `deny_`, `dismiss_`, `retry_`, `cleanup_`, `resolve_`,
+/// `auto_`). No `Bash`/`Read`/`Write` — agentd-system covers filesystem and
+/// CLI inspection; the diagnostician is MCP-only.
+///
+/// With [`DIAGNOSTICIAN_REMEDIATION_ENV`] set, four specific remediation
+/// tools are appended. `auto_approve_safe_tools` is never included — it
+/// weakens *other* agents' approval posture.
+fn diagnostician_tool_policy() -> ToolPolicy {
+    let mut tools = vec![
+        "mcp__agentd__diagnose_*".to_string(),
+        "mcp__agentd__check_*".to_string(),
+        "mcp__agentd__get_*".to_string(),
+        "mcp__agentd__list_*".to_string(),
+        "mcp__agentd__search_*".to_string(),
+        "mcp__agentd__inspect_*".to_string(),
+    ];
+
+    let remediation_enabled = std::env::var(DIAGNOSTICIAN_REMEDIATION_ENV)
+        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
+        .unwrap_or(false);
+    if remediation_enabled {
+        tools.extend([
+            "mcp__agentd__restart_failed_agents".to_string(),
+            "mcp__agentd__retry_failed_dispatches".to_string(),
+            "mcp__agentd__cleanup_stale_dispatches".to_string(),
+            "mcp__agentd__resolve_notification_backlog".to_string(),
+        ]);
+    }
+
+    ToolPolicy::AllowList { tools, sandbox_bypass: vec![] }
+}
+
+/// System prompt for the diagnostician. Short by design (~700 tokens): the
+/// MCP tool descriptions carry the operational details.
+fn diagnostician_prompt() -> String {
+    let version = env!("CARGO_PKG_VERSION");
+    format!("agentd version: {version}\n\n{DIAGNOSTICIAN_PROMPT}")
+}
+
+const DIAGNOSTICIAN_PROMPT: &str = "\
+You are the agentd diagnostician — a built-in agent that investigates the
+health of the agentd platform using the `agentd` MCP server's tools.
+
+WORKFLOW
+
+1. Start wide: `diagnose_system` or `check_service_health` for an overview.
+2. Drill down with `diagnose_agent`, `diagnose_workflow`,
+   `diagnose_state_mismatches`, `inspect_queue`, `get_failed_dispatches`,
+   `get_prometheus_metrics`, and `get_system_metrics`.
+3. Report findings as a structured summary:
+   - Symptom — what is observably wrong
+   - Evidence — the tool outputs that demonstrate it
+   - Root cause — your best-supported explanation
+   - Remediation — the EXACT command or tool call that would fix it
+
+WHAT YOU CAN AND CANNOT DO
+
+Your tool policy allows only read-only agentd MCP tools (diagnose_*, check_*,
+get_*, list_*, search_*, inspect_*). By default you cannot restart agents,
+retry dispatches, approve tools, or modify anything — recommend the exact
+remediation for a human (or an authorized agent) to run instead.
+
+If remediation tools appear in your toolbox (restart_failed_agents,
+retry_failed_dispatches, cleanup_stale_dispatches,
+resolve_notification_backlog), the operator has explicitly enabled them; use
+them only when your diagnosis clearly supports the action, and report what
+you did.
+
+You have no filesystem or shell access. For source-level questions, defer to
+the agentd-system agent in the `system` room.
+";
 
 /// Carry runtime-derived fields from a stored config over to a freshly built
 /// one, producing the config a drifted agent should be updated to.
@@ -489,9 +647,94 @@ mod tests {
         let defs = builtin_agent_defs();
         let mut names: Vec<&str> = defs.iter().map(|d| d.name).collect();
         assert!(names.contains(&SYSTEM_AGENT_NAME));
+        assert!(names.contains(&DIAGNOSTICIAN_AGENT_NAME));
         names.sort_unstable();
         names.dedup();
         assert_eq!(names.len(), defs.len(), "registry names must be unique");
+    }
+
+    #[test]
+    fn diagnostician_is_lazy_with_agentd_mcp_server() {
+        let def = diagnostician_def();
+        assert!(def.lazy, "diagnostician spawns on first message");
+
+        let config = def.build_config();
+        let servers = config.mcp_servers.expect("diagnostician has MCP servers");
+        let agentd = &servers["agentd"];
+        assert!(!agentd.command.is_empty());
+        assert_eq!(agentd.args, vec!["mcp"]);
+        // Service URLs pinned for the MCP server process.
+        assert!(agentd.env["AGENTD_ORCHESTRATOR_URL"].starts_with("http://localhost:"));
+        assert_eq!(agentd.env.len(), 8, "all eight AGENTD_*_URL vars pinned");
+    }
+
+    #[test]
+    fn diagnostician_policy_allows_read_tools_and_denies_mutations() {
+        let policy = diagnostician_tool_policy();
+
+        for allowed in [
+            "mcp__agentd__diagnose_system",
+            "mcp__agentd__diagnose_state_mismatches",
+            "mcp__agentd__check_service_health",
+            "mcp__agentd__get_prometheus_metrics",
+            "mcp__agentd__list_agents",
+            "mcp__agentd__search_memories",
+            "mcp__agentd__inspect_queue",
+        ] {
+            assert!(policy.evaluate(allowed, None), "must allow {allowed}");
+        }
+
+        // Note: the remediation-gated tools are asserted in
+        // `diagnostician_remediation_env_gates_specific_tools`, which owns the
+        // env var — checking them here would race with that test's set_var.
+        for denied in [
+            "mcp__agentd__restart_agent",
+            "mcp__agentd__terminate_agent",
+            "mcp__agentd__update_agent_model",
+            "mcp__agentd__send_room_message",
+            "mcp__agentd__create_notification",
+            "mcp__agentd__approve_tool_request",
+            "mcp__agentd__auto_approve_safe_tools",
+            "Bash",
+            "Read",
+            "Write",
+            "Edit",
+        ] {
+            assert!(!policy.evaluate(denied, None), "must deny {denied}");
+        }
+    }
+
+    #[test]
+    fn diagnostician_remediation_env_gates_specific_tools() {
+        // Env-var tests mutate process state — keep both halves in one test
+        // to avoid races with parallel test threads on the same var.
+        std::env::set_var(DIAGNOSTICIAN_REMEDIATION_ENV, "1");
+        let policy = diagnostician_tool_policy();
+        std::env::remove_var(DIAGNOSTICIAN_REMEDIATION_ENV);
+
+        for allowed in [
+            "mcp__agentd__restart_failed_agents",
+            "mcp__agentd__retry_failed_dispatches",
+            "mcp__agentd__cleanup_stale_dispatches",
+            "mcp__agentd__resolve_notification_backlog",
+        ] {
+            assert!(policy.evaluate(allowed, None), "remediation on: must allow {allowed}");
+        }
+        // Never included, even with remediation on.
+        assert!(!policy.evaluate("mcp__agentd__auto_approve_safe_tools", None));
+        assert!(!policy.evaluate("mcp__agentd__terminate_agent", None));
+
+        // And the default policy (var unset) excludes them again.
+        let default_policy = diagnostician_tool_policy();
+        assert!(!default_policy.evaluate("mcp__agentd__restart_failed_agents", None));
+    }
+
+    #[test]
+    fn diagnostician_prompt_is_focused_and_within_budget() {
+        let prompt = diagnostician_prompt();
+        assert!(prompt.starts_with("agentd version: "));
+        assert!(prompt.contains("diagnose_system"));
+        assert!(prompt.len() < 4_000, "diagnostician prompt should stay small: {}", prompt.len());
     }
 
     #[test]

--- a/crates/orchestrator/src/system_agents.rs
+++ b/crates/orchestrator/src/system_agents.rs
@@ -1,21 +1,23 @@
 //! Built-in system agent definitions.
 //!
 //! This module defines the programmatically-managed system agents that the
-//! orchestrator spawns automatically at startup.  System agents are always
+//! orchestrator manages automatically at startup.  System agents are always
 //! present while the service is running and cannot be deleted via the
 //! user-facing API.
 //!
 //! # Design
 //!
-//! A single omniscient agent named `agentd-system` acts as a domain expert on
-//! the full agentd platform.  It auto-joins a `system` communicate room and
-//! uses a restrictive tool policy that prevents destructive operations while
-//! still allowing read-oriented tooling for diagnostics and information
-//! gathering.
+//! Each built-in agent is described by a [`SystemAgentDef`] in the
+//! [`builtin_agent_defs`] registry.  At startup the orchestrator iterates the
+//! registry: eager agents are spawned immediately, lazy agents get a dormant
+//! database record and are spawned on first message.  When a definition
+//! changes between releases (prompt, policy, model, ...), the stored config is
+//! refreshed and the agent restarted so deployments pick up the new
+//! definition — see [`config_drifted`].
 //!
-//! The system prompt and tool policy constants defined here are embedded
-//! directly as Rust string literals so that they are version-controlled with
-//! the code and require no files on disk.
+//! The system prompts and tool policies defined here are embedded directly as
+//! Rust string literals so that they are version-controlled with the code and
+//! require no files on disk.
 
 use crate::types::{AgentConfig, ToolPolicy};
 use std::collections::HashMap;
@@ -23,24 +25,86 @@ use std::collections::HashMap;
 /// Name of the primary built-in system agent.
 pub const SYSTEM_AGENT_NAME: &str = "agentd-system";
 
-/// Build the [`AgentConfig`] for the agentd system agent.
+/// How a built-in agent's `working_dir` is derived at bootstrap time.
+#[derive(Debug, Clone, Copy)]
+pub enum WorkingDirStrategy {
+    /// The orchestrator process's current working directory.
+    ///
+    /// The value is captured when the agent record is first created and is
+    /// deliberately excluded from drift detection (see [`refreshed_config`]):
+    /// the orchestrator may be launched from a different directory on a later
+    /// boot (launchd vs. manual) and that must not restart-loop the agent.
+    CurrentDir,
+}
+
+/// Declarative definition of one built-in system agent.
 ///
-/// The configuration sets:
-/// - An inline system prompt covering the agentd architecture and services.
-///   Version/build info is interpolated at call time from `CARGO_PKG_VERSION`.
-/// - A restrictive `AllowList` tool policy (read-only tooling only).
-/// - Automatic membership in the `system` communicate room.
-/// - The `sonnet` model alias.
+/// `prompt` and `tool_policy` are function pointers (not values) so that each
+/// bootstrap evaluates them fresh — they may incorporate the crate version,
+/// loaded service configuration, or environment gates, all of which
+/// participate in drift detection.
+pub struct SystemAgentDef {
+    /// Unique agent name; doubles as the registry identity for drift and
+    /// orphan detection.
+    pub name: &'static str,
+    /// Model alias passed to the Claude session.
+    pub model: &'static str,
+    /// Communicate rooms auto-joined on connect.
+    pub rooms: &'static [&'static str],
+    /// How `working_dir` is derived when the record is first created.
+    pub working_dir: WorkingDirStrategy,
+    /// When `true`, bootstrap creates a dormant record only; the session is
+    /// spawned on the first message delivered to the agent.
+    pub lazy: bool,
+    /// Builds the full system prompt.
+    pub prompt: fn() -> String,
+    /// Builds the agent's tool policy.
+    pub tool_policy: fn() -> ToolPolicy,
+}
+
+impl SystemAgentDef {
+    /// Assemble a fresh [`AgentConfig`] from this definition.
+    pub fn build_config(&self) -> AgentConfig {
+        let working_dir = match self.working_dir {
+            WorkingDirStrategy::CurrentDir => std::env::current_dir()
+                .map(|p| p.to_string_lossy().to_string())
+                .unwrap_or_else(|_| "/".to_string()),
+        };
+
+        AgentConfig {
+            working_dir,
+            user: None,
+            shell: "zsh".to_string(),
+            interactive: false,
+            prompt: None,
+            worktree: false,
+            system_prompt: Some((self.prompt)()),
+            system_prompt_file: None,
+            append_system_prompt: false,
+            tool_policy: (self.tool_policy)(),
+            model: Some(self.model.to_string()),
+            env: HashMap::new(),
+            auto_clear_threshold: None,
+            network_policy: None,
+            docker_image: None,
+            extra_mounts: None,
+            resource_limits: None,
+            additional_dirs: vec![],
+            rooms: self.rooms.iter().map(|r| r.to_string()).collect(),
+        }
+    }
+}
+
+/// The registry of all built-in system agents.
 ///
-/// # Prompt authorship
-///
-/// The prompt is authored to cover:
-/// - Service inventory with ports and responsibilities
-/// - Agent lifecycle (create → spawn → connect → message → terminate)
-/// - Common CLI operations (`agent list`, `agent send-message`, etc.)
-/// - Communicate room system (rooms, members, broadcasting)
-/// - Diagnostics (health checks, log locations, debug endpoints)
-/// - Tool policy rationale (why certain operations are blocked)
+/// Bootstrap iterates this list: missing agents are created, drifted configs
+/// are refreshed, and stored built-ins whose name is no longer listed here
+/// are removed as orphans.
+pub fn builtin_agent_defs() -> Vec<SystemAgentDef> {
+    vec![system_agent_def()]
+}
+
+/// Definition of the `agentd-system` domain-expert agent.
 ///
 /// # Tool policy rationale
 ///
@@ -54,34 +118,53 @@ pub const SYSTEM_AGENT_NAME: &str = "agentd-system";
 /// Notably absent: `Write`, `Edit`, `NotebookEdit`, unrestricted `Bash`.
 /// This prevents the system agent from modifying source code, configuration
 /// files, or agent state — it can explain and diagnose but not act.
-pub fn build_system_agent_config() -> AgentConfig {
-    // Include version/build metadata in the prompt so the agent can report it.
-    let version = env!("CARGO_PKG_VERSION");
-    let prompt = format!("agentd version: {version}\n\n{SYSTEM_AGENT_PROMPT}");
-
-    AgentConfig {
-        working_dir: std::env::current_dir()
-            .map(|p| p.to_string_lossy().to_string())
-            .unwrap_or_else(|_| "/".to_string()),
-        user: None,
-        shell: "zsh".to_string(),
-        interactive: false,
-        prompt: None,
-        worktree: false,
-        system_prompt: Some(prompt),
-        system_prompt_file: None,
-        append_system_prompt: false,
-        tool_policy: system_agent_tool_policy(),
-        model: Some("sonnet".to_string()),
-        env: HashMap::new(),
-        auto_clear_threshold: None,
-        network_policy: None,
-        docker_image: None,
-        extra_mounts: None,
-        resource_limits: None,
-        additional_dirs: vec![],
-        rooms: vec!["system".to_string()],
+fn system_agent_def() -> SystemAgentDef {
+    SystemAgentDef {
+        name: SYSTEM_AGENT_NAME,
+        model: "sonnet",
+        rooms: &["system"],
+        working_dir: WorkingDirStrategy::CurrentDir,
+        lazy: false,
+        prompt: system_agent_prompt,
+        tool_policy: system_agent_tool_policy,
     }
+}
+
+/// Full system prompt for `agentd-system`: version line + embedded body.
+fn system_agent_prompt() -> String {
+    // Include version/build metadata in the prompt so the agent can report
+    // it.  The version line also makes every release a config drift, which
+    // is how new prompt text reaches existing deployments.
+    let version = env!("CARGO_PKG_VERSION");
+    format!("agentd version: {version}\n\n{SYSTEM_AGENT_PROMPT}")
+}
+
+/// Carry runtime-derived fields from a stored config over to a freshly built
+/// one, producing the config a drifted agent should be updated to.
+///
+/// Two fields are environment- or runtime-derived rather than definitional
+/// and must never count as drift:
+/// - `working_dir` — captured from the orchestrator cwd at first creation
+///   (see [`WorkingDirStrategy::CurrentDir`]).
+/// - `interactive` — `spawn_agent` persists the *effective* interactive mode,
+///   which PTY-capable backends force to `true`.  Comparing it against the
+///   definition's `false` would restart-loop the agent on every boot.
+pub fn refreshed_config(stored: &AgentConfig, mut fresh: AgentConfig) -> AgentConfig {
+    fresh.working_dir = stored.working_dir.clone();
+    fresh.interactive = stored.interactive;
+    fresh
+}
+
+/// Whether a stored built-in agent config has drifted from its definition.
+///
+/// Compares via `serde_json::Value` so map key order is irrelevant and no
+/// `PartialEq` impls need to ripple through `wrap` types.  Runtime-derived
+/// fields are normalized out by [`refreshed_config`] first.
+pub fn config_drifted(stored: &AgentConfig, fresh: &AgentConfig) -> bool {
+    let normalized = refreshed_config(stored, fresh.clone());
+    let lhs = serde_json::to_value(&normalized).expect("AgentConfig serializes");
+    let rhs = serde_json::to_value(stored).expect("AgentConfig serializes");
+    lhs != rhs
 }
 
 /// Restrictive tool policy for the system agent.
@@ -352,3 +435,89 @@ DENIED (everything else, including):
 When you cannot complete a request due to your tool policy, say so clearly
 and provide the exact command the user should run themselves.
 ";
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn registry_has_unique_names_and_includes_system_agent() {
+        let defs = builtin_agent_defs();
+        let mut names: Vec<&str> = defs.iter().map(|d| d.name).collect();
+        assert!(names.contains(&SYSTEM_AGENT_NAME));
+        names.sort_unstable();
+        names.dedup();
+        assert_eq!(names.len(), defs.len(), "registry names must be unique");
+    }
+
+    #[test]
+    fn system_agent_config_matches_previous_behavior() {
+        let config = system_agent_def().build_config();
+        assert_eq!(config.model.as_deref(), Some("sonnet"));
+        assert_eq!(config.rooms, vec!["system".to_string()]);
+        assert!(!config.interactive);
+        let prompt = config.system_prompt.expect("system prompt set");
+        assert!(prompt.starts_with("agentd version: "));
+        assert!(prompt.contains("agentd system agent"));
+    }
+
+    #[test]
+    fn config_drifted_false_for_identical_configs() {
+        let def = system_agent_def();
+        let stored = def.build_config();
+        let fresh = def.build_config();
+        assert!(!config_drifted(&stored, &fresh));
+    }
+
+    #[test]
+    fn config_drifted_ignores_interactive_flag() {
+        // spawn_agent persists effective_interactive = true on PTY backends;
+        // that must never count as drift or the agent restart-loops at boot.
+        let def = system_agent_def();
+        let mut stored = def.build_config();
+        stored.interactive = true;
+        let fresh = def.build_config();
+        assert!(!config_drifted(&stored, &fresh));
+    }
+
+    #[test]
+    fn config_drifted_ignores_working_dir() {
+        let def = system_agent_def();
+        let mut stored = def.build_config();
+        stored.working_dir = "/somewhere/else".to_string();
+        let fresh = def.build_config();
+        assert!(!config_drifted(&stored, &fresh));
+    }
+
+    #[test]
+    fn config_drifted_detects_prompt_change() {
+        let def = system_agent_def();
+        let mut stored = def.build_config();
+        stored.system_prompt = Some("an old prompt from a previous release".to_string());
+        let fresh = def.build_config();
+        assert!(config_drifted(&stored, &fresh));
+    }
+
+    #[test]
+    fn config_drifted_detects_policy_change() {
+        let def = system_agent_def();
+        let mut stored = def.build_config();
+        stored.tool_policy = ToolPolicy::AllowList { tools: vec![], sandbox_bypass: vec![] };
+        let fresh = def.build_config();
+        assert!(config_drifted(&stored, &fresh));
+    }
+
+    #[test]
+    fn refreshed_config_preserves_runtime_fields_and_takes_the_rest() {
+        let def = system_agent_def();
+        let mut stored = def.build_config();
+        stored.interactive = true;
+        stored.working_dir = "/captured/at/first/boot".to_string();
+        stored.system_prompt = Some("stale prompt".to_string());
+
+        let refreshed = refreshed_config(&stored, def.build_config());
+        assert!(refreshed.interactive, "interactive carried over from stored");
+        assert_eq!(refreshed.working_dir, "/captured/at/first/boot");
+        assert_ne!(refreshed.system_prompt.as_deref(), Some("stale prompt"));
+    }
+}

--- a/crates/orchestrator/src/system_agents.rs
+++ b/crates/orchestrator/src/system_agents.rs
@@ -28,6 +28,9 @@ pub const SYSTEM_AGENT_NAME: &str = "agentd-system";
 /// Name of the built-in diagnostician agent.
 pub const DIAGNOSTICIAN_AGENT_NAME: &str = "agentd-diagnostician";
 
+/// Name of the built-in architect agent (creates agents and workflows).
+pub const ARCHITECT_AGENT_NAME: &str = "agentd-architect";
+
 /// Env var that, when set to `1`/`true`, adds remediation tools to the
 /// diagnostician's allowlist (restart_failed_agents, retry_failed_dispatches,
 /// cleanup_stale_dispatches, resolve_notification_backlog). Default off.
@@ -113,7 +116,7 @@ impl SystemAgentDef {
 /// are refreshed, and stored built-ins whose name is no longer listed here
 /// are removed as orphans.
 pub fn builtin_agent_defs() -> Vec<SystemAgentDef> {
-    vec![system_agent_def(), diagnostician_def()]
+    vec![system_agent_def(), diagnostician_def(), architect_def()]
 }
 
 /// Definition of the `agentd-system` domain-expert agent.
@@ -218,17 +221,18 @@ fn diagnostician_def() -> SystemAgentDef {
         lazy: true,
         prompt: diagnostician_prompt,
         tool_policy: diagnostician_tool_policy,
-        mcp_servers: diagnostician_mcp_servers,
+        mcp_servers: agentd_mcp_servers,
     }
 }
 
-/// MCP server map for the diagnostician: the agentd MCP server over stdio.
+/// MCP server map shared by the MCP-driven built-ins: the agentd MCP server
+/// over stdio.
 ///
 /// Service URLs are pinned via `AGENTD_*_URL` env vars derived from this
 /// deployment's loaded configuration (the exact vars `agentd-mcp` reads), so
 /// the MCP server talks to the right ports regardless of the tmux shell
 /// environment. Localhost URLs only — no secrets, drift-stable.
-fn diagnostician_mcp_servers() -> Option<HashMap<String, McpServerConfig>> {
+fn agentd_mcp_servers() -> Option<HashMap<String, McpServerConfig>> {
     let services = agentd_common::config::load().map(|c| c.services).unwrap_or_default();
     let env: HashMap<String, String> = [
         ("AGENTD_ORCHESTRATOR_URL", services.orchestrator.port),
@@ -342,6 +346,174 @@ you did.
 
 You have no filesystem or shell access. For source-level questions, defer to
 the agentd-system agent in the `system` room.
+";
+
+// ---------------------------------------------------------------------------
+// agentd-architect
+// ---------------------------------------------------------------------------
+
+/// Definition of the `agentd-architect` agent.
+///
+/// A lazy built-in that designs and provisions agents and workflows through
+/// the agentd MCP server's creation tools. It can create and adjust live
+/// resources but deliberately cannot delete workflows, terminate or restart
+/// agents, or write files (repository `.agentd/*.yml` templates are
+/// human-gated).
+fn architect_def() -> SystemAgentDef {
+    SystemAgentDef {
+        name: ARCHITECT_AGENT_NAME,
+        model: "sonnet",
+        rooms: &["system"],
+        working_dir: WorkingDirStrategy::CurrentDir,
+        lazy: true,
+        prompt: architect_prompt,
+        tool_policy: architect_tool_policy,
+        mcp_servers: agentd_mcp_servers,
+    }
+}
+
+/// Tool policy for the architect: creation + inspection, no destruction.
+///
+/// Write tools are enumerated individually (never globbed) so adding a new
+/// mutating MCP tool can't silently expand the architect's capabilities.
+/// Excluded deliberately: `delete_workflow`, `terminate_agent`,
+/// `restart_agent`, all approval tools, `Write`/`Edit`, unrestricted `Bash`.
+fn architect_tool_policy() -> ToolPolicy {
+    ToolPolicy::AllowList {
+        tools: vec![
+            // ── MCP write tools (exact names only) ────────────────────────
+            "mcp__agentd__create_agent".to_string(),
+            "mcp__agentd__create_workflow".to_string(),
+            "mcp__agentd__update_workflow".to_string(),
+            "mcp__agentd__set_workflow_enabled".to_string(),
+            "mcp__agentd__trigger_workflow".to_string(),
+            "mcp__agentd__send_agent_message".to_string(),
+            "mcp__agentd__send_room_message".to_string(),
+            // ── MCP read tools ─────────────────────────────────────────────
+            "mcp__agentd__list_*".to_string(),
+            "mcp__agentd__get_*".to_string(),
+            "mcp__agentd__diagnose_agent".to_string(),
+            "mcp__agentd__diagnose_workflow".to_string(),
+            "mcp__agentd__check_service_health".to_string(),
+            // ── Local read-only tools for studying the codebase ───────────
+            "Read".to_string(),
+            "Grep".to_string(),
+            "Glob".to_string(),
+            "LS".to_string(),
+            "Bash(curl *)".to_string(),
+            "Bash(agent *)".to_string(),
+        ],
+        sandbox_bypass: vec![],
+    }
+}
+
+/// System prompt for the architect.
+fn architect_prompt() -> String {
+    let version = env!("CARGO_PKG_VERSION");
+    format!("agentd version: {version}\n\n{ARCHITECT_PROMPT}")
+}
+
+/// # Token budget
+///
+/// Target: under 6 000 tokens (≈ 24 000 characters). The TriggerConfig
+/// reference must list every variant — a test enforces this stays in sync
+/// with the scheduler enum.
+const ARCHITECT_PROMPT: &str = "\
+You are the agentd architect — a built-in agent that designs and provisions
+agents and workflows on the agentd platform.
+
+─────────────────────────────────────────────────────────────────────────────
+HARD CONSTRAINT: API ONLY, NEVER FILES
+─────────────────────────────────────────────────────────────────────────────
+
+You create live resources EXCLUSIVELY through the agentd MCP tools
+(create_agent, create_workflow, ...). You must NEVER edit repository files —
+in particular `.agentd/*.yml` templates, which are human-gated declarative
+state applied via `agent apply`. If asked to change a template, output the
+YAML for a human to commit instead, and say why you cannot write it yourself.
+
+─────────────────────────────────────────────────────────────────────────────
+WORKFLOW TRIGGER REFERENCE (trigger_config)
+─────────────────────────────────────────────────────────────────────────────
+
+`trigger_config` is a JSON object whose `type` selects the trigger:
+
+  manual                 {\"type\":\"manual\"} — fired explicitly via
+                         trigger_workflow; ideal for smoke tests.
+  cron                   {\"type\":\"cron\",\"expression\":\"0 9 * * MON-FRI\"}
+  delay                  {\"type\":\"delay\",\"run_at\":\"2026-06-12T09:00:00Z\"}
+                         — one-shot at an ISO 8601 time.
+  agent_idle             {\"type\":\"agent_idle\",\"idle_seconds\":600}
+                         — fires after the agent has been idle that long.
+  agent_lifecycle        {\"type\":\"agent_lifecycle\",\"event\":\"session_start\"}
+                         — events: session_start | session_end | context_clear.
+  dispatch_result        {\"type\":\"dispatch_result\",\"source_workflow_id\":
+                         \"<uuid>\",\"status\":\"completed\"} — workflow
+                         chaining; both filters optional.
+  webhook                {\"type\":\"webhook\",\"secret\":\"...\",\"source\":
+                         \"github\"} — inbound webhooks (github | linear | any).
+  queue                  {\"type\":\"queue\",\"queue_name\":\"my-queue\"}
+                         — consumes tasks pushed to a named internal queue.
+  ask_response           {\"type\":\"ask_response\",\"agent_id\":\"...\",
+                         \"category\":\"...\",\"response_pattern\":\".*\"}
+                         — fires when a human answers a question; all optional.
+  composite              {\"type\":\"composite\",\"mode\":\"or\",\"triggers\":
+                         [...]} — combine ≥2 sub-triggers with \"or\"/\"and\"
+                         (AND uses correlation_window_secs, default 60).
+  github_issues          {\"type\":\"github_issues\",\"owner\":\"o\",\"repo\":
+                         \"r\",\"labels\":[\"bug\"],\"state\":\"open\"}
+  github_pull_requests   {\"type\":\"github_pull_requests\",\"owner\":\"o\",
+                         \"repo\":\"r\",\"state\":\"open\"}
+  linear_issues          {\"type\":\"linear_issues\",\"team_key\":\"ENG\",
+                         \"status\":[\"Todo\"]} — needs AGENTD_LINEAR_API_KEY.
+  gitlab_issues          {\"type\":\"gitlab_issues\",\"owner\":\"group\",
+                         \"repo\":\"project\",\"state\":\"opened\"}
+  gitlab_merge_requests  {\"type\":\"gitlab_merge_requests\",\"owner\":\"group\",
+                         \"repo\":\"project\",\"state\":\"opened\"}
+                         — GitLab triggers need AGENTD_GITLAB_TOKEN; GitLab
+                         states use \"opened\", not \"open\".
+
+─────────────────────────────────────────────────────────────────────────────
+PROMPT TEMPLATES
+─────────────────────────────────────────────────────────────────────────────
+
+`prompt_template` supports {{placeholder}} substitution from the trigger's
+task payload. Unknown placeholders are REJECTED at create time (the API error
+tells you which); {{metadata.*}} passes through verbatim when absent.
+
+Always available: {{title}}, {{body}}, {{url}}, {{labels}}, {{assignee}},
+{{source_id}}, {{metadata}}.
+
+Per-trigger highlights: cron adds {{fire_time}}/{{cron_expression}};
+dispatch_result adds {{source_workflow_id}}/{{dispatch_id}}/{{status}};
+github_pull_requests adds {{head_ref}}/{{base_ref}}/{{is_draft}};
+linear_issues adds {{identifier}}/{{state}}/{{team}}/{{priority}};
+gitlab merge requests add {{source_branch}}/{{target_branch}}/{{draft}};
+queue adds {{queue_name}}/{{queue_task_id}}; ask_response adds
+{{question}}/{{answer}}/{{category}}/{{event_type}}.
+
+─────────────────────────────────────────────────────────────────────────────
+DESIGN GUIDANCE
+─────────────────────────────────────────────────────────────────────────────
+
+1. Look before you build: list_agents / list_workflows / get_workflow to copy
+   proven configs and avoid duplicate names.
+2. Give every agent a restrictive tool policy (allow_list with exactly what
+   the job needs). Do the same for workflow tool policies.
+3. Never put secrets in prompts. You cannot set env vars by design — if an
+   agent needs credentials, tell the human to create it via the CLI with
+   --env.
+4. Pick poll intervals deliberately (default 60s; faster polling costs API
+   quota on GitHub/Linear/GitLab triggers).
+5. Smoke-test: create new workflows with a manual trigger first (or disabled,
+   enabled: false), fire once with trigger_workflow, inspect with
+   list_dispatches and diagnose_workflow, then switch the real trigger via
+   update_workflow.
+6. Report what you built in the `system` room: names, IDs, trigger summary,
+   and how to verify.
+
+You cannot delete workflows, terminate or restart agents, or approve tool
+requests. For those, give the human the exact command instead.
 ";
 
 /// Carry runtime-derived fields from a stored config over to a freshly built
@@ -727,6 +899,87 @@ mod tests {
         // And the default policy (var unset) excludes them again.
         let default_policy = diagnostician_tool_policy();
         assert!(!default_policy.evaluate("mcp__agentd__restart_failed_agents", None));
+    }
+
+    #[test]
+    fn architect_is_lazy_with_agentd_mcp_server() {
+        let def = architect_def();
+        assert!(def.lazy);
+        let config = def.build_config();
+        assert!(config.mcp_servers.is_some_and(|s| s.contains_key("agentd")));
+    }
+
+    #[test]
+    fn architect_policy_allows_creation_and_denies_destruction() {
+        let policy = architect_tool_policy();
+
+        for allowed in [
+            "mcp__agentd__create_agent",
+            "mcp__agentd__create_workflow",
+            "mcp__agentd__update_workflow",
+            "mcp__agentd__set_workflow_enabled",
+            "mcp__agentd__trigger_workflow",
+            "mcp__agentd__send_agent_message",
+            "mcp__agentd__list_workflows",
+            "mcp__agentd__get_workflow",
+            "mcp__agentd__diagnose_workflow",
+            "Read",
+            "Grep",
+        ] {
+            assert!(policy.evaluate(allowed, None), "must allow {allowed}");
+        }
+
+        for denied in [
+            "mcp__agentd__delete_workflow",
+            "mcp__agentd__terminate_agent",
+            "mcp__agentd__restart_agent",
+            "mcp__agentd__restart_failed_agents",
+            "mcp__agentd__update_agent_tool_policy",
+            "mcp__agentd__update_agent_model",
+            "mcp__agentd__approve_tool_request",
+            "mcp__agentd__auto_approve_safe_tools",
+            "Write",
+            "Edit",
+            "Bash",
+        ] {
+            assert!(!policy.evaluate(denied, None), "must deny {denied}");
+        }
+
+        // Bash is restricted to specific prefixes.
+        let curl = serde_json::json!({"command": "curl http://localhost:17006/health"});
+        assert!(policy.evaluate("Bash", Some(&curl)));
+        let rm = serde_json::json!({"command": "rm -rf /"});
+        assert!(!policy.evaluate("Bash", Some(&rm)));
+    }
+
+    #[test]
+    fn architect_prompt_covers_every_trigger_variant() {
+        // Keep in sync with the scheduler's TriggerConfig variants. A new
+        // variant must be documented in the architect prompt.
+        const TRIGGER_TYPES: &[&str] = &[
+            "github_issues",
+            "github_pull_requests",
+            "cron",
+            "delay",
+            "agent_lifecycle",
+            "dispatch_result",
+            "webhook",
+            "manual",
+            "agent_idle",
+            "linear_issues",
+            "composite",
+            "queue",
+            "ask_response",
+            "gitlab_issues",
+            "gitlab_merge_requests",
+        ];
+        let prompt = architect_prompt();
+        for t in TRIGGER_TYPES {
+            assert!(prompt.contains(t), "architect prompt must document trigger `{t}`");
+        }
+        // The hard constraint is stated prominently.
+        assert!(prompt.contains(".agentd/*.yml"));
+        assert!(prompt.len() < 26_000, "architect prompt budget: {}", prompt.len());
     }
 
     #[test]

--- a/crates/orchestrator/src/types.rs
+++ b/crates/orchestrator/src/types.rs
@@ -485,6 +485,27 @@ pub struct AgentConfig {
     /// Each entry is a room name — rooms will be created if they don't exist.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub rooms: Vec<String>,
+    /// MCP servers available to the agent's Claude session, keyed by server
+    /// name. When set, the orchestrator writes the map to a per-agent config
+    /// file at spawn time and launches claude with
+    /// `--mcp-config <file> --strict-mcp-config` so the agent gets exactly
+    /// these servers and nothing inherited from user-level configuration.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mcp_servers: Option<HashMap<String, McpServerConfig>>,
+}
+
+/// One stdio MCP server entry, mirroring Claude Code's `mcpServers` format.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+pub struct McpServerConfig {
+    /// Executable to launch (resolved via PATH or an absolute path).
+    pub command: String,
+    /// Arguments passed to the command.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub args: Vec<String>,
+    /// Environment variables set for the server process. Values are redacted
+    /// in API responses like `AgentConfig::env`.
+    #[serde(default, skip_serializing_if = "HashMap::is_empty")]
+    pub env: HashMap<String, String>,
 }
 
 fn default_shell() -> String {
@@ -675,6 +696,10 @@ pub struct CreateAgentRequest {
     /// Rooms the agent should automatically join when it connects.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub rooms: Vec<String>,
+    /// MCP servers for the agent's Claude session (see
+    /// [`AgentConfig::mcp_servers`]).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub mcp_servers: Option<HashMap<String, McpServerConfig>>,
 }
 
 /// Response body for agent endpoints.
@@ -724,6 +749,15 @@ impl From<Agent> for AgentResponse {
         // to avoid leaking secrets (API keys, tokens) via the REST API.
         let mut config = agent.config;
         config.env = config.env.into_keys().map(|k| (k, ENV_REDACTED.to_string())).collect();
+        // MCP server env maps can carry the same class of secrets.
+        if let Some(servers) = config.mcp_servers.as_mut() {
+            for server in servers.values_mut() {
+                server.env = std::mem::take(&mut server.env)
+                    .into_keys()
+                    .map(|k| (k, ENV_REDACTED.to_string()))
+                    .collect();
+            }
+        }
         Self {
             id: agent.id,
             name: agent.name,
@@ -802,10 +836,16 @@ pub struct UpdateAgentRequest {
     pub rooms: Option<Vec<String>>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub worktree: Option<bool>,
+    /// Full replacement of the MCP server map when present. An empty map
+    /// clears all servers. Entry env values that are exactly [`ENV_REDACTED`]
+    /// keep the currently stored value for that key (matching `env`
+    /// round-trip semantics). Omitted = unchanged.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub mcp_servers: Option<HashMap<String, McpServerConfig>>,
     /// Restart the agent process immediately so launch-affecting changes
     /// (working_dir, shell, model, env, system prompt, additional_dirs,
-    /// worktree) take effect. Defaults to `false`: the config is persisted
-    /// and applies on the next restart.
+    /// worktree, mcp_servers) take effect. Defaults to `false`: the config is
+    /// persisted and applies on the next restart.
     #[serde(default)]
     pub restart: bool,
 }
@@ -1250,6 +1290,7 @@ mod tests {
             resource_limits: None,
             additional_dirs: vec![],
             rooms: vec![],
+            mcp_servers: None,
         };
         let json = serde_json::to_string(&config).unwrap();
         assert!(json.contains("\"model\":\"opus\""));
@@ -1280,6 +1321,7 @@ mod tests {
             resource_limits: None,
             additional_dirs: vec![],
             rooms: vec![],
+            mcp_servers: None,
         };
         let json = serde_json::to_string(&config).unwrap();
         assert!(!json.contains("model"));
@@ -1308,6 +1350,7 @@ mod tests {
             resource_limits: None,
             additional_dirs: vec![],
             rooms: vec![],
+            mcp_servers: None,
         };
         let json = serde_json::to_string(&request).unwrap();
         assert!(json.contains("\"model\":\"sonnet\""));
@@ -1342,6 +1385,7 @@ mod tests {
             resource_limits: None,
             additional_dirs: vec![],
             rooms: vec![],
+            mcp_servers: None,
         };
 
         let json = serde_json::to_string(&config).unwrap();
@@ -1374,6 +1418,7 @@ mod tests {
             resource_limits: None,
             additional_dirs: vec![],
             rooms: vec![],
+            mcp_servers: None,
         };
 
         let json = serde_json::to_string(&config).unwrap();
@@ -1418,6 +1463,7 @@ mod tests {
             resource_limits: None,
             additional_dirs: vec![],
             rooms: vec![],
+            mcp_servers: None,
         };
 
         let json = serde_json::to_string(&request).unwrap();
@@ -1453,6 +1499,7 @@ mod tests {
             resource_limits: None,
             additional_dirs: vec![],
             rooms: vec![],
+            mcp_servers: None,
         };
         let agent = Agent::new("test".to_string(), config);
         let response = AgentResponse::from(agent);
@@ -1572,6 +1619,7 @@ mod tests {
             resource_limits: None,
             additional_dirs: vec![],
             rooms: vec![],
+            mcp_servers: None,
         };
         let json = serde_json::to_string(&config).unwrap();
         assert!(!json.contains("docker_image"));
@@ -1608,6 +1656,7 @@ mod tests {
             }),
             additional_dirs: vec![],
             rooms: vec![],
+            mcp_servers: None,
         };
         let json = serde_json::to_string(&config).unwrap();
         assert!(json.contains("custom-image:v1"));
@@ -1654,6 +1703,7 @@ mod tests {
             resource_limits: None,
             additional_dirs: vec!["/opt/configs".to_string(), "/shared/libs".to_string()],
             rooms: vec![],
+            mcp_servers: None,
         };
         let json = serde_json::to_string(&config).unwrap();
         assert!(json.contains("additional_dirs"));
@@ -1686,6 +1736,7 @@ mod tests {
             resource_limits: None,
             additional_dirs: vec![],
             rooms: vec![],
+            mcp_servers: None,
         };
         let json = serde_json::to_string(&config).unwrap();
         // Empty vec should be omitted from JSON output
@@ -2046,6 +2097,7 @@ mod tests {
             resource_limits: None,
             additional_dirs: vec![],
             rooms: vec![],
+            mcp_servers: None,
         };
         let agent = Agent::new("test".to_string(), config);
         let response = AgentResponse::from(agent);

--- a/crates/orchestrator/src/types.rs
+++ b/crates/orchestrator/src/types.rs
@@ -100,6 +100,8 @@ impl std::str::FromStr for AgentStatus {
 /// Example glob syntax:
 /// - `"Bash(git-spice *)"` — any git-spice command
 /// - `"Bash(gh pr *)"` — any `gh pr` subcommand
+/// - `"mcp__agentd__*"` — any tool of the `agentd` MCP server (trailing
+///   name glob; see [`match_tool`] — a bare `"*"` is deliberately inert)
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(tag = "mode", rename_all = "snake_case")]
 pub enum ToolPolicy {
@@ -208,17 +210,33 @@ impl ToolPolicy {
 
 /// Match a tool entry against a tool name and its input.
 ///
-/// Supports three forms:
+/// Supports four forms:
 /// - `"Bash"` — plain name match, ignores input.
+/// - `"mcp__agentd__*"` — trailing-glob name match: any tool whose name
+///   starts with the prefix before the `*`. Primarily for allowlisting MCP
+///   tool families (`mcp__<server>__<tool>`). A bare `"*"` is deliberately
+///   inert — use the `AllowAll` mode for that.
 /// - `"Bash(cargo *)"` — matches only when the tool is `Bash` and its
 ///   `command` input field satisfies the glob-style pattern.
 /// - `"Write(docs/**)"` — matches only when the tool is `Write` (or any
 ///   file tool with a `file_path` input field) and the path satisfies
 ///   the glob-style pattern. Supports `*` (single segment) and `**`
 ///   (any number of segments).
+///
+/// `sandbox_bypass` lists share this matcher, so name globs work there too.
 fn match_tool(pattern: &str, tool_name: &str, input: Option<&serde_json::Value>) -> bool {
     if pattern == tool_name {
         return true;
+    }
+    // Trailing-glob on a plain tool name: "mcp__agentd__*" matches
+    // "mcp__agentd__diagnose_system". Requires a non-empty prefix and no
+    // parentheses so "Bash(cargo *)" handling below is untouched.
+    if !pattern.contains('(') {
+        if let Some(prefix) = pattern.strip_suffix('*') {
+            if !prefix.is_empty() {
+                return tool_name.starts_with(prefix);
+            }
+        }
     }
     if let Some((tool, cmd_pattern)) = parse_tool_pattern(pattern) {
         if tool == tool_name {
@@ -1068,6 +1086,60 @@ mod tests {
         assert!(!policy.evaluate("Write", None));
         assert!(policy.evaluate("Read", None));
         assert!(policy.evaluate("Grep", None));
+    }
+
+    #[test]
+    fn test_match_tool_trailing_name_glob() {
+        assert!(match_tool("mcp__agentd__*", "mcp__agentd__diagnose_system", None));
+        assert!(match_tool("mcp__agentd__*", "mcp__agentd__list_agents", None));
+        assert!(match_tool("mcp__agentd__diagnose_*", "mcp__agentd__diagnose_workflow", None));
+        assert!(!match_tool("mcp__agentd__*", "mcp__other__diagnose_system", None));
+        assert!(!match_tool("mcp__agentd__diagnose_*", "mcp__agentd__restart_agent", None));
+    }
+
+    #[test]
+    fn test_match_tool_bare_star_is_inert() {
+        // AllowAll mode exists for "allow everything"; a bare "*" entry in a
+        // list must not become a backdoor allow-all.
+        assert!(!match_tool("*", "Bash", None));
+        assert!(!match_tool("*", "mcp__agentd__diagnose_system", None));
+    }
+
+    #[test]
+    fn test_match_tool_name_glob_does_not_affect_parenthesized_patterns() {
+        let input = serde_json::json!({"command": "cargo test --workspace"});
+        assert!(match_tool("Bash(cargo *)", "Bash", Some(&input)));
+        assert!(!match_tool("Bash(cargo *)", "Bashful", Some(&input)));
+        // A parenthesized pattern ending in `*)` must still go through
+        // command matching, not name-glob matching.
+        let rm = serde_json::json!({"command": "rm -rf /"});
+        assert!(!match_tool("Bash(cargo *)", "Bash", Some(&rm)));
+    }
+
+    #[test]
+    fn test_tool_policy_name_glob_in_allow_and_deny_lists() {
+        let allow = ToolPolicy::AllowList {
+            tools: vec!["mcp__agentd__diagnose_*".to_string(), "Read".to_string()],
+            sandbox_bypass: vec![],
+        };
+        assert!(allow.evaluate("mcp__agentd__diagnose_system", None));
+        assert!(allow.evaluate("Read", None));
+        assert!(!allow.evaluate("mcp__agentd__restart_agent", None));
+        assert!(!allow.evaluate("Write", None));
+
+        let deny = ToolPolicy::DenyList {
+            tools: vec!["mcp__agentd__restart_*".to_string()],
+            sandbox_bypass: vec![],
+        };
+        assert!(!deny.evaluate("mcp__agentd__restart_failed_agents", None));
+        assert!(deny.evaluate("mcp__agentd__diagnose_system", None));
+    }
+
+    #[test]
+    fn test_sandbox_bypass_name_glob() {
+        let policy = ToolPolicy::AllowAll { sandbox_bypass: vec!["mcp__agentd__*".to_string()] };
+        assert!(policy.matches_sandbox_bypass("mcp__agentd__list_agents", None));
+        assert!(!policy.matches_sandbox_bypass("mcp__other__list", None));
     }
 
     #[test]

--- a/crates/orchestrator/tests/agent_update_http.rs
+++ b/crates/orchestrator/tests/agent_update_http.rs
@@ -78,12 +78,15 @@ async fn build_app() -> (axum::Router, Arc<AgentStorage>, TempDir) {
     let scheduler_storage = SchedulerStorage::new(storage.db().clone());
     let registry = ConnectionRegistry::new();
     let scheduler = Arc::new(Scheduler::new(scheduler_storage, registry.clone()));
-    let manager = Arc::new(AgentManager::new(
-        storage.clone(),
-        Arc::new(NullBackend),
-        registry.clone(),
-        "ws://localhost:7006".to_string(),
-    ));
+    let manager = Arc::new(
+        AgentManager::new(
+            storage.clone(),
+            Arc::new(NullBackend),
+            registry.clone(),
+            "ws://localhost:7006".to_string(),
+        )
+        .with_mcp_config_dir(temp_dir.path().join("mcp")),
+    );
     let communicate = CommunicateClient::new("http://localhost:17010");
 
     let state =
@@ -347,4 +350,215 @@ async fn test_patch_system_prompt_mutual_exclusion_and_clearing() {
     assert_eq!(response.status(), StatusCode::OK);
     let stored = storage.get(&agent.id).await.unwrap().unwrap();
     assert_eq!(stored.config.system_prompt, None, "empty string must clear the prompt");
+}
+
+// ---------------------------------------------------------------------------
+// MCP server config (mcp_servers)
+// ---------------------------------------------------------------------------
+
+/// PATCH with mcp_servers persists the map and reports requires_restart on a
+/// running agent.
+#[tokio::test]
+async fn test_patch_mcp_servers_persists_and_requires_restart() {
+    let (app, storage, _tmp) = build_app().await;
+    let agent = insert_agent(&storage, "mcp-me", AgentStatus::Running, HashMap::new(), false).await;
+
+    let response = patch_agent(
+        app,
+        agent.id,
+        serde_json::json!({
+            "mcp_servers": {
+                "agentd": { "command": "agent", "args": ["mcp"] }
+            }
+        }),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = body_json(response).await;
+    assert_eq!(json["requires_restart"], true, "mcp_servers is launch-affecting");
+
+    let stored = storage.get(&agent.id).await.unwrap().unwrap();
+    let servers = stored.config.mcp_servers.expect("mcp_servers persisted");
+    assert_eq!(servers["agentd"].command, "agent");
+    assert_eq!(servers["agentd"].args, vec!["mcp"]);
+}
+
+/// An empty mcp_servers map clears the config.
+#[tokio::test]
+async fn test_patch_mcp_servers_empty_map_clears() {
+    let (app, storage, _tmp) = build_app().await;
+    let mut config: AgentConfig =
+        serde_json::from_value(serde_json::json!({ "working_dir": "/tmp" })).unwrap();
+    config.mcp_servers = Some(
+        serde_json::from_value(serde_json::json!({ "agentd": { "command": "agent" } })).unwrap(),
+    );
+    let mut agent = Agent::new("mcp-clear".to_string(), config);
+    agent.status = AgentStatus::Stopped;
+    storage.add(&agent).await.unwrap();
+
+    let response = patch_agent(app, agent.id, serde_json::json!({ "mcp_servers": {} })).await;
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let stored = storage.get(&agent.id).await.unwrap().unwrap();
+    assert_eq!(stored.config.mcp_servers, None, "empty map must clear mcp_servers");
+}
+
+/// MCP server env values are redacted in responses and round-trip via "***".
+#[tokio::test]
+async fn test_mcp_servers_env_redaction_round_trip() {
+    let (app, storage, _tmp) = build_app().await;
+    let mut config: AgentConfig =
+        serde_json::from_value(serde_json::json!({ "working_dir": "/tmp" })).unwrap();
+    config.mcp_servers = Some(
+        serde_json::from_value(serde_json::json!({
+            "agentd": { "command": "agent", "env": { "SECRET_TOKEN": "hunter2" } }
+        }))
+        .unwrap(),
+    );
+    let mut agent = Agent::new("mcp-secret".to_string(), config);
+    agent.status = AgentStatus::Stopped;
+    storage.add(&agent).await.unwrap();
+
+    // GET must redact the env value.
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder().uri(format!("/agents/{}", agent.id)).body(Body::empty()).unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    let json = body_json(response).await;
+    assert_eq!(
+        json["config"]["mcp_servers"]["agentd"]["env"]["SECRET_TOKEN"], "***",
+        "MCP env values must be redacted in responses"
+    );
+
+    // PATCH sending the sentinel back keeps the stored secret.
+    let response = patch_agent(
+        app,
+        agent.id,
+        serde_json::json!({
+            "mcp_servers": {
+                "agentd": { "command": "agent", "env": { "SECRET_TOKEN": "***" } }
+            }
+        }),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::OK);
+
+    let stored = storage.get(&agent.id).await.unwrap().unwrap();
+    let servers = stored.config.mcp_servers.unwrap();
+    assert_eq!(
+        servers["agentd"].env["SECRET_TOKEN"], "hunter2",
+        "redaction sentinel must keep the stored value"
+    );
+}
+
+/// The sentinel for a key with no stored value is rejected.
+#[tokio::test]
+async fn test_mcp_servers_redaction_sentinel_without_stored_value_rejected() {
+    let (app, storage, _tmp) = build_app().await;
+    let agent =
+        insert_agent(&storage, "mcp-bad", AgentStatus::Stopped, HashMap::new(), false).await;
+
+    let response = patch_agent(
+        app,
+        agent.id,
+        serde_json::json!({
+            "mcp_servers": {
+                "agentd": { "command": "agent", "env": { "NEW_KEY": "***" } }
+            }
+        }),
+    )
+    .await;
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+}
+
+/// POST /agents with mcp_servers writes the per-agent config file and bakes
+/// --mcp-config / --strict-mcp-config into the launch command; DELETE removes
+/// the file again.
+#[tokio::test]
+async fn test_create_agent_with_mcp_servers_writes_config_file() {
+    let (app, _storage, tmp) = build_app().await;
+
+    let body = serde_json::json!({
+        "name": "mcp-agent",
+        "working_dir": "/tmp",
+        "mcp_servers": {
+            "agentd": { "command": "agent", "args": ["mcp"] }
+        }
+    })
+    .to_string();
+
+    let response = app
+        .clone()
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/agents")
+                .header("Content-Type", "application/json")
+                .body(Body::from(body))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::CREATED);
+    let json = body_json(response).await;
+    let id = json["id"].as_str().unwrap().to_string();
+    let launch_command = json["launch_command"].as_str().unwrap();
+    assert!(launch_command.contains("--mcp-config"), "launch: {launch_command}");
+    assert!(launch_command.contains("--strict-mcp-config"), "launch: {launch_command}");
+
+    let config_path = tmp.path().join("mcp").join(format!("{id}.json"));
+    assert!(config_path.is_file(), "MCP config file must exist at {config_path:?}");
+    let written: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&config_path).unwrap()).unwrap();
+    assert_eq!(written["mcpServers"]["agentd"]["command"], "agent");
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mode = std::fs::metadata(&config_path).unwrap().permissions().mode() & 0o777;
+        assert_eq!(mode, 0o600, "MCP config file must be private (0600)");
+    }
+
+    // DELETE removes the file.
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("DELETE")
+                .uri(format!("/agents/{id}"))
+                .body(Body::empty())
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::OK);
+    assert!(!config_path.exists(), "MCP config file must be removed on terminate");
+}
+
+/// An empty command in an mcp_servers entry is rejected at create time.
+#[tokio::test]
+async fn test_create_agent_with_empty_mcp_command_rejected() {
+    let (app, _storage, _tmp) = build_app().await;
+
+    let body = serde_json::json!({
+        "name": "mcp-bad-create",
+        "working_dir": "/tmp",
+        "mcp_servers": { "agentd": { "command": "  " } }
+    })
+    .to_string();
+
+    let response = app
+        .oneshot(
+            Request::builder()
+                .method("POST")
+                .uri("/agents")
+                .header("Content-Type", "application/json")
+                .body(Body::from(body))
+                .unwrap(),
+        )
+        .await
+        .unwrap();
+    assert_eq!(response.status(), StatusCode::BAD_REQUEST);
 }

--- a/crates/orchestrator/tests/conversation_persistence.rs
+++ b/crates/orchestrator/tests/conversation_persistence.rs
@@ -146,6 +146,7 @@ async fn create_agent(storage: &AgentStorage) -> Uuid {
             resource_limits: None,
             additional_dirs: vec![],
             rooms: vec![],
+            mcp_servers: None,
         },
     );
     storage.add(&agent).await.unwrap();

--- a/crates/orchestrator/tests/conversation_stream_v2.rs
+++ b/crates/orchestrator/tests/conversation_stream_v2.rs
@@ -200,6 +200,7 @@ async fn create_agent(storage: &AgentStorage) -> Uuid {
             resource_limits: None,
             additional_dirs: vec![],
             rooms: vec![],
+            mcp_servers: None,
         },
     );
     storage.add(&agent).await.unwrap();

--- a/crates/orchestrator/tests/system_agent_http.rs
+++ b/crates/orchestrator/tests/system_agent_http.rs
@@ -150,6 +150,7 @@ async fn insert_builtin_agent(storage: &AgentStorage, name: &str) -> Agent {
             resource_limits: None,
             additional_dirs: vec![],
             rooms: vec!["system".to_string()],
+            mcp_servers: None,
         },
     );
     agent.built_in = true;
@@ -182,6 +183,7 @@ async fn insert_user_agent(storage: &AgentStorage, name: &str) -> Agent {
             resource_limits: None,
             additional_dirs: vec![],
             rooms: vec![],
+            mcp_servers: None,
         },
     );
     storage.add(&agent).await.unwrap();

--- a/crates/orchestrator/tests/system_agent_http.rs
+++ b/crates/orchestrator/tests/system_agent_http.rs
@@ -394,7 +394,7 @@ async fn test_bootstrap_creates_system_agent() {
     manager.bootstrap_system_agents().await.unwrap();
 
     let system_agents = storage.list_system_agents().await.unwrap();
-    assert_eq!(system_agents.len(), 3, "one agent per registry definition");
+    assert_eq!(system_agents.len(), 4, "one agent per registry definition");
     assert!(system_agents.iter().all(|a| a.built_in));
 
     let system = system_agents.iter().find(|a| a.name == SYSTEM_AGENT_NAME).unwrap();
@@ -419,7 +419,7 @@ async fn test_bootstrap_is_idempotent() {
     manager.bootstrap_system_agents().await.unwrap();
 
     let system_agents = storage.list_system_agents().await.unwrap();
-    assert_eq!(system_agents.len(), 3, "bootstrap must not create duplicate system agents");
+    assert_eq!(system_agents.len(), 4, "bootstrap must not create duplicate system agents");
     let diagnostician = system_agents.iter().find(|a| a.name == DIAGNOSTICIAN_AGENT_NAME).unwrap();
     assert_eq!(
         diagnostician.status,

--- a/crates/orchestrator/tests/system_agent_http.rs
+++ b/crates/orchestrator/tests/system_agent_http.rs
@@ -26,7 +26,7 @@ use orchestrator::{
     manager::AgentManager,
     scheduler::{storage::SchedulerStorage, Scheduler},
     storage::AgentStorage,
-    system_agents::SYSTEM_AGENT_NAME,
+    system_agents::{DIAGNOSTICIAN_AGENT_NAME, SYSTEM_AGENT_NAME},
     types::{Agent, AgentConfig, ToolPolicy},
     websocket::ConnectionRegistry,
 };
@@ -384,7 +384,9 @@ async fn test_create_agent_ignores_builtin_field() {
 // Tests: bootstrap_system_agents()
 // ---------------------------------------------------------------------------
 
-/// `bootstrap_system_agents()` creates the system agent with `built_in = true`.
+/// `bootstrap_system_agents()` creates every registry agent with
+/// `built_in = true`: the eager system agent running, the lazy diagnostician
+/// as a dormant `Pending` record without a session.
 #[tokio::test]
 async fn test_bootstrap_creates_system_agent() {
     let (_app, storage, manager, _tmp) = build_app().await;
@@ -392,15 +394,23 @@ async fn test_bootstrap_creates_system_agent() {
     manager.bootstrap_system_agents().await.unwrap();
 
     let system_agents = storage.list_system_agents().await.unwrap();
-    assert_eq!(system_agents.len(), 1, "exactly one system agent should exist");
+    assert_eq!(system_agents.len(), 2, "one agent per registry definition");
+    assert!(system_agents.iter().all(|a| a.built_in));
 
-    let agent = &system_agents[0];
-    assert_eq!(agent.name, SYSTEM_AGENT_NAME);
-    assert!(agent.built_in, "system agent must have built_in = true");
+    let system = system_agents.iter().find(|a| a.name == SYSTEM_AGENT_NAME).unwrap();
+    assert_eq!(system.status, orchestrator::types::AgentStatus::Running);
+
+    let diagnostician = system_agents.iter().find(|a| a.name == DIAGNOSTICIAN_AGENT_NAME).unwrap();
+    assert_eq!(
+        diagnostician.status,
+        orchestrator::types::AgentStatus::Pending,
+        "lazy built-ins stay dormant until first message"
+    );
+    assert!(diagnostician.session_id.is_none(), "dormant agents have no session");
 }
 
 /// `bootstrap_system_agents()` is idempotent — calling it twice does not
-/// create a second system agent.
+/// create duplicate agents or wake dormant ones.
 #[tokio::test]
 async fn test_bootstrap_is_idempotent() {
     let (_app, storage, manager, _tmp) = build_app().await;
@@ -409,7 +419,13 @@ async fn test_bootstrap_is_idempotent() {
     manager.bootstrap_system_agents().await.unwrap();
 
     let system_agents = storage.list_system_agents().await.unwrap();
-    assert_eq!(system_agents.len(), 1, "bootstrap must not create duplicate system agents");
+    assert_eq!(system_agents.len(), 2, "bootstrap must not create duplicate system agents");
+    let diagnostician = system_agents.iter().find(|a| a.name == DIAGNOSTICIAN_AGENT_NAME).unwrap();
+    assert_eq!(
+        diagnostician.status,
+        orchestrator::types::AgentStatus::Pending,
+        "repeated bootstrap must not wake lazy agents"
+    );
 }
 
 /// Config drift: a stale stored config is refreshed from the definition.
@@ -420,7 +436,13 @@ async fn test_bootstrap_refreshes_drifted_config() {
     manager.bootstrap_system_agents().await.unwrap();
 
     // Simulate a previous release's stored config.
-    let mut agent = storage.list_system_agents().await.unwrap().pop().unwrap();
+    let mut agent = storage
+        .list_system_agents()
+        .await
+        .unwrap()
+        .into_iter()
+        .find(|a| a.name == SYSTEM_AGENT_NAME)
+        .unwrap();
     agent.config.model = Some("opus".to_string());
     agent.config.system_prompt = Some("stale prompt from v0.0.1".to_string());
     storage.update(&agent).await.unwrap();
@@ -444,7 +466,13 @@ async fn test_bootstrap_ignores_working_dir_drift() {
 
     manager.bootstrap_system_agents().await.unwrap();
 
-    let mut agent = storage.list_system_agents().await.unwrap().pop().unwrap();
+    let mut agent = storage
+        .list_system_agents()
+        .await
+        .unwrap()
+        .into_iter()
+        .find(|a| a.name == SYSTEM_AGENT_NAME)
+        .unwrap();
     agent.config.working_dir = "/from/a/previous/launchd/boot".to_string();
     storage.update(&agent).await.unwrap();
     let before = storage.get(&agent.id).await.unwrap().unwrap();
@@ -574,7 +602,13 @@ async fn test_bootstrap_pty_backend_does_not_restart_loop() {
 
     manager.bootstrap_system_agents().await.unwrap();
 
-    let agent = storage.list_system_agents().await.unwrap().pop().unwrap();
+    let agent = storage
+        .list_system_agents()
+        .await
+        .unwrap()
+        .into_iter()
+        .find(|a| a.name == SYSTEM_AGENT_NAME)
+        .unwrap();
     assert!(agent.config.interactive, "PTY backend persists effective_interactive = true");
     let first_updated_at = agent.updated_at;
 
@@ -584,6 +618,52 @@ async fn test_bootstrap_pty_backend_does_not_restart_loop() {
     assert_eq!(
         agent.updated_at, first_updated_at,
         "second bootstrap must not refresh or restart a PTY-backend system agent"
+    );
+}
+
+/// Waking the bootstrapped diagnostician writes its agentd MCP config file
+/// and bakes --mcp-config/--strict-mcp-config into the launch command.
+#[tokio::test]
+async fn test_diagnostician_wake_writes_mcp_config() {
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("test.db");
+    let mcp_dir = temp_dir.path().join("mcp");
+    let storage = Arc::new(AgentStorage::with_path(&db_path).await.unwrap());
+    let registry = ConnectionRegistry::new();
+    let manager = Arc::new(
+        AgentManager::new(
+            storage.clone(),
+            Arc::new(NullBackend),
+            registry,
+            "ws://localhost:7006".to_string(),
+        )
+        .with_mcp_config_dir(mcp_dir.clone()),
+    );
+
+    manager.bootstrap_system_agents().await.unwrap();
+
+    let dormant = storage
+        .list_system_agents()
+        .await
+        .unwrap()
+        .into_iter()
+        .find(|a| a.name == DIAGNOSTICIAN_AGENT_NAME)
+        .unwrap();
+    assert!(!mcp_dir.join(format!("{}.json", dormant.id)).exists(), "dormant: no file yet");
+
+    let woken = manager.ensure_builtin_running(&dormant.id).await.unwrap();
+    assert_eq!(woken.status, orchestrator::types::AgentStatus::Running);
+
+    let launch = woken.launch_command.expect("launch command recorded");
+    assert!(launch.contains("--mcp-config"), "launch: {launch}");
+    assert!(launch.contains("--strict-mcp-config"), "launch: {launch}");
+
+    let config_path = mcp_dir.join(format!("{}.json", dormant.id));
+    let written: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&config_path).unwrap()).unwrap();
+    assert!(
+        written["mcpServers"]["agentd"]["command"].as_str().is_some_and(|c| !c.is_empty()),
+        "agentd MCP server configured: {written}"
     );
 }
 

--- a/crates/orchestrator/tests/system_agent_http.rs
+++ b/crates/orchestrator/tests/system_agent_http.rs
@@ -394,7 +394,7 @@ async fn test_bootstrap_creates_system_agent() {
     manager.bootstrap_system_agents().await.unwrap();
 
     let system_agents = storage.list_system_agents().await.unwrap();
-    assert_eq!(system_agents.len(), 2, "one agent per registry definition");
+    assert_eq!(system_agents.len(), 3, "one agent per registry definition");
     assert!(system_agents.iter().all(|a| a.built_in));
 
     let system = system_agents.iter().find(|a| a.name == SYSTEM_AGENT_NAME).unwrap();
@@ -419,7 +419,7 @@ async fn test_bootstrap_is_idempotent() {
     manager.bootstrap_system_agents().await.unwrap();
 
     let system_agents = storage.list_system_agents().await.unwrap();
-    assert_eq!(system_agents.len(), 2, "bootstrap must not create duplicate system agents");
+    assert_eq!(system_agents.len(), 3, "bootstrap must not create duplicate system agents");
     let diagnostician = system_agents.iter().find(|a| a.name == DIAGNOSTICIAN_AGENT_NAME).unwrap();
     assert_eq!(
         diagnostician.status,

--- a/crates/orchestrator/tests/system_agent_http.rs
+++ b/crates/orchestrator/tests/system_agent_http.rs
@@ -410,6 +410,181 @@ async fn test_bootstrap_is_idempotent() {
     assert_eq!(system_agents.len(), 1, "bootstrap must not create duplicate system agents");
 }
 
+/// Config drift: a stale stored config is refreshed from the definition.
+#[tokio::test]
+async fn test_bootstrap_refreshes_drifted_config() {
+    let (_app, storage, manager, _tmp) = build_app().await;
+
+    manager.bootstrap_system_agents().await.unwrap();
+
+    // Simulate a previous release's stored config.
+    let mut agent = storage.list_system_agents().await.unwrap().pop().unwrap();
+    agent.config.model = Some("opus".to_string());
+    agent.config.system_prompt = Some("stale prompt from v0.0.1".to_string());
+    storage.update(&agent).await.unwrap();
+
+    manager.bootstrap_system_agents().await.unwrap();
+
+    let refreshed = storage.get(&agent.id).await.unwrap().unwrap();
+    assert_eq!(refreshed.config.model.as_deref(), Some("sonnet"), "model refreshed");
+    assert_ne!(
+        refreshed.config.system_prompt.as_deref(),
+        Some("stale prompt from v0.0.1"),
+        "prompt refreshed"
+    );
+}
+
+/// `working_dir` differences must NOT count as drift (it is captured from the
+/// orchestrator cwd at first boot and legitimately varies between launches).
+#[tokio::test]
+async fn test_bootstrap_ignores_working_dir_drift() {
+    let (_app, storage, manager, _tmp) = build_app().await;
+
+    manager.bootstrap_system_agents().await.unwrap();
+
+    let mut agent = storage.list_system_agents().await.unwrap().pop().unwrap();
+    agent.config.working_dir = "/from/a/previous/launchd/boot".to_string();
+    storage.update(&agent).await.unwrap();
+    let before = storage.get(&agent.id).await.unwrap().unwrap();
+
+    manager.bootstrap_system_agents().await.unwrap();
+
+    let after = storage.get(&agent.id).await.unwrap().unwrap();
+    assert_eq!(after.config.working_dir, "/from/a/previous/launchd/boot");
+    assert_eq!(after.updated_at, before.updated_at, "no refresh/restart should occur");
+}
+
+/// Stored built-ins whose name left the registry are removed as orphans.
+#[tokio::test]
+async fn test_bootstrap_removes_orphaned_builtin() {
+    let (_app, storage, manager, _tmp) = build_app().await;
+
+    insert_builtin_agent(&storage, "agentd-defunct").await;
+    manager.bootstrap_system_agents().await.unwrap();
+
+    let names: Vec<String> =
+        storage.list_system_agents().await.unwrap().into_iter().map(|a| a.name).collect();
+    assert!(!names.contains(&"agentd-defunct".to_string()), "orphan must be removed");
+    assert!(names.contains(&SYSTEM_AGENT_NAME.to_string()), "registry agent must remain");
+}
+
+/// User agents are never touched by orphan cleanup.
+#[tokio::test]
+async fn test_bootstrap_orphan_cleanup_spares_user_agents() {
+    let (_app, storage, manager, _tmp) = build_app().await;
+
+    let user = insert_user_agent(&storage, "my-user-agent").await;
+    manager.bootstrap_system_agents().await.unwrap();
+
+    assert!(
+        storage.get(&user.id).await.unwrap().is_some(),
+        "user agents must survive bootstrap orphan cleanup"
+    );
+}
+
+/// `ensure_builtin_running` wakes a dormant built-in agent.
+#[tokio::test]
+async fn test_ensure_builtin_running_wakes_dormant_agent() {
+    let (_app, storage, manager, _tmp) = build_app().await;
+
+    let dormant = insert_builtin_agent(&storage, "agentd-dormant").await;
+    assert_eq!(dormant.status, orchestrator::types::AgentStatus::Pending);
+
+    let woken = manager.ensure_builtin_running(&dormant.id).await.unwrap();
+    assert_eq!(woken.status, orchestrator::types::AgentStatus::Running);
+    assert!(woken.session_id.is_some(), "waking must create a session");
+    assert!(woken.launch_command.is_some(), "waking must launch claude");
+}
+
+/// `ensure_builtin_running` leaves non-built-in agents untouched.
+#[tokio::test]
+async fn test_ensure_builtin_running_ignores_user_agents() {
+    let (_app, storage, manager, _tmp) = build_app().await;
+
+    let user = insert_user_agent(&storage, "sleepy-user-agent").await;
+    let result = manager.ensure_builtin_running(&user.id).await.unwrap();
+    assert_eq!(result.status, orchestrator::types::AgentStatus::Pending, "must not spawn");
+}
+
+// ---------------------------------------------------------------------------
+// Tests: PTY backend regression (config refresh must not restart-loop)
+// ---------------------------------------------------------------------------
+
+/// NullBackend variant that reports PTY support, mirroring the wrap PTY
+/// backend: `spawn_agent` persists `effective_interactive = true` for these.
+struct PtyNullBackend;
+
+#[async_trait]
+impl ExecutionBackend for PtyNullBackend {
+    async fn create_session(&self, _config: &SessionConfig) -> anyhow::Result<()> {
+        Ok(())
+    }
+    async fn launch_agent(&self, _config: &SessionConfig) -> anyhow::Result<()> {
+        Ok(())
+    }
+    async fn session_exists(&self, _session_name: &str) -> anyhow::Result<bool> {
+        Ok(false)
+    }
+    async fn kill_session(&self, _session_name: &str) -> anyhow::Result<()> {
+        Ok(())
+    }
+    async fn send_command(&self, _session_name: &str, _command: &str) -> anyhow::Result<()> {
+        Ok(())
+    }
+    async fn list_sessions(&self) -> anyhow::Result<Vec<String>> {
+        Ok(vec![])
+    }
+    fn prefix(&self) -> &str {
+        "test-pty"
+    }
+    fn supports_pty_input(&self) -> bool {
+        true
+    }
+    async fn session_health(&self, _session_name: &str) -> anyhow::Result<SessionHealth> {
+        Ok(SessionHealth::Unknown)
+    }
+    async fn session_exit_info(
+        &self,
+        _session_name: &str,
+    ) -> anyhow::Result<Option<SessionExitInfo>> {
+        Ok(None)
+    }
+    async fn session_pid(&self, _session_name: &str) -> anyhow::Result<Option<u32>> {
+        Ok(None)
+    }
+}
+
+/// On PTY backends, `spawn_agent` persists `interactive = true` into the
+/// stored config. A second bootstrap must NOT see that as config drift —
+/// otherwise every boot restarts every system agent forever.
+#[tokio::test]
+async fn test_bootstrap_pty_backend_does_not_restart_loop() {
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("test.db");
+    let storage = Arc::new(AgentStorage::with_path(&db_path).await.unwrap());
+    let registry = ConnectionRegistry::new();
+    let manager = Arc::new(AgentManager::new(
+        storage.clone(),
+        Arc::new(PtyNullBackend),
+        registry,
+        "ws://localhost:7006".to_string(),
+    ));
+
+    manager.bootstrap_system_agents().await.unwrap();
+
+    let agent = storage.list_system_agents().await.unwrap().pop().unwrap();
+    assert!(agent.config.interactive, "PTY backend persists effective_interactive = true");
+    let first_updated_at = agent.updated_at;
+
+    manager.bootstrap_system_agents().await.unwrap();
+
+    let agent = storage.get(&agent.id).await.unwrap().unwrap();
+    assert_eq!(
+        agent.updated_at, first_updated_at,
+        "second bootstrap must not refresh or restart a PTY-backend system agent"
+    );
+}
+
 /// `AgentResponse` for a built-in agent includes `built_in = true`.
 #[tokio::test]
 async fn test_agent_response_includes_builtin_field() {

--- a/docs/planning/system-agents-expansion.md
+++ b/docs/planning/system-agents-expansion.md
@@ -1,0 +1,69 @@
+# System Agents Expansion
+
+Tracking document for the `feature/system-agents` stack: a definitions
+registry for built-in agents, MCP server support for agent sessions, and
+three new built-ins (diagnostician, architect, analyst) backed by a
+Prometheus query layer in the monitor service.
+
+## Motivation
+
+agentd shipped with a single hardcoded built-in (`agentd-system`). Adding
+more built-ins surfaced structural gaps:
+
+- Bootstrap restarted existing built-ins with their **stored** config, so
+  prompt/policy changes in a release never reached deployments.
+- The system prompt's service table had drifted from the real port defaults
+  (notify 17005 vs actual 17004, wrap 17007 vs actual 17005; ask, hook, and
+  monitor missing).
+- `AgentConfig` had no MCP server support, and tool policies could not
+  allowlist MCP tool families (plain-name patterns matched exactly).
+- The monitor service collected host metrics nobody consumed, while the MCP
+  server's Prometheus tooling scraped raw `/metrics` endpoints with no
+  history and no PromQL.
+
+## Stack
+
+PRs merge into `feature/system-agents`, never directly to `main`.
+
+1. **fix(mcp): scrape monitor Prometheus metrics from /prom-metrics** — the
+   monitor serves Prometheus text at `/prom-metrics`; `/metrics` is JSON.
+2. **System-agent registry** — `SystemAgentDef` + `builtin_agent_defs()`;
+   config-drift refresh (normalizing runtime-mutated fields such as
+   `interactive` on PTY backends and the cwd-derived `working_dir`); lazy
+   built-ins (dormant record, spawn on first message); orphan cleanup.
+3. **Generated service table** — the agentd-system prompt's service
+   inventory and example ports render from the loaded `ServicesConfig`.
+4. **Tool-policy name globs** — trailing-`*` matching on plain tool names so
+   policies can allowlist `mcp__agentd__*` families. Bare `*` stays inert.
+5. **`mcp_servers` agent config** — per-agent MCP config files written at
+   spawn/restart, launched with `--mcp-config <file> --strict-mcp-config`;
+   full surface propagation (API, CLI, templates, schema, UI) plus env
+   redaction. Docker backends are warn-and-skip for now.
+6. **agentd-diagnostician** — lazy built-in, MCP-only read policy by verb
+   prefix; remediation tools gated behind
+   `AGENTD_DIAGNOSTICIAN_REMEDIATION=1`.
+7. **MCP creation tools** — `create_agent` (no env — secrets must not
+   transit MCP), `create_workflow`/`update_workflow`/`set_workflow_enabled`/
+   `trigger_workflow`/`delete_workflow`; fixes the internally-tagged
+   ToolPolicy wire shape and two POST-vs-PUT method bugs in existing
+   lifecycle tools.
+8. **agentd-architect** — lazy built-in that provisions agents/workflows via
+   the API only; repository `.agentd/*.yml` templates remain human-gated.
+9. **Monitor query layer** — hand-rolled Prometheus HTTP API client, a
+   14-entry curated PromQL catalog with `$__window` validation, and
+   `GET /queries` / `GET /queries/{name}` / `GET /query` endpoints
+   (404/400/502 error contract).
+10. **`query_metrics` MCP tool** — catalog rendering and instant/range
+    result summaries via the monitor.
+11. **agentd-analyst** — lazy, read-only built-in with catalog baselines and
+    investigation playbooks; escalates via notifications and the `system`
+    room.
+
+## Follow-ups (out of stack scope)
+
+- Docker delivery of MCP config files (mount-based; inline JSON would leak
+  env values into the UI-visible launch command).
+- A cron workflow dispatching a daily routine review to the analyst —
+  ideally created by the architect as dogfood.
+- Migrating monitor's threshold/prometheus_url settings into the shared
+  config schema (tracked as TODO(#1201) comments).

--- a/schemas/agent.yml
+++ b/schemas/agent.yml
@@ -27,6 +27,7 @@ propertyOrder:
   - auto_clear_threshold
   - additional_dirs
   - rooms
+  - mcp_servers
   - network_policy
   - docker_image
   - extra_mounts
@@ -202,6 +203,51 @@ properties:
             - engineering
             - name: operations
               role: observer
+
+  mcp_servers:
+    description: |
+      MCP servers available to the agent's Claude session, keyed by
+      server name. The orchestrator writes the map to a per-agent config
+      file and launches claude with --mcp-config <file>
+      --strict-mcp-config, so the agent gets exactly these servers and
+      nothing inherited from user-level configuration.
+
+      Requires a Claude Code version that supports --mcp-config and
+      --strict-mcp-config. Currently tmux-backed agents only — the
+      config file is not visible inside Docker containers.
+    type: object
+    additionalProperties:
+      type: object
+      properties:
+        command:
+          description: "Executable to launch (PATH-resolved or absolute)."
+          type: string
+          minLength: 1
+        args:
+          description: "Arguments passed to the command."
+          type: array
+          items:
+            type: string
+        env:
+          description: |
+            Environment variables for the server process. Values are
+            redacted in API responses.
+          type: object
+          additionalProperties:
+            type: string
+      required:
+        - command
+      additionalProperties: false
+    examples:
+      -
+        - "agentd MCP server via the agent CLI"
+        - |
+          mcp_servers:
+            agentd:
+              command: agent
+              args: [mcp]
+              env:
+                AGENTD_ORCHESTRATOR_URL: http://localhost:17006
 
 required:
   - name

--- a/ui/src/types/orchestrator.ts
+++ b/ui/src/types/orchestrator.ts
@@ -50,6 +50,16 @@ export interface ResourceLimits {
 	memory_limit_mb?: number;
 }
 
+/**
+ * One stdio MCP server entry, mirroring Claude Code's `mcpServers` format.
+ * `env` values are redacted in API responses like `AgentConfig.env`.
+ */
+export interface McpServerConfig {
+	command: string;
+	args?: string[];
+	env?: Record<string, string>;
+}
+
 /** Full agent configuration */
 export interface AgentConfig {
 	working_dir: string;
@@ -75,6 +85,8 @@ export interface AgentConfig {
 	docker_image?: string;
 	extra_mounts?: VolumeMount[];
 	resource_limits?: ResourceLimits;
+	/** MCP servers for the agent's Claude session, keyed by server name. */
+	mcp_servers?: Record<string, McpServerConfig>;
 }
 
 // ---------------------------------------------------------------------------
@@ -133,6 +145,8 @@ export interface CreateAgentRequest {
 	docker_image?: string;
 	extra_mounts?: VolumeMount[];
 	resource_limits?: ResourceLimits;
+	/** MCP servers for the agent's Claude session, keyed by server name. */
+	mcp_servers?: Record<string, McpServerConfig>;
 }
 
 /**
@@ -167,9 +181,15 @@ export interface UpdateAgentRequest {
 	rooms?: string[];
 	worktree?: boolean;
 	/**
+	 * Full replacement of the MCP server map when present (empty object
+	 * clears). Entry env values equal to `ENV_REDACTED` keep the stored
+	 * value, matching the `env` round-trip semantics.
+	 */
+	mcp_servers?: Record<string, McpServerConfig>;
+	/**
 	 * Restart the agent process immediately so launch-affecting changes
 	 * (working_dir, shell, model, env, system prompt, additional_dirs,
-	 * worktree) take effect. Defaults to false.
+	 * worktree, mcp_servers) take effect. Defaults to false.
 	 */
 	restart?: boolean;
 }


### PR DESCRIPTION
Anchor commit for the feature/system-agents stack: registry + config
refresh for built-in agents, MCP server support in agent sessions,
diagnostician/architect/analyst built-ins, and the monitor service's
Prometheus query layer.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>