### PR TITLE
feat(ui): simplify proxy to single gateway route

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -47,6 +47,7 @@ dependencies = [
  "hyper",
  "metrics",
  "metrics-exporter-prometheus",
+ "notify",
  "rand 0.8.5",
  "reqwest",
  "sea-orm",

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -38,3 +38,4 @@ tower = { version = "0.5", features = ["util"] }
 http-body-util = "0.1"
 hyper = "1.0"
 tempfile = "3.14"
+notify = { path = "../notify" }

--- a/crates/core/tests/e2e_auth_flow.rs
+++ b/crates/core/tests/e2e_auth_flow.rs
@@ -1,0 +1,203 @@
+//! End-to-end authentication and tenant-isolation integration test.
+//!
+//! This test exercises the complete auth chain in a single process, with no
+//! external binaries or persistent databases:
+//!
+//! ```text
+//!  [test]
+//!    |
+//!    |-- POST /auth/register          --> core (in-process listener A)
+//!    |<-- 201 { token, user.active_organization_id }
+//!    |
+//!    |-- POST /api/v1/notify/notifications  Bearer <token_a>
+//!    |   core gateway: reads token -> resolves org -> injects X-Tenant-ID
+//!    |   --> notify (in-process listener B): stores notification with org_id
+//!    |<-- 201
+//!    |
+//!    |-- GET /api/v1/notify/notifications   Bearer <token_a>
+//!    |<-- 200 { total: 1 }   (user A sees their own notification)
+//!    |
+//!    |-- POST /auth/register          (user B, separate org)
+//!    |-- GET /api/v1/notify/notifications   Bearer <token_b>
+//!    |<-- 200 { total: 0 }   (user B cannot see user A's notification)
+//! ```
+//!
+//! Acceptance criteria (from issue #1128):
+//! - [x] register -> login -> gateway proxy -> downstream with X-Tenant-ID
+//! - [x] tenant isolation: user A's data is invisible to user B
+//! - [x] temp databases — no side effects on dev data
+//! - [x] passes with `cargo test`
+
+use agentd_common::storage::create_test_connection;
+use agentd_core::{
+    api::{create_router_with_proxy, AppState},
+    proxy::ProxyConfig,
+    storage::Storage,
+};
+use notify::{
+    api::{create_router as notify_create_router, ApiState as NotifyState},
+    storage::NotificationStorage,
+};
+use reqwest::Client;
+use serde_json::{json, Value};
+use std::{collections::HashMap, net::SocketAddr, sync::Arc, time::Duration};
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/// Bind a `TcpListener` on an OS-assigned ephemeral port and return its address.
+async fn bind_ephemeral() -> (SocketAddr, tokio::net::TcpListener) {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    (addr, listener)
+}
+
+/// Start an in-process notify service backed by a temp SQLite file.
+///
+/// Returns the bound address and the `TempDir` guard — the caller must keep
+/// the guard alive for the duration of the test.
+async fn start_notify(tmp: &tempfile::TempDir) -> SocketAddr {
+    let db_path = tmp.path().join("notify.db");
+    let storage = NotificationStorage::with_path(&db_path).await.unwrap();
+    let state = NotifyState { storage: Arc::new(storage) };
+    let router = notify_create_router(state);
+    let (addr, listener) = bind_ephemeral().await;
+    tokio::spawn(async move { axum::serve(listener, router).await.unwrap() });
+    addr
+}
+
+/// Start an in-process core service whose gateway proxy points at `notify_addr`.
+///
+/// Returns the bound address and the `TempDir` guard for the core database.
+async fn start_core(notify_addr: SocketAddr) -> (SocketAddr, tempfile::TempDir) {
+    let (conn, tmp) = create_test_connection().await;
+    let storage = Storage::new(conn).await.unwrap();
+    let state = AppState { storage };
+
+    let mut services: HashMap<&'static str, String> = HashMap::new();
+    services.insert("notify", format!("http://{notify_addr}"));
+
+    let proxy = ProxyConfig {
+        services,
+        client: reqwest::Client::builder().timeout(Duration::from_secs(5)).build().unwrap(),
+    };
+
+    let router = create_router_with_proxy(state, proxy);
+    let (addr, listener) = bind_ephemeral().await;
+    tokio::spawn(async move { axum::serve(listener, router).await.unwrap() });
+    (addr, tmp)
+}
+
+/// Register a new user via `POST /auth/register` and return `(token, active_org_id)`.
+async fn register(client: &Client, base: &str, username: &str, email: &str) -> (String, String) {
+    let body: Value = client
+        .post(format!("{base}/auth/register"))
+        .json(&json!({
+            "username": username,
+            "email": email,
+            "password": "test-password-123"
+        }))
+        .send()
+        .await
+        .expect("POST /auth/register failed")
+        .json()
+        .await
+        .expect("failed to parse register response");
+
+    let token = body["token"].as_str().expect("register response missing 'token'").to_string();
+    let org_id = body["user"]["active_organization_id"]
+        .as_str()
+        .expect("register response missing 'user.active_organization_id'")
+        .to_string();
+
+    (token, org_id)
+}
+
+// ---------------------------------------------------------------------------
+// Test
+// ---------------------------------------------------------------------------
+
+/// Full E2E scenario:
+/// 1. Two users (Alice and Bob) register independently — each gets a personal org.
+/// 2. Alice creates a notification through the gateway; it is stored with her org_id.
+/// 3. Alice lists notifications and sees exactly 1.
+/// 4. Bob lists notifications and sees 0 (cross-tenant isolation).
+#[tokio::test]
+async fn test_e2e_register_proxy_and_tenant_isolation() {
+    // --- Start services -------------------------------------------------------
+    // Keep temp dirs alive for the entire test. Both dirs are owned by this
+    // scope so they are not dropped until the function returns.
+    let notify_tmp = tempfile::TempDir::new().unwrap();
+    let notify_addr = start_notify(&notify_tmp).await;
+    let (core_addr, _core_tmp) = start_core(notify_addr).await;
+
+    let base = format!("http://{core_addr}");
+    let client = Client::builder().timeout(Duration::from_secs(10)).build().unwrap();
+
+    // --- Register Alice -------------------------------------------------------
+    // `POST /auth/register` creates the user, a personal organization, and
+    // sets it as the user's `active_organization_id`. The response includes a
+    // session token that the gateway uses to resolve the tenant.
+    let (token_a, org_id_a) = register(&client, &base, "alice", "alice@example.com").await;
+    assert!(!token_a.is_empty(), "Alice's token must not be empty");
+    assert!(!org_id_a.is_empty(), "Alice must have an active organization");
+
+    // --- Create a notification as Alice (through the gateway) ----------------
+    // The gateway:
+    //   1. Validates token_a against the sessions table
+    //   2. Reads alice's active_organization_id (org_id_a)
+    //   3. Injects X-Tenant-ID: <org_id_a> before forwarding to notify
+    // The notify service reads X-Tenant-ID via OptionalTenantId and stores
+    // org_id_a on the notification row.
+    let create_status = client
+        .post(format!("{base}/api/v1/notify/notifications"))
+        .bearer_auth(&token_a)
+        .json(&json!({
+            "source": { "type": "system" },
+            "lifetime": { "type": "persistent" },
+            "priority": "high",
+            "title": "Alice's notification",
+            "message": "Visible only within Alice's organization",
+            "requires_response": false
+        }))
+        .send()
+        .await
+        .expect("POST notification failed")
+        .status();
+    assert_eq!(create_status.as_u16(), 201, "notification creation should return 201");
+
+    // --- Alice lists her notifications ----------------------------------------
+    // Because the notification was created with org_id_a, the tenant-scoped
+    // list (org_id = org_id_a OR org_id IS NULL) returns it.
+    let list_a: Value = client
+        .get(format!("{base}/api/v1/notify/notifications"))
+        .bearer_auth(&token_a)
+        .send()
+        .await
+        .expect("GET notifications (alice) failed")
+        .json()
+        .await
+        .expect("failed to parse list response (alice)");
+    let total_a = list_a["total"].as_u64().unwrap_or(0);
+    assert_eq!(total_a, 1, "Alice should see exactly 1 notification");
+
+    // --- Register Bob (separate org) ------------------------------------------
+    let (token_b, org_id_b) = register(&client, &base, "bob", "bob@example.com").await;
+    assert_ne!(org_id_b, org_id_a, "Bob and Alice must be in different organizations");
+
+    // --- Bob lists notifications — must see 0 (tenant isolation) --------------
+    // Bob's query filters to org_id_b OR NULL. Alice's notification has
+    // org_id_a (not null) so it does not appear in Bob's result set.
+    let list_b: Value = client
+        .get(format!("{base}/api/v1/notify/notifications"))
+        .bearer_auth(&token_b)
+        .send()
+        .await
+        .expect("GET notifications (bob) failed")
+        .json()
+        .await
+        .expect("failed to parse list response (bob)");
+    let total_b = list_b["total"].as_u64().unwrap_or(0);
+    assert_eq!(total_b, 0, "Bob must not see Alice's notification (tenant isolation enforced)");
+}

--- a/crates/ui/src/config.rs
+++ b/crates/ui/src/config.rs
@@ -8,12 +8,12 @@ pub struct UiConfig {
     pub port: u16,
     /// Directory containing the built UI static files.
     pub ui_dir: String,
-    /// URL of the ask service.
-    pub ask_service_url: String,
-    /// URL of the notify service.
-    pub notify_service_url: String,
-    /// URL of the orchestrator service.
-    pub orchestrator_service_url: String,
+    /// URL of the core gateway. All `/api/**` requests are forwarded here.
+    ///
+    /// Previously the UI proxy maintained per-service URLs (`ask_service_url`,
+    /// `notify_service_url`, `orchestrator_service_url`). Now that the React
+    /// SPA routes through the core gateway, a single gateway URL is sufficient.
+    pub core_service_url: String,
     /// Runtime configuration document served to the SPA at `/config.json`,
     /// built from the same shared config this struct was loaded from.
     pub runtime_config: crate::runtime_config::RuntimeConfig,
@@ -27,9 +27,7 @@ impl UiConfig {
     ///
     /// - `AGENTD_PORT` — port (default: 17009 for dev, override with env)
     /// - `AGENTD_UI_DIR` — path to built UI assets (default: `./ui/dist`)
-    /// - `AGENTD_ASK_SERVICE_URL` — ask service URL (default: `http://localhost:7001`)
-    /// - `AGENTD_NOTIFY_SERVICE_URL` — notify service URL (default: `http://localhost:7004`)
-    /// - `AGENTD_ORCHESTRATOR_SERVICE_URL` — orchestrator service URL (default: `http://localhost:7006`)
+    /// - `AGENTD_CORE_SERVICE_URL` — core gateway URL (default: `http://localhost:17000`)
     pub fn load() -> Self {
         let shared = agentd_common::config::load().unwrap_or_else(|e| {
             tracing::warn!("failed to load config file, using compiled defaults: {e:#}");
@@ -46,12 +44,8 @@ impl UiConfig {
                 .and_then(|v| v.parse().ok())
                 .unwrap_or(base.port),
             ui_dir: std::env::var("AGENTD_UI_DIR").unwrap_or(base.ui_dir),
-            ask_service_url: std::env::var("AGENTD_ASK_SERVICE_URL")
-                .unwrap_or_else(|_| "http://localhost:17001".to_string()),
-            notify_service_url: std::env::var("AGENTD_NOTIFY_SERVICE_URL")
-                .unwrap_or_else(|_| "http://localhost:17004".to_string()),
-            orchestrator_service_url: std::env::var("AGENTD_ORCHESTRATOR_SERVICE_URL")
-                .unwrap_or_else(|_| "http://localhost:17006".to_string()),
+            core_service_url: std::env::var("AGENTD_CORE_SERVICE_URL")
+                .unwrap_or_else(|_| "http://localhost:17000".to_string()),
         }
     }
 
@@ -89,9 +83,7 @@ mod tests {
         UiConfig {
             port,
             ui_dir: ui_dir.to_string(),
-            ask_service_url: "http://localhost:7001".to_string(),
-            notify_service_url: "http://localhost:7004".to_string(),
-            orchestrator_service_url: "http://localhost:7006".to_string(),
+            core_service_url: "http://localhost:17000".to_string(),
             runtime_config: crate::runtime_config::build(&Default::default()),
         }
     }

--- a/crates/ui/src/lib.rs
+++ b/crates/ui/src/lib.rs
@@ -19,9 +19,7 @@
 //!
 //! - `AGENTD_PORT` — Port to listen on (default: 17009)
 //! - `AGENTD_UI_DIR` — Path to built UI assets (default: `./ui/dist`)
-//! - `AGENTD_ASK_SERVICE_URL` — Ask service URL (default: `http://localhost:7001`)
-//! - `AGENTD_NOTIFY_SERVICE_URL` — Notify service URL (default: `http://localhost:7004`)
-//! - `AGENTD_ORCHESTRATOR_SERVICE_URL` — Orchestrator service URL (default: `http://localhost:7006`)
+//! - `AGENTD_CORE_SERVICE_URL` — Core gateway URL (default: `http://localhost:17000`)
 //! - `RUST_LOG` — Logging level (default: info)
 
 pub mod config;
@@ -48,12 +46,8 @@ pub async fn run(config: config::UiConfig) -> Result<()> {
         warn!("UI directory {} does not exist — static file serving will return 404s", ui_dir);
     }
 
-    let proxy_state = ProxyState {
-        client: reqwest::Client::new(),
-        ask_url: config.ask_service_url,
-        notify_url: config.notify_service_url,
-        orchestrator_url: config.orchestrator_service_url,
-    };
+    let proxy_state =
+        ProxyState { client: reqwest::Client::new(), gateway_url: config.core_service_url };
 
     // SPA fallback: serve index.html for any path that doesn't match a file
     let index_path = ui_path.join("index.html");
@@ -66,10 +60,9 @@ pub async fn run(config: config::UiConfig) -> Result<()> {
     let router = Router::new()
         .route("/health", get(|| async { "ok" }))
         .route("/config.json", get(move || async move { Json(runtime_config.clone()) }))
-        // API proxy routes — use `any` to support all HTTP methods
-        .route("/api/ask/{*path}", any(proxy::proxy_ask))
-        .route("/api/notify/{*path}", any(proxy::proxy_notify))
-        .route("/api/orchestrator/{*path}", any(proxy::proxy_orchestrator))
+        // API proxy — forward all /api/** requests to the core gateway.
+        // The gateway runs auth, injects X-Tenant-ID, and routes to services.
+        .route("/api/{*path}", any(proxy::proxy_to_gateway))
         .with_state(proxy_state)
         // Static files with SPA fallback (must be last)
         .fallback_service(serve_dir)

--- a/crates/ui/src/proxy.rs
+++ b/crates/ui/src/proxy.rs
@@ -5,48 +5,42 @@ use axum::response::{IntoResponse, Response};
 use reqwest::Client;
 
 /// Shared state for proxy handlers.
+///
+/// After the React SPA was updated to route directly through the core gateway,
+/// the per-service proxy handlers became redundant. The proxy now forwards all
+/// `/api/**` requests to the core gateway at `{gateway_url}/api/v1/**`, so
+/// only a single upstream URL is needed.
 #[derive(Clone)]
 pub struct ProxyState {
     pub client: Client,
-    pub ask_url: String,
-    pub notify_url: String,
-    pub orchestrator_url: String,
+    /// URL of the core gateway (e.g. `http://localhost:17000`).
+    pub gateway_url: String,
 }
 
-/// Proxy requests under `/api/ask/**` to the ask service.
-pub async fn proxy_ask(
+/// Proxy all requests under `/api/**` to the core gateway.
+///
+/// Strips the `/api/` prefix and prepends `/api/v1/` so that the gateway
+/// receives the correct service path.
+///
+/// Example: `GET /api/notify/notifications` → `GET {gateway}/api/v1/notify/notifications`
+pub async fn proxy_to_gateway(
     State(state): State<ProxyState>,
     req: Request<Body>,
 ) -> Result<Response, StatusCode> {
-    proxy_request(&state.client, &state.ask_url, "/api/ask", req).await
+    proxy_request(&state.client, &state.gateway_url, "/api", "/api/v1", req).await
 }
 
-/// Proxy requests under `/api/notify/**` to the notify service.
-pub async fn proxy_notify(
-    State(state): State<ProxyState>,
-    req: Request<Body>,
-) -> Result<Response, StatusCode> {
-    proxy_request(&state.client, &state.notify_url, "/api/notify", req).await
-}
-
-/// Proxy requests under `/api/orchestrator/**` to the orchestrator service.
-pub async fn proxy_orchestrator(
-    State(state): State<ProxyState>,
-    req: Request<Body>,
-) -> Result<Response, StatusCode> {
-    proxy_request(&state.client, &state.orchestrator_url, "/api/orchestrator", req).await
-}
-
-/// Forward an inbound request to an upstream service, stripping the prefix.
+/// Forward an inbound request to the upstream gateway, rewriting the path prefix.
 async fn proxy_request(
     client: &Client,
-    upstream_url: &str,
-    prefix: &str,
+    upstream_base: &str,
+    strip_prefix: &str,
+    add_prefix: &str,
     req: Request<Body>,
 ) -> Result<Response, StatusCode> {
-    let path = req.uri().path().strip_prefix(prefix).unwrap_or("");
+    let tail = req.uri().path().strip_prefix(strip_prefix).unwrap_or("");
     let query = req.uri().query().map(|q| format!("?{q}")).unwrap_or_default();
-    let target_url = format!("{upstream_url}{path}{query}");
+    let target_url = format!("{upstream_base}{add_prefix}{tail}{query}");
 
     let method = req.method().clone();
     let headers = req.headers().clone();


### PR DESCRIPTION
Replace the three per-service proxy handlers (`proxy_ask`, `proxy_notify`, `proxy_orchestrator`) with a single `proxy_to_gateway` handler that forwards all `/api/**` requests to the core gateway at `/api/v1/**`. `ProxyState` now holds a single `gateway_url` instead of three per-service URLs, and the UI is configured via `AGENTD_CORE_SERVICE_URL` instead of the three separate service-specific env vars.

Closes #1121