### PR TITLE
feat(ui): Platform Metrics section from the monitor named-query catalog

### DIFF
--- a/ui/src/components/monitoring/PlatformMetricsSection.tsx
+++ b/ui/src/components/monitoring/PlatformMetricsSection.tsx
@@ -1,0 +1,287 @@
+/**
+ * PlatformMetricsSection — Prometheus-backed platform health from the
+ * monitor service's curated named-query API.
+ *
+ * Stat cards (dispatch success, agents vs connections, approvals backlog,
+ * session cost, restarts) over per-service HTTP error-rate and p95-latency
+ * bar lists. Renders explicit degraded states that distinguish "Prometheus
+ * offline" (system resources still live) from "monitor unreachable".
+ */
+
+import { AlertTriangle } from "lucide-react";
+import { ChartSkeleton } from "@/components/common/LoadingSkeleton";
+import type {
+	PlatformQueryResults,
+	UsePlatformMetricsResult,
+} from "@/hooks/usePlatformMetrics";
+import { vectorEntries, vectorValue } from "@/hooks/usePlatformMetrics";
+
+// ---------------------------------------------------------------------------
+// Stat card
+// ---------------------------------------------------------------------------
+
+export type StatTone = "neutral" | "ok" | "warn" | "error";
+
+export interface PlatformStatCardProps {
+	label: string;
+	/** Pre-formatted display value; "—" when no data */
+	value: string;
+	/** Small line under the value (e.g. the window or a breakdown) */
+	hint?: string;
+	tone?: StatTone;
+}
+
+const TONE_CLASSES: Record<StatTone, string> = {
+	neutral: "text-th-text",
+	ok: "text-th-status-success-text",
+	warn: "text-th-status-warning-text",
+	error: "text-th-status-error-text",
+};
+
+export function PlatformStatCard({
+	label,
+	value,
+	hint,
+	tone = "neutral",
+}: PlatformStatCardProps) {
+	return (
+		<div className="rounded-lg border border-th-border bg-th-surface p-4">
+			<p className="text-xs text-th-text-muted">{label}</p>
+			<p className={`mt-1 text-2xl font-semibold ${TONE_CLASSES[tone]}`}>
+				{value}
+			</p>
+			{hint && <p className="mt-0.5 text-xs text-th-text-faint">{hint}</p>}
+		</div>
+	);
+}
+
+// ---------------------------------------------------------------------------
+// Per-service bar list
+// ---------------------------------------------------------------------------
+
+export interface ServiceBarListProps {
+	title: string;
+	/** Window hint shown next to the title (e.g. "15m") */
+	window?: string;
+	entries: Array<{ service: string; value: number }>;
+	/** Format a value for the row readout */
+	format: (value: number) => string;
+	/** Bar fill fraction for a value (clamped to [0, 1]) */
+	fraction: (value: number) => number;
+	/** Threshold above which a row renders in the warning colour */
+	warnAt: number;
+	emptyText: string;
+}
+
+export function ServiceBarList({
+	title,
+	window: windowHint,
+	entries,
+	format,
+	fraction,
+	warnAt,
+	emptyText,
+}: ServiceBarListProps) {
+	return (
+		<div className="rounded-lg border border-th-border bg-th-surface p-4">
+			<h3 className="text-sm font-semibold text-th-text">
+				{title}
+				{windowHint && (
+					<span className="ml-2 text-xs font-normal text-th-text-faint">
+						{windowHint}
+					</span>
+				)}
+			</h3>
+			{entries.length === 0 ? (
+				<p className="mt-3 text-xs text-th-text-muted">{emptyText}</p>
+			) : (
+				<ul className="mt-3 space-y-2">
+					{entries.map((entry) => {
+						const warn = entry.value >= warnAt;
+						return (
+							<li
+								key={entry.service}
+								className="flex items-center gap-3 text-xs"
+							>
+								<span className="w-24 shrink-0 truncate text-th-text-muted">
+									{entry.service}
+								</span>
+								<div className="h-1.5 flex-1 overflow-hidden rounded-full bg-th-surface-hover">
+									<div
+										className="h-full rounded-full"
+										style={{
+											width: `${Math.min(100, fraction(entry.value) * 100)}%`,
+											background: warn
+												? "var(--th-status-warning-text, #f59e0b)"
+												: "#3b82f6",
+										}}
+									/>
+								</div>
+								<span
+									className={`w-16 shrink-0 text-right font-medium ${
+										warn ? "text-th-status-warning-text" : "text-th-text"
+									}`}
+								>
+									{format(entry.value)}
+								</span>
+							</li>
+						);
+					})}
+				</ul>
+			)}
+		</div>
+	);
+}
+
+// ---------------------------------------------------------------------------
+// Derivations
+// ---------------------------------------------------------------------------
+
+function dispatchSuccessCard(results: PlatformQueryResults) {
+	const rate = vectorValue(results["dispatch-success-rate"]);
+	const throughput = vectorEntries(results["dispatch-throughput"]);
+	const byStatus = Object.fromEntries(
+		throughput.map((e) => [e.labels.status ?? "?", Math.round(e.value)]),
+	);
+	const finished = (byStatus.completed ?? 0) + (byStatus.failed ?? 0);
+
+	const hint =
+		throughput.length > 0
+			? `${byStatus.completed ?? 0} completed / ${byStatus.failed ?? 0} failed (1h)`
+			: "last 1h";
+
+	if (rate === null || finished === 0) {
+		return { value: "—", hint: "no dispatches in the window", tone: "neutral" as StatTone };
+	}
+	const tone: StatTone = rate >= 0.9 ? "ok" : rate >= 0.5 ? "warn" : "error";
+	return { value: `${(rate * 100).toFixed(0)}%`, hint, tone };
+}
+
+function agentsCard(results: PlatformQueryResults) {
+	const active = vectorValue(results["agents-active"]);
+	const connections = vectorValue(results["websocket-connections"]);
+	if (active === null) {
+		return { value: "—", hint: "agents active", tone: "neutral" as StatTone };
+	}
+	const mismatch = connections !== null && connections !== active;
+	return {
+		value: `${active}`,
+		hint:
+			connections === null
+				? "agents active"
+				: `${connections} connection${connections === 1 ? "" : "s"}${mismatch ? " — state mismatch?" : ""}`,
+		tone: (mismatch ? "warn" : "neutral") as StatTone,
+	};
+}
+
+// ---------------------------------------------------------------------------
+// Section
+// ---------------------------------------------------------------------------
+
+export type PlatformMetricsSectionProps = UsePlatformMetricsResult;
+
+export function PlatformMetricsSection({
+	results,
+	monitorDown,
+	prometheusDown,
+	loading,
+}: PlatformMetricsSectionProps) {
+	const dispatch = dispatchSuccessCard(results);
+	const agents = agentsCard(results);
+	const approvals = vectorValue(results["approvals-backlog"]);
+	const cost = vectorValue(results["session-cost"]);
+	const restarts = vectorValue(results["agent-restart-rate"]);
+
+	const errorRates = vectorEntries(results["http-error-rate"]).map((e) => ({
+		service: e.labels.service ?? "?",
+		value: e.value,
+	}));
+	const latencies = vectorEntries(results["http-p95-latency"])
+		.map((e) => ({
+			service: e.labels.service ?? "?",
+			// histogram_quantile yields NaN for services with no traffic yet.
+			value: e.value,
+		}))
+		.filter((e) => Number.isFinite(e.value));
+
+	const degraded = monitorDown || prometheusDown;
+
+	return (
+		<section aria-label="Platform metrics">
+			<h2 className="mb-3 text-sm font-semibold text-th-text-secondary">
+				Platform Metrics
+			</h2>
+
+			{/* Degraded banner */}
+			{!loading && degraded && (
+				<div className="mb-4 flex items-center gap-2 rounded-md border border-th-status-warning-border bg-th-status-warning-bg px-4 py-2.5 text-sm text-th-status-warning-text">
+					<AlertTriangle size={14} className="shrink-0" />
+					{monitorDown
+						? "Monitor service unreachable — platform metrics unavailable."
+						: "Prometheus is offline — platform metrics unavailable (system resources are still live)."}
+				</div>
+			)}
+
+			{loading && <ChartSkeleton height={96} />}
+
+			{!loading && !degraded && (
+				<>
+					<div className="grid grid-cols-2 gap-4 sm:grid-cols-3 xl:grid-cols-5">
+						<PlatformStatCard
+							label="Dispatch Success"
+							value={dispatch.value}
+							hint={dispatch.hint}
+							tone={dispatch.tone}
+						/>
+						<PlatformStatCard
+							label="Active Agents"
+							value={agents.value}
+							hint={agents.hint}
+							tone={agents.tone}
+						/>
+						<PlatformStatCard
+							label="Approvals Backlog"
+							value={approvals === null ? "—" : `${Math.round(approvals)}`}
+							hint="pending tool approvals"
+							tone={approvals !== null && approvals > 0 ? "warn" : "neutral"}
+						/>
+						<PlatformStatCard
+							label="Session Cost"
+							value={cost === null ? "—" : `$${cost.toFixed(2)}`}
+							hint="last 24h"
+						/>
+						<PlatformStatCard
+							label="Agent Restarts"
+							value={restarts === null ? "—" : `${Math.round(restarts)}`}
+							hint="last 1h"
+							tone={restarts !== null && restarts > 0 ? "warn" : "neutral"}
+						/>
+					</div>
+
+					<div className="mt-4 grid grid-cols-1 gap-4 lg:grid-cols-2">
+						<ServiceBarList
+							title="HTTP Error Rate"
+							window="15m"
+							entries={errorRates}
+							format={(v) => `${(v * 100).toFixed(2)}%`}
+							fraction={(v) => v}
+							warnAt={0.01}
+							emptyText="No HTTP traffic in the window."
+						/>
+						<ServiceBarList
+							title="HTTP p95 Latency"
+							window="15m"
+							entries={latencies}
+							format={(v) => `${(v * 1000).toFixed(0)} ms`}
+							fraction={(v) => v / 1}
+							warnAt={0.5}
+							emptyText="No latency samples in the window."
+						/>
+					</div>
+				</>
+			)}
+		</section>
+	);
+}
+
+export default PlatformMetricsSection;

