### PR TITLE
feat(monitor): Prometheus query client and curated named-query API

### DIFF
--- a/crates/mcp/src/server.rs
+++ b/crates/mcp/src/server.rs
@@ -7,8 +7,8 @@
 use crate::client::AgentdClient;
 use crate::config::AgentdMcpConfig;
 use crate::tools::{
-    agents, approvals, communicate, creation, diagnostic, health, lifecycle, memory, notifications,
-    orchestrator_debug, remediation, workflows,
+    agents, approvals, communicate, creation, diagnostic, health, lifecycle, memory, metrics,
+    notifications, orchestrator_debug, remediation, workflows,
 };
 use rmcp::{
     model::{ServerCapabilities, ServerInfo},
@@ -963,6 +963,33 @@ impl AgentdMcp {
         service: Option<String>,
     ) -> String {
         health::run_get_prometheus_metrics(&self.client, service.as_deref()).await
+    }
+
+    /// Run a curated PromQL query via the monitor service.
+    #[tool(
+        description = "Run a curated PromQL query against the agentd Prometheus stack via the monitor service. Call without a name to list the catalog (dispatch-success-rate, dispatch-throughput, agent-restart-rate, http-error-rate, http-p95-latency, session-cost, approvals-backlog, host-saturation, ...). window is like 15m/1h/24h; range=true returns a six-hour trend summarized per series instead of an instant value. Falls back gracefully when Prometheus is down (use get_prometheus_metrics for direct scraping)."
+    )]
+    async fn query_metrics(
+        &self,
+        #[tool(param)]
+        #[schemars(description = "Catalog query name; omit to list the catalog")]
+        name: Option<String>,
+        #[tool(param)]
+        #[schemars(description = "Time window for rate/increase queries, e.g. 15m, 1h, 24h")]
+        window: Option<String>,
+        #[tool(param)]
+        #[schemars(
+            description = "true for a range query (trend over the last 6h) instead of an instant value"
+        )]
+        range: Option<bool>,
+    ) -> String {
+        metrics::run_query_metrics(
+            &self.client,
+            name.as_deref(),
+            window.as_deref(),
+            range.unwrap_or(false),
+        )
+        .await
     }
 }
 

