### PR TITLE
feat(mcp): query_metrics tool backed by the monitor named-query API

### DIFF
--- a/crates/mcp/src/server.rs
+++ b/crates/mcp/src/server.rs
@@ -7,8 +7,8 @@
 use crate::client::AgentdClient;
 use crate::config::AgentdMcpConfig;
 use crate::tools::{
-    agents, approvals, communicate, creation, diagnostic, health, lifecycle, memory, notifications,
-    orchestrator_debug, remediation, workflows,
+    agents, approvals, communicate, creation, diagnostic, health, lifecycle, memory, metrics,
+    notifications, orchestrator_debug, remediation, workflows,
 };
 use rmcp::{
     model::{ServerCapabilities, ServerInfo},
@@ -963,6 +963,33 @@ impl AgentdMcp {
         service: Option<String>,
     ) -> String {
         health::run_get_prometheus_metrics(&self.client, service.as_deref()).await
+    }
+
+    /// Run a curated PromQL query via the monitor service.
+    #[tool(
+        description = "Run a curated PromQL query against the agentd Prometheus stack via the monitor service. Call without a name to list the catalog (dispatch-success-rate, dispatch-throughput, agent-restart-rate, http-error-rate, http-p95-latency, session-cost, approvals-backlog, host-saturation, ...). window is like 15m/1h/24h; range=true returns a six-hour trend summarized per series instead of an instant value. Falls back gracefully when Prometheus is down (use get_prometheus_metrics for direct scraping)."
+    )]
+    async fn query_metrics(
+        &self,
+        #[tool(param)]
+        #[schemars(description = "Catalog query name; omit to list the catalog")]
+        name: Option<String>,
+        #[tool(param)]
+        #[schemars(description = "Time window for rate/increase queries, e.g. 15m, 1h, 24h")]
+        window: Option<String>,
+        #[tool(param)]
+        #[schemars(
+            description = "true for a range query (trend over the last 6h) instead of an instant value"
+        )]
+        range: Option<bool>,
+    ) -> String {
+        metrics::run_query_metrics(
+            &self.client,
+            name.as_deref(),
+            window.as_deref(),
+            range.unwrap_or(false),
+        )
+        .await
     }
 }
 

