### PR TITLE
fix(ui): expose core service in runtime /config.json

### DIFF
--- a/crates/ui/src/runtime_config.rs
+++ b/crates/ui/src/runtime_config.rs
@@ -29,10 +29,11 @@ pub struct ServiceEntry {
     pub url: Option<String>,
 }
 
-/// Services the SPA talks to directly. `hook`, `wrap`, and `core` are
-/// backend-only and intentionally not exposed.
+/// Services the SPA talks to directly. The browser calls `core` for auth
+/// (`/auth/register`, `/auth/login`), so it must be exposed here; `hook` and
+/// `wrap` are backend-only and intentionally not exposed.
 const BROWSER_SERVICES: &[&str] =
-    &["ask", "notify", "orchestrator", "memory", "monitor", "communicate"];
+    &["core", "ask", "notify", "orchestrator", "memory", "monitor", "communicate"];
 
 /// Build the runtime configuration from the shared agentd config.
 pub fn build(shared: &agentd_common::config::AgentdConfig) -> RuntimeConfig {
@@ -42,6 +43,7 @@ pub fn build(shared: &agentd_common::config::AgentdConfig) -> RuntimeConfig {
     let mut services = BTreeMap::new();
     for &name in BROWSER_SERVICES {
         let port = match name {
+            "core" => s.core.port,
             "ask" => s.ask.port,
             "notify" => s.notify.port,
             "orchestrator" => s.orchestrator.port,
@@ -67,10 +69,24 @@ mod tests {
         let runtime = build(&cfg);
 
         assert_eq!(runtime.services.len(), BROWSER_SERVICES.len());
+        // `core` must be exposed: the SPA talks to it directly for auth.
+        assert_eq!(runtime.services["core"].port, 17000);
         assert_eq!(runtime.services["ask"].port, 17001);
         assert_eq!(runtime.services["orchestrator"].port, 17006);
         assert_eq!(runtime.services["communicate"].port, 17010);
         assert!(runtime.services.values().all(|s| s.url.is_none()));
+    }
+
+    #[test]
+    fn test_core_public_url_override() {
+        let mut cfg = AgentdConfig::default();
+        cfg.services
+            .ui
+            .public_urls
+            .insert("core".to_string(), "https://agentd.example.com".to_string());
+        let runtime = build(&cfg);
+
+        assert_eq!(runtime.services["core"].url.as_deref(), Some("https://agentd.example.com"));
     }
 
     #[test]

--- a/docs/public/install.md
+++ b/docs/public/install.md
@@ -68,10 +68,13 @@ service is reached at the page's own hostname with the service's configured
 port, which works for direct access to the host.
 
 Deployments that front services with a reverse proxy or TLS can override the
-full URL per service:
+full URL per service. `core` handles login/registration (`/auth/*`), so it must
+resolve to a host the browser can reach — override it too when the default
+hostname + port derivation does not apply:
 
 ```toml
 [services.ui.public_urls]
+core = "https://agentd.example.com"
 orchestrator = "https://agentd.example.com/orchestrator"
 notify = "https://agentd.example.com/notify"
 ```


### PR DESCRIPTION
The SPA calls the core service directly for auth (/auth/register,
/auth/login) via `runtimeServiceUrl("core")`, but `core` was omitted
from BROWSER_SERVICES, so /config.json never carried it. The frontend
fell through to the compiled-in `http://localhost:17000` default,
ignoring AGENTD_CORE_SERVICE_URL (backend-only) and the build-time
VITE_AGENTD_CORE_SERVICE_URL (baked into the prebuilt bundle). On a
remote host this produced ERR_CONNECTION_REFUSED against localhost.

Add `core` to BROWSER_SERVICES and its port lookup so the SPA derives
the core URL from the page host + port, and honors a
[services.ui.public_urls] core override. Document the core override in
install.md and add test coverage.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>