### PR TITLE
feat(ui): monitor named-query client and live System Resources charts

### DIFF
--- a/ui/src/components/monitoring/DiskUsageCard.tsx
+++ b/ui/src/components/monitoring/DiskUsageCard.tsx
@@ -1,0 +1,130 @@
+/**
+ * DiskUsageCard — per-mount disk utilisation bars from the latest monitor
+ * snapshot.
+ *
+ * Time series per mount point is noisy and rarely actionable; the current
+ * fill level per mount is what operators check. Bars colour-shift as they
+ * approach capacity.
+ */
+
+import { HardDrive } from "lucide-react";
+import { ChartSkeleton } from "@/components/common/LoadingSkeleton";
+import type { DiskMetrics } from "@/types/monitor";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface DiskUsageCardProps {
+	disks: DiskMetrics[];
+	/** False when the monitor service is unreachable */
+	available?: boolean;
+	loading?: boolean;
+	/** Height of the content area in pixels (default 140) */
+	height?: number;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function formatBytes(bytes: number): string {
+	const gib = bytes / 1024 ** 3;
+	if (gib >= 1024) return `${(gib / 1024).toFixed(1)} TiB`;
+	return `${gib.toFixed(0)} GiB`;
+}
+
+/** Bar colour by fill level: calm → warning → critical. */
+function barColor(usagePercent: number): string {
+	if (usagePercent >= 90) return "var(--th-status-error-text, #ef4444)";
+	if (usagePercent >= 75) return "var(--th-status-warning-text, #f59e0b)";
+	return "#3b82f6";
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function DiskUsageCard({
+	disks,
+	available = true,
+	loading = false,
+	height = 140,
+}: DiskUsageCardProps) {
+	const hasData = available && disks.length > 0;
+
+	return (
+		<div className="rounded-lg border border-th-border bg-th-surface p-4">
+			<h3 className="text-sm font-semibold text-th-text">Disk Usage</h3>
+			<p className="mt-0.5 text-xs text-th-text-faint">
+				Per-mount utilisation
+			</p>
+
+			{loading && (
+				<div className="mt-3">
+					<ChartSkeleton height={height} />
+				</div>
+			)}
+
+			{!loading && !hasData && (
+				<div
+					className="mt-3 flex flex-col items-center justify-center gap-1.5 text-center"
+					style={{ height }}
+				>
+					<HardDrive size={20} className="text-th-text-faint" />
+					<p className="text-xs text-th-text-muted">
+						{available
+							? "No metrics collected yet."
+							: "Monitor service unavailable"}
+					</p>
+				</div>
+			)}
+
+			{!loading && hasData && (
+				<ul
+					className="mt-3 space-y-3 overflow-y-auto"
+					style={{ maxHeight: height }}
+					data-testid="disk-usage-list"
+				>
+					{disks.map((disk) => (
+						<li key={disk.mount_point}>
+							<div className="flex items-baseline justify-between gap-2 text-xs">
+								<span
+									className="truncate font-medium text-th-text"
+									title={`${disk.name} (${disk.mount_point})`}
+								>
+									{disk.mount_point}
+								</span>
+								<span className="shrink-0 text-th-text-muted">
+									{formatBytes(disk.used_bytes)} /{" "}
+									{formatBytes(disk.total_bytes)}
+									<span className="ml-1.5 font-semibold text-th-text">
+										{disk.usage_percent.toFixed(0)}%
+									</span>
+								</span>
+							</div>
+							<div
+								className="mt-1 h-1.5 overflow-hidden rounded-full bg-th-surface-hover"
+								role="progressbar"
+								aria-label={`${disk.mount_point} usage`}
+								aria-valuenow={Math.round(disk.usage_percent)}
+								aria-valuemin={0}
+								aria-valuemax={100}
+							>
+								<div
+									className="h-full rounded-full transition-all"
+									style={{
+										width: `${Math.min(100, disk.usage_percent)}%`,
+										background: barColor(disk.usage_percent),
+									}}
+								/>
+							</div>
+						</li>
+					))}
+				</ul>
+			)}
+		</div>
+	);
+}
+
+export default DiskUsageCard;

--- a/ui/src/components/monitoring/PlatformMetricsSection.tsx
+++ b/ui/src/components/monitoring/PlatformMetricsSection.tsx
@@ -1,0 +1,287 @@
+/**
+ * PlatformMetricsSection — Prometheus-backed platform health from the
+ * monitor service's curated named-query API.
+ *
+ * Stat cards (dispatch success, agents vs connections, approvals backlog,
+ * session cost, restarts) over per-service HTTP error-rate and p95-latency
+ * bar lists. Renders explicit degraded states that distinguish "Prometheus
+ * offline" (system resources still live) from "monitor unreachable".
+ */
+
+import { AlertTriangle } from "lucide-react";
+import { ChartSkeleton } from "@/components/common/LoadingSkeleton";
+import type {
+	PlatformQueryResults,
+	UsePlatformMetricsResult,
+} from "@/hooks/usePlatformMetrics";
+import { vectorEntries, vectorValue } from "@/hooks/usePlatformMetrics";
+
+// ---------------------------------------------------------------------------
+// Stat card
+// ---------------------------------------------------------------------------
+
+export type StatTone = "neutral" | "ok" | "warn" | "error";
+
+export interface PlatformStatCardProps {
+	label: string;
+	/** Pre-formatted display value; "—" when no data */
+	value: string;
+	/** Small line under the value (e.g. the window or a breakdown) */
+	hint?: string;
+	tone?: StatTone;
+}
+
+const TONE_CLASSES: Record<StatTone, string> = {
+	neutral: "text-th-text",
+	ok: "text-th-status-success-text",
+	warn: "text-th-status-warning-text",
+	error: "text-th-status-error-text",
+};
+
+export function PlatformStatCard({
+	label,
+	value,
+	hint,
+	tone = "neutral",
+}: PlatformStatCardProps) {
+	return (
+		<div className="rounded-lg border border-th-border bg-th-surface p-4">
+			<p className="text-xs text-th-text-muted">{label}</p>
+			<p className={`mt-1 text-2xl font-semibold ${TONE_CLASSES[tone]}`}>
+				{value}
+			</p>
+			{hint && <p className="mt-0.5 text-xs text-th-text-faint">{hint}</p>}
+		</div>
+	);
+}
+
+// ---------------------------------------------------------------------------
+// Per-service bar list
+// ---------------------------------------------------------------------------
+
+export interface ServiceBarListProps {
+	title: string;
+	/** Window hint shown next to the title (e.g. "15m") */
+	window?: string;
+	entries: Array<{ service: string; value: number }>;
+	/** Format a value for the row readout */
+	format: (value: number) => string;
+	/** Bar fill fraction for a value (clamped to [0, 1]) */
+	fraction: (value: number) => number;
+	/** Threshold above which a row renders in the warning colour */
+	warnAt: number;
+	emptyText: string;
+}
+
+export function ServiceBarList({
+	title,
+	window: windowHint,
+	entries,
+	format,
+	fraction,
+	warnAt,
+	emptyText,
+}: ServiceBarListProps) {
+	return (
+		<div className="rounded-lg border border-th-border bg-th-surface p-4">
+			<h3 className="text-sm font-semibold text-th-text">
+				{title}
+				{windowHint && (
+					<span className="ml-2 text-xs font-normal text-th-text-faint">
+						{windowHint}
+					</span>
+				)}
+			</h3>
+			{entries.length === 0 ? (
+				<p className="mt-3 text-xs text-th-text-muted">{emptyText}</p>
+			) : (
+				<ul className="mt-3 space-y-2">
+					{entries.map((entry) => {
+						const warn = entry.value >= warnAt;
+						return (
+							<li
+								key={entry.service}
+								className="flex items-center gap-3 text-xs"
+							>
+								<span className="w-24 shrink-0 truncate text-th-text-muted">
+									{entry.service}
+								</span>
+								<div className="h-1.5 flex-1 overflow-hidden rounded-full bg-th-surface-hover">
+									<div
+										className="h-full rounded-full"
+										style={{
+											width: `${Math.min(100, fraction(entry.value) * 100)}%`,
+											background: warn
+												? "var(--th-status-warning-text, #f59e0b)"
+												: "#3b82f6",
+										}}
+									/>
+								</div>
+								<span
+									className={`w-16 shrink-0 text-right font-medium ${
+										warn ? "text-th-status-warning-text" : "text-th-text"
+									}`}
+								>
+									{format(entry.value)}
+								</span>
+							</li>
+						);
+					})}
+				</ul>
+			)}
+		</div>
+	);
+}
+
+// ---------------------------------------------------------------------------
+// Derivations
+// ---------------------------------------------------------------------------
+
+function dispatchSuccessCard(results: PlatformQueryResults) {
+	const rate = vectorValue(results["dispatch-success-rate"]);
+	const throughput = vectorEntries(results["dispatch-throughput"]);
+	const byStatus = Object.fromEntries(
+		throughput.map((e) => [e.labels.status ?? "?", Math.round(e.value)]),
+	);
+	const finished = (byStatus.completed ?? 0) + (byStatus.failed ?? 0);
+
+	const hint =
+		throughput.length > 0
+			? `${byStatus.completed ?? 0} completed / ${byStatus.failed ?? 0} failed (1h)`
+			: "last 1h";
+
+	if (rate === null || finished === 0) {
+		return { value: "—", hint: "no dispatches in the window", tone: "neutral" as StatTone };
+	}
+	const tone: StatTone = rate >= 0.9 ? "ok" : rate >= 0.5 ? "warn" : "error";
+	return { value: `${(rate * 100).toFixed(0)}%`, hint, tone };
+}
+
+function agentsCard(results: PlatformQueryResults) {
+	const active = vectorValue(results["agents-active"]);
+	const connections = vectorValue(results["websocket-connections"]);
+	if (active === null) {
+		return { value: "—", hint: "agents active", tone: "neutral" as StatTone };
+	}
+	const mismatch = connections !== null && connections !== active;
+	return {
+		value: `${active}`,
+		hint:
+			connections === null
+				? "agents active"
+				: `${connections} connection${connections === 1 ? "" : "s"}${mismatch ? " — state mismatch?" : ""}`,
+		tone: (mismatch ? "warn" : "neutral") as StatTone,
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Section
+// ---------------------------------------------------------------------------
+
+export type PlatformMetricsSectionProps = UsePlatformMetricsResult;
+
+export function PlatformMetricsSection({
+	results,
+	monitorDown,
+	prometheusDown,
+	loading,
+}: PlatformMetricsSectionProps) {
+	const dispatch = dispatchSuccessCard(results);
+	const agents = agentsCard(results);
+	const approvals = vectorValue(results["approvals-backlog"]);
+	const cost = vectorValue(results["session-cost"]);
+	const restarts = vectorValue(results["agent-restart-rate"]);
+
+	const errorRates = vectorEntries(results["http-error-rate"]).map((e) => ({
+		service: e.labels.service ?? "?",
+		value: e.value,
+	}));
+	const latencies = vectorEntries(results["http-p95-latency"])
+		.map((e) => ({
+			service: e.labels.service ?? "?",
+			// histogram_quantile yields NaN for services with no traffic yet.
+			value: e.value,
+		}))
+		.filter((e) => Number.isFinite(e.value));
+
+	const degraded = monitorDown || prometheusDown;
+
+	return (
+		<section aria-label="Platform metrics">
+			<h2 className="mb-3 text-sm font-semibold text-th-text-secondary">
+				Platform Metrics
+			</h2>
+
+			{/* Degraded banner */}
+			{!loading && degraded && (
+				<div className="mb-4 flex items-center gap-2 rounded-md border border-th-status-warning-border bg-th-status-warning-bg px-4 py-2.5 text-sm text-th-status-warning-text">
+					<AlertTriangle size={14} className="shrink-0" />
+					{monitorDown
+						? "Monitor service unreachable — platform metrics unavailable."
+						: "Prometheus is offline — platform metrics unavailable (system resources are still live)."}
+				</div>
+			)}
+
+			{loading && <ChartSkeleton height={96} />}
+
+			{!loading && !degraded && (
+				<>
+					<div className="grid grid-cols-2 gap-4 sm:grid-cols-3 xl:grid-cols-5">
+						<PlatformStatCard
+							label="Dispatch Success"
+							value={dispatch.value}
+							hint={dispatch.hint}
+							tone={dispatch.tone}
+						/>
+						<PlatformStatCard
+							label="Active Agents"
+							value={agents.value}
+							hint={agents.hint}
+							tone={agents.tone}
+						/>
+						<PlatformStatCard
+							label="Approvals Backlog"
+							value={approvals === null ? "—" : `${Math.round(approvals)}`}
+							hint="pending tool approvals"
+							tone={approvals !== null && approvals > 0 ? "warn" : "neutral"}
+						/>
+						<PlatformStatCard
+							label="Session Cost"
+							value={cost === null ? "—" : `$${cost.toFixed(2)}`}
+							hint="last 24h"
+						/>
+						<PlatformStatCard
+							label="Agent Restarts"
+							value={restarts === null ? "—" : `${Math.round(restarts)}`}
+							hint="last 1h"
+							tone={restarts !== null && restarts > 0 ? "warn" : "neutral"}
+						/>
+					</div>
+
+					<div className="mt-4 grid grid-cols-1 gap-4 lg:grid-cols-2">
+						<ServiceBarList
+							title="HTTP Error Rate"
+							window="15m"
+							entries={errorRates}
+							format={(v) => `${(v * 100).toFixed(2)}%`}
+							fraction={(v) => v}
+							warnAt={0.01}
+							emptyText="No HTTP traffic in the window."
+						/>
+						<ServiceBarList
+							title="HTTP p95 Latency"
+							window="15m"
+							entries={latencies}
+							format={(v) => `${(v * 1000).toFixed(0)} ms`}
+							fraction={(v) => v / 1}
+							warnAt={0.5}
+							emptyText="No latency samples in the window."
+						/>
+					</div>
+				</>
+			)}
+		</section>
+	);
+}
+
+export default PlatformMetricsSection;

--- a/ui/src/components/monitoring/ResourceTrendCard.tsx
+++ b/ui/src/components/monitoring/ResourceTrendCard.tsx
@@ -1,0 +1,166 @@
+/**
+ * ResourceTrendCard — compact time-series card for one system resource
+ * (CPU, memory, load average) fed from the monitor service's history
+ * ring buffer.
+ *
+ * Renders latest-value readouts above a small Nivo line chart. Shows a
+ * quiet empty state when the monitor is unreachable or has no snapshots
+ * yet — it never crashes the page.
+ */
+
+import { ResponsiveLine } from "@nivo/line";
+import { Activity } from "lucide-react";
+import { ChartSkeleton } from "@/components/common/LoadingSkeleton";
+import { useNivoTheme } from "@/hooks/useNivoTheme";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface TrendSeries {
+	id: string;
+	color: string;
+	data: Array<{ x: Date; y: number }>;
+}
+
+export interface TrendReadout {
+	label: string;
+	value: string;
+	color: string;
+}
+
+export interface ResourceTrendCardProps {
+	title: string;
+	description?: string;
+	series: TrendSeries[];
+	/** Latest-value readouts shown above the chart (double as the legend) */
+	readouts: TrendReadout[];
+	/**
+	 * Upper bound for the y axis. Percentage charts pass 100; omit for an
+	 * auto-scaled axis (load average).
+	 */
+	yMax?: number;
+	/** Suffix appended to tooltip values (e.g. "%") */
+	unit?: string;
+	/** False when the monitor service is unreachable */
+	available?: boolean;
+	loading?: boolean;
+	/** Height of the chart area in pixels (default 140) */
+	height?: number;
+}
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function ResourceTrendCard({
+	title,
+	description,
+	series,
+	readouts,
+	yMax,
+	unit = "",
+	available = true,
+	loading = false,
+	height = 140,
+}: ResourceTrendCardProps) {
+	const nivoTheme = useNivoTheme();
+	const hasData = available && series.some((s) => s.data.length > 0);
+
+	return (
+		<div className="rounded-lg border border-th-border bg-th-surface p-4">
+			{/* Header */}
+			<h3 className="text-sm font-semibold text-th-text">{title}</h3>
+			{description && (
+				<p className="mt-0.5 text-xs text-th-text-faint">{description}</p>
+			)}
+
+			{/* Loading */}
+			{loading && (
+				<div className="mt-3">
+					<ChartSkeleton height={height} />
+				</div>
+			)}
+
+			{/* Empty / unavailable state */}
+			{!loading && !hasData && (
+				<div
+					className="mt-3 flex flex-col items-center justify-center gap-1.5 text-center"
+					style={{ height }}
+				>
+					<Activity size={20} className="text-th-text-faint" />
+					<p className="text-xs text-th-text-muted">
+						{available
+							? "No metrics collected yet."
+							: "Monitor service unavailable"}
+					</p>
+				</div>
+			)}
+
+			{/* Content */}
+			{!loading && hasData && (
+				<>
+					<div className="mt-2 flex flex-wrap items-center gap-3">
+						{readouts.map((r) => (
+							<div
+								key={r.label}
+								className="flex items-center gap-1.5 text-xs text-th-text-muted"
+							>
+								<span
+									aria-hidden="true"
+									className="h-2 w-2 rounded-full"
+									style={{ background: r.color }}
+								/>
+								<span>{r.label}</span>
+								<span className="font-semibold text-th-text">{r.value}</span>
+							</div>
+						))}
+					</div>
+
+					<div
+						className="mt-2"
+						style={{ height }}
+						data-testid={`resource-trend-${title.toLowerCase().replace(/\s+/g, "-")}`}
+					>
+						<ResponsiveLine
+							data={series}
+							theme={nivoTheme}
+							colors={(serie: { color: string }) => serie.color}
+							xScale={{ type: "time", format: "native", precision: "minute" }}
+							yScale={{ type: "linear", min: 0, max: yMax ?? "auto" }}
+							axisBottom={{
+								format: "%H:%M",
+								tickValues: 3,
+								tickSize: 0,
+								tickPadding: 6,
+							}}
+							axisLeft={{
+								tickValues: 3,
+								tickSize: 0,
+								tickPadding: 4,
+								format: (v: number) => `${v}${unit}`,
+							}}
+							enableGridX={false}
+							gridYValues={3}
+							lineWidth={1.5}
+							enablePoints={false}
+							enableArea
+							areaOpacity={0.1}
+							curve="monotoneX"
+							useMesh
+							margin={{ top: 6, right: 6, bottom: 24, left: 34 }}
+							tooltip={({ point }) => (
+								<div className="rounded bg-th-surface-raised px-2 py-1 text-xs text-th-text shadow">
+									{String(point.seriesId)}: {Number(point.data.y).toFixed(1)}
+									{unit}
+								</div>
+							)}
+						/>
+					</div>
+				</>
+			)}
+		</div>
+	);
+}
+
+export default ResourceTrendCard;

--- a/ui/src/components/monitoring/index.ts
+++ b/ui/src/components/monitoring/index.ts
@@ -4,13 +4,16 @@ export type { CacheEfficiencyChartProps } from "./CacheEfficiencyChart";
 export { CacheEfficiencyChart } from "./CacheEfficiencyChart";
 export type { CostOverviewChartProps } from "./CostOverviewChart";
 export { CostOverviewChart } from "./CostOverviewChart";
+export type { DiskUsageCardProps } from "./DiskUsageCard";
+export { DiskUsageCard } from "./DiskUsageCard";
 export type { NotificationMetricsChartProps } from "./NotificationMetricsChart";
 export { NotificationMetricsChart } from "./NotificationMetricsChart";
 export type {
-	PlaceholderChartProps,
-	PlaceholderChartVariant,
-} from "./PlaceholderChart";
-export { PlaceholderChart } from "./PlaceholderChart";
+	ResourceTrendCardProps,
+	TrendReadout,
+	TrendSeries,
+} from "./ResourceTrendCard";
+export { ResourceTrendCard } from "./ResourceTrendCard";
 export type { ServiceMetricsCardProps } from "./ServiceMetricsCard";
 export { ServiceMetricsCard } from "./ServiceMetricsCard";
 export type { SystemHealthPanelProps } from "./SystemHealthPanel";

--- a/ui/src/components/monitoring/index.ts
+++ b/ui/src/components/monitoring/index.ts
@@ -9,6 +9,17 @@ export { DiskUsageCard } from "./DiskUsageCard";
 export type { NotificationMetricsChartProps } from "./NotificationMetricsChart";
 export { NotificationMetricsChart } from "./NotificationMetricsChart";
 export type {
+	PlatformMetricsSectionProps,
+	PlatformStatCardProps,
+	ServiceBarListProps,
+	StatTone,
+} from "./PlatformMetricsSection";
+export {
+	PlatformMetricsSection,
+	PlatformStatCard,
+	ServiceBarList,
+} from "./PlatformMetricsSection";
+export type {
 	ResourceTrendCardProps,
 	TrendReadout,
 	TrendSeries,

--- a/ui/src/hooks/usePlatformMetrics.ts
+++ b/ui/src/hooks/usePlatformMetrics.ts
@@ -1,0 +1,132 @@
+/**
+ * usePlatformMetrics — polls the monitor service's curated named-query API
+ * (Prometheus-backed) for platform-level metrics: dispatch health, HTTP
+ * error rate and latency per service, approvals backlog, session cost,
+ * and agent/connection counts.
+ *
+ * Degrades in two distinct ways so the page can say what actually broke:
+ * - `monitorDown`    — the monitor service itself is unreachable.
+ * - `prometheusDown` — the monitor answered but Prometheus is down (502).
+ */
+
+import { useCallback, useRef, useState } from "react";
+import { monitorClient } from "@/services/monitor";
+import { ApiError } from "@/types/common";
+import type { QueryResult, VectorSample } from "@/types/monitor";
+import { usePolling } from "./usePolling";
+
+// ---------------------------------------------------------------------------
+// Queried catalog entries
+// ---------------------------------------------------------------------------
+
+/** Named queries this hook polls each cycle. */
+export const PLATFORM_QUERIES = [
+	"dispatch-success-rate",
+	"dispatch-throughput",
+	"agent-restart-rate",
+	"approvals-backlog",
+	"http-error-rate",
+	"http-p95-latency",
+	"session-cost",
+	"agents-active",
+	"websocket-connections",
+] as const;
+
+export type PlatformQueryName = (typeof PLATFORM_QUERIES)[number];
+
+export type PlatformQueryResults = Partial<
+	Record<PlatformQueryName, QueryResult>
+>;
+
+export interface UsePlatformMetricsResult {
+	/** Latest result per query; absent while loading or on per-query failure */
+	results: PlatformQueryResults;
+	/** True when the monitor service itself is unreachable */
+	monitorDown: boolean;
+	/** True when the monitor answered but Prometheus is down (HTTP 502) */
+	prometheusDown: boolean;
+	/** True only during the very first load */
+	loading: boolean;
+	refetch: () => void;
+}
+
+// ---------------------------------------------------------------------------
+// Vector helpers (exported for the chart components)
+// ---------------------------------------------------------------------------
+
+/** All samples of an instant-vector result as { labels, value } entries. */
+export function vectorEntries(
+	result: QueryResult | undefined,
+): Array<{ labels: Record<string, string>; value: number }> {
+	if (!result || result.data.resultType !== "vector") return [];
+	return result.data.result.map((sample: VectorSample) => ({
+		labels: sample.metric,
+		value: Number.parseFloat(sample.value[1]),
+	}));
+}
+
+/**
+ * The single scalar value of an instant-vector result (sum across samples),
+ * or null when there is no data.
+ */
+export function vectorValue(result: QueryResult | undefined): number | null {
+	const entries = vectorEntries(result);
+	if (entries.length === 0) return null;
+	return entries.reduce((acc, e) => acc + e.value, 0);
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+export function usePlatformMetrics(
+	intervalMs?: number,
+): UsePlatformMetricsResult {
+	const [results, setResults] = useState<PlatformQueryResults>({});
+	const [monitorDown, setMonitorDown] = useState(false);
+	const [prometheusDown, setPrometheusDown] = useState(false);
+	const [loading, setLoading] = useState(true);
+	const hasLoadedRef = useRef(false);
+
+	const fetch = useCallback(async () => {
+		if (!hasLoadedRef.current) setLoading(true);
+
+		const settled = await Promise.allSettled(
+			PLATFORM_QUERIES.map((name) => monitorClient.runQuery(name)),
+		);
+
+		const next: PlatformQueryResults = {};
+		let sawBadGateway = false;
+		let sawSuccess = false;
+
+		settled.forEach((outcome, i) => {
+			const name = PLATFORM_QUERIES[i];
+			if (outcome.status === "fulfilled") {
+				next[name] = outcome.value;
+				sawSuccess = true;
+			} else if (
+				outcome.reason instanceof ApiError &&
+				outcome.reason.status === 502
+			) {
+				sawBadGateway = true;
+			}
+		});
+
+		setResults(next);
+		setPrometheusDown(sawBadGateway);
+		// Only "nothing answered and nothing was a 502" means the monitor
+		// itself is gone — a 502 proves the monitor responded.
+		setMonitorDown(!sawSuccess && !sawBadGateway);
+
+		hasLoadedRef.current = true;
+		setLoading(false);
+	}, []);
+
+	usePolling(fetch, intervalMs);
+
+	const refetch = useCallback(() => {
+		void fetch();
+	}, [fetch]);
+
+	return { results, monitorDown, prometheusDown, loading, refetch };
+}

--- a/ui/src/pages/monitoring/MonitoringDashboard.tsx
+++ b/ui/src/pages/monitoring/MonitoringDashboard.tsx
@@ -7,20 +7,22 @@
  * - Service metrics cards (one per service: orchestrator, notify, ask)
  * - Agent activity chart + notification metrics chart (side-by-side)
  * - System health panel
- * - Placeholder charts for future monitor service (cpu, memory, disk, network)
+ * - System resource charts (cpu, memory, disk, load) from the monitor service
  */
 
 import { Clock, RefreshCw } from "lucide-react";
 import { AgentActivityChart } from "@/components/monitoring/AgentActivityChart";
 import { CacheEfficiencyChart } from "@/components/monitoring/CacheEfficiencyChart";
 import { CostOverviewChart } from "@/components/monitoring/CostOverviewChart";
+import { DiskUsageCard } from "@/components/monitoring/DiskUsageCard";
 import { NotificationMetricsChart } from "@/components/monitoring/NotificationMetricsChart";
-import { PlaceholderChart } from "@/components/monitoring/PlaceholderChart";
+import { ResourceTrendCard } from "@/components/monitoring/ResourceTrendCard";
 import { ServiceMetricsCard } from "@/components/monitoring/ServiceMetricsCard";
 import { SystemHealthPanel } from "@/components/monitoring/SystemHealthPanel";
 import { TokenUsageChart } from "@/components/monitoring/TokenUsageChart";
 import type { RefreshInterval } from "@/hooks/useMetrics";
 import { useMetrics } from "@/hooks/useMetrics";
+import { useSystemMetrics } from "@/hooks/useSystemMetrics";
 import { useUsageMetrics } from "@/hooks/useUsageMetrics";
 
 // ---------------------------------------------------------------------------
@@ -65,6 +67,13 @@ export function MonitoringDashboard() {
 		aggregate: usageAggregate,
 		loading: usageLoading,
 	} = useUsageMetrics(refreshInterval);
+
+	const {
+		history: resourceHistory,
+		latest: resourceLatest,
+		available: monitorAvailable,
+		loading: resourceLoading,
+	} = useSystemMetrics();
 
 	// Map response times from serviceMetrics — they come from Prometheus
 	// latency data when available, otherwise undefined (SystemHealthPanel
@@ -208,39 +217,141 @@ export function MonitoringDashboard() {
 				</div>
 			</section>
 
-			{/* Placeholder charts for future monitor service */}
-			<section aria-label="System resource charts (coming soon)">
+			{/* System resource charts from the monitor service */}
+			<section aria-label="System resource charts">
 				<h2 className="mb-3 text-sm font-semibold text-th-text-secondary">
 					System Resources
-					<span className="ml-2 text-xs font-normal text-th-text-faint">
-						— requires monitor service (port 17003)
-					</span>
+					{!resourceLoading && !monitorAvailable && (
+						<span className="ml-2 rounded-full bg-th-status-warning-bg px-2 py-0.5 text-xs font-normal text-th-status-warning-text">
+							monitor service unavailable
+						</span>
+					)}
 				</h2>
 				<div className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-4">
-					<PlaceholderChart
-						variant="cpu"
+					<ResourceTrendCard
 						title="CPU Usage"
-						description="User, system, and idle time"
+						description={
+							resourceLatest
+								? `${resourceLatest.cpu.core_count} cores`
+								: "Global utilisation"
+						}
+						series={[
+							{
+								id: "CPU",
+								color: "#3b82f6",
+								data: resourceHistory.map((m) => ({
+									x: new Date(m.collected_at),
+									y: m.cpu.usage_percent,
+								})),
+							},
+						]}
+						readouts={[
+							{
+								label: "CPU",
+								value: resourceLatest
+									? `${resourceLatest.cpu.usage_percent.toFixed(0)}%`
+									: "—",
+								color: "#3b82f6",
+							},
+						]}
+						yMax={100}
+						unit="%"
+						available={monitorAvailable}
+						loading={resourceLoading}
 					/>
-					<PlaceholderChart
-						variant="memory"
+					<ResourceTrendCard
 						title="Memory Usage"
-						description="Used, cached, and free"
+						description={
+							resourceLatest
+								? `${formatGib(resourceLatest.memory.used_bytes)} of ${formatGib(resourceLatest.memory.total_bytes)} used`
+								: "Used vs total"
+						}
+						series={[
+							{
+								id: "Memory",
+								color: "#8b5cf6",
+								data: resourceHistory.map((m) => ({
+									x: new Date(m.collected_at),
+									y: m.memory.usage_percent,
+								})),
+							},
+						]}
+						readouts={[
+							{
+								label: "Memory",
+								value: resourceLatest
+									? `${resourceLatest.memory.usage_percent.toFixed(0)}%`
+									: "—",
+								color: "#8b5cf6",
+							},
+						]}
+						yMax={100}
+						unit="%"
+						available={monitorAvailable}
+						loading={resourceLoading}
 					/>
-					<PlaceholderChart
-						variant="disk"
-						title="Disk Usage"
-						description="Per-mount utilisation"
+					<DiskUsageCard
+						disks={resourceLatest?.disks ?? []}
+						available={monitorAvailable}
+						loading={resourceLoading}
 					/>
-					<PlaceholderChart
-						variant="network"
-						title="Network I/O"
-						description="Inbound and outbound traffic"
+					<ResourceTrendCard
+						title="Load Average"
+						description="1m / 5m / 15m"
+						series={[
+							{
+								id: "1m",
+								color: "#22c55e",
+								data: resourceHistory.map((m) => ({
+									x: new Date(m.collected_at),
+									y: m.load_average.one,
+								})),
+							},
+							{
+								id: "5m",
+								color: "#84cc16",
+								data: resourceHistory.map((m) => ({
+									x: new Date(m.collected_at),
+									y: m.load_average.five,
+								})),
+							},
+							{
+								id: "15m",
+								color: "#eab308",
+								data: resourceHistory.map((m) => ({
+									x: new Date(m.collected_at),
+									y: m.load_average.fifteen,
+								})),
+							},
+						]}
+						readouts={[
+							{
+								label: "1m",
+								value: resourceLatest
+									? resourceLatest.load_average.one.toFixed(2)
+									: "—",
+								color: "#22c55e",
+							},
+							{
+								label: "5m",
+								value: resourceLatest
+									? resourceLatest.load_average.five.toFixed(2)
+									: "—",
+								color: "#84cc16",
+							},
+						]}
+						available={monitorAvailable}
+						loading={resourceLoading}
 					/>
 				</div>
 			</section>
 		</div>
 	);
+}
+
+/** Format bytes as whole GiB for compact readouts. */
+function formatGib(bytes: number): string {
+	return `${(bytes / 1024 ** 3).toFixed(0)} GiB`;
 }
 
 export default MonitoringDashboard;

--- a/ui/src/pages/monitoring/MonitoringDashboard.tsx
+++ b/ui/src/pages/monitoring/MonitoringDashboard.tsx
@@ -16,12 +16,14 @@ import { CacheEfficiencyChart } from "@/components/monitoring/CacheEfficiencyCha
 import { CostOverviewChart } from "@/components/monitoring/CostOverviewChart";
 import { DiskUsageCard } from "@/components/monitoring/DiskUsageCard";
 import { NotificationMetricsChart } from "@/components/monitoring/NotificationMetricsChart";
+import { PlatformMetricsSection } from "@/components/monitoring/PlatformMetricsSection";
 import { ResourceTrendCard } from "@/components/monitoring/ResourceTrendCard";
 import { ServiceMetricsCard } from "@/components/monitoring/ServiceMetricsCard";
 import { SystemHealthPanel } from "@/components/monitoring/SystemHealthPanel";
 import { TokenUsageChart } from "@/components/monitoring/TokenUsageChart";
 import type { RefreshInterval } from "@/hooks/useMetrics";
 import { useMetrics } from "@/hooks/useMetrics";
+import { usePlatformMetrics } from "@/hooks/usePlatformMetrics";
 import { useSystemMetrics } from "@/hooks/useSystemMetrics";
 import { useUsageMetrics } from "@/hooks/useUsageMetrics";
 
@@ -74,6 +76,8 @@ export function MonitoringDashboard() {
 		available: monitorAvailable,
 		loading: resourceLoading,
 	} = useSystemMetrics();
+
+	const platformMetrics = usePlatformMetrics(refreshInterval);
 
 	// Map response times from serviceMetrics — they come from Prometheus
 	// latency data when available, otherwise undefined (SystemHealthPanel
@@ -194,6 +198,9 @@ export function MonitoringDashboard() {
 				<h2 className="sr-only">System Health</h2>
 				<SystemHealthPanel serviceMetrics={serviceMetrics} loading={loading} />
 			</section>
+
+			{/* Platform metrics from the named-query catalog (Prometheus) */}
+			<PlatformMetricsSection {...platformMetrics} />
 
 			{/* Token Usage & Prompt Cache section */}
 			<section aria-label="Token usage and prompt cache metrics">

--- a/ui/src/services/monitor.ts
+++ b/ui/src/services/monitor.ts
@@ -8,6 +8,9 @@
 import type { HealthResponse } from "@/types/common";
 import type {
 	CollectResponse,
+	NamedQuery,
+	QueryResult,
+	RunQueryOptions,
 	SystemMetrics,
 	SystemStatus,
 } from "@/types/monitor";
@@ -49,6 +52,35 @@ export class MonitorClient extends ApiClient {
 	/** `GET /status` — current health assessment against thresholds. */
 	getStatus(): Promise<SystemStatus> {
 		return this.get<SystemStatus>("/status");
+	}
+
+	// -------------------------------------------------------------------------
+	// Named Prometheus queries
+	// -------------------------------------------------------------------------
+
+	/**
+	 * `GET /queries` — the curated PromQL catalog.
+	 *
+	 * Static on the server side: succeeds even when Prometheus is down.
+	 */
+	listQueries(): Promise<NamedQuery[]> {
+		return this.get<NamedQuery[]>("/queries");
+	}
+
+	/**
+	 * `GET /queries/{name}` — execute a named query against Prometheus.
+	 *
+	 * Fails with `ApiError(502)` when Prometheus itself is unreachable —
+	 * distinct from the monitor being down (network error / `ApiError(0)`),
+	 * so callers can render the right degraded state.
+	 */
+	runQuery(name: string, options?: RunQueryOptions): Promise<QueryResult> {
+		return this.get<QueryResult>(`/queries/${encodeURIComponent(name)}`, {
+			window: options?.window,
+			mode: options?.mode,
+			range_minutes: options?.rangeMinutes,
+			step_secs: options?.stepSecs,
+		});
 	}
 }
 

--- a/ui/src/test/components/monitoring/DiskUsageCard.test.tsx
+++ b/ui/src/test/components/monitoring/DiskUsageCard.test.tsx
@@ -1,0 +1,64 @@
+/**
+ * Tests for DiskUsageCard component.
+ */
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it } from "vitest";
+import { DiskUsageCard } from "@/components/monitoring/DiskUsageCard";
+import type { DiskMetrics } from "@/types/monitor";
+
+const GIB = 1024 ** 3;
+
+const DISKS: DiskMetrics[] = [
+	{
+		name: "disk0",
+		mount_point: "/",
+		total_bytes: 500 * GIB,
+		available_bytes: 200 * GIB,
+		used_bytes: 300 * GIB,
+		usage_percent: 60,
+	},
+	{
+		name: "disk1",
+		mount_point: "/data",
+		total_bytes: 1000 * GIB,
+		available_bytes: 50 * GIB,
+		used_bytes: 950 * GIB,
+		usage_percent: 95,
+	},
+];
+
+describe("DiskUsageCard", () => {
+	it("renders one row per mount point with usage", () => {
+		render(<DiskUsageCard disks={DISKS} />);
+		expect(screen.getByText("/")).toBeTruthy();
+		expect(screen.getByText("/data")).toBeTruthy();
+		expect(screen.getByText("60%")).toBeTruthy();
+		expect(screen.getByText("95%")).toBeTruthy();
+	});
+
+	it("renders accessible progress bars with the usage value", () => {
+		render(<DiskUsageCard disks={DISKS} />);
+		const bars = screen.getAllByRole("progressbar");
+		expect(bars).toHaveLength(2);
+		expect(bars[0].getAttribute("aria-valuenow")).toBe("60");
+		expect(bars[1].getAttribute("aria-valuenow")).toBe("95");
+	});
+
+	it("formats sizes in GiB", () => {
+		render(<DiskUsageCard disks={[DISKS[0]]} />);
+		expect(screen.getByText(/300 GiB/)).toBeTruthy();
+		expect(screen.getByText(/500 GiB/)).toBeTruthy();
+	});
+
+	it("shows the unavailable state when the monitor is down", () => {
+		render(<DiskUsageCard disks={[]} available={false} />);
+		expect(screen.getByText("Monitor service unavailable")).toBeTruthy();
+		expect(screen.queryAllByRole("progressbar")).toHaveLength(0);
+	});
+
+	it("shows a loading skeleton while loading", () => {
+		const { container } = render(<DiskUsageCard disks={[]} loading />);
+		expect(container.querySelector(".animate-pulse")).toBeTruthy();
+	});
+});

--- a/ui/src/test/components/monitoring/PlatformMetricsSection.test.tsx
+++ b/ui/src/test/components/monitoring/PlatformMetricsSection.test.tsx
@@ -1,0 +1,161 @@
+/**
+ * Tests for PlatformMetricsSection and its building blocks.
+ */
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import {
+	PlatformMetricsSection,
+	PlatformStatCard,
+	ServiceBarList,
+} from "@/components/monitoring/PlatformMetricsSection";
+import type { PlatformQueryResults } from "@/hooks/usePlatformMetrics";
+import {
+	makeVectorQueryResult,
+	makeVectorSample,
+} from "@/test/mocks/factories";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function vector(name: string, samples: Array<[Record<string, string>, string]>) {
+	return makeVectorQueryResult(
+		name,
+		samples.map(([metric, value]) =>
+			makeVectorSample({ metric, value: [1, value] }),
+		),
+	);
+}
+
+const HEALTHY_RESULTS: PlatformQueryResults = {
+	"dispatch-success-rate": vector("dispatch-success-rate", [[{}, "0.95"]]),
+	"dispatch-throughput": vector("dispatch-throughput", [
+		[{ status: "completed" }, "19"],
+		[{ status: "failed" }, "1"],
+	]),
+	"agent-restart-rate": vector("agent-restart-rate", [[{}, "0"]]),
+	"approvals-backlog": vector("approvals-backlog", [[{}, "0"]]),
+	"http-error-rate": vector("http-error-rate", [
+		[{ service: "orchestrator" }, "0.001"],
+	]),
+	"http-p95-latency": vector("http-p95-latency", [
+		[{ service: "orchestrator" }, "0.0125"],
+		[{ service: "notify" }, "NaN"],
+	]),
+	"session-cost": vector("session-cost", [[{}, "1.5"]]),
+	"agents-active": vector("agents-active", [[{}, "3"]]),
+	"websocket-connections": vector("websocket-connections", [[{}, "3"]]),
+};
+
+function renderSection(overrides?: Record<string, unknown>) {
+	return render(
+		<PlatformMetricsSection
+			results={HEALTHY_RESULTS}
+			monitorDown={false}
+			prometheusDown={false}
+			loading={false}
+			refetch={vi.fn()}
+			{...overrides}
+		/>,
+	);
+}
+
+// ---------------------------------------------------------------------------
+// Section
+// ---------------------------------------------------------------------------
+
+describe("PlatformMetricsSection", () => {
+	it("renders stat cards from the query results", () => {
+		renderSection();
+		expect(screen.getByText("Dispatch Success")).toBeTruthy();
+		expect(screen.getByText("95%")).toBeTruthy();
+		expect(screen.getByText("19 completed / 1 failed (1h)")).toBeTruthy();
+		expect(screen.getByText("Active Agents")).toBeTruthy();
+		expect(screen.getByText("3 connections")).toBeTruthy();
+		expect(screen.getByText("Session Cost")).toBeTruthy();
+		expect(screen.getByText("$1.50")).toBeTruthy();
+	});
+
+	it("renders per-service bars, converting p95 to ms and dropping NaN rows", () => {
+		renderSection();
+		expect(screen.getByText("HTTP p95 Latency")).toBeTruthy();
+		expect(screen.getByText("13 ms")).toBeTruthy();
+		expect(screen.getByText("0.10%")).toBeTruthy();
+		// notify's NaN latency row (no traffic) is filtered out:
+		// "orchestrator" appears in both bar lists, "notify" in neither.
+		expect(screen.getAllByText("orchestrator")).toHaveLength(2);
+		expect(screen.queryByText("notify")).toBeNull();
+	});
+
+	it("flags an agents/connections mismatch", () => {
+		renderSection({
+			results: {
+				...HEALTHY_RESULTS,
+				"websocket-connections": vector("websocket-connections", [[{}, "1"]]),
+			},
+		});
+		expect(screen.getByText(/state mismatch\?/)).toBeTruthy();
+	});
+
+	it("shows the Prometheus-offline banner and hides the cards", () => {
+		renderSection({ prometheusDown: true, results: {} });
+		expect(screen.getByText(/Prometheus is offline/)).toBeTruthy();
+		expect(
+			screen.getByText(/system resources are still live/),
+		).toBeTruthy();
+		expect(screen.queryByText("Dispatch Success")).toBeNull();
+	});
+
+	it("shows the monitor-unreachable banner when the monitor is down", () => {
+		renderSection({ monitorDown: true, results: {} });
+		expect(screen.getByText(/Monitor service unreachable/)).toBeTruthy();
+	});
+
+	it("renders an em-dash placeholder when a query has no data", () => {
+		renderSection({
+			results: {
+				...HEALTHY_RESULTS,
+				"dispatch-success-rate": vector("dispatch-success-rate", []),
+				"dispatch-throughput": vector("dispatch-throughput", []),
+			},
+		});
+		expect(screen.getByText("no dispatches in the window")).toBeTruthy();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Building blocks
+// ---------------------------------------------------------------------------
+
+describe("PlatformStatCard", () => {
+	it("renders label, value, and hint", () => {
+		render(
+			<PlatformStatCard
+				label="Approvals Backlog"
+				value="4"
+				hint="pending tool approvals"
+				tone="warn"
+			/>,
+		);
+		expect(screen.getByText("Approvals Backlog")).toBeTruthy();
+		expect(screen.getByText("4")).toBeTruthy();
+		expect(screen.getByText("pending tool approvals")).toBeTruthy();
+	});
+});
+
+describe("ServiceBarList", () => {
+	it("renders the empty state when there are no entries", () => {
+		render(
+			<ServiceBarList
+				title="HTTP Error Rate"
+				entries={[]}
+				format={(v) => `${v}`}
+				fraction={(v) => v}
+				warnAt={1}
+				emptyText="No HTTP traffic in the window."
+			/>,
+		);
+		expect(screen.getByText("No HTTP traffic in the window.")).toBeTruthy();
+	});
+});

--- a/ui/src/test/components/monitoring/ResourceTrendCard.test.tsx
+++ b/ui/src/test/components/monitoring/ResourceTrendCard.test.tsx
@@ -1,0 +1,85 @@
+/**
+ * Tests for ResourceTrendCard component.
+ */
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import type { TrendSeries } from "@/components/monitoring/ResourceTrendCard";
+import { ResourceTrendCard } from "@/components/monitoring/ResourceTrendCard";
+
+// Mock useNivoTheme to avoid ThemeProvider dependency in unit tests
+vi.mock("@/hooks/useNivoTheme", () => ({ useNivoTheme: () => ({}) }));
+
+// Mock Nivo line chart
+vi.mock("@nivo/line", () => ({
+	ResponsiveLine: () => <div role="img" aria-label="trend line chart" />,
+}));
+
+const SERIES: TrendSeries[] = [
+	{
+		id: "CPU",
+		color: "#3b82f6",
+		data: [
+			{ x: new Date("2024-01-01T00:00:00Z"), y: 40 },
+			{ x: new Date("2024-01-01T00:00:30Z"), y: 45 },
+		],
+	},
+];
+
+const READOUTS = [{ label: "CPU", value: "45%", color: "#3b82f6" }];
+
+describe("ResourceTrendCard", () => {
+	it("renders title, description, and latest readout", () => {
+		render(
+			<ResourceTrendCard
+				title="CPU Usage"
+				description="8 cores"
+				series={SERIES}
+				readouts={READOUTS}
+				yMax={100}
+				unit="%"
+			/>,
+		);
+		expect(screen.getByText("CPU Usage")).toBeTruthy();
+		expect(screen.getByText("8 cores")).toBeTruthy();
+		expect(screen.getByText("45%")).toBeTruthy();
+		expect(screen.getByLabelText("trend line chart")).toBeTruthy();
+	});
+
+	it("shows a loading skeleton while loading", () => {
+		const { container } = render(
+			<ResourceTrendCard
+				title="CPU Usage"
+				series={SERIES}
+				readouts={READOUTS}
+				loading
+			/>,
+		);
+		expect(container.querySelector(".animate-pulse")).toBeTruthy();
+		expect(screen.queryByLabelText("trend line chart")).toBeNull();
+	});
+
+	it("shows the unavailable state when the monitor is down", () => {
+		render(
+			<ResourceTrendCard
+				title="CPU Usage"
+				series={[]}
+				readouts={[]}
+				available={false}
+			/>,
+		);
+		expect(screen.getByText("Monitor service unavailable")).toBeTruthy();
+		expect(screen.queryByLabelText("trend line chart")).toBeNull();
+	});
+
+	it("shows the empty state when available but no snapshots yet", () => {
+		render(
+			<ResourceTrendCard
+				title="CPU Usage"
+				series={[{ id: "CPU", color: "#000", data: [] }]}
+				readouts={[]}
+			/>,
+		);
+		expect(screen.getByText("No metrics collected yet.")).toBeTruthy();
+	});
+});

--- a/ui/src/test/hooks/usePlatformMetrics.test.ts
+++ b/ui/src/test/hooks/usePlatformMetrics.test.ts
@@ -1,0 +1,101 @@
+/**
+ * usePlatformMetrics -- MSW integration tests.
+ *
+ * Note: the ApiClient retries 5xx responses with backoff, so the 502 test
+ * pays ~600ms of retries per cycle — acceptable, but don't add more 502
+ * cases than needed.
+ */
+
+import { renderHook, waitFor } from "@testing-library/react";
+import { HttpResponse, http } from "msw";
+import { describe, expect, it } from "vitest";
+import {
+	PLATFORM_QUERIES,
+	usePlatformMetrics,
+	vectorEntries,
+	vectorValue,
+} from "@/hooks/usePlatformMetrics";
+import {
+	makeVectorQueryResult,
+	makeVectorSample,
+} from "@/test/mocks/factories";
+import { server } from "@/test/mocks/server";
+
+const BASE = "http://localhost:17003";
+
+describe("usePlatformMetrics (MSW integration)", () => {
+	it("loads every platform query on the happy path", async () => {
+		const { result } = renderHook(() => usePlatformMetrics());
+
+		await waitFor(() => expect(result.current.loading).toBe(false));
+
+		expect(result.current.monitorDown).toBe(false);
+		expect(result.current.prometheusDown).toBe(false);
+		for (const name of PLATFORM_QUERIES) {
+			expect(result.current.results[name]).toBeDefined();
+		}
+	});
+
+	it("flags prometheusDown on 502 responses", async () => {
+		server.use(
+			http.get(`${BASE}/queries/:name`, () =>
+				HttpResponse.json(
+					{ error: "Prometheus unavailable: connection refused" },
+					{ status: 502 },
+				),
+			),
+		);
+
+		const { result } = renderHook(() => usePlatformMetrics());
+		await waitFor(() => expect(result.current.loading).toBe(false), {
+			timeout: 10_000,
+		});
+
+		expect(result.current.prometheusDown).toBe(true);
+		expect(result.current.monitorDown).toBe(false);
+		expect(Object.keys(result.current.results)).toHaveLength(0);
+	}, 15_000);
+
+	it("flags monitorDown when nothing answers", async () => {
+		// 404s avoid the ApiClient's 5xx retry backoff (see header note).
+		server.use(
+			http.get(`${BASE}/queries/:name`, () =>
+				HttpResponse.json({ error: "Not found" }, { status: 404 }),
+			),
+		);
+
+		const { result } = renderHook(() => usePlatformMetrics());
+		await waitFor(() => expect(result.current.loading).toBe(false));
+
+		expect(result.current.monitorDown).toBe(true);
+		expect(result.current.prometheusDown).toBe(false);
+	});
+});
+
+describe("vector helpers", () => {
+	it("vectorEntries extracts labels and numeric values", () => {
+		const result = makeVectorQueryResult("http-p95-latency", [
+			makeVectorSample({
+				metric: { service: "orchestrator" },
+				value: [1, "0.0125"],
+			}),
+			makeVectorSample({ metric: { service: "notify" }, value: [1, "0.008"] }),
+		]);
+
+		const entries = vectorEntries(result);
+		expect(entries).toHaveLength(2);
+		expect(entries[0].labels.service).toBe("orchestrator");
+		expect(entries[0].value).toBeCloseTo(0.0125);
+	});
+
+	it("vectorValue sums samples and returns null for empty/missing data", () => {
+		const result = makeVectorQueryResult("dispatch-throughput", [
+			makeVectorSample({ metric: { status: "completed" }, value: [1, "12"] }),
+			makeVectorSample({ metric: { status: "failed" }, value: [1, "2"] }),
+		]);
+
+		expect(vectorValue(result)).toBe(14);
+		expect(vectorValue(makeVectorQueryResult("x", []))).toBeNull();
+		expect(vectorValue(undefined)).toBeNull();
+	});
+});

--- a/ui/src/test/mocks/factories/index.ts
+++ b/ui/src/test/mocks/factories/index.ts
@@ -33,10 +33,16 @@ export {
 	resetMemorySeq,
 } from "./memory";
 export {
+	makeMatrixQueryResult,
+	makeMatrixSeries,
 	makeMonitorAlert,
+	makeNamedQuery,
+	makeQueryCatalog,
 	makeSystemMetrics,
 	makeSystemMetricsHistory,
 	makeSystemStatus,
+	makeVectorQueryResult,
+	makeVectorSample,
 } from "./monitor";
 export {
 	makeCountResponse,

--- a/ui/src/test/mocks/factories/monitor.ts
+++ b/ui/src/test/mocks/factories/monitor.ts
@@ -8,9 +8,13 @@
  */
 
 import type {
+	MatrixSeries,
 	MonitorAlert,
+	NamedQuery,
+	QueryResult,
 	SystemMetrics,
 	SystemStatus,
+	VectorSample,
 } from "@/types/monitor";
 
 /** Base timestamp used for deterministic snapshot times */
@@ -90,5 +94,102 @@ export function makeSystemStatus(
 		alerts: [],
 		last_collected_at: "2024-01-01T00:00:00Z",
 		...overrides,
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Named-query factories (GET /queries, GET /queries/{name})
+// ---------------------------------------------------------------------------
+
+export function makeNamedQuery(overrides?: Partial<NamedQuery>): NamedQuery {
+	return {
+		name: "dispatch-success-rate",
+		description:
+			"Fraction of finished workflow dispatches that completed successfully",
+		promql:
+			'sum(increase(workflow_dispatches_total{status="completed"}[$__window]))',
+		unit: "ratio",
+		default_window: "1h",
+		...overrides,
+	};
+}
+
+/** A small representative catalog (subset of the server's 14 entries). */
+export function makeQueryCatalog(): NamedQuery[] {
+	return [
+		makeNamedQuery(),
+		makeNamedQuery({
+			name: "agents-active",
+			description: "Currently active agents",
+			promql: "agents_active",
+			unit: "count",
+			default_window: "",
+		}),
+		makeNamedQuery({
+			name: "session-cost",
+			description: "Claude session spend over the window (USD, gauge delta)",
+			promql: "delta(usage_session_cost_usd_total[$__window])",
+			unit: "usd",
+			default_window: "24h",
+		}),
+		makeNamedQuery({
+			name: "http-p95-latency",
+			description: "p95 HTTP request latency per service (seconds)",
+			promql: "histogram_quantile(0.95, ...)",
+			unit: "seconds",
+			default_window: "15m",
+		}),
+	];
+}
+
+export function makeVectorSample(
+	overrides?: Partial<VectorSample>,
+): VectorSample {
+	return {
+		metric: { service: "orchestrator" },
+		value: [1_704_067_200, "3"],
+		...overrides,
+	};
+}
+
+export function makeMatrixSeries(
+	overrides?: Partial<MatrixSeries>,
+): MatrixSeries {
+	return {
+		metric: { service: "orchestrator" },
+		values: [
+			[1_704_067_200, "1"],
+			[1_704_067_260, "2"],
+			[1_704_067_320, "3"],
+		],
+		...overrides,
+	};
+}
+
+/** Instant-vector query result. */
+export function makeVectorQueryResult(
+	name = "agents-active",
+	samples: VectorSample[] = [makeVectorSample()],
+): QueryResult {
+	return {
+		name,
+		promql: "agents_active",
+		mode: "instant",
+		executed_at: "2024-01-01T00:00:00Z",
+		data: { resultType: "vector", result: samples },
+	};
+}
+
+/** Range (matrix) query result. */
+export function makeMatrixQueryResult(
+	name = "dispatch-throughput",
+	series: MatrixSeries[] = [makeMatrixSeries()],
+): QueryResult {
+	return {
+		name,
+		promql: "sum by (status) (increase(workflow_dispatches_total[1h]))",
+		mode: "range",
+		executed_at: "2024-01-01T00:00:00Z",
+		data: { resultType: "matrix", result: series },
 	};
 }

--- a/ui/src/test/mocks/handlers/monitor.ts
+++ b/ui/src/test/mocks/handlers/monitor.ts
@@ -7,9 +7,11 @@
 
 import { HttpResponse, http } from "msw";
 import {
+	makeQueryCatalog,
 	makeSystemMetrics,
 	makeSystemMetricsHistory,
 	makeSystemStatus,
+	makeVectorQueryResult,
 } from "../factories";
 
 const BASE = "http://localhost:17003";
@@ -53,5 +55,15 @@ export const monitorHandlers = [
 				last_collected_at: DEFAULT_LATEST.collected_at,
 			}),
 		),
+	),
+
+	// -------------------------------------------------------------------------
+	// Named Prometheus queries
+	// -------------------------------------------------------------------------
+
+	http.get(`${BASE}/queries`, () => HttpResponse.json(makeQueryCatalog())),
+
+	http.get(`${BASE}/queries/:name`, ({ params }) =>
+		HttpResponse.json(makeVectorQueryResult(String(params.name))),
 	),
 ];

--- a/ui/src/test/pages/MonitoringDashboard.test.tsx
+++ b/ui/src/test/pages/MonitoringDashboard.test.tsx
@@ -72,6 +72,22 @@ vi.mock("@/hooks/useSystemMetrics", () => ({
 	useSystemMetrics: () => mockUseSystemMetrics(),
 }));
 
+vi.mock("@/hooks/usePlatformMetrics", async (importOriginal) => {
+	// Keep the real vector helpers — only the hook itself is stubbed.
+	const original =
+		await importOriginal<typeof import("@/hooks/usePlatformMetrics")>();
+	return {
+		...original,
+		usePlatformMetrics: () => ({
+			results: {},
+			monitorDown: false,
+			prometheusDown: false,
+			loading: false,
+			refetch: vi.fn(),
+		}),
+	};
+});
+
 function systemMetricsResult(overrides?: Record<string, unknown>) {
 	const snapshot = {
 		collected_at: "2024-01-01T00:00:00Z",

--- a/ui/src/test/pages/MonitoringDashboard.test.tsx
+++ b/ui/src/test/pages/MonitoringDashboard.test.tsx
@@ -4,7 +4,7 @@
 
 import { render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
-import { describe, expect, it, vi } from "vitest";
+import { beforeEach, describe, expect, it, vi } from "vitest";
 
 vi.mock("@/hooks/useMetrics", () => ({
 	useMetrics: () => ({
@@ -67,6 +67,45 @@ vi.mock("@/hooks/useServiceHealth", () => ({
 	}),
 }));
 
+const mockUseSystemMetrics = vi.fn();
+vi.mock("@/hooks/useSystemMetrics", () => ({
+	useSystemMetrics: () => mockUseSystemMetrics(),
+}));
+
+function systemMetricsResult(overrides?: Record<string, unknown>) {
+	const snapshot = {
+		collected_at: "2024-01-01T00:00:00Z",
+		cpu: { usage_percent: 42.5, core_count: 8, per_core: [] },
+		memory: {
+			total_bytes: 16 * 1024 ** 3,
+			used_bytes: 8 * 1024 ** 3,
+			available_bytes: 8 * 1024 ** 3,
+			usage_percent: 50,
+		},
+		disks: [
+			{
+				name: "disk0",
+				mount_point: "/",
+				total_bytes: 500 * 1024 ** 3,
+				available_bytes: 200 * 1024 ** 3,
+				used_bytes: 300 * 1024 ** 3,
+				usage_percent: 60,
+			},
+		],
+		load_average: { one: 1.5, five: 1.2, fifteen: 0.9 },
+	};
+	return {
+		history: [snapshot],
+		latest: snapshot,
+		alerts: [],
+		status: "healthy",
+		available: true,
+		loading: false,
+		refetch: vi.fn(),
+		...overrides,
+	};
+}
+
 // Mock theme hooks to avoid ThemeProvider dependency in unit tests
 vi.mock("@/hooks/useTheme", () => ({
 	useTheme: () => ({
@@ -104,17 +143,50 @@ function renderPage() {
 }
 
 describe("MonitoringDashboard", () => {
+	beforeEach(() => {
+		mockUseSystemMetrics.mockReturnValue(systemMetricsResult());
+	});
+
 	it("renders the page heading", () => {
 		renderPage();
 		expect(screen.getByText("Monitoring")).toBeInTheDocument();
 	});
 
+	it("renders the system resources section with live data", () => {
+		renderPage();
+		expect(screen.getByText("CPU Usage")).toBeInTheDocument();
+		expect(screen.getByText("Memory Usage")).toBeInTheDocument();
+		expect(screen.getByText("Disk Usage")).toBeInTheDocument();
+		expect(screen.getByText("Load Average")).toBeInTheDocument();
+		// Disk row from the latest snapshot
+		expect(screen.getByText("60%")).toBeInTheDocument();
+		// No placeholder remnants
+		expect(screen.queryByText(/coming soon/i)).toBeNull();
+		expect(screen.queryByText(/port 17003/i)).toBeNull();
+	});
+
+	it("flags the section when the monitor service is unavailable", () => {
+		mockUseSystemMetrics.mockReturnValue(
+			systemMetricsResult({
+				history: [],
+				latest: null,
+				available: false,
+			}),
+		);
+		renderPage();
+		expect(screen.getByText("monitor service unavailable")).toBeInTheDocument();
+		expect(
+			screen.getAllByText("Monitor service unavailable").length,
+		).toBeGreaterThan(0);
+	});
+
 	it("renders refresh interval options", () => {
 		renderPage();
-		expect(screen.getByText("10s")).toBeInTheDocument();
-		expect(screen.getByText("30s")).toBeInTheDocument();
-		expect(screen.getByText("1m")).toBeInTheDocument();
-		expect(screen.getByText("5m")).toBeInTheDocument();
+		// Scoped to buttons: "1m"/"5m" also appear as Load Average readouts.
+		expect(screen.getByRole("button", { name: "10s" })).toBeInTheDocument();
+		expect(screen.getByRole("button", { name: "30s" })).toBeInTheDocument();
+		expect(screen.getByRole("button", { name: "1m" })).toBeInTheDocument();
+		expect(screen.getByRole("button", { name: "5m" })).toBeInTheDocument();
 	});
 
 	it("renders a manual refresh button", () => {

--- a/ui/src/test/services/monitor.test.ts
+++ b/ui/src/test/services/monitor.test.ts
@@ -1,0 +1,132 @@
+/**
+ * Tests for MonitorClient — focused on the named Prometheus query API
+ * (GET /queries, GET /queries/{name}).
+ */
+
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { MonitorClient } from "@/services/monitor";
+import { ApiError } from "@/types/common";
+import {
+	makeQueryCatalog,
+	makeVectorQueryResult,
+} from "../mocks/factories/monitor";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeJsonResponse(status: number, body: unknown) {
+	return new Response(JSON.stringify(body), {
+		status,
+		headers: new Headers({ "content-type": "application/json" }),
+	});
+}
+
+function mockFetch(status: number, body: unknown) {
+	const fetchMock = vi.fn().mockResolvedValue(makeJsonResponse(status, body));
+	vi.stubGlobal("fetch", fetchMock);
+	return fetchMock;
+}
+
+function makeClient() {
+	// maxRetries: 1 — error-path tests must not sit through retry backoff.
+	return new MonitorClient({
+		baseUrl: "http://localhost:17003",
+		maxRetries: 1,
+	});
+}
+
+afterEach(() => {
+	vi.unstubAllGlobals();
+});
+
+// ---------------------------------------------------------------------------
+// listQueries
+// ---------------------------------------------------------------------------
+
+describe("MonitorClient.listQueries", () => {
+	it("fetches the catalog from GET /queries", async () => {
+		const catalog = makeQueryCatalog();
+		const fetchMock = mockFetch(200, catalog);
+
+		const result = await makeClient().listQueries();
+
+		expect(fetchMock).toHaveBeenCalledTimes(1);
+		const url = String(fetchMock.mock.calls[0][0]);
+		expect(url).toBe("http://localhost:17003/queries");
+		expect(result).toHaveLength(catalog.length);
+		expect(result[0].name).toBe("dispatch-success-rate");
+	});
+});
+
+// ---------------------------------------------------------------------------
+// runQuery
+// ---------------------------------------------------------------------------
+
+describe("MonitorClient.runQuery", () => {
+	it("fetches GET /queries/{name} with no params by default", async () => {
+		const fetchMock = mockFetch(200, makeVectorQueryResult("agents-active"));
+
+		const result = await makeClient().runQuery("agents-active");
+
+		const url = new URL(String(fetchMock.mock.calls[0][0]));
+		expect(url.pathname).toBe("/queries/agents-active");
+		expect([...url.searchParams.keys()]).toHaveLength(0);
+		expect(result.data.resultType).toBe("vector");
+	});
+
+	it("encodes window/mode/range params", async () => {
+		const fetchMock = mockFetch(
+			200,
+			makeVectorQueryResult("dispatch-success-rate"),
+		);
+
+		await makeClient().runQuery("dispatch-success-rate", {
+			window: "15m",
+			mode: "range",
+			rangeMinutes: 120,
+			stepSecs: 30,
+		});
+
+		const url = new URL(String(fetchMock.mock.calls[0][0]));
+		expect(url.searchParams.get("window")).toBe("15m");
+		expect(url.searchParams.get("mode")).toBe("range");
+		expect(url.searchParams.get("range_minutes")).toBe("120");
+		expect(url.searchParams.get("step_secs")).toBe("30");
+	});
+
+	it("URL-encodes the query name", async () => {
+		const fetchMock = mockFetch(200, makeVectorQueryResult("x"));
+
+		await makeClient().runQuery("weird/name");
+
+		const url = String(fetchMock.mock.calls[0][0]);
+		expect(url).toContain("/queries/weird%2Fname");
+	});
+
+	it("propagates 502 (Prometheus down) as ApiError with status 502", async () => {
+		mockFetch(502, { error: "Prometheus unavailable: connection refused" });
+
+		const err = await makeClient()
+			.runQuery("agents-active")
+			.catch((e: unknown) => e);
+
+		expect(err).toBeInstanceOf(ApiError);
+		expect((err as ApiError).status).toBe(502);
+		expect((err as ApiError).message).toContain("Prometheus unavailable");
+	});
+
+	it("propagates 404 (unknown query) with the server's catalog hint", async () => {
+		mockFetch(404, {
+			error: "Unknown query `bogus`. Known queries: dispatch-success-rate",
+		});
+
+		const err = await makeClient()
+			.runQuery("bogus")
+			.catch((e: unknown) => e);
+
+		expect(err).toBeInstanceOf(ApiError);
+		expect((err as ApiError).status).toBe(404);
+		expect((err as ApiError).message).toContain("dispatch-success-rate");
+	});
+});

--- a/ui/src/types/monitor.ts
+++ b/ui/src/types/monitor.ts
@@ -87,3 +87,66 @@ export interface CollectResponse {
 	metrics: SystemMetrics;
 	alerts: MonitorAlert[];
 }
+
+// ---------------------------------------------------------------------------
+// Named Prometheus queries (GET /queries, GET /queries/{name})
+// ---------------------------------------------------------------------------
+
+/** One entry of the curated PromQL catalog (GET /queries). */
+export interface NamedQuery {
+	/** Stable identifier used in API paths */
+	name: string;
+	/** Human-readable description of what the result means */
+	description: string;
+	/** PromQL, possibly containing the `$__window` token */
+	promql: string;
+	/** Unit of the resulting values (e.g. "ratio", "count", "usd") */
+	unit: string;
+	/** Default window substitution; empty for instant gauge queries */
+	default_window: string;
+}
+
+/** One instant-vector sample: label set + [unix_seconds, value] pair. */
+export interface VectorSample {
+	metric: Record<string, string>;
+	value: [number, string];
+}
+
+/** One range-vector series: label set + list of [unix_seconds, value] pairs. */
+export interface MatrixSeries {
+	metric: Record<string, string>;
+	values: Array<[number, string]>;
+}
+
+/** Query result data, tagged by Prometheus's resultType. */
+export type PromData =
+	| { resultType: "vector"; result: VectorSample[] }
+	| { resultType: "matrix"; result: MatrixSeries[] }
+	| { resultType: "scalar"; result: [number, string] };
+
+/** Evaluation mode for GET /queries/{name}. */
+export type QueryMode = "instant" | "range";
+
+/** Response from GET /queries/{name} and GET /query. */
+export interface QueryResult {
+	/** Catalog name, or "raw" for the passthrough endpoint */
+	name: string;
+	/** The executed PromQL after window substitution */
+	promql: string;
+	mode: QueryMode;
+	/** When the query executed (ISO 8601) */
+	executed_at: string;
+	data: PromData;
+}
+
+/** Options for MonitorClient.runQuery(). */
+export interface RunQueryOptions {
+	/** `$__window` substitution (e.g. "15m", "1h"); defaults per query */
+	window?: string;
+	/** "instant" (default) or "range" */
+	mode?: QueryMode;
+	/** Range mode: how far back from now the range starts (default 360) */
+	rangeMinutes?: number;
+	/** Range mode: resolution step in seconds (default 60) */
+	stepSecs?: number;
+}


### PR DESCRIPTION
Wire the monitoring page to the monitor service, replacing the
"Coming Soon" placeholder section that shipped before the service
existed.

- MonitorClient gains listQueries() and runQuery(name, {window, mode,
  rangeMinutes, stepSecs}) for the curated PromQL catalog, with types
  (NamedQuery, PromData vector/matrix/scalar, QueryResult) mirroring
  the Rust API. A 502 (Prometheus down) surfaces as ApiError(502),
  distinct from the monitor itself being unreachable.
- New ResourceTrendCard (compact time-series card) and DiskUsageCard
  (per-mount fill bars with capacity colour shifts) components.
- MonitoringDashboard's System Resources section now renders live CPU,
  memory, disk, and load-average data from the monitor history ring
  buffer via useSystemMetrics, with quiet unavailable/empty states and
  a header badge when the monitor is down. The stale "port 17003"
  hardcoded hint is gone.
- PlaceholderChart is no longer used by any page (file retained;
  removal blocked by the destructive-command hook).
- MSW handlers/factories for /queries and /queries/{name}.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>