--- a/crates/mcp/src/tools/metrics.rs
+++ b/crates/mcp/src/tools/metrics.rs
@@ -1,0 +1,252 @@
+//! Curated Prometheus metrics queries via the monitor service.
+//!
+//! The monitor service owns the named PromQL catalog (`GET /queries`) and
+//! executes queries against the agentd Prometheus stack. This tool renders
+//! the results for MCP clients — instant vectors as a table, range matrices
+//! as per-series summaries (never raw sample dumps; token discipline).
+//!
+//! `get_prometheus_metrics` remains the direct-scrape path that works even
+//! when Prometheus itself is down; this tool is the aggregated/historical
+//! path.
+
+use crate::client::AgentdClient;
+use serde_json::Value;
+
+/// Run a named metrics query, or render the catalog when no/unknown name.
+pub async fn run_query_metrics(
+    client: &AgentdClient,
+    name: Option<&str>,
+    window: Option<&str>,
+    range: bool,
+) -> String {
+    let monitor = client.monitor_url();
+
+    let Some(name) = name.filter(|n| !n.trim().is_empty()) else {
+        return render_catalog(client).await;
+    };
+
+    let mut url = format!("{monitor}/queries/{name}");
+    let mut params = vec![];
+    if let Some(window) = window {
+        params.push(format!("window={window}"));
+    }
+    if range {
+        params.push("mode=range".to_string());
+    }
+    if !params.is_empty() {
+        url = format!("{url}?{}", params.join("&"));
+    }
+
+    let response = match client.inner.get(&url).send().await {
+        Ok(r) => r,
+        Err(e) => {
+            return format!(
+                "🔴 Monitor service unreachable: {e}\n\
+                 → Check it with `check_single_service(\"monitor\")`."
+            );
+        }
+    };
+
+    let status = response.status();
+    let body = response.text().await.unwrap_or_default();
+
+    if status.as_u16() == 502 {
+        return format!(
+            "🟡 Prometheus is unreachable (monitor returned 502).\n\
+             Is the observability stack running? On macOS: \
+             `launchctl list | grep com.agentd.prometheus`.\n\
+             → Fallback: `get_prometheus_metrics(<service>)` scrapes services \
+             directly without Prometheus.\n\n\
+             Details: {body}"
+        );
+    }
+    if !status.is_success() {
+        // 404 includes the catalog names; 400 explains the bad parameter.
+        return format!("🔴 Query `{name}` failed (HTTP {}): {body}", status.as_u16());
+    }
+
+    match serde_json::from_str::<Value>(&body) {
+        Ok(result) => render_query_result(name, &result),
+        Err(e) => format!("🔴 Failed to parse monitor response for `{name}`: {e}"),
+    }
+}
+
+/// Render the catalog fetched from `GET {monitor}/queries`.
+async fn render_catalog(client: &AgentdClient) -> String {
+    let url = format!("{}/queries", client.monitor_url());
+    let catalog: Value = match client.get(&url).await {
+        Ok(v) => v,
+        Err(e) => {
+            return format!(
+                "🔴 Could not fetch the query catalog from the monitor service: {e}\n\
+                 → Check it with `check_single_service(\"monitor\")`."
+            );
+        }
+    };
+
+    let Some(entries) = catalog.as_array() else {
+        return "🔴 Unexpected catalog shape from the monitor service.".to_string();
+    };
+
+    let mut out = String::from(
+        "## Metrics Query Catalog\n\n\
+         Call `query_metrics(name, window?, range?)` with one of:\n\n\
+         | Name | Unit | Description |\n|---|---|---|\n",
+    );
+    for entry in entries {
+        out.push_str(&format!(
+            "| `{}` | {} | {} |\n",
+            entry["name"].as_str().unwrap_or("?"),
+            entry["unit"].as_str().unwrap_or("?"),
+            entry["description"].as_str().unwrap_or(""),
+        ));
+    }
+    out.push_str(
+        "\nWindows look like `15m`, `1h`, `24h`. Pass `range: true` for a \
+         six-hour trend (per-series min/avg/max/last) instead of an instant value.",
+    );
+    out
+}
+
+/// Render a monitor QueryResult JSON as markdown.
+fn render_query_result(name: &str, result: &Value) -> String {
+    let promql = result["promql"].as_str().unwrap_or("?");
+    let mode = result["mode"].as_str().unwrap_or("instant");
+    let data = &result["data"];
+
+    let mut out = format!("## Query `{name}` ({mode})\n\n`{promql}`\n\n");
+
+    match data["resultType"].as_str() {
+        Some("vector") => {
+            let samples = data["result"].as_array().cloned().unwrap_or_default();
+            if samples.is_empty() {
+                out.push_str("_No data — the underlying series have no samples (yet)._");
+                return out;
+            }
+            out.push_str("| Labels | Value |\n|---|---|\n");
+            for sample in &samples {
+                let labels = render_labels(&sample["metric"]);
+                let value = sample["value"][1].as_str().unwrap_or("?");
+                out.push_str(&format!("| {labels} | {value} |\n"));
+            }
+        }
+        Some("matrix") => {
+            let series = data["result"].as_array().cloned().unwrap_or_default();
+            if series.is_empty() {
+                out.push_str("_No data in the requested range._");
+                return out;
+            }
+            out.push_str("| Labels | Min | Avg | Max | Last |\n|---|---|---|---|---|\n");
+            for s in &series {
+                let labels = render_labels(&s["metric"]);
+                let values: Vec<f64> = s["values"]
+                    .as_array()
+                    .cloned()
+                    .unwrap_or_default()
+                    .iter()
+                    .filter_map(|pair| pair[1].as_str().and_then(|v| v.parse().ok()))
+                    .collect();
+                if values.is_empty() {
+                    continue;
+                }
+                let min = values.iter().cloned().fold(f64::INFINITY, f64::min);
+                let max = values.iter().cloned().fold(f64::NEG_INFINITY, f64::max);
+                let avg = values.iter().sum::<f64>() / values.len() as f64;
+                let last = values.last().copied().unwrap_or(f64::NAN);
+                out.push_str(&format!(
+                    "| {labels} | {min:.4} | {avg:.4} | {max:.4} | {last:.4} |\n"
+                ));
+            }
+        }
+        Some("scalar") => {
+            let value = data["result"][1].as_str().unwrap_or("?");
+            out.push_str(&format!("**Value:** {value}"));
+        }
+        other => {
+            out.push_str(&format!("_Unrecognized result type: {other:?}_"));
+        }
+    }
+
+    out
+}
+
+/// Render a Prometheus label map compactly, skipping `__name__`.
+fn render_labels(metric: &Value) -> String {
+    let Some(map) = metric.as_object() else { return "—".to_string() };
+    let rendered: Vec<String> = map
+        .iter()
+        .filter(|(k, _)| *k != "__name__")
+        .map(|(k, v)| format!("{k}={}", v.as_str().unwrap_or("?")))
+        .collect();
+    if rendered.is_empty() {
+        "—".to_string()
+    } else {
+        rendered.join(", ")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn vector_result_renders_label_value_table() {
+        let result = json!({
+            "name": "agents-active",
+            "promql": "agents_active",
+            "mode": "instant",
+            "data": {
+                "resultType": "vector",
+                "result": [
+                    {"metric": {"__name__": "agents_active", "service": "orchestrator"},
+                     "value": [1718100000.0, "3"]}
+                ]
+            }
+        });
+        let out = render_query_result("agents-active", &result);
+        assert!(out.contains("| service=orchestrator | 3 |"), "{out}");
+        assert!(!out.contains("__name__"), "name label hidden: {out}");
+    }
+
+    #[test]
+    fn matrix_result_renders_summary_not_samples() {
+        let result = json!({
+            "promql": "x",
+            "mode": "range",
+            "data": {
+                "resultType": "matrix",
+                "result": [
+                    {"metric": {"service": "notify"},
+                     "values": [[1.0, "1"], [2.0, "3"], [3.0, "2"]]}
+                ]
+            }
+        });
+        let out = render_query_result("test", &result);
+        assert!(out.contains("| Min | Avg | Max | Last |"), "{out}");
+        assert!(out.contains("1.0000"), "min: {out}");
+        assert!(out.contains("3.0000"), "max: {out}");
+        assert!(out.contains("2.0000"), "last/avg: {out}");
+        assert!(!out.contains("[[1.0"), "no raw sample dumps: {out}");
+    }
+
+    #[test]
+    fn empty_vector_renders_no_data_note() {
+        let result = json!({
+            "promql": "x", "mode": "instant",
+            "data": { "resultType": "vector", "result": [] }
+        });
+        let out = render_query_result("test", &result);
+        assert!(out.contains("No data"), "{out}");
+    }
+
+    #[test]
+    fn scalar_result_renders_value() {
+        let result = json!({
+            "promql": "scalar(1)", "mode": "instant",
+            "data": { "resultType": "scalar", "result": [1718100000.0, "42"] }
+        });
+        let out = render_query_result("test", &result);
+        assert!(out.contains("**Value:** 42"), "{out}");
+    }
+}

--- a/crates/mcp/src/tools/mod.rs
+++ b/crates/mcp/src/tools/mod.rs
@@ -12,6 +12,7 @@
 //! - `health`             — service health probes, system metrics, prometheus
 //! - `lifecycle`          — restart/terminate agents, send messages, update policy/model
 //! - `memory`             — search and list stored memories
+//! - `metrics`            — curated Prometheus queries via the monitor service
 //! - `notifications`      — list/create/dismiss notifications
 //! - `orchestrator_debug` — state-mismatch detection, queue inspection, conversation summary, projects
 //! - `policy`             — shared ToolPolicy JSON construction
@@ -26,6 +27,7 @@ pub mod diagnostic;
 pub mod health;
 pub mod lifecycle;
 pub mod memory;
+pub mod metrics;
 pub mod notifications;
 pub mod orchestrator_debug;
 pub mod policy;

--- a/crates/monitor/src/api.rs
+++ b/crates/monitor/src/api.rs
@@ -2,30 +2,39 @@
 //!
 //! Provides the following endpoints:
 //!
-//! - `GET /health`   — standard health check
-//! - `GET /metrics`  — latest system metrics snapshot
-//! - `POST /collect` — trigger an immediate metrics collection
-//! - `GET /history`  — full metrics history (ring buffer)
-//! - `GET /status`   — health assessment against configured thresholds
+//! - `GET /health`            — standard health check
+//! - `GET /metrics`           — latest system metrics snapshot
+//! - `POST /collect`          — trigger an immediate metrics collection
+//! - `GET /history`           — full metrics history (ring buffer)
+//! - `GET /status`            — health assessment against configured thresholds
+//! - `GET /queries`           — the curated named-query catalog
+//! - `GET /queries/{name}`    — execute a named query against Prometheus
+//! - `GET /query`             — raw PromQL passthrough (read-only escape hatch)
 
 use crate::{
     error::ApiError,
     metrics_collector,
+    prometheus::{PromClient, PromData, PromError},
+    queries,
     state::AppState,
     types::{CollectResponse, HealthResponse, SystemStatus},
 };
 use axum::{
-    extract::State,
+    extract::{Path, Query, State},
     response::IntoResponse,
     routing::{get, post},
     Json, Router,
 };
+use chrono::{DateTime, Duration, Utc};
+use serde::{Deserialize, Serialize};
+use std::sync::Arc;
 use tracing::info;
 
 /// Shared state passed to every API handler.
 #[derive(Clone)]
 pub struct ApiState {
     pub app_state: AppState,
+    pub prom: Arc<PromClient>,
 }
 
 /// Create the base router (no middleware).
@@ -36,6 +45,9 @@ pub fn create_router(state: ApiState) -> Router {
         .route("/collect", post(collect_metrics))
         .route("/history", get(get_history))
         .route("/status", get(get_status))
+        .route("/queries", get(list_queries))
+        .route("/queries/{name}", get(run_named_query))
+        .route("/query", get(run_raw_query))
         .with_state(state)
 }
 
@@ -86,6 +98,112 @@ async fn get_status(State(state): State<ApiState>) -> Json<SystemStatus> {
     Json(state.app_state.evaluate_status().await)
 }
 
+// ---------------------------------------------------------------------------
+// Prometheus named queries
+// ---------------------------------------------------------------------------
+
+/// Query-string parameters for query execution endpoints.
+#[derive(Debug, Default, Deserialize)]
+struct QueryParams {
+    /// `$__window` substitution (e.g. `15m`, `1h`). Defaults per query.
+    window: Option<String>,
+    /// `instant` (default) or `range`.
+    mode: Option<String>,
+    /// Range mode: how far back from now the range starts (default: 360).
+    range_minutes: Option<u64>,
+    /// Range mode: resolution step in seconds (default: 60).
+    step_secs: Option<u64>,
+    /// Raw passthrough only: the PromQL expression.
+    promql: Option<String>,
+}
+
+/// Response body for query execution endpoints.
+#[derive(Debug, Serialize)]
+struct QueryResult {
+    /// Catalog name, or `"raw"` for the passthrough endpoint.
+    name: String,
+    /// The executed PromQL after window substitution.
+    promql: String,
+    /// `instant` or `range`.
+    mode: String,
+    executed_at: DateTime<Utc>,
+    data: PromData,
+}
+
+fn map_prom_error(e: PromError) -> ApiError {
+    match e {
+        PromError::Query { .. } => ApiError::BadQueryParam(e.to_string()),
+        _ => ApiError::PrometheusUnavailable(e.to_string()),
+    }
+}
+
+/// Execute resolved PromQL in the requested mode.
+async fn execute_query(
+    state: &ApiState,
+    name: &str,
+    promql: String,
+    params: &QueryParams,
+) -> Result<Json<QueryResult>, ApiError> {
+    let mode = params.mode.as_deref().unwrap_or("instant");
+    let data = match mode {
+        "instant" => state.prom.query(&promql).await.map_err(map_prom_error)?,
+        "range" => {
+            let end = Utc::now();
+            let minutes = params.range_minutes.unwrap_or(360).min(7 * 24 * 60);
+            let step = params.step_secs.unwrap_or(60).max(1);
+            let start = end - Duration::minutes(minutes as i64);
+            state.prom.query_range(&promql, start, end, step).await.map_err(map_prom_error)?
+        }
+        other => {
+            return Err(ApiError::BadQueryParam(format!(
+                "invalid mode `{other}` — expected `instant` or `range`"
+            )));
+        }
+    };
+
+    Ok(Json(QueryResult {
+        name: name.to_string(),
+        promql,
+        mode: mode.to_string(),
+        executed_at: Utc::now(),
+        data,
+    }))
+}
+
+/// `GET /queries` — the catalog with descriptions. Always 200; never touches
+/// Prometheus.
+async fn list_queries() -> Json<&'static [queries::NamedQuery]> {
+    Json(queries::QUERY_CATALOG)
+}
+
+/// `GET /queries/{name}?window=1h&mode=instant|range` — run a named query.
+async fn run_named_query(
+    State(state): State<ApiState>,
+    Path(name): Path<String>,
+    Query(params): Query<QueryParams>,
+) -> Result<impl IntoResponse, ApiError> {
+    let query = queries::find(&name).ok_or_else(|| ApiError::UnknownQuery(name.clone()))?;
+    let promql =
+        queries::resolve(query, params.window.as_deref()).map_err(ApiError::BadQueryParam)?;
+    execute_query(&state, &name, promql, &params).await
+}
+
+/// `GET /query?promql=...` — raw PromQL passthrough.
+///
+/// Read-only escape hatch for ad-hoc analysis; Prometheus itself listens on
+/// loopback only. Prefer the named catalog for anything recurring.
+async fn run_raw_query(
+    State(state): State<ApiState>,
+    Query(params): Query<QueryParams>,
+) -> Result<impl IntoResponse, ApiError> {
+    let promql = params
+        .promql
+        .clone()
+        .filter(|p| !p.trim().is_empty())
+        .ok_or_else(|| ApiError::BadQueryParam("missing `promql` parameter".to_string()))?;
+    execute_query(&state, "raw", promql, &params).await
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -96,7 +214,58 @@ mod tests {
     use tower::ServiceExt;
 
     fn make_state() -> ApiState {
-        ApiState { app_state: AppState::new(MonitorConfig::default()) }
+        // Port 1 — connection refused; only the Prometheus-backed endpoints
+        // touch it, and those tests use stub_prometheus() instead.
+        make_state_with_prometheus("http://127.0.0.1:1")
+    }
+
+    fn make_state_with_prometheus(prometheus_url: &str) -> ApiState {
+        ApiState {
+            app_state: AppState::new(MonitorConfig::default()),
+            prom: Arc::new(PromClient::new(prometheus_url.to_string())),
+        }
+    }
+
+    /// Spawn a stub Prometheus answering /api/v1/query and /api/v1/query_range
+    /// with canned vector/matrix envelopes. Returns its base URL.
+    async fn stub_prometheus() -> String {
+        let router = Router::new()
+            .route(
+                "/api/v1/query",
+                get(|| async {
+                    Json(serde_json::json!({
+                        "status": "success",
+                        "data": {
+                            "resultType": "vector",
+                            "result": [
+                                {"metric": {"service": "orchestrator"},
+                                 "value": [1718100000.0, "3"]}
+                            ]
+                        }
+                    }))
+                }),
+            )
+            .route(
+                "/api/v1/query_range",
+                get(|| async {
+                    Json(serde_json::json!({
+                        "status": "success",
+                        "data": {
+                            "resultType": "matrix",
+                            "result": [
+                                {"metric": {"service": "orchestrator"},
+                                 "values": [[1718100000.0, "1"], [1718100060.0, "2"]]}
+                            ]
+                        }
+                    }))
+                }),
+            );
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+        tokio::spawn(async move {
+            axum::serve(listener, router).await.unwrap();
+        });
+        format!("http://{addr}")
     }
 
     #[tokio::test]
@@ -171,5 +340,115 @@ mod tests {
         let body = resp.into_body().collect().await.unwrap().to_bytes();
         let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
         assert_eq!(json["status"], "healthy");
+    }
+
+    // -----------------------------------------------------------------------
+    // Named-query endpoints
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_list_queries_returns_catalog_without_prometheus() {
+        // Prometheus deliberately unreachable — the catalog is static.
+        let router = create_router(make_state());
+        let req = Request::builder().uri("/queries").body(Body::empty()).unwrap();
+        let resp = router.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = resp.into_body().collect().await.unwrap().to_bytes();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        let entries = json.as_array().unwrap();
+        assert_eq!(entries.len(), crate::queries::QUERY_CATALOG.len());
+        assert!(entries.iter().any(|e| e["name"] == "dispatch-success-rate"));
+    }
+
+    #[tokio::test]
+    async fn test_named_query_instant_happy_path() {
+        let prom_url = stub_prometheus().await;
+        let router = create_router(make_state_with_prometheus(&prom_url));
+        let req = Request::builder()
+            .uri("/queries/dispatch-success-rate?window=15m")
+            .body(Body::empty())
+            .unwrap();
+        let resp = router.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = resp.into_body().collect().await.unwrap().to_bytes();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["name"], "dispatch-success-rate");
+        assert_eq!(json["mode"], "instant");
+        assert!(json["promql"].as_str().unwrap().contains("[15m]"));
+        assert_eq!(json["data"]["resultType"], "vector");
+    }
+
+    #[tokio::test]
+    async fn test_named_query_range_mode() {
+        let prom_url = stub_prometheus().await;
+        let router = create_router(make_state_with_prometheus(&prom_url));
+        let req = Request::builder()
+            .uri("/queries/dispatch-throughput?mode=range&range_minutes=60&step_secs=60")
+            .body(Body::empty())
+            .unwrap();
+        let resp = router.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = resp.into_body().collect().await.unwrap().to_bytes();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["mode"], "range");
+        assert_eq!(json["data"]["resultType"], "matrix");
+    }
+
+    #[tokio::test]
+    async fn test_unknown_query_returns_404_with_catalog() {
+        let router = create_router(make_state());
+        let req = Request::builder().uri("/queries/bogus").body(Body::empty()).unwrap();
+        let resp = router.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+        let body = resp.into_body().collect().await.unwrap().to_bytes();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert!(
+            json["error"].as_str().unwrap().contains("dispatch-success-rate"),
+            "404 should list the catalog: {json}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_bad_window_returns_400() {
+        let router = create_router(make_state());
+        let req = Request::builder()
+            .uri("/queries/dispatch-success-rate?window=1h)%20or%20vector(1)")
+            .body(Body::empty())
+            .unwrap();
+        let resp = router.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn test_prometheus_down_returns_502() {
+        // make_state points the client at a refused port.
+        let router = create_router(make_state());
+        let req = Request::builder().uri("/queries/agents-active").body(Body::empty()).unwrap();
+        let resp = router.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_GATEWAY);
+        let body = resp.into_body().collect().await.unwrap().to_bytes();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert!(json["error"].as_str().unwrap().contains("unreachable"), "{json}");
+    }
+
+    #[tokio::test]
+    async fn test_raw_query_requires_promql() {
+        let router = create_router(make_state());
+        let req = Request::builder().uri("/query").body(Body::empty()).unwrap();
+        let resp = router.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn test_raw_query_passthrough() {
+        let prom_url = stub_prometheus().await;
+        let router = create_router(make_state_with_prometheus(&prom_url));
+        let req = Request::builder().uri("/query?promql=up").body(Body::empty()).unwrap();
+        let resp = router.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = resp.into_body().collect().await.unwrap().to_bytes();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["name"], "raw");
+        assert_eq!(json["promql"], "up");
     }
 }