--- a/crates/mcp/src/tools/metrics.rs
+++ b/crates/mcp/src/tools/metrics.rs
@@ -1,0 +1,252 @@
+//! Curated Prometheus metrics queries via the monitor service.
+//!
+//! The monitor service owns the named PromQL catalog (`GET /queries`) and
+//! executes queries against the agentd Prometheus stack. This tool renders
+//! the results for MCP clients — instant vectors as a table, range matrices
+//! as per-series summaries (never raw sample dumps; token discipline).
+//!
+//! `get_prometheus_metrics` remains the direct-scrape path that works even
+//! when Prometheus itself is down; this tool is the aggregated/historical
+//! path.
+
+use crate::client::AgentdClient;
+use serde_json::Value;
+
+/// Run a named metrics query, or render the catalog when no/unknown name.
+pub async fn run_query_metrics(
+    client: &AgentdClient,
+    name: Option<&str>,
+    window: Option<&str>,
+    range: bool,
+) -> String {
+    let monitor = client.monitor_url();
+
+    let Some(name) = name.filter(|n| !n.trim().is_empty()) else {
+        return render_catalog(client).await;
+    };
+
+    let mut url = format!("{monitor}/queries/{name}");
+    let mut params = vec![];
+    if let Some(window) = window {
+        params.push(format!("window={window}"));
+    }
+    if range {
+        params.push("mode=range".to_string());
+    }
+    if !params.is_empty() {
+        url = format!("{url}?{}", params.join("&"));
+    }
+
+    let response = match client.inner.get(&url).send().await {
+        Ok(r) => r,
+        Err(e) => {
+            return format!(
+                "🔴 Monitor service unreachable: {e}\n\
+                 → Check it with `check_single_service(\"monitor\")`."
+            );
+        }
+    };
+
+    let status = response.status();
+    let body = response.text().await.unwrap_or_default();
+
+    if status.as_u16() == 502 {
+        return format!(
+            "🟡 Prometheus is unreachable (monitor returned 502).\n\
+             Is the observability stack running? On macOS: \
+             `launchctl list | grep com.agentd.prometheus`.\n\
+             → Fallback: `get_prometheus_metrics(<service>)` scrapes services \
+             directly without Prometheus.\n\n\
+             Details: {body}"
+        );
+    }
+    if !status.is_success() {
+        // 404 includes the catalog names; 400 explains the bad parameter.
+        return format!("🔴 Query `{name}` failed (HTTP {}): {body}", status.as_u16());
+    }
+
+    match serde_json::from_str::<Value>(&body) {
+        Ok(result) => render_query_result(name, &result),
+        Err(e) => format!("🔴 Failed to parse monitor response for `{name}`: {e}"),
+    }
+}
+
+/// Render the catalog fetched from `GET {monitor}/queries`.
+async fn render_catalog(client: &AgentdClient) -> String {
+    let url = format!("{}/queries", client.monitor_url());
+    let catalog: Value = match client.get(&url).await {
+        Ok(v) => v,
+        Err(e) => {
+            return format!(
+                "🔴 Could not fetch the query catalog from the monitor service: {e}\n\
+                 → Check it with `check_single_service(\"monitor\")`."
+            );
+        }
+    };
+
+    let Some(entries) = catalog.as_array() else {
+        return "🔴 Unexpected catalog shape from the monitor service.".to_string();
+    };
+
+    let mut out = String::from(
+        "## Metrics Query Catalog\n\n\
+         Call `query_metrics(name, window?, range?)` with one of:\n\n\
+         | Name | Unit | Description |\n|---|---|---|\n",
+    );
+    for entry in entries {
+        out.push_str(&format!(
+            "| `{}` | {} | {} |\n",
+            entry["name"].as_str().unwrap_or("?"),
+            entry["unit"].as_str().unwrap_or("?"),
+            entry["description"].as_str().unwrap_or(""),
+        ));
+    }
+    out.push_str(
+        "\nWindows look like `15m`, `1h`, `24h`. Pass `range: true` for a \
+         six-hour trend (per-series min/avg/max/last) instead of an instant value.",
+    );
+    out
+}
+
+/// Render a monitor QueryResult JSON as markdown.
+fn render_query_result(name: &str, result: &Value) -> String {
+    let promql = result["promql"].as_str().unwrap_or("?");
+    let mode = result["mode"].as_str().unwrap_or("instant");
+    let data = &result["data"];
+
+    let mut out = format!("## Query `{name}` ({mode})\n\n`{promql}`\n\n");
+
+    match data["resultType"].as_str() {
+        Some("vector") => {
+            let samples = data["result"].as_array().cloned().unwrap_or_default();
+            if samples.is_empty() {
+                out.push_str("_No data — the underlying series have no samples (yet)._");
+                return out;
+            }
+            out.push_str("| Labels | Value |\n|---|---|\n");
+            for sample in &samples {
+                let labels = render_labels(&sample["metric"]);
+                let value = sample["value"][1].as_str().unwrap_or("?");
+                out.push_str(&format!("| {labels} | {value} |\n"));
+            }
+        }
+        Some("matrix") => {
+            let series = data["result"].as_array().cloned().unwrap_or_default();
+            if series.is_empty() {
+                out.push_str("_No data in the requested range._");
+                return out;
+            }
+            out.push_str("| Labels | Min | Avg | Max | Last |\n|---|---|---|---|---|\n");
+            for s in &series {
+                let labels = render_labels(&s["metric"]);
+                let values: Vec<f64> = s["values"]
+                    .as_array()
+                    .cloned()
+                    .unwrap_or_default()
+                    .iter()
+                    .filter_map(|pair| pair[1].as_str().and_then(|v| v.parse().ok()))
+                    .collect();
+                if values.is_empty() {
+                    continue;
+                }
+                let min = values.iter().cloned().fold(f64::INFINITY, f64::min);
+                let max = values.iter().cloned().fold(f64::NEG_INFINITY, f64::max);
+                let avg = values.iter().sum::<f64>() / values.len() as f64;
+                let last = values.last().copied().unwrap_or(f64::NAN);
+                out.push_str(&format!(
+                    "| {labels} | {min:.4} | {avg:.4} | {max:.4} | {last:.4} |\n"
+                ));
+            }
+        }
+        Some("scalar") => {
+            let value = data["result"][1].as_str().unwrap_or("?");
+            out.push_str(&format!("**Value:** {value}"));
+        }
+        other => {
+            out.push_str(&format!("_Unrecognized result type: {other:?}_"));
+        }
+    }
+
+    out
+}
+
+/// Render a Prometheus label map compactly, skipping `__name__`.
+fn render_labels(metric: &Value) -> String {
+    let Some(map) = metric.as_object() else { return "—".to_string() };
+    let rendered: Vec<String> = map
+        .iter()
+        .filter(|(k, _)| *k != "__name__")
+        .map(|(k, v)| format!("{k}={}", v.as_str().unwrap_or("?")))
+        .collect();
+    if rendered.is_empty() {
+        "—".to_string()
+    } else {
+        rendered.join(", ")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    #[test]
+    fn vector_result_renders_label_value_table() {
+        let result = json!({
+            "name": "agents-active",
+            "promql": "agents_active",
+            "mode": "instant",
+            "data": {
+                "resultType": "vector",
+                "result": [
+                    {"metric": {"__name__": "agents_active", "service": "orchestrator"},
+                     "value": [1718100000.0, "3"]}
+                ]
+            }
+        });
+        let out = render_query_result("agents-active", &result);
+        assert!(out.contains("| service=orchestrator | 3 |"), "{out}");
+        assert!(!out.contains("__name__"), "name label hidden: {out}");
+    }
+
+    #[test]
+    fn matrix_result_renders_summary_not_samples() {
+        let result = json!({
+            "promql": "x",
+            "mode": "range",
+            "data": {
+                "resultType": "matrix",
+                "result": [
+                    {"metric": {"service": "notify"},
+                     "values": [[1.0, "1"], [2.0, "3"], [3.0, "2"]]}
+                ]
+            }
+        });
+        let out = render_query_result("test", &result);
+        assert!(out.contains("| Min | Avg | Max | Last |"), "{out}");
+        assert!(out.contains("1.0000"), "min: {out}");
+        assert!(out.contains("3.0000"), "max: {out}");
+        assert!(out.contains("2.0000"), "last/avg: {out}");
+        assert!(!out.contains("[[1.0"), "no raw sample dumps: {out}");
+    }
+
+    #[test]
+    fn empty_vector_renders_no_data_note() {
+        let result = json!({
+            "promql": "x", "mode": "instant",
+            "data": { "resultType": "vector", "result": [] }
+        });
+        let out = render_query_result("test", &result);
+        assert!(out.contains("No data"), "{out}");
+    }
+
+    #[test]
+    fn scalar_result_renders_value() {
+        let result = json!({
+            "promql": "scalar(1)", "mode": "instant",
+            "data": { "resultType": "scalar", "result": [1718100000.0, "42"] }
+        });
+        let out = render_query_result("test", &result);
+        assert!(out.contains("**Value:** 42"), "{out}");
+    }
+}

--- a/crates/mcp/src/tools/mod.rs
+++ b/crates/mcp/src/tools/mod.rs
@@ -12,6 +12,7 @@
 //! - `health`             — service health probes, system metrics, prometheus
 //! - `lifecycle`          — restart/terminate agents, send messages, update policy/model
 //! - `memory`             — search and list stored memories
+//! - `metrics`            — curated Prometheus queries via the monitor service
 //! - `notifications`      — list/create/dismiss notifications
 //! - `orchestrator_debug` — state-mismatch detection, queue inspection, conversation summary, projects
 //! - `policy`             — shared ToolPolicy JSON construction
@@ -26,6 +27,7 @@ pub mod diagnostic;
 pub mod health;
 pub mod lifecycle;
 pub mod memory;
+pub mod metrics;
 pub mod notifications;
 pub mod orchestrator_debug;
 pub mod policy;

--- a/crates/orchestrator/src/system_agents.rs
+++ b/crates/orchestrator/src/system_agents.rs
@@ -31,6 +31,9 @@ pub const DIAGNOSTICIAN_AGENT_NAME: &str = "agentd-diagnostician";
 /// Name of the built-in architect agent (creates agents and workflows).
 pub const ARCHITECT_AGENT_NAME: &str = "agentd-architect";
 
+/// Name of the built-in analyst agent (metrics and health analysis).
+pub const ANALYST_AGENT_NAME: &str = "agentd-analyst";
+
 /// Env var that, when set to `1`/`true`, adds remediation tools to the
 /// diagnostician's allowlist (restart_failed_agents, retry_failed_dispatches,
 /// cleanup_stale_dispatches, resolve_notification_backlog). Default off.
@@ -116,7 +119,7 @@ impl SystemAgentDef {
 /// are refreshed, and stored built-ins whose name is no longer listed here
 /// are removed as orphans.
 pub fn builtin_agent_defs() -> Vec<SystemAgentDef> {
-    vec![system_agent_def(), diagnostician_def(), architect_def()]
+    vec![system_agent_def(), diagnostician_def(), architect_def(), analyst_def()]
 }
 
 /// Definition of the `agentd-system` domain-expert agent.
@@ -514,6 +517,132 @@ DESIGN GUIDANCE
 
 You cannot delete workflows, terminate or restart agents, or approve tool
 requests. For those, give the human the exact command instead.
+";
+
+// ---------------------------------------------------------------------------
+// agentd-analyst
+// ---------------------------------------------------------------------------
+
+/// Definition of the `agentd-analyst` agent.
+///
+/// A lazy built-in that analyzes platform metrics and health: the curated
+/// Prometheus query catalog (via the monitor service's `query_metrics` MCP
+/// tool) plus the orchestrator's read APIs. Strictly read-only except for
+/// posting findings (notifications and room messages).
+fn analyst_def() -> SystemAgentDef {
+    SystemAgentDef {
+        name: ANALYST_AGENT_NAME,
+        model: "sonnet",
+        rooms: &["system"],
+        working_dir: WorkingDirStrategy::CurrentDir,
+        lazy: true,
+        prompt: analyst_prompt,
+        tool_policy: analyst_tool_policy,
+        mcp_servers: agentd_mcp_servers,
+    }
+}
+
+/// Tool policy for the analyst: read/diagnose tool families plus the two
+/// escalation channels (create_notification, send_room_message). No
+/// lifecycle, creation, approval, or remediation tools.
+fn analyst_tool_policy() -> ToolPolicy {
+    ToolPolicy::AllowList {
+        tools: vec![
+            // ── Metrics and diagnostics (read-only families) ──────────────
+            "mcp__agentd__query_metrics".to_string(),
+            "mcp__agentd__diagnose_*".to_string(),
+            "mcp__agentd__check_*".to_string(),
+            "mcp__agentd__get_*".to_string(),
+            "mcp__agentd__list_*".to_string(),
+            "mcp__agentd__search_*".to_string(),
+            "mcp__agentd__inspect_*".to_string(),
+            // ── Escalation channels (exact names) ─────────────────────────
+            "mcp__agentd__create_notification".to_string(),
+            "mcp__agentd__send_room_message".to_string(),
+            // ── Local read-only tools ──────────────────────────────────────
+            "Read".to_string(),
+            "Grep".to_string(),
+            "Glob".to_string(),
+            "Bash(curl *)".to_string(),
+        ],
+        sandbox_bypass: vec![],
+    }
+}
+
+/// System prompt for the analyst.
+fn analyst_prompt() -> String {
+    let version = env!("CARGO_PKG_VERSION");
+    format!("agentd version: {version}\n\n{ANALYST_PROMPT}")
+}
+
+/// # Coverage note
+///
+/// The query-name list must stay in sync with
+/// `monitor::queries::QUERY_CATALOG` (cross-crate, so the unit test pins a
+/// const string list rather than importing the catalog).
+const ANALYST_PROMPT: &str = "\
+You are the agentd analyst — a built-in agent that analyzes platform metrics
+and health trends, surfaces anomalies, and recommends actions. You are
+read-only: you never modify agents, workflows, or configuration.
+
+─────────────────────────────────────────────────────────────────────────────
+METRICS TOOLKIT
+─────────────────────────────────────────────────────────────────────────────
+
+`query_metrics(name, window?, range?)` runs curated PromQL via the monitor
+service. Call it with no name to list the catalog. Key queries and healthy
+baselines:
+
+  service-up              All targets at 1. Any 0 → check_single_service.
+  dispatch-success-rate   ≥ 0.9 over 24h. Lower → get_failed_dispatches,
+                          then diagnose_workflow on the offenders.
+  dispatch-throughput     Know your normal; a sudden drop to zero on an
+                          enabled workflow means its trigger or agent broke.
+  agent-restart-rate      ~0. Sustained nonzero → crash-looping; diagnose
+                          the restarting agents.
+  agents-active vs websocket-connections
+                          Should match. A gap → diagnose_state_mismatches.
+  approvals-backlog       Near 0. Growth → agents are blocked on humans;
+                          notify the operator.
+  http-error-rate         ~0 per service. Spikes → check that service's
+                          health and recent deploys.
+  http-p95-latency        Know your normal (typically ms). Sustained growth
+                          → host-saturation next.
+  session-cost            Watch the 24h delta; a spike → list_agents and
+                          get_conversation_summary to find the hot agent.
+  notifications-backlog, message-drops, host-saturation
+                          Self-explanatory; drops and saturation are 🔴.
+
+Use `range: true` for trends (per-series min/avg/max/last over 6h) when an
+instant value needs context. If Prometheus is down (502), fall back to
+`get_prometheus_metrics(<service>)` direct scrapes and say so in your report.
+
+─────────────────────────────────────────────────────────────────────────────
+PLAYBOOKS
+─────────────────────────────────────────────────────────────────────────────
+
+Cost spike     → session-cost (24h) → list_agents →
+                 get_conversation_summary on busy agents → report the top
+                 spenders and what they were doing.
+Latency        → http-p95-latency per service → host-saturation →
+                 the slow service's health endpoint via curl.
+Failures       → dispatch-success-rate → get_failed_dispatches →
+                 diagnose_workflow → name the failing workflow and the
+                 pattern (always-fails vs intermittent).
+Routine review → service-up, dispatch-success-rate, agent-restart-rate,
+                 approvals-backlog, session-cost, host-saturation — then
+                 report only what deviates.
+
+─────────────────────────────────────────────────────────────────────────────
+REPORTING
+─────────────────────────────────────────────────────────────────────────────
+
+Post findings to the `system` room (send_room_message). For anything needing
+human action, also create_notification with priority matched to impact:
+data-loss or all-agents-blocked → high; degradation → medium; observations →
+low. Every finding needs: metric evidence, time window, suspected cause, and
+a concrete recommended action (you cannot act — name the command or the agent
+that should).
 ";
 
 /// Carry runtime-derived fields from a stored config over to a freshly built
@@ -980,6 +1109,86 @@ mod tests {
         // The hard constraint is stated prominently.
         assert!(prompt.contains(".agentd/*.yml"));
         assert!(prompt.len() < 26_000, "architect prompt budget: {}", prompt.len());
+    }
+
+    #[test]
+    fn analyst_is_lazy_with_agentd_mcp_server() {
+        let def = analyst_def();
+        assert!(def.lazy);
+        let config = def.build_config();
+        assert!(config.mcp_servers.is_some_and(|s| s.contains_key("agentd")));
+    }
+
+    #[test]
+    fn analyst_policy_is_read_only_plus_escalation() {
+        let policy = analyst_tool_policy();
+
+        for allowed in [
+            "mcp__agentd__query_metrics",
+            "mcp__agentd__get_prometheus_metrics",
+            "mcp__agentd__get_system_metrics",
+            "mcp__agentd__diagnose_system",
+            "mcp__agentd__check_service_health",
+            "mcp__agentd__list_agents",
+            "mcp__agentd__get_failed_dispatches",
+            "mcp__agentd__get_conversation_summary",
+            "mcp__agentd__inspect_queue",
+            "mcp__agentd__create_notification",
+            "mcp__agentd__send_room_message",
+            "Read",
+        ] {
+            assert!(policy.evaluate(allowed, None), "must allow {allowed}");
+        }
+
+        for denied in [
+            "mcp__agentd__create_agent",
+            "mcp__agentd__create_workflow",
+            "mcp__agentd__update_workflow",
+            "mcp__agentd__delete_workflow",
+            "mcp__agentd__terminate_agent",
+            "mcp__agentd__restart_agent",
+            "mcp__agentd__restart_failed_agents",
+            "mcp__agentd__send_agent_message",
+            "mcp__agentd__approve_tool_request",
+            "Write",
+            "Edit",
+            "Bash",
+        ] {
+            assert!(!policy.evaluate(denied, None), "must deny {denied}");
+        }
+    }
+
+    #[test]
+    fn analyst_prompt_covers_the_query_catalog() {
+        // Keep in sync with monitor::queries::QUERY_CATALOG (cross-crate, so
+        // pinned here as a const list). A new catalog entry should be added
+        // to the analyst's baseline guidance.
+        const CATALOG_NAMES: &[&str] = &[
+            "service-up",
+            "dispatch-success-rate",
+            "dispatch-throughput",
+            "agent-restart-rate",
+            "agents-active",
+            "websocket-connections",
+            "approvals-backlog",
+            "approvals-resolution",
+            "http-error-rate",
+            "http-p95-latency",
+            "session-cost",
+            "notifications-backlog",
+            "message-drops",
+            "host-saturation",
+        ];
+        let prompt = analyst_prompt();
+        for name in CATALOG_NAMES {
+            // approvals-resolution is covered by the approvals-backlog
+            // guidance; everything else must appear verbatim.
+            if *name == "approvals-resolution" {
+                continue;
+            }
+            assert!(prompt.contains(name), "analyst prompt must mention `{name}`");
+        }
+        assert!(prompt.len() < 26_000, "analyst prompt budget: {}", prompt.len());
     }
 
     #[test]

--- a/crates/orchestrator/tests/system_agent_http.rs
+++ b/crates/orchestrator/tests/system_agent_http.rs
@@ -394,7 +394,7 @@ async fn test_bootstrap_creates_system_agent() {
     manager.bootstrap_system_agents().await.unwrap();
 
     let system_agents = storage.list_system_agents().await.unwrap();
-    assert_eq!(system_agents.len(), 3, "one agent per registry definition");
+    assert_eq!(system_agents.len(), 4, "one agent per registry definition");
     assert!(system_agents.iter().all(|a| a.built_in));
 
     let system = system_agents.iter().find(|a| a.name == SYSTEM_AGENT_NAME).unwrap();
@@ -419,7 +419,7 @@ async fn test_bootstrap_is_idempotent() {
     manager.bootstrap_system_agents().await.unwrap();
 
     let system_agents = storage.list_system_agents().await.unwrap();
-    assert_eq!(system_agents.len(), 3, "bootstrap must not create duplicate system agents");
+    assert_eq!(system_agents.len(), 4, "bootstrap must not create duplicate system agents");
     let diagnostician = system_agents.iter().find(|a| a.name == DIAGNOSTICIAN_AGENT_NAME).unwrap();
     assert_eq!(
         diagnostician.status,


### PR DESCRIPTION
One tool covers the whole curated catalog: called without a name it
renders the catalog fetched from GET {monitor}/queries; with a name it
executes GET /queries/{name} and renders instant vectors as a
label/value table and range matrices as per-series min/avg/max/last
summaries (never raw sample dumps).

A 502 from the monitor (Prometheus down) yields an actionable message
with the launchd hint and the get_prometheus_metrics direct-scrape
fallback, which deliberately remains the unaggregated path that works
without Prometheus.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>