--- a/ui/src/components/monitoring/index.ts
+++ b/ui/src/components/monitoring/index.ts
@@ -9,6 +9,17 @@ export { DiskUsageCard } from "./DiskUsageCard";
 export type { NotificationMetricsChartProps } from "./NotificationMetricsChart";
 export { NotificationMetricsChart } from "./NotificationMetricsChart";
 export type {
+	PlatformMetricsSectionProps,
+	PlatformStatCardProps,
+	ServiceBarListProps,
+	StatTone,
+} from "./PlatformMetricsSection";
+export {
+	PlatformMetricsSection,
+	PlatformStatCard,
+	ServiceBarList,
+} from "./PlatformMetricsSection";
+export type {
 	ResourceTrendCardProps,
 	TrendReadout,
 	TrendSeries,

--- a/ui/src/hooks/usePlatformMetrics.ts
+++ b/ui/src/hooks/usePlatformMetrics.ts
@@ -1,0 +1,132 @@
+/**
+ * usePlatformMetrics — polls the monitor service's curated named-query API
+ * (Prometheus-backed) for platform-level metrics: dispatch health, HTTP
+ * error rate and latency per service, approvals backlog, session cost,
+ * and agent/connection counts.
+ *
+ * Degrades in two distinct ways so the page can say what actually broke:
+ * - `monitorDown`    — the monitor service itself is unreachable.
+ * - `prometheusDown` — the monitor answered but Prometheus is down (502).
+ */
+
+import { useCallback, useRef, useState } from "react";
+import { monitorClient } from "@/services/monitor";
+import { ApiError } from "@/types/common";
+import type { QueryResult, VectorSample } from "@/types/monitor";
+import { usePolling } from "./usePolling";
+
+// ---------------------------------------------------------------------------
+// Queried catalog entries
+// ---------------------------------------------------------------------------
+
+/** Named queries this hook polls each cycle. */
+export const PLATFORM_QUERIES = [
+	"dispatch-success-rate",
+	"dispatch-throughput",
+	"agent-restart-rate",
+	"approvals-backlog",
+	"http-error-rate",
+	"http-p95-latency",
+	"session-cost",
+	"agents-active",
+	"websocket-connections",
+] as const;
+
+export type PlatformQueryName = (typeof PLATFORM_QUERIES)[number];
+
+export type PlatformQueryResults = Partial<
+	Record<PlatformQueryName, QueryResult>
+>;
+
+export interface UsePlatformMetricsResult {
+	/** Latest result per query; absent while loading or on per-query failure */
+	results: PlatformQueryResults;
+	/** True when the monitor service itself is unreachable */
+	monitorDown: boolean;
+	/** True when the monitor answered but Prometheus is down (HTTP 502) */
+	prometheusDown: boolean;
+	/** True only during the very first load */
+	loading: boolean;
+	refetch: () => void;
+}
+
+// ---------------------------------------------------------------------------
+// Vector helpers (exported for the chart components)
+// ---------------------------------------------------------------------------
+
+/** All samples of an instant-vector result as { labels, value } entries. */
+export function vectorEntries(
+	result: QueryResult | undefined,
+): Array<{ labels: Record<string, string>; value: number }> {
+	if (!result || result.data.resultType !== "vector") return [];
+	return result.data.result.map((sample: VectorSample) => ({
+		labels: sample.metric,
+		value: Number.parseFloat(sample.value[1]),
+	}));
+}
+
+/**
+ * The single scalar value of an instant-vector result (sum across samples),
+ * or null when there is no data.
+ */
+export function vectorValue(result: QueryResult | undefined): number | null {
+	const entries = vectorEntries(result);
+	if (entries.length === 0) return null;
+	return entries.reduce((acc, e) => acc + e.value, 0);
+}
+
+// ---------------------------------------------------------------------------
+// Hook
+// ---------------------------------------------------------------------------
+
+export function usePlatformMetrics(
+	intervalMs?: number,
+): UsePlatformMetricsResult {
+	const [results, setResults] = useState<PlatformQueryResults>({});
+	const [monitorDown, setMonitorDown] = useState(false);
+	const [prometheusDown, setPrometheusDown] = useState(false);
+	const [loading, setLoading] = useState(true);
+	const hasLoadedRef = useRef(false);
+
+	const fetch = useCallback(async () => {
+		if (!hasLoadedRef.current) setLoading(true);
+
+		const settled = await Promise.allSettled(
+			PLATFORM_QUERIES.map((name) => monitorClient.runQuery(name)),
+		);
+
+		const next: PlatformQueryResults = {};
+		let sawBadGateway = false;
+		let sawSuccess = false;
+
+		settled.forEach((outcome, i) => {
+			const name = PLATFORM_QUERIES[i];
+			if (outcome.status === "fulfilled") {
+				next[name] = outcome.value;
+				sawSuccess = true;
+			} else if (
+				outcome.reason instanceof ApiError &&
+				outcome.reason.status === 502
+			) {
+				sawBadGateway = true;
+			}
+		});
+
+		setResults(next);
+		setPrometheusDown(sawBadGateway);
+		// Only "nothing answered and nothing was a 502" means the monitor
+		// itself is gone — a 502 proves the monitor responded.
+		setMonitorDown(!sawSuccess && !sawBadGateway);
+
+		hasLoadedRef.current = true;
+		setLoading(false);
+	}, []);
+
+	usePolling(fetch, intervalMs);
+
+	const refetch = useCallback(() => {
+		void fetch();
+	}, [fetch]);
+
+	return { results, monitorDown, prometheusDown, loading, refetch };
+}

--- a/ui/src/pages/monitoring/MonitoringDashboard.tsx
+++ b/ui/src/pages/monitoring/MonitoringDashboard.tsx
@@ -16,12 +16,14 @@ import { CacheEfficiencyChart } from "@/components/monitoring/CacheEfficiencyCha
 import { CostOverviewChart } from "@/components/monitoring/CostOverviewChart";
 import { DiskUsageCard } from "@/components/monitoring/DiskUsageCard";
 import { NotificationMetricsChart } from "@/components/monitoring/NotificationMetricsChart";
+import { PlatformMetricsSection } from "@/components/monitoring/PlatformMetricsSection";
 import { ResourceTrendCard } from "@/components/monitoring/ResourceTrendCard";
 import { ServiceMetricsCard } from "@/components/monitoring/ServiceMetricsCard";
 import { SystemHealthPanel } from "@/components/monitoring/SystemHealthPanel";
 import { TokenUsageChart } from "@/components/monitoring/TokenUsageChart";
 import type { RefreshInterval } from "@/hooks/useMetrics";
 import { useMetrics } from "@/hooks/useMetrics";
+import { usePlatformMetrics } from "@/hooks/usePlatformMetrics";
 import { useSystemMetrics } from "@/hooks/useSystemMetrics";
 import { useUsageMetrics } from "@/hooks/useUsageMetrics";
 
@@ -74,6 +76,8 @@ export function MonitoringDashboard() {
 		available: monitorAvailable,
 		loading: resourceLoading,
 	} = useSystemMetrics();
+
+	const platformMetrics = usePlatformMetrics(refreshInterval);
 
 	// Map response times from serviceMetrics — they come from Prometheus
 	// latency data when available, otherwise undefined (SystemHealthPanel
@@ -194,6 +198,9 @@ export function MonitoringDashboard() {
 				<h2 className="sr-only">System Health</h2>
 				<SystemHealthPanel serviceMetrics={serviceMetrics} loading={loading} />
 			</section>
+
+			{/* Platform metrics from the named-query catalog (Prometheus) */}
+			<PlatformMetricsSection {...platformMetrics} />
 
 			{/* Token Usage & Prompt Cache section */}
 			<section aria-label="Token usage and prompt cache metrics">

--- a/ui/src/test/components/monitoring/PlatformMetricsSection.test.tsx
+++ b/ui/src/test/components/monitoring/PlatformMetricsSection.test.tsx
@@ -1,0 +1,161 @@
+/**
+ * Tests for PlatformMetricsSection and its building blocks.
+ */
+
+import { render, screen } from "@testing-library/react";
+import { describe, expect, it, vi } from "vitest";
+import {
+	PlatformMetricsSection,
+	PlatformStatCard,
+	ServiceBarList,
+} from "@/components/monitoring/PlatformMetricsSection";
+import type { PlatformQueryResults } from "@/hooks/usePlatformMetrics";
+import {
+	makeVectorQueryResult,
+	makeVectorSample,
+} from "@/test/mocks/factories";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function vector(name: string, samples: Array<[Record<string, string>, string]>) {
+	return makeVectorQueryResult(
+		name,
+		samples.map(([metric, value]) =>
+			makeVectorSample({ metric, value: [1, value] }),
+		),
+	);
+}
+
+const HEALTHY_RESULTS: PlatformQueryResults = {
+	"dispatch-success-rate": vector("dispatch-success-rate", [[{}, "0.95"]]),
+	"dispatch-throughput": vector("dispatch-throughput", [
+		[{ status: "completed" }, "19"],
+		[{ status: "failed" }, "1"],
+	]),
+	"agent-restart-rate": vector("agent-restart-rate", [[{}, "0"]]),
+	"approvals-backlog": vector("approvals-backlog", [[{}, "0"]]),
+	"http-error-rate": vector("http-error-rate", [
+		[{ service: "orchestrator" }, "0.001"],
+	]),
+	"http-p95-latency": vector("http-p95-latency", [
+		[{ service: "orchestrator" }, "0.0125"],
+		[{ service: "notify" }, "NaN"],
+	]),
+	"session-cost": vector("session-cost", [[{}, "1.5"]]),
+	"agents-active": vector("agents-active", [[{}, "3"]]),
+	"websocket-connections": vector("websocket-connections", [[{}, "3"]]),
+};
+
+function renderSection(overrides?: Record<string, unknown>) {
+	return render(
+		<PlatformMetricsSection
+			results={HEALTHY_RESULTS}
+			monitorDown={false}
+			prometheusDown={false}
+			loading={false}
+			refetch={vi.fn()}
+			{...overrides}
+		/>,
+	);
+}
+
+// ---------------------------------------------------------------------------
+// Section
+// ---------------------------------------------------------------------------
+
+describe("PlatformMetricsSection", () => {
+	it("renders stat cards from the query results", () => {
+		renderSection();
+		expect(screen.getByText("Dispatch Success")).toBeTruthy();
+		expect(screen.getByText("95%")).toBeTruthy();
+		expect(screen.getByText("19 completed / 1 failed (1h)")).toBeTruthy();
+		expect(screen.getByText("Active Agents")).toBeTruthy();
+		expect(screen.getByText("3 connections")).toBeTruthy();
+		expect(screen.getByText("Session Cost")).toBeTruthy();
+		expect(screen.getByText("$1.50")).toBeTruthy();
+	});
+
+	it("renders per-service bars, converting p95 to ms and dropping NaN rows", () => {
+		renderSection();
+		expect(screen.getByText("HTTP p95 Latency")).toBeTruthy();
+		expect(screen.getByText("13 ms")).toBeTruthy();
+		expect(screen.getByText("0.10%")).toBeTruthy();
+		// notify's NaN latency row (no traffic) is filtered out:
+		// "orchestrator" appears in both bar lists, "notify" in neither.
+		expect(screen.getAllByText("orchestrator")).toHaveLength(2);
+		expect(screen.queryByText("notify")).toBeNull();
+	});
+
+	it("flags an agents/connections mismatch", () => {
+		renderSection({
+			results: {
+				...HEALTHY_RESULTS,
+				"websocket-connections": vector("websocket-connections", [[{}, "1"]]),
+			},
+		});
+		expect(screen.getByText(/state mismatch\?/)).toBeTruthy();
+	});
+
+	it("shows the Prometheus-offline banner and hides the cards", () => {
+		renderSection({ prometheusDown: true, results: {} });
+		expect(screen.getByText(/Prometheus is offline/)).toBeTruthy();
+		expect(
+			screen.getByText(/system resources are still live/),
+		).toBeTruthy();
+		expect(screen.queryByText("Dispatch Success")).toBeNull();
+	});
+
+	it("shows the monitor-unreachable banner when the monitor is down", () => {
+		renderSection({ monitorDown: true, results: {} });
+		expect(screen.getByText(/Monitor service unreachable/)).toBeTruthy();
+	});
+
+	it("renders an em-dash placeholder when a query has no data", () => {
+		renderSection({
+			results: {
+				...HEALTHY_RESULTS,
+				"dispatch-success-rate": vector("dispatch-success-rate", []),
+				"dispatch-throughput": vector("dispatch-throughput", []),
+			},
+		});
+		expect(screen.getByText("no dispatches in the window")).toBeTruthy();
+	});
+});
+
+// ---------------------------------------------------------------------------
+// Building blocks
+// ---------------------------------------------------------------------------
+
+describe("PlatformStatCard", () => {
+	it("renders label, value, and hint", () => {
+		render(
+			<PlatformStatCard
+				label="Approvals Backlog"
+				value="4"
+				hint="pending tool approvals"
+				tone="warn"
+			/>,
+		);
+		expect(screen.getByText("Approvals Backlog")).toBeTruthy();
+		expect(screen.getByText("4")).toBeTruthy();
+		expect(screen.getByText("pending tool approvals")).toBeTruthy();
+	});
+});
+
+describe("ServiceBarList", () => {
+	it("renders the empty state when there are no entries", () => {
+		render(
+			<ServiceBarList
+				title="HTTP Error Rate"
+				entries={[]}
+				format={(v) => `${v}`}
+				fraction={(v) => v}
+				warnAt={1}
+				emptyText="No HTTP traffic in the window."
+			/>,
+		);
+		expect(screen.getByText("No HTTP traffic in the window.")).toBeTruthy();
+	});
+});

--- a/ui/src/test/hooks/usePlatformMetrics.test.ts
+++ b/ui/src/test/hooks/usePlatformMetrics.test.ts
@@ -1,0 +1,101 @@
+/**
+ * usePlatformMetrics -- MSW integration tests.
+ *
+ * Note: the ApiClient retries 5xx responses with backoff, so the 502 test
+ * pays ~600ms of retries per cycle — acceptable, but don't add more 502
+ * cases than needed.
+ */
+
+import { renderHook, waitFor } from "@testing-library/react";
+import { HttpResponse, http } from "msw";
+import { describe, expect, it } from "vitest";
+import {
+	PLATFORM_QUERIES,
+	usePlatformMetrics,
+	vectorEntries,
+	vectorValue,
+} from "@/hooks/usePlatformMetrics";
+import {
+	makeVectorQueryResult,
+	makeVectorSample,
+} from "@/test/mocks/factories";
+import { server } from "@/test/mocks/server";
+
+const BASE = "http://localhost:17003";
+
+describe("usePlatformMetrics (MSW integration)", () => {
+	it("loads every platform query on the happy path", async () => {
+		const { result } = renderHook(() => usePlatformMetrics());
+
+		await waitFor(() => expect(result.current.loading).toBe(false));
+
+		expect(result.current.monitorDown).toBe(false);
+		expect(result.current.prometheusDown).toBe(false);
+		for (const name of PLATFORM_QUERIES) {
+			expect(result.current.results[name]).toBeDefined();
+		}
+	});
+
+	it("flags prometheusDown on 502 responses", async () => {
+		server.use(
+			http.get(`${BASE}/queries/:name`, () =>
+				HttpResponse.json(
+					{ error: "Prometheus unavailable: connection refused" },
+					{ status: 502 },
+				),
+			),
+		);
+
+		const { result } = renderHook(() => usePlatformMetrics());
+		await waitFor(() => expect(result.current.loading).toBe(false), {
+			timeout: 10_000,
+		});
+
+		expect(result.current.prometheusDown).toBe(true);
+		expect(result.current.monitorDown).toBe(false);
+		expect(Object.keys(result.current.results)).toHaveLength(0);
+	}, 15_000);
+
+	it("flags monitorDown when nothing answers", async () => {
+		// 404s avoid the ApiClient's 5xx retry backoff (see header note).
+		server.use(
+			http.get(`${BASE}/queries/:name`, () =>
+				HttpResponse.json({ error: "Not found" }, { status: 404 }),
+			),
+		);
+
+		const { result } = renderHook(() => usePlatformMetrics());
+		await waitFor(() => expect(result.current.loading).toBe(false));
+
+		expect(result.current.monitorDown).toBe(true);
+		expect(result.current.prometheusDown).toBe(false);
+	});
+});
+
+describe("vector helpers", () => {
+	it("vectorEntries extracts labels and numeric values", () => {
+		const result = makeVectorQueryResult("http-p95-latency", [
+			makeVectorSample({
+				metric: { service: "orchestrator" },
+				value: [1, "0.0125"],
+			}),
+			makeVectorSample({ metric: { service: "notify" }, value: [1, "0.008"] }),
+		]);
+
+		const entries = vectorEntries(result);
+		expect(entries).toHaveLength(2);
+		expect(entries[0].labels.service).toBe("orchestrator");
+		expect(entries[0].value).toBeCloseTo(0.0125);
+	});
+
+	it("vectorValue sums samples and returns null for empty/missing data", () => {
+		const result = makeVectorQueryResult("dispatch-throughput", [
+			makeVectorSample({ metric: { status: "completed" }, value: [1, "12"] }),
+			makeVectorSample({ metric: { status: "failed" }, value: [1, "2"] }),
+		]);
+
+		expect(vectorValue(result)).toBe(14);
+		expect(vectorValue(makeVectorQueryResult("x", []))).toBeNull();
+		expect(vectorValue(undefined)).toBeNull();
+	});
+});

--- a/ui/src/test/pages/MonitoringDashboard.test.tsx
+++ b/ui/src/test/pages/MonitoringDashboard.test.tsx
@@ -72,6 +72,22 @@ vi.mock("@/hooks/useSystemMetrics", () => ({
 	useSystemMetrics: () => mockUseSystemMetrics(),
 }));
 
+vi.mock("@/hooks/usePlatformMetrics", async (importOriginal) => {
+	// Keep the real vector helpers — only the hook itself is stubbed.
+	const original =
+		await importOriginal<typeof import("@/hooks/usePlatformMetrics")>();
+	return {
+		...original,
+		usePlatformMetrics: () => ({
+			results: {},
+			monitorDown: false,
+			prometheusDown: false,
+			loading: false,
+			refetch: vi.fn(),
+		}),
+	};
+});
+
 function systemMetricsResult(overrides?: Record<string, unknown>) {
 	const snapshot = {
 		collected_at: "2024-01-01T00:00:00Z",


### PR DESCRIPTION
Add a Prometheus-backed Platform Metrics section to the monitoring page,
between the system health panel and the token-usage charts.

- usePlatformMetrics polls nine catalog queries (dispatch success rate
  and throughput, agent restarts, approvals backlog, HTTP error rate
  and p95 latency per service, session cost, agents-active vs
  websocket-connections) and distinguishes monitorDown (service
  unreachable) from prometheusDown (502) so the page can say which
  layer broke. Exported vectorEntries/vectorValue helpers parse
  instant-vector results.
- PlatformMetricsSection renders tone-coded stat cards (dispatch
  success warns below 90%, an agents/connections mismatch hints at
  diagnose_state_mismatches, nonzero backlogs and restarts warn) and
  per-service bar lists with p95 converted to ms and NaN rows (no
  traffic) filtered out.
- Degraded banner: "Prometheus is offline — platform metrics
  unavailable (system resources are still live)" vs monitor
  unreachable.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>