--- a/crates/monitor/src/client.rs
+++ b/crates/monitor/src/client.rs
@@ -104,6 +104,50 @@ impl MonitorClient {
 
         resp.json::<SystemStatus>().await.context("Failed to parse status response")
     }
+
+    /// `GET /queries` — fetch the named-query catalog as raw JSON.
+    pub async fn list_queries(&self) -> Result<serde_json::Value> {
+        let url = format!("{}/queries", self.base_url);
+        let resp = self.http.get(&url).send().await.with_context(|| format!("GET {url}"))?;
+
+        if !resp.status().is_success() {
+            return Err(anyhow!("GET /queries failed: HTTP {}", resp.status()));
+        }
+
+        resp.json().await.context("Failed to parse queries catalog")
+    }
+
+    /// `GET /queries/{name}` — execute a named query.
+    ///
+    /// `window` substitutes `$__window` (e.g. `"15m"`); `range` switches from
+    /// an instant evaluation to a range query over the last six hours.
+    pub async fn run_query(
+        &self,
+        name: &str,
+        window: Option<&str>,
+        range: bool,
+    ) -> Result<serde_json::Value> {
+        let mut url = format!("{}/queries/{name}", self.base_url);
+        let mut params = vec![];
+        if let Some(window) = window {
+            params.push(format!("window={window}"));
+        }
+        if range {
+            params.push("mode=range".to_string());
+        }
+        if !params.is_empty() {
+            url = format!("{url}?{}", params.join("&"));
+        }
+
+        let resp = self.http.get(&url).send().await.with_context(|| format!("GET {url}"))?;
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let body = resp.text().await.unwrap_or_default();
+            return Err(anyhow!("GET /queries/{name} failed: HTTP {} — {}", status, body));
+        }
+
+        resp.json().await.context("Failed to parse query result")
+    }
 }
 
 #[cfg(test)]

