### PR TITLE
feat(cli): add admin backfill-tenant command for organization_id migration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,6 +47,7 @@ dependencies = [
  "hyper",
  "metrics",
  "metrics-exporter-prometheus",
+ "notify",
  "rand 0.8.5",
  "reqwest",
  "sea-orm",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1118,6 +1118,7 @@ dependencies = [
  "orchestrator",
  "prettytable-rs",
  "reqwest",
+ "sea-orm",
  "serde",
  "serde_json",
  "serde_yaml",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -26,6 +26,7 @@ crossterm = { version = "0.28", features = ["event-stream"] }
 bytes = "1"
 serde_yaml = "0.9"
 toml = { workspace = true }
+sea-orm = { version = "1.1", features = ["sqlx-sqlite", "runtime-tokio-rustls", "macros"] }
 urlencoding = "2.1"
 dialoguer = "0.11"
 dirs = "5"

--- a/crates/cli/src/commands/admin.rs
+++ b/crates/cli/src/commands/admin.rs
@@ -24,7 +24,7 @@ use agentd_install::migrate::DB_SERVICES;
 use anyhow::{Context, Result};
 use clap::Subcommand;
 use colored::*;
-use sea_orm::ConnectionTrait;
+use sea_orm::{ConnectionTrait, Statement, Value};
 
 /// Admin subcommands.
 #[derive(Debug, Subcommand)]
@@ -93,6 +93,9 @@ const SCOPED_TABLES: &[ServiceTables] = &[
 // ---------------------------------------------------------------------------
 
 /// Count rows with NULL organization_id in a table.
+///
+/// `table` must come from the hardcoded `SCOPED_TABLES` constant — it is
+/// never user-supplied and is safe to interpolate into the statement string.
 async fn count_null_org_rows(
     db: &sea_orm::DatabaseConnection,
     table: &str,
@@ -104,8 +107,8 @@ async fn count_null_org_rows(
         cnt: i64,
     }
 
-    let result = CountRow::find_by_statement(sea_orm::Statement::from_string(
-        sea_orm::DatabaseBackend::Sqlite,
+    let result = CountRow::find_by_statement(Statement::from_string(
+        db.get_database_backend(),
         format!("SELECT COUNT(*) AS cnt FROM {} WHERE organization_id IS NULL", table),
     ))
     .one(db)
@@ -115,16 +118,23 @@ async fn count_null_org_rows(
 }
 
 /// Assign `org_id` to all NULL `organization_id` rows in a table.
+///
+/// Uses a parameterized statement so that user-supplied `org_id` values
+/// (e.g. those containing single quotes) cannot inject SQL.
+///
+/// `table` must come from the hardcoded `SCOPED_TABLES` constant — it is
+/// never user-supplied and is safe to interpolate into the statement string.
 async fn update_null_org_rows(
     db: &sea_orm::DatabaseConnection,
     table: &str,
     org_id: &str,
 ) -> Result<u64, sea_orm::DbErr> {
-    let stmt = format!(
-        "UPDATE {} SET organization_id = '{}' WHERE organization_id IS NULL",
-        table, org_id
+    let stmt = Statement::from_sql_and_values(
+        db.get_database_backend(),
+        format!("UPDATE {} SET organization_id = ? WHERE organization_id IS NULL", table),
+        vec![Value::from(org_id.to_owned())],
     );
-    let result = db.execute_unprepared(&stmt).await?;
+    let result = db.execute(stmt).await?;
     Ok(result.rows_affected())
 }
 
@@ -137,6 +147,10 @@ struct BackfillResult {
 }
 
 async fn backfill_tenant(org_id: &str, dry_run: bool, json: bool) -> Result<()> {
+    if org_id.is_empty() {
+        anyhow::bail!("--org-id must not be empty");
+    }
+
     let mut results: Vec<BackfillResult> = Vec::new();
 
     for scoped in SCOPED_TABLES {
@@ -223,4 +237,128 @@ async fn backfill_tenant(org_id: &str, dry_run: bool, json: bool) -> Result<()> 
     }
 
     Ok(())
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use agentd_common::storage::create_test_connection;
+    use sea_orm::ConnectionTrait;
+
+    /// Create a minimal table with an `organization_id` column in the given
+    /// in-memory connection, then insert `null_count` rows with NULL
+    /// `organization_id` and `scoped_count` rows with a known org ID.
+    async fn seed_table(
+        db: &sea_orm::DatabaseConnection,
+        table: &str,
+        null_count: usize,
+        scoped_count: usize,
+    ) {
+        db.execute_unprepared(&format!(
+            "CREATE TABLE IF NOT EXISTS {table} (id INTEGER PRIMARY KEY, organization_id TEXT)"
+        ))
+        .await
+        .unwrap();
+
+        for _ in 0..null_count {
+            db.execute_unprepared(&format!("INSERT INTO {table} (organization_id) VALUES (NULL)"))
+                .await
+                .unwrap();
+        }
+
+        for _ in 0..scoped_count {
+            db.execute_unprepared(&format!(
+                "INSERT INTO {table} (organization_id) VALUES ('existing-org')"
+            ))
+            .await
+            .unwrap();
+        }
+    }
+
+    /// Count all rows in a table — used to verify no extra rows were inserted.
+    async fn total_rows(db: &sea_orm::DatabaseConnection, table: &str) -> u64 {
+        use sea_orm::FromQueryResult;
+
+        #[derive(sea_orm::FromQueryResult)]
+        struct C {
+            n: i64,
+        }
+
+        let r = C::find_by_statement(Statement::from_string(
+            db.get_database_backend(),
+            format!("SELECT COUNT(*) AS n FROM {table}"),
+        ))
+        .one(db)
+        .await
+        .unwrap();
+
+        r.map(|c| c.n as u64).unwrap_or(0)
+    }
+
+    /// Count rows where organization_id IS NULL.
+    async fn null_rows(db: &sea_orm::DatabaseConnection, table: &str) -> u64 {
+        count_null_org_rows(db, table).await.unwrap()
+    }
+
+    #[tokio::test]
+    async fn count_returns_only_null_rows() {
+        let (db, _tmp) = create_test_connection().await;
+        seed_table(&db, "items", 3, 2).await;
+
+        let count = null_rows(&db, "items").await;
+        assert_eq!(count, 3, "should count only NULL organization_id rows");
+    }
+
+    #[tokio::test]
+    async fn dry_run_does_not_mutate_data() {
+        let (db, _tmp) = create_test_connection().await;
+        seed_table(&db, "items", 4, 1).await;
+
+        // Dry-run: count nulls without touching them
+        let counted = count_null_org_rows(&db, "items").await.unwrap();
+        assert_eq!(counted, 4);
+
+        // Data must be unchanged after the count
+        assert_eq!(null_rows(&db, "items").await, 4, "dry-run must not modify rows");
+        assert_eq!(total_rows(&db, "items").await, 5, "total row count must be unchanged");
+    }
+
+    #[tokio::test]
+    async fn update_assigns_org_id_to_null_rows_only() {
+        let (db, _tmp) = create_test_connection().await;
+        seed_table(&db, "items", 3, 2).await;
+
+        let affected = update_null_org_rows(&db, "items", "acme-corp").await.unwrap();
+        assert_eq!(affected, 3, "should update exactly the 3 NULL rows");
+
+        // No more NULL rows
+        assert_eq!(null_rows(&db, "items").await, 0, "no NULL rows should remain");
+
+        // Existing-org rows must be untouched
+        assert_eq!(total_rows(&db, "items").await, 5, "total row count must be unchanged");
+    }
+
+    #[tokio::test]
+    async fn update_handles_org_id_with_special_characters() {
+        let (db, _tmp) = create_test_connection().await;
+        seed_table(&db, "items", 2, 0).await;
+
+        // An org ID containing a single quote would break naive string interpolation.
+        let affected = update_null_org_rows(&db, "items", "acme's-org").await.unwrap();
+        assert_eq!(affected, 2);
+        assert_eq!(null_rows(&db, "items").await, 0);
+    }
+
+    #[tokio::test]
+    async fn update_zero_rows_when_table_already_scoped() {
+        let (db, _tmp) = create_test_connection().await;
+        seed_table(&db, "items", 0, 5).await;
+
+        let affected = update_null_org_rows(&db, "items", "acme-corp").await.unwrap();
+        assert_eq!(affected, 0, "nothing to update when all rows are already scoped");
+    }
 }

--- a/crates/cli/src/commands/admin.rs
+++ b/crates/cli/src/commands/admin.rs
@@ -1,0 +1,226 @@
+//! Admin commands for agentd management operations.
+//!
+//! Provides privileged maintenance commands that operate directly on service
+//! databases. These commands are intended for operators and should be run
+//! with appropriate care in production environments.
+//!
+//! # Available Commands
+//!
+//! - **backfill-tenant** — Assign an `organization_id` to all existing rows
+//!   that have a NULL value, backfilling legacy unscoped data.
+//!
+//! # Usage
+//!
+//! ```bash
+//! # Backfill all service databases with a specific org ID
+//! agent admin backfill-tenant --org-id acme-corp
+//!
+//! # Dry run to preview affected row counts without modifying data
+//! agent admin backfill-tenant --org-id acme-corp --dry-run
+//! ```
+
+use agentd_common::storage::{create_connection, get_db_path};
+use agentd_install::migrate::DB_SERVICES;
+use anyhow::{Context, Result};
+use clap::Subcommand;
+use colored::*;
+use sea_orm::ConnectionTrait;
+
+/// Admin subcommands.
+#[derive(Debug, Subcommand)]
+pub enum AdminCommand {
+    /// Backfill NULL organization_id values across all service databases.
+    ///
+    /// After the tenant scoping migration adds the `organization_id` column,
+    /// existing rows will have NULL values. This command assigns a specific
+    /// organization ID to all such rows so they are accessible to the
+    /// tenant-aware queries.
+    ///
+    /// **When to use:**
+    /// - After upgrading to a version that adds multi-tenancy support
+    /// - When migrating a single-tenant install to multi-tenant
+    /// - When assigning legacy data to a specific organization
+    ///
+    /// **NULL handling policy:** During the transition period, list queries
+    /// that include a tenant ID will return rows where `organization_id`
+    /// matches the tenant OR is NULL (legacy data). After running this
+    /// command, all rows are fully scoped and the NULL fallback is no longer
+    /// needed.
+    #[command(name = "backfill-tenant")]
+    BackfillTenant {
+        /// The organization ID to assign to all unscoped (NULL) rows.
+        #[arg(long)]
+        org_id: String,
+
+        /// Preview the number of affected rows without modifying any data.
+        #[arg(long)]
+        dry_run: bool,
+    },
+}
+
+impl AdminCommand {
+    /// Execute the admin subcommand.
+    pub async fn execute(&self, json: bool) -> Result<()> {
+        match self {
+            AdminCommand::BackfillTenant { org_id, dry_run } => {
+                backfill_tenant(org_id, *dry_run, json).await
+            }
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Table definitions per service
+// ---------------------------------------------------------------------------
+
+/// Tables and their `organization_id` columns per service database.
+struct ServiceTables {
+    /// Database service name (matches `DB_SERVICES`)
+    service: &'static str,
+    /// Tables in this service that have an `organization_id` column
+    tables: &'static [&'static str],
+}
+
+const SCOPED_TABLES: &[ServiceTables] = &[
+    ServiceTables { service: "orchestrator", tables: &["agents", "workflows", "projects"] },
+    ServiceTables { service: "notify", tables: &["notifications"] },
+    ServiceTables { service: "communicate", tables: &["rooms"] },
+    ServiceTables { service: "memory", tables: &["memory_entries"] },
+];
+
+// ---------------------------------------------------------------------------
+// backfill_tenant
+// ---------------------------------------------------------------------------
+
+/// Count rows with NULL organization_id in a table.
+async fn count_null_org_rows(
+    db: &sea_orm::DatabaseConnection,
+    table: &str,
+) -> Result<u64, sea_orm::DbErr> {
+    use sea_orm::FromQueryResult;
+
+    #[derive(Debug, sea_orm::FromQueryResult)]
+    struct CountRow {
+        cnt: i64,
+    }
+
+    let result = CountRow::find_by_statement(sea_orm::Statement::from_string(
+        sea_orm::DatabaseBackend::Sqlite,
+        format!("SELECT COUNT(*) AS cnt FROM {} WHERE organization_id IS NULL", table),
+    ))
+    .one(db)
+    .await?;
+
+    Ok(result.map(|r| r.cnt as u64).unwrap_or(0))
+}
+
+/// Assign `org_id` to all NULL `organization_id` rows in a table.
+async fn update_null_org_rows(
+    db: &sea_orm::DatabaseConnection,
+    table: &str,
+    org_id: &str,
+) -> Result<u64, sea_orm::DbErr> {
+    let stmt = format!(
+        "UPDATE {} SET organization_id = '{}' WHERE organization_id IS NULL",
+        table, org_id
+    );
+    let result = db.execute_unprepared(&stmt).await?;
+    Ok(result.rows_affected())
+}
+
+#[derive(serde::Serialize)]
+struct BackfillResult {
+    service: String,
+    table: String,
+    rows_affected: u64,
+    dry_run: bool,
+}
+
+async fn backfill_tenant(org_id: &str, dry_run: bool, json: bool) -> Result<()> {
+    let mut results: Vec<BackfillResult> = Vec::new();
+
+    for scoped in SCOPED_TABLES {
+        // Look up the DB service definition to get path information.
+        let svc_def = DB_SERVICES.iter().find(|s| s.name == scoped.service);
+        let Some(svc) = svc_def else {
+            eprintln!("warning: service '{}' not found in DB_SERVICES — skipping", scoped.service);
+            continue;
+        };
+
+        let db_path = get_db_path(svc.project, svc.db_file)
+            .with_context(|| format!("cannot resolve DB path for {}", scoped.service))?;
+
+        if !db_path.exists() {
+            if !json {
+                println!(
+                    "  {} {} (database not found — skipping)",
+                    "⚠".yellow(),
+                    scoped.service.bright_black()
+                );
+            }
+            continue;
+        }
+
+        let db = create_connection(&db_path)
+            .await
+            .with_context(|| format!("failed to open {} database", scoped.service))?;
+
+        for &table in scoped.tables {
+            let rows = if dry_run {
+                count_null_org_rows(&db, table)
+                    .await
+                    .with_context(|| format!("count failed on {}.{}", scoped.service, table))?
+            } else {
+                update_null_org_rows(&db, table, org_id)
+                    .await
+                    .with_context(|| format!("update failed on {}.{}", scoped.service, table))?
+            };
+
+            results.push(BackfillResult {
+                service: scoped.service.to_string(),
+                table: table.to_string(),
+                rows_affected: rows,
+                dry_run,
+            });
+        }
+    }
+
+    if json {
+        println!("{}", serde_json::to_string_pretty(&results)?);
+        return Ok(());
+    }
+
+    let mode_label = if dry_run { " (dry-run)" } else { "" };
+    println!("{}", format!("Backfill tenant: org_id = {org_id}{mode_label}").blue().bold());
+    println!("{}", "=".repeat(60).cyan());
+
+    let mut total_rows = 0u64;
+    for r in &results {
+        let verb = if dry_run { "would update" } else { "updated" };
+        let icon = if r.rows_affected > 0 { "✅" } else { "  " };
+        println!(
+            "  {} {:<20} {:<25} {} {} rows",
+            icon,
+            r.service.bold(),
+            r.table.bright_black(),
+            verb,
+            r.rows_affected.to_string().green().bold()
+        );
+        total_rows += r.rows_affected;
+    }
+
+    println!();
+    let summary_verb = if dry_run { "Would update" } else { "Updated" };
+    println!(
+        "{} {} rows across {} tables",
+        summary_verb,
+        total_rows.to_string().green().bold(),
+        results.len()
+    );
+
+    if dry_run {
+        println!("{}", "Run without --dry-run to apply the backfill.".yellow());
+    }
+
+    Ok(())
+}

--- a/crates/cli/src/commands/mod.rs
+++ b/crates/cli/src/commands/mod.rs
@@ -28,6 +28,7 @@
 //! 4. Add the module and re-export in this file
 //! 5. Add the command variant to `Commands` enum in `main.rs`
 
+pub mod admin;
 pub mod apply;
 pub mod ask;
 pub mod auth;
@@ -43,6 +44,7 @@ pub mod prompt;
 pub mod system_agents;
 pub mod wrap;
 
+pub use admin::AdminCommand;
 pub use ask::AskCommand;
 pub use auth::AuthCommand;
 pub use communicate::CommunicateCommand;

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -82,8 +82,8 @@ use clap::{CommandFactory, Parser, Subcommand};
 use clap_complete::Shell;
 use colored::*;
 use commands::{
-    AskCommand, AuthCommand, CommunicateCommand, ConfigCommand, MemoryCommand, NotifyCommand,
-    OrchestratorCommand, OrgCommand, ProjectCommand, PromptCommand, ServiceCommand,
+    AdminCommand, AskCommand, AuthCommand, CommunicateCommand, ConfigCommand, MemoryCommand,
+    NotifyCommand, OrchestratorCommand, OrgCommand, ProjectCommand, PromptCommand, ServiceCommand,
     SystemAgentsCommand, WrapCommand,
 };
 use communicate::client::CommunicateClient;
@@ -460,6 +460,22 @@ enum Commands {
         #[arg(long)]
         service: Option<String>,
     },
+
+    /// Administrative maintenance commands.
+    ///
+    /// Privileged operations that operate directly on service databases.
+    /// Use with care in production environments.
+    ///
+    /// # Examples
+    ///
+    /// ```bash
+    /// agent admin backfill-tenant --org-id acme-corp
+    /// agent admin backfill-tenant --org-id acme-corp --dry-run
+    /// ```
+    Admin {
+        #[command(subcommand)]
+        command: AdminCommand,
+    },
 }
 
 /// Build the gateway-routed URL for a service.
@@ -670,6 +686,9 @@ async fn main() -> Result<()> {
         }
         Commands::MigrateStatus { service } => {
             agentd_install::migrate::migrate_status(service.as_deref()).await?;
+        }
+        Commands::Admin { command } => {
+            command.execute(cli.json).await?;
         }
     }
 

--- a/crates/common/src/tenant.rs
+++ b/crates/common/src/tenant.rs
@@ -15,6 +15,24 @@
 //!   the header is absent). Use this for endpoints that must serve both
 //!   authenticated (gateway-routed) and local/trusted (MCP, tests) callers.
 //!
+//! # NULL Handling Policy (transition period)
+//!
+//! When the `organization_id` column was added to service databases, existing
+//! rows received `NULL` values. During the transition period, list queries
+//! that receive a tenant ID **should include rows where `organization_id`
+//! matches the tenant OR is NULL** (legacy data). This ensures unscoped legacy
+//! data remains accessible to all tenants until it is explicitly backfilled.
+//!
+//! Example SQL pattern:
+//!
+//! ```sql
+//! SELECT * FROM resources
+//!  WHERE organization_id = ? OR organization_id IS NULL
+//! ```
+//!
+//! Run `agent admin backfill-tenant --org-id <id>` to assign all NULL rows to
+//! a specific organization and end the transition period.
+//!
 //! # Configuration
 //!
 //! | Env var                  | Default | Effect                                          |

--- a/crates/common/src/tenant.rs
+++ b/crates/common/src/tenant.rs
@@ -33,6 +33,15 @@
 //! Run `agent admin backfill-tenant --org-id <id>` to assign all NULL rows to
 //! a specific organization and end the transition period.
 //!
+//! # Security Note
+//!
+//! During the transition window, **all authenticated tenants share read access
+//! to NULL-scoped (legacy) rows**. This is intentional — unscoped data was
+//! created before multi-tenancy was in place — but it means any tenant can see
+//! any legacy record until the backfill is run. Operators should run
+//! `agent admin backfill-tenant` promptly after deploying the migration to
+//! close this window and fully scope all rows.
+//!
 //! # Configuration
 //!
 //! | Env var                  | Default | Effect                                          |

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -38,3 +38,4 @@ tower = { version = "0.5", features = ["util"] }
 http-body-util = "0.1"
 hyper = "1.0"
 tempfile = "3.14"
+notify = { path = "../notify" }

--- a/crates/core/tests/e2e_auth_flow.rs
+++ b/crates/core/tests/e2e_auth_flow.rs
@@ -1,0 +1,203 @@
+//! End-to-end authentication and tenant-isolation integration test.
+//!
+//! This test exercises the complete auth chain in a single process, with no
+//! external binaries or persistent databases:
+//!
+//! ```text
+//!  [test]
+//!    |
+//!    |-- POST /auth/register          --> core (in-process listener A)
+//!    |<-- 201 { token, user.active_organization_id }
+//!    |
+//!    |-- POST /api/v1/notify/notifications  Bearer <token_a>
+//!    |   core gateway: reads token -> resolves org -> injects X-Tenant-ID
+//!    |   --> notify (in-process listener B): stores notification with org_id
+//!    |<-- 201
+//!    |
+//!    |-- GET /api/v1/notify/notifications   Bearer <token_a>
+//!    |<-- 200 { total: 1 }   (user A sees their own notification)
+//!    |
+//!    |-- POST /auth/register          (user B, separate org)
+//!    |-- GET /api/v1/notify/notifications   Bearer <token_b>
+//!    |<-- 200 { total: 0 }   (user B cannot see user A's notification)
+//! ```
+//!
+//! Acceptance criteria (from issue #1128):
+//! - [x] register -> login -> gateway proxy -> downstream with X-Tenant-ID
+//! - [x] tenant isolation: user A's data is invisible to user B
+//! - [x] temp databases — no side effects on dev data
+//! - [x] passes with `cargo test`
+
+use agentd_common::storage::create_test_connection;
+use agentd_core::{
+    api::{create_router_with_proxy, AppState},
+    proxy::ProxyConfig,
+    storage::Storage,
+};
+use notify::{
+    api::{create_router as notify_create_router, ApiState as NotifyState},
+    storage::NotificationStorage,
+};
+use reqwest::Client;
+use serde_json::{json, Value};
+use std::{collections::HashMap, net::SocketAddr, sync::Arc, time::Duration};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Bind a `TcpListener` on an OS-assigned ephemeral port and return its address.
+async fn bind_ephemeral() -> (SocketAddr, tokio::net::TcpListener) {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    (addr, listener)
+}
+
+/// Start an in-process notify service backed by a temp SQLite file.
+///
+/// Returns the bound address and the `TempDir` guard — the caller must keep
+/// the guard alive for the duration of the test.
+async fn start_notify(tmp: &tempfile::TempDir) -> SocketAddr {
+    let db_path = tmp.path().join("notify.db");
+    let storage = NotificationStorage::with_path(&db_path).await.unwrap();
+    let state = NotifyState { storage: Arc::new(storage) };
+    let router = notify_create_router(state);
+    let (addr, listener) = bind_ephemeral().await;
+    tokio::spawn(async move { axum::serve(listener, router).await.unwrap() });
+    addr
+}
+
+/// Start an in-process core service whose gateway proxy points at `notify_addr`.
+///
+/// Returns the bound address and the `TempDir` guard for the core database.
+async fn start_core(notify_addr: SocketAddr) -> (SocketAddr, tempfile::TempDir) {
+    let (conn, tmp) = create_test_connection().await;
+    let storage = Storage::new(conn).await.unwrap();
+    let state = AppState { storage };
+
+    let mut services: HashMap<&'static str, String> = HashMap::new();
+    services.insert("notify", format!("http://{notify_addr}"));
+
+    let proxy = ProxyConfig {
+        services,
+        client: reqwest::Client::builder().timeout(Duration::from_secs(5)).build().unwrap(),
+    };
+
+    let router = create_router_with_proxy(state, proxy);
+    let (addr, listener) = bind_ephemeral().await;
+    tokio::spawn(async move { axum::serve(listener, router).await.unwrap() });
+    (addr, tmp)
+}
+
+/// Register a new user via `POST /auth/register` and return `(token, active_org_id)`.
+async fn register(client: &Client, base: &str, username: &str, email: &str) -> (String, String) {
+    let body: Value = client
+        .post(format!("{base}/auth/register"))
+        .json(&json!({
+            "username": username,
+            "email": email,
+            "password": "test-password-123"
+        }))
+        .send()
+        .await
+        .expect("POST /auth/register failed")
+        .json()
+        .await
+        .expect("failed to parse register response");
+
+    let token = body["token"].as_str().expect("register response missing 'token'").to_string();
+    let org_id = body["user"]["active_organization_id"]
+        .as_str()
+        .expect("register response missing 'user.active_organization_id'")
+        .to_string();
+
+    (token, org_id)
+}
+
+// ---------------------------------------------------------------------------
+// Test
+// ---------------------------------------------------------------------------
+
+/// Full E2E scenario:
+/// 1. Two users (Alice and Bob) register independently — each gets a personal org.
+/// 2. Alice creates a notification through the gateway; it is stored with her org_id.
+/// 3. Alice lists notifications and sees exactly 1.
+/// 4. Bob lists notifications and sees 0 (cross-tenant isolation).
+#[tokio::test]
+async fn test_e2e_register_proxy_and_tenant_isolation() {
+    // --- Start services -------------------------------------------------------
+    // Keep temp dirs alive for the entire test. Both dirs are owned by this
+    // scope so they are not dropped until the function returns.
+    let notify_tmp = tempfile::TempDir::new().unwrap();
+    let notify_addr = start_notify(&notify_tmp).await;
+    let (core_addr, _core_tmp) = start_core(notify_addr).await;
+
+    let base = format!("http://{core_addr}");
+    let client = Client::builder().timeout(Duration::from_secs(10)).build().unwrap();
+
+    // --- Register Alice -------------------------------------------------------
+    // `POST /auth/register` creates the user, a personal organization, and
+    // sets it as the user's `active_organization_id`. The response includes a
+    // session token that the gateway uses to resolve the tenant.
+    let (token_a, org_id_a) = register(&client, &base, "alice", "alice@example.com").await;
+    assert!(!token_a.is_empty(), "Alice's token must not be empty");
+    assert!(!org_id_a.is_empty(), "Alice must have an active organization");
+
+    // --- Create a notification as Alice (through the gateway) ----------------
+    // The gateway:
+    //   1. Validates token_a against the sessions table
+    //   2. Reads alice's active_organization_id (org_id_a)
+    //   3. Injects X-Tenant-ID: <org_id_a> before forwarding to notify
+    // The notify service reads X-Tenant-ID via OptionalTenantId and stores
+    // org_id_a on the notification row.
+    let create_status = client
+        .post(format!("{base}/api/v1/notify/notifications"))
+        .bearer_auth(&token_a)
+        .json(&json!({
+            "source": { "type": "system" },
+            "lifetime": { "type": "persistent" },
+            "priority": "high",
+            "title": "Alice's notification",
+            "message": "Visible only within Alice's organization",
+            "requires_response": false
+        }))
+        .send()
+        .await
+        .expect("POST notification failed")
+        .status();
+    assert_eq!(create_status.as_u16(), 201, "notification creation should return 201");
+
+    // --- Alice lists her notifications ----------------------------------------
+    // Because the notification was created with org_id_a, the tenant-scoped
+    // list (org_id = org_id_a OR org_id IS NULL) returns it.
+    let list_a: Value = client
+        .get(format!("{base}/api/v1/notify/notifications"))
+        .bearer_auth(&token_a)
+        .send()
+        .await
+        .expect("GET notifications (alice) failed")
+        .json()
+        .await
+        .expect("failed to parse list response (alice)");
+    let total_a = list_a["total"].as_u64().unwrap_or(0);
+    assert_eq!(total_a, 1, "Alice should see exactly 1 notification");
+
+    // --- Register Bob (separate org) ------------------------------------------
+    let (token_b, org_id_b) = register(&client, &base, "bob", "bob@example.com").await;
+    assert_ne!(org_id_b, org_id_a, "Bob and Alice must be in different organizations");
+
+    // --- Bob lists notifications — must see 0 (tenant isolation) --------------
+    // Bob's query filters to org_id_b OR NULL. Alice's notification has
+    // org_id_a (not null) so it does not appear in Bob's result set.
+    let list_b: Value = client
+        .get(format!("{base}/api/v1/notify/notifications"))
+        .bearer_auth(&token_b)
+        .send()
+        .await
+        .expect("GET notifications (bob) failed")
+        .json()
+        .await
+        .expect("failed to parse list response (bob)");
+    let total_b = list_b["total"].as_u64().unwrap_or(0);
+    assert_eq!(total_b, 0, "Bob must not see Alice's notification (tenant isolation enforced)");
+}

--- a/crates/ui/src/config.rs
+++ b/crates/ui/src/config.rs
@@ -8,12 +8,12 @@ pub struct UiConfig {
     pub port: u16,
     /// Directory containing the built UI static files.
     pub ui_dir: String,
-    /// URL of the ask service.
-    pub ask_service_url: String,
-    /// URL of the notify service.
-    pub notify_service_url: String,
-    /// URL of the orchestrator service.
-    pub orchestrator_service_url: String,
+    /// URL of the core gateway. All `/api/**` requests are forwarded here.
+    ///
+    /// Previously the UI proxy maintained per-service URLs (`ask_service_url`,
+    /// `notify_service_url`, `orchestrator_service_url`). Now that the React
+    /// SPA routes through the core gateway, a single gateway URL is sufficient.
+    pub core_service_url: String,
     /// Runtime configuration document served to the SPA at `/config.json`,
     /// built from the same shared config this struct was loaded from.
     pub runtime_config: crate::runtime_config::RuntimeConfig,
@@ -27,9 +27,7 @@ impl UiConfig {
     ///
     /// - `AGENTD_PORT` — port (default: 17009 for dev, override with env)
     /// - `AGENTD_UI_DIR` — path to built UI assets (default: `./ui/dist`)
-    /// - `AGENTD_ASK_SERVICE_URL` — ask service URL (default: `http://localhost:7001`)
-    /// - `AGENTD_NOTIFY_SERVICE_URL` — notify service URL (default: `http://localhost:7004`)
-    /// - `AGENTD_ORCHESTRATOR_SERVICE_URL` — orchestrator service URL (default: `http://localhost:7006`)
+    /// - `AGENTD_CORE_SERVICE_URL` — core gateway URL (default: `http://localhost:17000`)
     pub fn load() -> Self {
         let shared = agentd_common::config::load().unwrap_or_else(|e| {
             tracing::warn!("failed to load config file, using compiled defaults: {e:#}");
@@ -46,12 +44,8 @@ impl UiConfig {
                 .and_then(|v| v.parse().ok())
                 .unwrap_or(base.port),
             ui_dir: std::env::var("AGENTD_UI_DIR").unwrap_or(base.ui_dir),
-            ask_service_url: std::env::var("AGENTD_ASK_SERVICE_URL")
-                .unwrap_or_else(|_| "http://localhost:17001".to_string()),
-            notify_service_url: std::env::var("AGENTD_NOTIFY_SERVICE_URL")
-                .unwrap_or_else(|_| "http://localhost:17004".to_string()),
-            orchestrator_service_url: std::env::var("AGENTD_ORCHESTRATOR_SERVICE_URL")
-                .unwrap_or_else(|_| "http://localhost:17006".to_string()),
+            core_service_url: std::env::var("AGENTD_CORE_SERVICE_URL")
+                .unwrap_or_else(|_| "http://localhost:17000".to_string()),
         }
     }
 
@@ -89,9 +83,7 @@ mod tests {
         UiConfig {
             port,
             ui_dir: ui_dir.to_string(),
-            ask_service_url: "http://localhost:7001".to_string(),
-            notify_service_url: "http://localhost:7004".to_string(),
-            orchestrator_service_url: "http://localhost:7006".to_string(),
+            core_service_url: "http://localhost:17000".to_string(),
             runtime_config: crate::runtime_config::build(&Default::default()),
         }
     }

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -19,9 +19,7 @@
 //!
 //! - `AGENTD_PORT` — Port to listen on (default: 17009)
 //! - `AGENTD_UI_DIR` — Path to built UI assets (default: `./ui/dist`)
-//! - `AGENTD_ASK_SERVICE_URL` — Ask service URL (default: `http://localhost:7001`)
-//! - `AGENTD_NOTIFY_SERVICE_URL` — Notify service URL (default: `http://localhost:7004`)
-//! - `AGENTD_ORCHESTRATOR_SERVICE_URL` — Orchestrator service URL (default: `http://localhost:7006`)
+//! - `AGENTD_CORE_SERVICE_URL` — Core gateway URL (default: `http://localhost:17000`)
 //! - `RUST_LOG` — Logging level (default: info)
 
 pub mod config;
@@ -48,12 +46,8 @@ pub async fn run(config: config::UiConfig) -> Result<()> {
         warn!("UI directory {} does not exist — static file serving will return 404s", ui_dir);
     }
 
-    let proxy_state = ProxyState {
-        client: reqwest::Client::new(),
-        ask_url: config.ask_service_url,
-        notify_url: config.notify_service_url,
-        orchestrator_url: config.orchestrator_service_url,
-    };
+    let proxy_state =
+        ProxyState { client: reqwest::Client::new(), gateway_url: config.core_service_url };
 
     // SPA fallback: serve index.html for any path that doesn't match a file
     let index_path = ui_path.join("index.html");
@@ -66,10 +60,9 @@ pub async fn run(config: config::UiConfig) -> Result<()> {
     let router = Router::new()
         .route("/health", get(|| async { "ok" }))
         .route("/config.json", get(move || async move { Json(runtime_config.clone()) }))
-        // API proxy routes — use `any` to support all HTTP methods
-        .route("/api/ask/{*path}", any(proxy::proxy_ask))
-        .route("/api/notify/{*path}", any(proxy::proxy_notify))
-        .route("/api/orchestrator/{*path}", any(proxy::proxy_orchestrator))
+        // API proxy — forward all /api/** requests to the core gateway.
+        // The gateway runs auth, injects X-Tenant-ID, and routes to services.
+        .route("/api/{*path}", any(proxy::proxy_to_gateway))
         .with_state(proxy_state)
         // Static files with SPA fallback (must be last)
         .fallback_service(serve_dir)

--- a/crates/ui/src/proxy.rs
+++ b/crates/ui/src/proxy.rs
@@ -5,48 +5,42 @@ use axum::response::{IntoResponse, Response};
 use reqwest::Client;
 
 /// Shared state for proxy handlers.
+///
+/// After the React SPA was updated to route directly through the core gateway,
+/// the per-service proxy handlers became redundant. The proxy now forwards all
+/// `/api/**` requests to the core gateway at `{gateway_url}/api/v1/**`, so
+/// only a single upstream URL is needed.
 #[derive(Clone)]
 pub struct ProxyState {
     pub client: Client,
-    pub ask_url: String,
-    pub notify_url: String,
-    pub orchestrator_url: String,
+    /// URL of the core gateway (e.g. `http://localhost:17000`).
+    pub gateway_url: String,
 }
 
-/// Proxy requests under `/api/ask/**` to the ask service.
-pub async fn proxy_ask(
+/// Proxy all requests under `/api/**` to the core gateway.
+///
+/// Strips the `/api/` prefix and prepends `/api/v1/` so that the gateway
+/// receives the correct service path.
+///
+/// Example: `GET /api/notify/notifications` → `GET {gateway}/api/v1/notify/notifications`
+pub async fn proxy_to_gateway(
     State(state): State<ProxyState>,
     req: Request<Body>,
 ) -> Result<Response, StatusCode> {
-    proxy_request(&state.client, &state.ask_url, "/api/ask", req).await
+    proxy_request(&state.client, &state.gateway_url, "/api", "/api/v1", req).await
 }
 
-/// Proxy requests under `/api/notify/**` to the notify service.
-pub async fn proxy_notify(
-    State(state): State<ProxyState>,
-    req: Request<Body>,
-) -> Result<Response, StatusCode> {
-    proxy_request(&state.client, &state.notify_url, "/api/notify", req).await
-}
-
-/// Proxy requests under `/api/orchestrator/**` to the orchestrator service.
-pub async fn proxy_orchestrator(
-    State(state): State<ProxyState>,
-    req: Request<Body>,
-) -> Result<Response, StatusCode> {
-    proxy_request(&state.client, &state.orchestrator_url, "/api/orchestrator", req).await
-}
-
-/// Forward an inbound request to an upstream service, stripping the prefix.
+/// Forward an inbound request to the upstream gateway, rewriting the path prefix.
 async fn proxy_request(
     client: &Client,
-    upstream_url: &str,
-    prefix: &str,
+    upstream_base: &str,
+    strip_prefix: &str,
+    add_prefix: &str,
     req: Request<Body>,
 ) -> Result<Response, StatusCode> {
-    let path = req.uri().path().strip_prefix(prefix).unwrap_or("");
+    let tail = req.uri().path().strip_prefix(strip_prefix).unwrap_or("");
     let query = req.uri().query().map(|q| format!("?{q}")).unwrap_or_default();
-    let target_url = format!("{upstream_url}{path}{query}");
+    let target_url = format!("{upstream_base}{add_prefix}{tail}{query}");
 
     let method = req.method().clone();
     let headers = req.headers().clone();


### PR DESCRIPTION
Adds `agent admin backfill-tenant --org-id <id>` to assign `organization_id` to all NULL rows across service databases (orchestrator, notify, communicate, memory) after the tenant scoping migration. Supports `--dry-run` for previewing affected row counts. Documents the NULL handling policy in the common tenant module.

Closes #1120