--- a/crates/monitor/src/config.rs
+++ b/crates/monitor/src/config.rs
@@ -33,6 +33,9 @@ pub struct MonitorConfig {
     pub disk_alert_threshold: f32,
     /// Maximum number of metric snapshots to retain in memory (default: 120)
     pub history_size: usize,
+    /// Base URL of the Prometheus server backing the named-query API
+    /// (default: http://127.0.0.1:9090, matching infra/prometheus/).
+    pub prometheus_url: String,
 }
 
 impl MonitorConfig {
@@ -77,6 +80,9 @@ impl MonitorConfig {
                 .ok()
                 .and_then(|v| v.parse().ok())
                 .unwrap_or(120),
+            // TODO(#1201): migrate when shared schema adds prometheus_url
+            prometheus_url: env::var("AGENTD_PROMETHEUS_URL")
+                .unwrap_or_else(|_| "http://127.0.0.1:9090".to_string()),
         }
     }
 
@@ -96,6 +102,7 @@ impl Default for MonitorConfig {
             memory_alert_threshold: 90.0,
             disk_alert_threshold: 90.0,
             history_size: 120,
+            prometheus_url: "http://127.0.0.1:9090".to_string(),
         }
     }
 }
@@ -116,6 +123,14 @@ impl ValidateConfig for MonitorConfig {
             if !(0.0..=100.0).contains(&threshold) {
                 bail!("{name} must be between 0.0 and 100.0, got: {threshold}");
             }
+        }
+        if !self.prometheus_url.starts_with("http://")
+            && !self.prometheus_url.starts_with("https://")
+        {
+            bail!(
+                "monitor.prometheus_url must start with http:// or https://, got: {}",
+                self.prometheus_url
+            );
         }
         Ok(())
     }

--- a/crates/monitor/src/error.rs
+++ b/crates/monitor/src/error.rs
@@ -19,6 +19,19 @@ pub enum ApiError {
     #[error("No metrics available — collection has not run yet")]
     NoMetricsAvailable,
 
+    /// Unknown named query — message lists the catalog.
+    #[error("Unknown query `{0}`")]
+    UnknownQuery(String),
+
+    /// Invalid query parameter (window, step, ...).
+    #[error("Invalid query parameter: {0}")]
+    BadQueryParam(String),
+
+    /// Prometheus itself is unreachable or rejected the query — distinct
+    /// from a monitor failure so callers can tell which layer is down.
+    #[error("Prometheus unavailable: {0}")]
+    PrometheusUnavailable(String),
+
     /// Internal service error
     #[error("Internal error: {0}")]
     Internal(String),
@@ -29,6 +42,14 @@ impl IntoResponse for ApiError {
         let (status, message) = match &self {
             ApiError::CollectionFailed(msg) => (StatusCode::SERVICE_UNAVAILABLE, msg.clone()),
             ApiError::NoMetricsAvailable => (StatusCode::SERVICE_UNAVAILABLE, self.to_string()),
+            ApiError::UnknownQuery(_) => {
+                let names: Vec<&str> =
+                    crate::queries::QUERY_CATALOG.iter().map(|q| q.name).collect();
+                let message = format!("{self}. Known queries: {}", names.join(", "));
+                return (StatusCode::NOT_FOUND, Json(json!({ "error": message }))).into_response();
+            }
+            ApiError::BadQueryParam(msg) => (StatusCode::BAD_REQUEST, msg.clone()),
+            ApiError::PrometheusUnavailable(msg) => (StatusCode::BAD_GATEWAY, msg.clone()),
             ApiError::Internal(msg) => (StatusCode::INTERNAL_SERVER_ERROR, msg.clone()),
         };
 

--- a/crates/monitor/src/lib.rs
+++ b/crates/monitor/src/lib.rs
@@ -62,13 +62,26 @@
 //! - `AGENTD_MEMORY_ALERT_THRESHOLD` - Memory usage % to trigger alert (default: 90.0)
 //! - `AGENTD_DISK_ALERT_THRESHOLD` - Disk usage % to trigger alert (default: 90.0)
 //! - `AGENTD_HISTORY_SIZE` - Number of metric snapshots to retain (default: 120)
+//! - `AGENTD_PROMETHEUS_URL` - Prometheus base URL for the named-query API
+//!   (default: http://127.0.0.1:9090)
 //! - `RUST_LOG` - Logging level (default: info)
+//!
+//! ## GET /queries and GET /queries/{name}
+//!
+//! The curated named-query API: `/queries` returns the catalog (name,
+//! description, unit, promql, default_window); `/queries/{name}` executes one
+//! against Prometheus with optional `window`, `mode=instant|range`,
+//! `range_minutes`, and `step_secs` parameters. `GET /query?promql=...` is a
+//! raw read-only passthrough. Prometheus being down yields HTTP 502 with a
+//! structured error body; the catalog endpoint never touches Prometheus.
 
 pub mod api;
 pub mod client;
 pub mod config;
 pub mod error;
 pub mod metrics_collector;
+pub mod prometheus;
+pub mod queries;
 pub mod state;
 pub mod types;
 
@@ -129,8 +142,10 @@ pub async fn run(config: config::MonitorConfig) -> Result<()> {
 
     let prom_handle = init_metrics();
 
+    let prom_client =
+        std::sync::Arc::new(prometheus::PromClient::new(config.prometheus_url.clone()));
     let app_state = state::AppState::new(config);
-    let api_state = api::ApiState { app_state: app_state.clone() };
+    let api_state = api::ApiState { app_state: app_state.clone(), prom: prom_client };
     let prom_router = axum::Router::new()
         .route("/prom-metrics", get(prom_metrics_handler))
         .with_state(prom_handle);

--- a/crates/monitor/src/prometheus.rs
+++ b/crates/monitor/src/prometheus.rs
@@ -1,0 +1,240 @@
+//! Minimal Prometheus HTTP API client.
+//!
+//! Hand-rolled over `reqwest` rather than pulling in a query-client crate:
+//! only two endpoints are needed (`/api/v1/query` and `/api/v1/query_range`),
+//! and the workspace convention is thin typed reqwest wrappers.
+//!
+//! The agentd observability stack runs Prometheus at `127.0.0.1:9090`
+//! (see `infra/prometheus/` and the launchd plist) scraping every service's
+//! metrics endpoint.
+
+use chrono::{DateTime, Utc};
+use serde::{Deserialize, Serialize};
+use std::collections::BTreeMap;
+use std::time::Duration;
+
+/// Errors from the Prometheus HTTP API.
+#[derive(Debug, thiserror::Error)]
+pub enum PromError {
+    /// Prometheus could not be reached at all.
+    #[error("Prometheus unreachable at {url}: {source}")]
+    Unreachable {
+        url: String,
+        #[source]
+        source: reqwest::Error,
+    },
+    /// Prometheus answered with a non-success HTTP status.
+    #[error("Prometheus returned HTTP {status}: {body}")]
+    HttpStatus { status: u16, body: String },
+    /// Prometheus accepted the request but rejected the query.
+    #[error("Prometheus query error ({error_type}): {error}")]
+    Query { error_type: String, error: String },
+    /// The response body did not match the expected envelope.
+    #[error("Failed to parse Prometheus response: {0}")]
+    Parse(String),
+}
+
+/// One instant-vector sample: label set + (timestamp, value) pair.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct VectorSample {
+    /// Label name → value, including `__name__` when present.
+    pub metric: BTreeMap<String, String>,
+    /// `[unix_seconds, "value"]` as returned by Prometheus.
+    pub value: (f64, String),
+}
+
+/// One range-vector series: label set + list of (timestamp, value) pairs.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct MatrixSeries {
+    pub metric: BTreeMap<String, String>,
+    /// `[[unix_seconds, "value"], ...]` as returned by Prometheus.
+    pub values: Vec<(f64, String)>,
+}
+
+/// Query result data, tagged by Prometheus's `resultType`.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "resultType", content = "result", rename_all = "lowercase")]
+pub enum PromData {
+    Vector(Vec<VectorSample>),
+    Matrix(Vec<MatrixSeries>),
+    Scalar((f64, String)),
+}
+
+/// The standard Prometheus HTTP API response envelope.
+#[derive(Debug, Deserialize)]
+struct PromEnvelope {
+    status: String,
+    #[serde(default)]
+    data: Option<PromData>,
+    #[serde(default, rename = "errorType")]
+    error_type: Option<String>,
+    #[serde(default)]
+    error: Option<String>,
+}
+
+/// Typed client for the Prometheus HTTP API.
+#[derive(Debug, Clone)]
+pub struct PromClient {
+    http: reqwest::Client,
+    base_url: String,
+}
+
+impl PromClient {
+    /// Create a client for `base_url` (e.g. `"http://127.0.0.1:9090"`).
+    pub fn new(base_url: String) -> Self {
+        let http = reqwest::Client::builder()
+            .timeout(Duration::from_secs(5))
+            .build()
+            .expect("Failed to build reqwest Client");
+        Self { http, base_url: base_url.trim_end_matches('/').to_string() }
+    }
+
+    /// The configured Prometheus base URL.
+    pub fn base_url(&self) -> &str {
+        &self.base_url
+    }
+
+    /// `GET /api/v1/query` — evaluate an instant query.
+    pub async fn query(&self, promql: &str) -> Result<PromData, PromError> {
+        let url = format!("{}/api/v1/query", self.base_url);
+        self.execute(self.http.get(&url).query(&[("query", promql)]), &url).await
+    }
+
+    /// `GET /api/v1/query_range` — evaluate a range query.
+    pub async fn query_range(
+        &self,
+        promql: &str,
+        start: DateTime<Utc>,
+        end: DateTime<Utc>,
+        step_secs: u64,
+    ) -> Result<PromData, PromError> {
+        let url = format!("{}/api/v1/query_range", self.base_url);
+        let request = self.http.get(&url).query(&[
+            ("query", promql.to_string()),
+            ("start", start.timestamp().to_string()),
+            ("end", end.timestamp().to_string()),
+            ("step", format!("{step_secs}s")),
+        ]);
+        self.execute(request, &url).await
+    }
+
+    async fn execute(
+        &self,
+        request: reqwest::RequestBuilder,
+        url: &str,
+    ) -> Result<PromData, PromError> {
+        let response = request
+            .send()
+            .await
+            .map_err(|source| PromError::Unreachable { url: url.to_string(), source })?;
+
+        let status = response.status();
+        let body = response
+            .text()
+            .await
+            .map_err(|source| PromError::Unreachable { url: url.to_string(), source })?;
+
+        // Prometheus returns query errors with non-2xx statuses AND a JSON
+        // envelope; prefer the envelope's message when it parses.
+        let envelope: Result<PromEnvelope, _> = serde_json::from_str(&body);
+        match envelope {
+            Ok(env) if env.status == "success" => {
+                env.data.ok_or_else(|| PromError::Parse("missing data field".to_string()))
+            }
+            Ok(env) => Err(PromError::Query {
+                error_type: env.error_type.unwrap_or_else(|| "unknown".to_string()),
+                error: env.error.unwrap_or_else(|| "unknown error".to_string()),
+            }),
+            Err(_) if !status.is_success() => {
+                Err(PromError::HttpStatus { status: status.as_u16(), body })
+            }
+            Err(e) => Err(PromError::Parse(e.to_string())),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn vector_envelope_deserializes() {
+        let body = r#"{
+            "status": "success",
+            "data": {
+                "resultType": "vector",
+                "result": [
+                    {"metric": {"__name__": "agents_active", "service": "orchestrator"},
+                     "value": [1718100000.0, "3"]}
+                ]
+            }
+        }"#;
+        let env: PromEnvelope = serde_json::from_str(body).unwrap();
+        assert_eq!(env.status, "success");
+        match env.data.unwrap() {
+            PromData::Vector(samples) => {
+                assert_eq!(samples.len(), 1);
+                assert_eq!(samples[0].metric["service"], "orchestrator");
+                assert_eq!(samples[0].value.1, "3");
+            }
+            other => panic!("expected vector, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn matrix_envelope_deserializes() {
+        let body = r#"{
+            "status": "success",
+            "data": {
+                "resultType": "matrix",
+                "result": [
+                    {"metric": {"service": "notify"},
+                     "values": [[1718100000.0, "1"], [1718100060.0, "2"]]}
+                ]
+            }
+        }"#;
+        let env: PromEnvelope = serde_json::from_str(body).unwrap();
+        match env.data.unwrap() {
+            PromData::Matrix(series) => {
+                assert_eq!(series[0].values.len(), 2);
+                assert_eq!(series[0].values[1].1, "2");
+            }
+            other => panic!("expected matrix, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn scalar_envelope_deserializes() {
+        let body = r#"{
+            "status": "success",
+            "data": { "resultType": "scalar", "result": [1718100000.0, "42"] }
+        }"#;
+        let env: PromEnvelope = serde_json::from_str(body).unwrap();
+        assert!(matches!(env.data.unwrap(), PromData::Scalar((_, v)) if v == "42"));
+    }
+
+    #[test]
+    fn error_envelope_maps_to_query_error() {
+        let body = r#"{
+            "status": "error",
+            "errorType": "bad_data",
+            "error": "parse error: unexpected character"
+        }"#;
+        let env: PromEnvelope = serde_json::from_str(body).unwrap();
+        assert_eq!(env.status, "error");
+        assert_eq!(env.error_type.as_deref(), Some("bad_data"));
+    }
+
+    #[test]
+    fn base_url_trailing_slash_is_trimmed() {
+        let client = PromClient::new("http://127.0.0.1:9090/".to_string());
+        assert_eq!(client.base_url(), "http://127.0.0.1:9090");
+    }
+
+    #[tokio::test]
+    async fn unreachable_prometheus_yields_unreachable_error() {
+        let client = PromClient::new("http://127.0.0.1:1".to_string());
+        let err = client.query("up").await.unwrap_err();
+        assert!(matches!(err, PromError::Unreachable { .. }), "{err}");
+    }
+}

--- a/crates/monitor/src/queries.rs
+++ b/crates/monitor/src/queries.rs
@@ -1,0 +1,237 @@
+//! Curated named PromQL queries over the agentd metric inventory.
+//!
+//! The catalog is the single version-controlled home for PromQL on the
+//! platform: agents and tools reference queries by name instead of embedding
+//! query text in prompts. Each entry may contain the `$__window` token, which
+//! [`resolve`] substitutes with a validated duration.
+//!
+//! Counter-based queries use `increase()`/`rate()` (reset-safe). Metrics
+//! labeled by unbounded values (e.g. `room_id`) are aggregated or excluded.
+
+/// One catalog entry.
+#[derive(Debug, Clone, Copy, serde::Serialize)]
+pub struct NamedQuery {
+    /// Stable identifier used in API paths and tool calls.
+    pub name: &'static str,
+    /// Human-readable description of what the result means.
+    pub description: &'static str,
+    /// PromQL, possibly containing the `$__window` token.
+    pub promql: &'static str,
+    /// Unit of the resulting values.
+    pub unit: &'static str,
+    /// Default `$__window` substitution when the caller omits one.
+    pub default_window: &'static str,
+}
+
+/// The curated query catalog.
+pub const QUERY_CATALOG: &[NamedQuery] = &[
+    NamedQuery {
+        name: "service-up",
+        description: "Scrape success per agentd service; 0 means Prometheus cannot reach it",
+        promql: r#"up{job=~"agentd-.*"}"#,
+        unit: "boolean",
+        default_window: "",
+    },
+    NamedQuery {
+        name: "dispatch-success-rate",
+        description: "Fraction of finished workflow dispatches that completed successfully",
+        promql: r#"sum(increase(workflow_dispatches_total{status="completed"}[$__window])) / clamp_min(sum(increase(workflow_dispatches_total{status=~"completed|failed"}[$__window])), 1)"#,
+        unit: "ratio",
+        default_window: "1h",
+    },
+    NamedQuery {
+        name: "dispatch-throughput",
+        description: "Workflow dispatch counts by status over the window",
+        promql: r#"sum by (status) (increase(workflow_dispatches_total[$__window]))"#,
+        unit: "count",
+        default_window: "1h",
+    },
+    NamedQuery {
+        name: "agent-restart-rate",
+        description:
+            "Agent restarts over the window; sustained nonzero values suggest crash-looping",
+        promql: r#"sum(increase(agents_restarted_total[$__window]))"#,
+        unit: "count",
+        default_window: "1h",
+    },
+    NamedQuery {
+        name: "agents-active",
+        description: "Currently active agents",
+        promql: "agents_active",
+        unit: "count",
+        default_window: "",
+    },
+    NamedQuery {
+        name: "websocket-connections",
+        description:
+            "Live agent SDK WebSocket connections; compare with agents-active for state mismatches",
+        promql: "websocket_connections_active",
+        unit: "count",
+        default_window: "",
+    },
+    NamedQuery {
+        name: "approvals-backlog",
+        description: "Pending tool approvals; sustained growth means agents are blocked on humans",
+        promql: "approvals_pending",
+        unit: "count",
+        default_window: "",
+    },
+    NamedQuery {
+        name: "approvals-resolution",
+        description: "Tool approvals resolved over the window, by decision (approve/deny)",
+        promql: r#"sum by (decision) (increase(approvals_resolved_total[$__window]))"#,
+        unit: "count",
+        default_window: "1h",
+    },
+    NamedQuery {
+        name: "http-error-rate",
+        description: "HTTP 5xx ratio per service over the window",
+        promql: r#"sum by (service) (rate(http_requests_total{status=~"5.."}[$__window])) / clamp_min(sum by (service) (rate(http_requests_total[$__window])), 1e-9)"#,
+        unit: "ratio",
+        default_window: "15m",
+    },
+    NamedQuery {
+        name: "http-p95-latency",
+        description: "p95 HTTP request latency per service over the window (seconds)",
+        promql: r#"histogram_quantile(0.95, sum by (service, le) (rate(http_request_duration_seconds_bucket[$__window])))"#,
+        unit: "seconds",
+        default_window: "15m",
+    },
+    NamedQuery {
+        name: "session-cost",
+        description: "Claude session spend over the window (USD, gauge delta)",
+        promql: r#"delta(usage_session_cost_usd_total[$__window])"#,
+        unit: "usd",
+        default_window: "24h",
+    },
+    NamedQuery {
+        name: "notifications-backlog",
+        description: "Pending notifications awaiting response or dismissal",
+        promql: "notifications_pending",
+        unit: "count",
+        default_window: "",
+    },
+    NamedQuery {
+        name: "message-drops",
+        description: "Agent-bound messages dropped by the message bridge over the window",
+        promql: r#"sum(increase(messages_dropped[$__window]))"#,
+        unit: "count",
+        default_window: "1h",
+    },
+    NamedQuery {
+        name: "host-saturation",
+        description: "Host CPU %, memory %, worst-disk %, and 1m load in one vector",
+        promql: r#"system_cpu_usage_percent or (100 * system_memory_used_bytes / system_memory_total_bytes) or max by (mountpoint) (system_disk_usage_percent) or system_load_average{period="1m"}"#,
+        unit: "mixed",
+        default_window: "",
+    },
+];
+
+/// Look up a catalog entry by name.
+pub fn find(name: &str) -> Option<&'static NamedQuery> {
+    QUERY_CATALOG.iter().find(|q| q.name == name)
+}
+
+/// Validate a window string: digits followed by one of `s m h d w`.
+///
+/// The window is the only caller-controlled text spliced into PromQL, so
+/// this check doubles as the injection guard.
+pub fn valid_window(window: &str) -> bool {
+    let Some(unit) = window.chars().last() else { return false };
+    if !matches!(unit, 's' | 'm' | 'h' | 'd' | 'w') {
+        return false;
+    }
+    let digits = &window[..window.len() - 1];
+    !digits.is_empty() && digits.chars().all(|c| c.is_ascii_digit())
+}
+
+/// Resolve a named query to executable PromQL, substituting `$__window`.
+///
+/// Returns `Err` with a user-facing message when the window is invalid or
+/// supplied for a windowless (instant gauge) query.
+pub fn resolve(query: &NamedQuery, window: Option<&str>) -> Result<String, String> {
+    if !query.promql.contains("$__window") {
+        return Ok(query.promql.to_string());
+    }
+
+    let window = window.unwrap_or(query.default_window);
+    if !valid_window(window) {
+        return Err(format!(
+            "invalid window `{window}` — expected digits plus a unit (s/m/h/d/w), e.g. 15m, 1h, 24h"
+        ));
+    }
+    Ok(query.promql.replace("$__window", window))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn catalog_names_are_unique() {
+        let mut names: Vec<&str> = QUERY_CATALOG.iter().map(|q| q.name).collect();
+        names.sort_unstable();
+        names.dedup();
+        assert_eq!(names.len(), QUERY_CATALOG.len());
+    }
+
+    #[test]
+    fn windowed_queries_declare_a_default_window() {
+        for q in QUERY_CATALOG {
+            let windowed = q.promql.contains("$__window");
+            assert_eq!(
+                windowed,
+                !q.default_window.is_empty(),
+                "query `{}` must declare a default window iff its promql is windowed",
+                q.name
+            );
+        }
+    }
+
+    #[test]
+    fn valid_windows_accepted() {
+        for w in ["30s", "15m", "1h", "24h", "7d", "2w"] {
+            assert!(valid_window(w), "{w} should be valid");
+        }
+    }
+
+    #[test]
+    fn invalid_windows_rejected() {
+        for w in ["", "1", "h", "1x", "1h)", "'; drop", "1h or vector(1)", "-1h", "1.5h"] {
+            assert!(!valid_window(w), "{w} should be rejected");
+        }
+    }
+
+    #[test]
+    fn resolve_substitutes_window() {
+        let q = find("dispatch-success-rate").unwrap();
+        let promql = resolve(q, Some("15m")).unwrap();
+        assert!(promql.contains("[15m]"));
+        assert!(!promql.contains("$__window"));
+    }
+
+    #[test]
+    fn resolve_uses_default_window() {
+        let q = find("session-cost").unwrap();
+        let promql = resolve(q, None).unwrap();
+        assert!(promql.contains("[24h]"));
+    }
+
+    #[test]
+    fn resolve_rejects_injection() {
+        let q = find("http-error-rate").unwrap();
+        assert!(resolve(q, Some("5m]) or vector(1) #")).is_err());
+    }
+
+    #[test]
+    fn windowless_queries_ignore_window() {
+        let q = find("agents-active").unwrap();
+        assert_eq!(resolve(q, Some("nonsense")).unwrap(), "agents_active");
+    }
+
+    #[test]
+    fn find_hit_and_miss() {
+        assert!(find("host-saturation").is_some());
+        assert!(find("does-not-exist").is_none());
+    }
+}

--- a/crates/orchestrator/src/system_agents.rs
+++ b/crates/orchestrator/src/system_agents.rs
@@ -31,6 +31,9 @@ pub const DIAGNOSTICIAN_AGENT_NAME: &str = "agentd-diagnostician";
 /// Name of the built-in architect agent (creates agents and workflows).
 pub const ARCHITECT_AGENT_NAME: &str = "agentd-architect";
 
+/// Name of the built-in analyst agent (metrics and health analysis).
+pub const ANALYST_AGENT_NAME: &str = "agentd-analyst";
+
 /// Env var that, when set to `1`/`true`, adds remediation tools to the
 /// diagnostician's allowlist (restart_failed_agents, retry_failed_dispatches,
 /// cleanup_stale_dispatches, resolve_notification_backlog). Default off.
@@ -116,7 +119,7 @@ impl SystemAgentDef {
 /// are refreshed, and stored built-ins whose name is no longer listed here
 /// are removed as orphans.
 pub fn builtin_agent_defs() -> Vec<SystemAgentDef> {
-    vec![system_agent_def(), diagnostician_def(), architect_def()]
+    vec![system_agent_def(), diagnostician_def(), architect_def(), analyst_def()]
 }
 
 /// Definition of the `agentd-system` domain-expert agent.
@@ -514,6 +517,132 @@ DESIGN GUIDANCE
 
 You cannot delete workflows, terminate or restart agents, or approve tool
 requests. For those, give the human the exact command instead.
+";
+
+// ---------------------------------------------------------------------------
+// agentd-analyst
+// ---------------------------------------------------------------------------
+
+/// Definition of the `agentd-analyst` agent.
+///
+/// A lazy built-in that analyzes platform metrics and health: the curated
+/// Prometheus query catalog (via the monitor service's `query_metrics` MCP
+/// tool) plus the orchestrator's read APIs. Strictly read-only except for
+/// posting findings (notifications and room messages).
+fn analyst_def() -> SystemAgentDef {
+    SystemAgentDef {
+        name: ANALYST_AGENT_NAME,
+        model: "sonnet",
+        rooms: &["system"],
+        working_dir: WorkingDirStrategy::CurrentDir,
+        lazy: true,
+        prompt: analyst_prompt,
+        tool_policy: analyst_tool_policy,
+        mcp_servers: agentd_mcp_servers,
+    }
+}
+
+/// Tool policy for the analyst: read/diagnose tool families plus the two
+/// escalation channels (create_notification, send_room_message). No
+/// lifecycle, creation, approval, or remediation tools.
+fn analyst_tool_policy() -> ToolPolicy {
+    ToolPolicy::AllowList {
+        tools: vec![
+            // ── Metrics and diagnostics (read-only families) ──────────────
+            "mcp__agentd__query_metrics".to_string(),
+            "mcp__agentd__diagnose_*".to_string(),
+            "mcp__agentd__check_*".to_string(),
+            "mcp__agentd__get_*".to_string(),
+            "mcp__agentd__list_*".to_string(),
+            "mcp__agentd__search_*".to_string(),
+            "mcp__agentd__inspect_*".to_string(),
+            // ── Escalation channels (exact names) ─────────────────────────
+            "mcp__agentd__create_notification".to_string(),
+            "mcp__agentd__send_room_message".to_string(),
+            // ── Local read-only tools ──────────────────────────────────────
+            "Read".to_string(),
+            "Grep".to_string(),
+            "Glob".to_string(),
+            "Bash(curl *)".to_string(),
+        ],
+        sandbox_bypass: vec![],
+    }
+}
+
+/// System prompt for the analyst.
+fn analyst_prompt() -> String {
+    let version = env!("CARGO_PKG_VERSION");
+    format!("agentd version: {version}\n\n{ANALYST_PROMPT}")
+}
+
+/// # Coverage note
+///
+/// The query-name list must stay in sync with
+/// `monitor::queries::QUERY_CATALOG` (cross-crate, so the unit test pins a
+/// const string list rather than importing the catalog).
+const ANALYST_PROMPT: &str = "\
+You are the agentd analyst — a built-in agent that analyzes platform metrics
+and health trends, surfaces anomalies, and recommends actions. You are
+read-only: you never modify agents, workflows, or configuration.
+
+─────────────────────────────────────────────────────────────────────────────
+METRICS TOOLKIT
+─────────────────────────────────────────────────────────────────────────────
+
+`query_metrics(name, window?, range?)` runs curated PromQL via the monitor
+service. Call it with no name to list the catalog. Key queries and healthy
+baselines:
+
+  service-up              All targets at 1. Any 0 → check_single_service.
+  dispatch-success-rate   ≥ 0.9 over 24h. Lower → get_failed_dispatches,
+                          then diagnose_workflow on the offenders.
+  dispatch-throughput     Know your normal; a sudden drop to zero on an
+                          enabled workflow means its trigger or agent broke.
+  agent-restart-rate      ~0. Sustained nonzero → crash-looping; diagnose
+                          the restarting agents.
+  agents-active vs websocket-connections
+                          Should match. A gap → diagnose_state_mismatches.
+  approvals-backlog       Near 0. Growth → agents are blocked on humans;
+                          notify the operator.
+  http-error-rate         ~0 per service. Spikes → check that service's
+                          health and recent deploys.
+  http-p95-latency        Know your normal (typically ms). Sustained growth
+                          → host-saturation next.
+  session-cost            Watch the 24h delta; a spike → list_agents and
+                          get_conversation_summary to find the hot agent.
+  notifications-backlog, message-drops, host-saturation
+                          Self-explanatory; drops and saturation are 🔴.
+
+Use `range: true` for trends (per-series min/avg/max/last over 6h) when an
+instant value needs context. If Prometheus is down (502), fall back to
+`get_prometheus_metrics(<service>)` direct scrapes and say so in your report.
+
+─────────────────────────────────────────────────────────────────────────────
+PLAYBOOKS
+─────────────────────────────────────────────────────────────────────────────
+
+Cost spike     → session-cost (24h) → list_agents →
+                 get_conversation_summary on busy agents → report the top
+                 spenders and what they were doing.
+Latency        → http-p95-latency per service → host-saturation →
+                 the slow service's health endpoint via curl.
+Failures       → dispatch-success-rate → get_failed_dispatches →
+                 diagnose_workflow → name the failing workflow and the
+                 pattern (always-fails vs intermittent).
+Routine review → service-up, dispatch-success-rate, agent-restart-rate,
+                 approvals-backlog, session-cost, host-saturation — then
+                 report only what deviates.
+
+─────────────────────────────────────────────────────────────────────────────
+REPORTING
+─────────────────────────────────────────────────────────────────────────────
+
+Post findings to the `system` room (send_room_message). For anything needing
+human action, also create_notification with priority matched to impact:
+data-loss or all-agents-blocked → high; degradation → medium; observations →
+low. Every finding needs: metric evidence, time window, suspected cause, and
+a concrete recommended action (you cannot act — name the command or the agent
+that should).
 ";
 
 /// Carry runtime-derived fields from a stored config over to a freshly built
@@ -980,6 +1109,86 @@ mod tests {
         // The hard constraint is stated prominently.
         assert!(prompt.contains(".agentd/*.yml"));
         assert!(prompt.len() < 26_000, "architect prompt budget: {}", prompt.len());
+    }
+
+    #[test]
+    fn analyst_is_lazy_with_agentd_mcp_server() {
+        let def = analyst_def();
+        assert!(def.lazy);
+        let config = def.build_config();
+        assert!(config.mcp_servers.is_some_and(|s| s.contains_key("agentd")));
+    }
+
+    #[test]
+    fn analyst_policy_is_read_only_plus_escalation() {
+        let policy = analyst_tool_policy();
+
+        for allowed in [
+            "mcp__agentd__query_metrics",
+            "mcp__agentd__get_prometheus_metrics",
+            "mcp__agentd__get_system_metrics",
+            "mcp__agentd__diagnose_system",
+            "mcp__agentd__check_service_health",
+            "mcp__agentd__list_agents",
+            "mcp__agentd__get_failed_dispatches",
+            "mcp__agentd__get_conversation_summary",
+            "mcp__agentd__inspect_queue",
+            "mcp__agentd__create_notification",
+            "mcp__agentd__send_room_message",
+            "Read",
+        ] {
+            assert!(policy.evaluate(allowed, None), "must allow {allowed}");
+        }
+
+        for denied in [
+            "mcp__agentd__create_agent",
+            "mcp__agentd__create_workflow",
+            "mcp__agentd__update_workflow",
+            "mcp__agentd__delete_workflow",
+            "mcp__agentd__terminate_agent",
+            "mcp__agentd__restart_agent",
+            "mcp__agentd__restart_failed_agents",
+            "mcp__agentd__send_agent_message",
+            "mcp__agentd__approve_tool_request",
+            "Write",
+            "Edit",
+            "Bash",
+        ] {
+            assert!(!policy.evaluate(denied, None), "must deny {denied}");
+        }
+    }
+
+    #[test]
+    fn analyst_prompt_covers_the_query_catalog() {
+        // Keep in sync with monitor::queries::QUERY_CATALOG (cross-crate, so
+        // pinned here as a const list). A new catalog entry should be added
+        // to the analyst's baseline guidance.
+        const CATALOG_NAMES: &[&str] = &[
+            "service-up",
+            "dispatch-success-rate",
+            "dispatch-throughput",
+            "agent-restart-rate",
+            "agents-active",
+            "websocket-connections",
+            "approvals-backlog",
+            "approvals-resolution",
+            "http-error-rate",
+            "http-p95-latency",
+            "session-cost",
+            "notifications-backlog",
+            "message-drops",
+            "host-saturation",
+        ];
+        let prompt = analyst_prompt();
+        for name in CATALOG_NAMES {
+            // approvals-resolution is covered by the approvals-backlog
+            // guidance; everything else must appear verbatim.
+            if *name == "approvals-resolution" {
+                continue;
+            }
+            assert!(prompt.contains(name), "analyst prompt must mention `{name}`");
+        }
+        assert!(prompt.len() < 26_000, "analyst prompt budget: {}", prompt.len());
     }
 
     #[test]

--- a/crates/orchestrator/tests/system_agent_http.rs
+++ b/crates/orchestrator/tests/system_agent_http.rs
@@ -394,7 +394,7 @@ async fn test_bootstrap_creates_system_agent() {
     manager.bootstrap_system_agents().await.unwrap();
 
     let system_agents = storage.list_system_agents().await.unwrap();
-    assert_eq!(system_agents.len(), 3, "one agent per registry definition");
+    assert_eq!(system_agents.len(), 4, "one agent per registry definition");
     assert!(system_agents.iter().all(|a| a.built_in));
 
     let system = system_agents.iter().find(|a| a.name == SYSTEM_AGENT_NAME).unwrap();
@@ -419,7 +419,7 @@ async fn test_bootstrap_is_idempotent() {
     manager.bootstrap_system_agents().await.unwrap();
 
     let system_agents = storage.list_system_agents().await.unwrap();
-    assert_eq!(system_agents.len(), 3, "bootstrap must not create duplicate system agents");
+    assert_eq!(system_agents.len(), 4, "bootstrap must not create duplicate system agents");
     let diagnostician = system_agents.iter().find(|a| a.name == DIAGNOSTICIAN_AGENT_NAME).unwrap();
     assert_eq!(
         diagnostician.status,


### PR DESCRIPTION
Give the previously unused monitor service its purpose as the metrics
query/analysis layer for the platform.

- prometheus.rs: minimal hand-rolled client for /api/v1/query and
  /api/v1/query_range (typed PromData vector/matrix/scalar envelope,
  thiserror PromError, 5s timeout). No new dependencies — reqwest was
  already in the tree, and two endpoints don't justify a query-client
  crate.
- queries.rs: a 14-entry curated PromQL catalog over the real agentd
  metric inventory (dispatch success rate/throughput, agent restarts,
  approvals backlog/resolution, websocket connections, per-service HTTP
  error rate and p95 latency, session cost, notification backlog,
  message drops, host saturation, service-up). The $__window token is
  the only caller-controlled text spliced into PromQL and is validated
  as ^[0-9]+[smhdw]$ — the injection guard. Counter queries use
  increase()/rate() (reset-safe); unbounded-cardinality labels
  (room_id) are aggregated or excluded.
- API: GET /queries (static catalog, always 200), GET /queries/{name}
  with window/mode/range_minutes/step_secs, GET /query raw passthrough
  (Prometheus is loopback-only). Errors: 404 unknown name listing the
  catalog, 400 bad params, 502 when Prometheus is down — distinct from
  monitor failures so callers can tell which layer broke.
- Config: prometheus_url via AGENTD_PROMETHEUS_URL (default
  http://127.0.0.1:9090, matching infra/launchd).
- MonitorClient gains list_queries()/run_query().

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>