### PR TITLE
feat(knowledge): KB-5 knowledgebase UI

### DIFF
--- a/crates/cli/src/commands/knowledge.rs
+++ b/crates/cli/src/commands/knowledge.rs
@@ -14,6 +14,7 @@
 //! - **delete**: Delete a document by ID
 //! - **gc**: Bulk-delete all documents for a project (garbage collect)
 //! - **tree**: Display the virtual folder/file tree for a project
+//! - **doctor**: Reconcile DB rows vs disk files; optionally fix divergences
 //!
 //! # Examples
 //!
@@ -28,6 +29,8 @@
 //! agent knowledge delete <project_id> <doc_id>
 //! agent knowledge gc <project_id>
 //! agent knowledge tree <project_id>
+//! agent knowledge doctor <project_id>
+//! agent knowledge doctor <project_id> --fix
 //! ```
 
 use anyhow::Result;
@@ -193,6 +196,26 @@ pub enum KnowledgeCommand {
         /// Project UUID
         project_id: String,
     },
+
+    /// Reconcile DB rows vs disk files for a project.
+    ///
+    /// Reports missing files (DB rows whose markdown file is absent from disk)
+    /// and orphaned files (disk files with no DB row). Pass `--fix` to
+    /// automatically delete the divergent entries.
+    ///
+    /// # Examples
+    ///
+    /// ```bash
+    /// agent knowledge doctor <project_id>
+    /// agent knowledge doctor <project_id> --fix
+    /// ```
+    Doctor {
+        /// Project UUID
+        project_id: String,
+        /// Automatically fix divergences (delete stale DB rows + orphaned files).
+        #[arg(long)]
+        fix: bool,
+    },
 }
 
 impl KnowledgeCommand {
@@ -251,6 +274,9 @@ impl KnowledgeCommand {
                 cmd_gc(client, project_id, *yes, json).await
             }
             KnowledgeCommand::Tree { project_id } => cmd_tree(client, project_id, json).await,
+            KnowledgeCommand::Doctor { project_id, fix } => {
+                cmd_doctor(client, project_id, *fix, json).await
+            }
         }
     }
 }
@@ -446,6 +472,42 @@ async fn cmd_tree(client: &KnowledgeClient, project_id: &str, json: bool) -> Res
         return Ok(());
     }
     print_tree_nodes(&tree, "");
+    Ok(())
+}
+
+async fn cmd_doctor(
+    client: &KnowledgeClient,
+    project_id: &str,
+    fix: bool,
+    json: bool,
+) -> Result<()> {
+    let report =
+        if fix { client.doctor_fix(project_id).await? } else { client.doctor(project_id).await? };
+    if json {
+        println!("{}", serde_json::to_string_pretty(&report)?);
+        return Ok(());
+    }
+    if report.missing_files.is_empty() && report.orphaned_files.is_empty() {
+        println!("{}", "No divergences found.".green());
+        return Ok(());
+    }
+    if !report.missing_files.is_empty() {
+        println!("{} (DB rows with no file on disk):", "Missing files".bold().yellow());
+        for f in &report.missing_files {
+            println!("  - {f}");
+        }
+    }
+    if !report.orphaned_files.is_empty() {
+        println!("{} (disk files with no DB row):", "Orphaned files".bold().yellow());
+        for f in &report.orphaned_files {
+            println!("  - {f}");
+        }
+    }
+    if fix {
+        println!("\n{} {} issue(s) fixed.", "Doctor:".bold().green(), report.fixed);
+    } else {
+        println!("\n{} Run with --fix to repair automatically.", "Hint:".bold());
+    }
     Ok(())
 }
 

--- a/crates/common/src/config.rs
+++ b/crates/common/src/config.rs
@@ -251,15 +251,21 @@ impl Default for MemoryConfig {
 }
 
 /// Configuration for the `agentd-knowledge` service (port 17011).
+///
+/// | Field  | Env var                   | Default                                |
+/// |--------|---------------------------|----------------------------------------|
+/// | `port` | `AGENTD_KNOWLEDGE_PORT`   | `17011`                                |
+/// | `root` | `AGENTD_KNOWLEDGE_ROOT`   | XDG data dir for `agentd-knowledge`    |
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(default)]
 pub struct KnowledgeConfig {
-    /// HTTP listen port. Defaults to `17011`.
+    /// HTTP listen port. Override with `AGENTD_KNOWLEDGE_PORT`. Defaults to `17011`.
     pub port: u16,
     /// Root directory for markdown document storage.
     ///
     /// Each project gets a subdirectory `<root>/<project_uuid>/`.
-    /// Defaults to XDG data dir for `agentd-knowledge`.
+    /// Override with `AGENTD_KNOWLEDGE_ROOT`. Defaults to the XDG data dir
+    /// for `agentd-knowledge` (e.g. `~/.local/share/agentd-knowledge/docs`).
     pub root: String,
 }
 

--- a/crates/core/src/api/gateway.rs
+++ b/crates/core/src/api/gateway.rs
@@ -17,6 +17,9 @@
 //! | `/api/v1/wrap/*`                    | agentd-wrap               |
 //! | `/api/v1/hook/*`                    | agentd-hook               |
 //! | `/api/v1/monitor/*`                 | agentd-monitor            |
+//! | `/api/v1/memory/*`                  | agentd-memory             |
+//! | `/api/v1/communicate/*`             | agentd-communicate        |
+//! | `/api/v1/knowledge/*`               | agentd-knowledge          |
 //!
 //! # WebSocket proxying
 //!

--- a/crates/knowledge/src/api.rs
+++ b/crates/knowledge/src/api.rs
@@ -13,6 +13,8 @@
 //! | `DELETE` | `/projects/:project_id/documents/:doc_id`     | Delete (204)             |
 //! | `DELETE` | `/projects/:project_id/documents`             | Bulk delete (204)        |
 //! | `GET`    | `/projects/:project_id/tree`                  | Virtual folder/file tree |
+//! | `GET`    | `/projects/:project_id/doctor`                | Reconciliation report    |
+//! | `POST`   | `/projects/:project_id/doctor`                | Reconcile and fix        |
 
 use axum::{
     extract::{Path, Query, State},
@@ -33,7 +35,7 @@ use agentd_common::types::clamp_limit;
 use crate::{
     error::KnowledgeError,
     storage::KnowledgeStorage,
-    types::{CreateDocumentRequest, TreeNode, UpdateDocumentRequest},
+    types::{CreateDocumentRequest, DoctorReport, TreeNode, UpdateDocumentRequest},
 };
 
 /// Maximum request body size: 5 MiB.
@@ -80,6 +82,8 @@ pub fn create_router_with_state(storage: Arc<KnowledgeStorage>) -> Router {
         .route("/projects/{project_id}/documents/{doc_id}/content", get(get_document_content))
         // Virtual tree
         .route("/projects/{project_id}/tree", get(get_tree))
+        // Doctor / reconciliation
+        .route("/projects/{project_id}/doctor", get(get_doctor).post(post_doctor))
         .with_state(state)
         .layer(RequestBodyLimitLayer::new(BODY_LIMIT_BYTES))
 }
@@ -328,6 +332,36 @@ fn build_level(docs: &[crate::types::Document], prefix: &str) -> Vec<TreeNode> {
 
     nodes.append(&mut files);
     nodes
+}
+
+// ---------------------------------------------------------------------------
+// Doctor / reconciliation
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+struct DoctorQuery {
+    /// When `true`, delete orphaned disk files and stale DB rows automatically.
+    fix: Option<bool>,
+}
+
+/// `GET /projects/{project_id}/doctor` — report divergences, no changes.
+async fn get_doctor(
+    State(state): State<ApiState>,
+    Path(project_id): Path<String>,
+) -> Result<Json<DoctorReport>, ApiError> {
+    let report = state.storage.doctor(&project_id, false).await.map_err(knowledge_to_api)?;
+    Ok(Json(report))
+}
+
+/// `POST /projects/{project_id}/doctor[?fix=true]` — reconcile and optionally fix.
+async fn post_doctor(
+    State(state): State<ApiState>,
+    Path(project_id): Path<String>,
+    Query(params): Query<DoctorQuery>,
+) -> Result<Json<DoctorReport>, ApiError> {
+    let fix = params.fix.unwrap_or(true);
+    let report = state.storage.doctor(&project_id, fix).await.map_err(knowledge_to_api)?;
+    Ok(Json(report))
 }
 
 // ---------------------------------------------------------------------------

--- a/crates/knowledge/src/client.rs
+++ b/crates/knowledge/src/client.rs
@@ -9,7 +9,7 @@ use serde_json::Value;
 use std::env;
 
 use crate::types::{
-    CreateDocumentRequest, Document, DocumentContent, PaginatedResponse, TreeNode,
+    CreateDocumentRequest, DoctorReport, Document, DocumentContent, PaginatedResponse, TreeNode,
     UpdateDocumentRequest,
 };
 
@@ -261,6 +261,45 @@ impl KnowledgeClient {
             let status = res.status();
             let body: Value = res.json().await.unwrap_or(Value::Null);
             anyhow::bail!("get_tree failed ({status}): {body}");
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Doctor / reconciliation
+    // -----------------------------------------------------------------------
+
+    /// Run a read-only reconciliation report for `project_id`.
+    ///
+    /// Returns lists of missing files (DB rows with no corresponding file on
+    /// disk) and orphaned files (disk files with no DB row), without making
+    /// any changes.
+    pub async fn doctor(&self, project_id: &str) -> Result<DoctorReport> {
+        let url = format!("{}/projects/{project_id}/doctor", self.base_url);
+        let res = self.auth(self.client.get(&url)).send().await.context("doctor request failed")?;
+        if res.status().is_success() {
+            res.json().await.context("failed to parse doctor response")
+        } else {
+            let status = res.status();
+            let body: Value = res.json().await.unwrap_or(Value::Null);
+            anyhow::bail!("doctor failed ({status}): {body}");
+        }
+    }
+
+    /// Run a reconciliation pass and automatically fix divergences.
+    ///
+    /// Deletes DB rows whose files are missing from disk, and removes disk
+    /// files that have no corresponding DB row. Returns a report of what was
+    /// found and how many issues were fixed.
+    pub async fn doctor_fix(&self, project_id: &str) -> Result<DoctorReport> {
+        let url = format!("{}/projects/{project_id}/doctor?fix=true", self.base_url);
+        let res =
+            self.auth(self.client.post(&url)).send().await.context("doctor_fix request failed")?;
+        if res.status().is_success() {
+            res.json().await.context("failed to parse doctor_fix response")
+        } else {
+            let status = res.status();
+            let body: Value = res.json().await.unwrap_or(Value::Null);
+            anyhow::bail!("doctor_fix failed ({status}): {body}");
         }
     }
 }

--- a/crates/knowledge/src/storage.rs
+++ b/crates/knowledge/src/storage.rs
@@ -27,7 +27,8 @@ use crate::{
     error::KnowledgeError,
     fs::{atomic_write, safe_doc_path},
     types::{
-        CreateDocumentRequest, Document, DocumentContent, PaginatedResponse, UpdateDocumentRequest,
+        CreateDocumentRequest, DoctorReport, Document, DocumentContent, PaginatedResponse,
+        UpdateDocumentRequest,
     },
 };
 
@@ -340,6 +341,90 @@ impl KnowledgeStorage {
     }
 
     // -----------------------------------------------------------------------
+    // Doctor / reconciliation
+    // -----------------------------------------------------------------------
+
+    /// Reconcile the DB vs the filesystem for `project_id`.
+    ///
+    /// Returns a [`DoctorReport`] describing:
+    /// - `missing_files` — DB rows whose markdown file is absent from disk.
+    /// - `orphaned_files` — disk files under the project directory that have
+    ///   no matching DB row.
+    ///
+    /// When `fix = true` the method also:
+    /// - Deletes DB rows for missing files.
+    /// - Deletes orphaned disk files.
+    ///
+    /// Emits the `knowledge_missing_file_total` gauge metric with the number
+    /// of missing-file divergences detected (before any fixing).
+    pub async fn doctor(
+        &self,
+        project_id: &str,
+        fix: bool,
+    ) -> std::result::Result<DoctorReport, KnowledgeError> {
+        // 1. Collect all DB rows for the project.
+        let models = document::Entity::find()
+            .filter(document::Column::ProjectId.eq(project_id))
+            .all(&self.db)
+            .await
+            .map_err(|e| KnowledgeError::Other(anyhow::anyhow!("doctor db list: {e}")))?;
+
+        // 2. Build the set of rel_paths known to the DB.
+        let db_paths: std::collections::HashMap<String, String> =
+            models.iter().map(|m| (m.rel_path.clone(), m.id.clone())).collect();
+
+        // 3. Scan disk for all .md files under <root>/<project_id>/.
+        let project_dir = self.root.join(project_id);
+        let disk_paths = collect_md_files(&project_dir);
+
+        // 4. Find DB rows whose files are missing from disk.
+        let mut missing_files: Vec<String> = Vec::new();
+        for rel_path in db_paths.keys() {
+            let abs = project_dir.join(rel_path.replace('/', std::path::MAIN_SEPARATOR_STR));
+            if !abs.exists() {
+                missing_files.push(rel_path.clone());
+            }
+        }
+
+        // 5. Find disk files that have no DB row.
+        let mut orphaned_files: Vec<String> = Vec::new();
+        for disk_rel in &disk_paths {
+            if !db_paths.contains_key(disk_rel) {
+                orphaned_files.push(disk_rel.clone());
+            }
+        }
+
+        // Emit metric.
+        metrics::gauge!("knowledge_missing_file_total").set(missing_files.len() as f64);
+
+        let mut fixed = 0u32;
+
+        if fix {
+            // Remove DB rows for missing files.
+            for rel_path in &missing_files {
+                let affected = document::Entity::delete_many()
+                    .filter(document::Column::ProjectId.eq(project_id))
+                    .filter(document::Column::RelPath.eq(rel_path.as_str()))
+                    .exec(&self.db)
+                    .await
+                    .map(|r| r.rows_affected)
+                    .unwrap_or(0);
+                fixed += affected as u32;
+            }
+
+            // Remove orphaned disk files.
+            for rel_path in &orphaned_files {
+                let abs = project_dir.join(rel_path.replace('/', std::path::MAIN_SEPARATOR_STR));
+                if std::fs::remove_file(&abs).is_ok() {
+                    fixed += 1;
+                }
+            }
+        }
+
+        Ok(DoctorReport { missing_files, orphaned_files, fixed })
+    }
+
+    // -----------------------------------------------------------------------
     // Helpers
     // -----------------------------------------------------------------------
 
@@ -376,6 +461,30 @@ fn model_to_document(m: document::Model) -> Document {
         created_at: m.created_at,
         updated_at: m.updated_at,
         organization_id: m.organization_id,
+    }
+}
+
+/// Recursively collect all `.md` file paths under `dir`, returning them as
+/// relative path strings (using `/` separators, matching `rel_path` in the DB).
+fn collect_md_files(dir: &Path) -> Vec<String> {
+    let mut out = Vec::new();
+    collect_md_files_inner(dir, dir, &mut out);
+    out
+}
+
+fn collect_md_files_inner(root: &Path, current: &Path, out: &mut Vec<String>) {
+    let Ok(entries) = std::fs::read_dir(current) else { return };
+    for entry in entries.flatten() {
+        let path = entry.path();
+        if path.is_dir() {
+            collect_md_files_inner(root, &path, out);
+        } else if path.extension().is_some_and(|e| e == "md") {
+            if let Ok(rel) = path.strip_prefix(root) {
+                // Normalise to forward-slash separators.
+                let rel_str = rel.to_string_lossy().replace(std::path::MAIN_SEPARATOR, "/");
+                out.push(rel_str);
+            }
+        }
     }
 }
 
@@ -584,6 +693,161 @@ mod tests {
         let remaining = s.list_documents(PROJ, None, 100, 0).await.unwrap();
         assert_eq!(remaining.total, 1);
         assert_eq!(remaining.items[0].rel_path, "b.md");
+    }
+
+    // -----------------------------------------------------------------------
+    // Doctor tests
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_doctor_clean_project_reports_no_divergences() {
+        let tmp = tempfile::tempdir().unwrap();
+        let s = make_storage(&tmp).await;
+        s.create_document(PROJ, create_req("docs/a.md", "alpha"), None).await.unwrap();
+        s.create_document(PROJ, create_req("docs/b.md", "beta"), None).await.unwrap();
+
+        let report = s.doctor(PROJ, false).await.unwrap();
+        assert!(report.missing_files.is_empty(), "expected no missing files");
+        assert!(report.orphaned_files.is_empty(), "expected no orphaned files");
+        assert_eq!(report.fixed, 0);
+    }
+
+    #[tokio::test]
+    async fn test_doctor_detects_missing_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        let s = make_storage(&tmp).await;
+        let doc = s.create_document(PROJ, create_req("orphan.md", "x"), None).await.unwrap();
+
+        // Delete the file on disk directly (simulates a lost file).
+        let file_path = tmp.path().join("docs").join(PROJ).join("orphan.md");
+        std::fs::remove_file(&file_path).unwrap();
+
+        let report = s.doctor(PROJ, false).await.unwrap();
+        assert_eq!(report.missing_files, vec![doc.rel_path]);
+        assert!(report.orphaned_files.is_empty());
+        assert_eq!(report.fixed, 0, "fix=false should not repair");
+    }
+
+    #[tokio::test]
+    async fn test_doctor_detects_orphaned_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        let s = make_storage(&tmp).await;
+
+        // Write a file that has no DB row.
+        let project_dir = tmp.path().join("docs").join(PROJ);
+        std::fs::create_dir_all(&project_dir).unwrap();
+        std::fs::write(project_dir.join("stray.md"), b"orphan").unwrap();
+
+        let report = s.doctor(PROJ, false).await.unwrap();
+        assert!(report.missing_files.is_empty());
+        assert_eq!(report.orphaned_files, vec!["stray.md".to_string()]);
+        assert_eq!(report.fixed, 0);
+    }
+
+    #[tokio::test]
+    async fn test_doctor_fix_removes_missing_db_row() {
+        let tmp = tempfile::tempdir().unwrap();
+        let s = make_storage(&tmp).await;
+        let doc = s.create_document(PROJ, create_req("gone.md", "bye"), None).await.unwrap();
+
+        // Remove file on disk.
+        let file_path = tmp.path().join("docs").join(PROJ).join("gone.md");
+        std::fs::remove_file(&file_path).unwrap();
+
+        let report = s.doctor(PROJ, true).await.unwrap();
+        assert_eq!(report.missing_files.len(), 1);
+        assert!(report.fixed >= 1, "expected at least one fix");
+
+        // DB row should now be gone.
+        let err = s.get_document(PROJ, &doc.id, None).await.unwrap_err();
+        assert!(matches!(err, KnowledgeError::NotFound(_)));
+    }
+
+    #[tokio::test]
+    async fn test_doctor_fix_removes_orphaned_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        let s = make_storage(&tmp).await;
+
+        // Write an orphaned file with no DB row.
+        let project_dir = tmp.path().join("docs").join(PROJ);
+        std::fs::create_dir_all(&project_dir).unwrap();
+        let orphan = project_dir.join("ghost.md");
+        std::fs::write(&orphan, b"ghost").unwrap();
+
+        let report = s.doctor(PROJ, true).await.unwrap();
+        assert_eq!(report.orphaned_files.len(), 1);
+        assert!(report.fixed >= 1, "expected at least one fix");
+        assert!(!orphan.exists(), "orphaned file should have been deleted");
+    }
+
+    // -----------------------------------------------------------------------
+    // End-to-end lifecycle test
+    // -----------------------------------------------------------------------
+
+    /// Full round-trip: create → list → confirm on disk → update → delete.
+    #[tokio::test]
+    async fn test_full_lifecycle_e2e() {
+        let tmp = tempfile::tempdir().unwrap();
+        let s = make_storage(&tmp).await;
+        let proj = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+
+        // Create a document.
+        let doc = s
+            .create_document(proj, create_req("guide.md", "# Guide\n\nInitial content."), None)
+            .await
+            .unwrap();
+        assert_eq!(doc.rel_path, "guide.md");
+        assert_eq!(doc.title, "guide");
+
+        // File must exist on disk.
+        let disk_path = tmp.path().join("docs").join(proj).join("guide.md");
+        assert!(disk_path.exists(), "file should exist after create");
+        assert_eq!(std::fs::read_to_string(&disk_path).unwrap(), "# Guide\n\nInitial content.");
+
+        // List returns the new document.
+        let page = s.list_documents(proj, None, 100, 0).await.unwrap();
+        assert_eq!(page.total, 1);
+        assert_eq!(page.items[0].id, doc.id);
+
+        // Get metadata.
+        let fetched = s.get_document(proj, &doc.id, None).await.unwrap();
+        assert_eq!(fetched.rel_path, "guide.md");
+
+        // Get with content.
+        let with_content = s.get_document_content(proj, &doc.id, None).await.unwrap();
+        assert_eq!(with_content.content, "# Guide\n\nInitial content.");
+
+        // Update content.
+        let updated = s
+            .update_document(
+                proj,
+                &doc.id,
+                None,
+                UpdateDocumentRequest {
+                    content: Some("# Guide\n\nUpdated content.".to_string()),
+                    title: Some("Guide (revised)".to_string()),
+                    expected_updated_at: None,
+                },
+            )
+            .await
+            .unwrap();
+        assert_eq!(updated.title, "Guide (revised)");
+        assert_eq!(std::fs::read_to_string(&disk_path).unwrap(), "# Guide\n\nUpdated content.");
+
+        // Doctor with no divergences.
+        let report = s.doctor(proj, false).await.unwrap();
+        assert!(report.missing_files.is_empty());
+        assert!(report.orphaned_files.is_empty());
+
+        // Delete.
+        s.delete_document(proj, &doc.id, None).await.unwrap();
+        assert!(!disk_path.exists(), "file should be gone after delete");
+        let err = s.get_document(proj, &doc.id, None).await.unwrap_err();
+        assert!(matches!(err, KnowledgeError::NotFound(_)));
+
+        // List is now empty.
+        let empty = s.list_documents(proj, None, 100, 0).await.unwrap();
+        assert_eq!(empty.total, 0);
     }
 
     #[tokio::test]

--- a/crates/knowledge/src/storage.rs
+++ b/crates/knowledge/src/storage.rs
@@ -14,8 +14,8 @@
 
 use anyhow::Result;
 use sea_orm::{
-    ActiveModelTrait, ActiveValue::Set, ColumnTrait, DatabaseConnection, EntityTrait, ModelTrait,
-    PaginatorTrait, QueryFilter, QueryOrder, QuerySelect,
+    ActiveModelTrait, ActiveValue::Set, ColumnTrait, Condition, DatabaseConnection, EntityTrait,
+    ModelTrait, PaginatorTrait, QueryFilter, QueryOrder, QuerySelect,
 };
 use std::{
     path::{Path, PathBuf},
@@ -179,8 +179,8 @@ impl KnowledgeStorage {
     ) -> std::result::Result<PaginatedResponse<Document>, KnowledgeError> {
         let mut base_query =
             document::Entity::find().filter(document::Column::ProjectId.eq(project_id));
-        if let Some(o) = org {
-            base_query = base_query.filter(document::Column::OrganizationId.eq(o));
+        if let Some(cond) = tenant_read_condition(org) {
+            base_query = base_query.filter(cond);
         }
         let base_query = base_query.order_by_asc(document::Column::RelPath);
 
@@ -436,8 +436,8 @@ impl KnowledgeStorage {
     ) -> std::result::Result<document::Model, KnowledgeError> {
         let mut query = document::Entity::find_by_id(doc_id.to_string())
             .filter(document::Column::ProjectId.eq(project_id));
-        if let Some(o) = org {
-            query = query.filter(document::Column::OrganizationId.eq(o));
+        if let Some(cond) = tenant_read_condition(org) {
+            query = query.filter(cond);
         }
         query
             .one(&self.db)
@@ -486,6 +486,29 @@ fn collect_md_files_inner(root: &Path, current: &Path, out: &mut Vec<String>) {
             }
         }
     }
+}
+
+/// Build the org-scoping [`Condition`] for read queries.
+///
+/// When `org` is `Some`, the condition is:
+///
+/// ```sql
+/// WHERE organization_id = <org> OR organization_id IS NULL
+/// ```
+///
+/// The `OR IS NULL` arm implements the NULL-row transition policy documented in
+/// `agentd-common::tenant`: rows created before multi-tenancy have a `NULL`
+/// `organization_id` and must remain readable by every authenticated tenant
+/// until an operator runs the backfill command.
+///
+/// When `org` is `None` (trusted/local access), no org filter is added and the
+/// caller sees all rows for the project.
+fn tenant_read_condition(org: Option<&str>) -> Option<Condition> {
+    org.map(|o| {
+        Condition::any()
+            .add(document::Column::OrganizationId.eq(o))
+            .add(document::Column::OrganizationId.is_null())
+    })
 }
 
 /// Map a SeaORM database error to a `KnowledgeError`.
@@ -693,6 +716,131 @@ mod tests {
         let remaining = s.list_documents(PROJ, None, 100, 0).await.unwrap();
         assert_eq!(remaining.total, 1);
         assert_eq!(remaining.items[0].rel_path, "b.md");
+    }
+
+    // -----------------------------------------------------------------------
+    // KB-7: tenant scoping and NULL-row transition policy
+    // -----------------------------------------------------------------------
+
+    /// Docs with `organization_id = NULL` (pre-tenancy / legacy) must be
+    /// visible to any tenant-scoped request during the transition window.
+    #[tokio::test]
+    async fn test_null_org_doc_visible_to_any_tenant() {
+        let tmp = tempfile::tempdir().unwrap();
+        let s = make_storage(&tmp).await;
+
+        // Legacy doc: no org assigned (NULL).
+        let legacy =
+            s.create_document(PROJ, create_req("legacy.md", "old content"), None).await.unwrap();
+        assert!(legacy.organization_id.is_none());
+
+        // Any authenticated tenant can list it.
+        let page_a = s.list_documents(PROJ, Some("org-a"), 100, 0).await.unwrap();
+        assert_eq!(page_a.total, 1, "org-a should see the NULL-org legacy doc");
+        assert_eq!(page_a.items[0].rel_path, "legacy.md");
+
+        let page_b = s.list_documents(PROJ, Some("org-b"), 100, 0).await.unwrap();
+        assert_eq!(page_b.total, 1, "org-b should also see the NULL-org legacy doc");
+    }
+
+    /// Any tenant can fetch a NULL-org doc by ID (transition period access).
+    #[tokio::test]
+    async fn test_null_org_doc_get_by_any_tenant() {
+        let tmp = tempfile::tempdir().unwrap();
+        let s = make_storage(&tmp).await;
+
+        let legacy =
+            s.create_document(PROJ, create_req("shared.md", "# Shared"), None).await.unwrap();
+
+        // Both orgs can fetch it by ID.
+        let fetched_a = s.get_document(PROJ, &legacy.id, Some("org-a")).await.unwrap();
+        assert_eq!(fetched_a.id, legacy.id);
+
+        let fetched_b = s.get_document(PROJ, &legacy.id, Some("org-b")).await.unwrap();
+        assert_eq!(fetched_b.id, legacy.id);
+    }
+
+    /// Org-scoped docs are NOT visible to another org (strict cross-tenant isolation).
+    #[tokio::test]
+    async fn test_cross_tenant_isolation() {
+        let tmp = tempfile::tempdir().unwrap();
+        let s = make_storage(&tmp).await;
+
+        let doc_a = s
+            .create_document(PROJ, create_req("a.md", "a"), Some("org-a".to_string()))
+            .await
+            .unwrap();
+        let doc_b = s
+            .create_document(PROJ, create_req("b.md", "b"), Some("org-b".to_string()))
+            .await
+            .unwrap();
+
+        // org-a list sees only its own doc (no NULL-org docs here).
+        let page_a = s.list_documents(PROJ, Some("org-a"), 100, 0).await.unwrap();
+        assert_eq!(page_a.total, 1);
+        assert_eq!(page_a.items[0].rel_path, "a.md");
+
+        // org-b list sees only its own doc.
+        let page_b = s.list_documents(PROJ, Some("org-b"), 100, 0).await.unwrap();
+        assert_eq!(page_b.total, 1);
+        assert_eq!(page_b.items[0].rel_path, "b.md");
+
+        // org-b cannot fetch org-a's doc by ID.
+        let err = s.get_document(PROJ, &doc_a.id, Some("org-b")).await.unwrap_err();
+        assert!(matches!(err, KnowledgeError::NotFound(_)), "org-b must not see org-a's doc");
+
+        // org-a cannot fetch org-b's doc by ID.
+        let err = s.get_document(PROJ, &doc_b.id, Some("org-a")).await.unwrap_err();
+        assert!(matches!(err, KnowledgeError::NotFound(_)), "org-a must not see org-b's doc");
+    }
+
+    /// An org-scoped `list` returns both its own docs AND legacy NULL-org docs,
+    /// but NOT docs owned by another org.
+    #[tokio::test]
+    async fn test_tenant_list_mixes_own_and_null_org_docs() {
+        let tmp = tempfile::tempdir().unwrap();
+        let s = make_storage(&tmp).await;
+
+        // One legacy doc (NULL org) and one from each org.
+        s.create_document(PROJ, create_req("legacy.md", "legacy"), None).await.unwrap();
+        s.create_document(PROJ, create_req("a.md", "a"), Some("org-a".to_string())).await.unwrap();
+        s.create_document(PROJ, create_req("b.md", "b"), Some("org-b".to_string())).await.unwrap();
+
+        // org-a sees: legacy.md + a.md (not b.md).
+        let page_a = s.list_documents(PROJ, Some("org-a"), 100, 0).await.unwrap();
+        assert_eq!(page_a.total, 2);
+        let paths_a: Vec<&str> = page_a.items.iter().map(|d| d.rel_path.as_str()).collect();
+        assert!(paths_a.contains(&"legacy.md"), "org-a must see the legacy doc");
+        assert!(paths_a.contains(&"a.md"), "org-a must see its own doc");
+        assert!(!paths_a.contains(&"b.md"), "org-a must NOT see org-b's doc");
+
+        // org-b sees: legacy.md + b.md (not a.md).
+        let page_b = s.list_documents(PROJ, Some("org-b"), 100, 0).await.unwrap();
+        assert_eq!(page_b.total, 2);
+        let paths_b: Vec<&str> = page_b.items.iter().map(|d| d.rel_path.as_str()).collect();
+        assert!(paths_b.contains(&"legacy.md"), "org-b must see the legacy doc");
+        assert!(paths_b.contains(&"b.md"), "org-b must see its own doc");
+        assert!(!paths_b.contains(&"a.md"), "org-b must NOT see org-a's doc");
+    }
+
+    /// Org-scoped `bulk_delete_project` (gc) removes only that org's docs;
+    /// NULL-org (legacy) docs are left untouched.
+    #[tokio::test]
+    async fn test_bulk_delete_org_scoped_leaves_null_org_docs() {
+        let tmp = tempfile::tempdir().unwrap();
+        let s = make_storage(&tmp).await;
+
+        let legacy =
+            s.create_document(PROJ, create_req("legacy.md", "legacy"), None).await.unwrap();
+        s.create_document(PROJ, create_req("a.md", "a"), Some("org-a".to_string())).await.unwrap();
+
+        // GC scoped to org-a.
+        s.bulk_delete_project(PROJ, Some("org-a")).await.unwrap();
+
+        // The legacy (NULL-org) doc must survive.
+        let remaining = s.list_documents(PROJ, None, 100, 0).await.unwrap();
+        assert_eq!(remaining.total, 1);
+        assert_eq!(remaining.items[0].id, legacy.id, "legacy doc must survive org-scoped gc");
     }
 
     // -----------------------------------------------------------------------

--- a/crates/knowledge/src/types.rs
+++ b/crates/knowledge/src/types.rs
@@ -81,3 +81,14 @@ pub struct PaginatedResponse<T> {
     pub limit: u64,
     pub offset: u64,
 }
+
+/// Result of a `doctor` reconciliation pass for a single project.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct DoctorReport {
+    /// DB rows whose markdown file is absent from disk.
+    pub missing_files: Vec<String>,
+    /// Disk files that have no corresponding DB row.
+    pub orphaned_files: Vec<String>,
+    /// Number of issues automatically repaired (set when `fix = true`).
+    pub fixed: u32,
+}

--- a/crates/ui/src/runtime_config.rs
+++ b/crates/ui/src/runtime_config.rs
@@ -33,7 +33,7 @@ pub struct ServiceEntry {
 /// (`/auth/register`, `/auth/login`), so it must be exposed here; `hook` and
 /// `wrap` are backend-only and intentionally not exposed.
 const BROWSER_SERVICES: &[&str] =
-    &["core", "ask", "notify", "orchestrator", "memory", "monitor", "communicate"];
+    &["core", "ask", "notify", "orchestrator", "memory", "monitor", "communicate", "knowledge"];
 
 /// Build the runtime configuration from the shared agentd config.
 pub fn build(shared: &agentd_common::config::AgentdConfig) -> RuntimeConfig {
@@ -50,6 +50,7 @@ pub fn build(shared: &agentd_common::config::AgentdConfig) -> RuntimeConfig {
             "memory" => s.memory.port,
             "monitor" => s.monitor.port,
             "communicate" => s.communicate.port,
+            "knowledge" => s.knowledge.port,
             _ => unreachable!("unknown browser service {name}"),
         };
         services.insert(name, ServiceEntry { port, url: overrides.get(name).cloned() });
@@ -74,6 +75,7 @@ mod tests {
         assert_eq!(runtime.services["ask"].port, 17001);
         assert_eq!(runtime.services["orchestrator"].port, 17006);
         assert_eq!(runtime.services["communicate"].port, 17010);
+        assert_eq!(runtime.services["knowledge"].port, 17011);
         assert!(runtime.services.values().all(|s| s.url.is_none()));
     }
 

--- a/ui/bun.lock
+++ b/ui/bun.lock
@@ -5,6 +5,13 @@
       "name": "ui",
       "dependencies": {
         "@animxyz/core": "^0.6.6",
+        "@codemirror/commands": "^6.10.3",
+        "@codemirror/lang-markdown": "^6.5.0",
+        "@codemirror/language": "^6.12.3",
+        "@codemirror/state": "^6.6.0",
+        "@codemirror/theme-one-dark": "^6.1.3",
+        "@codemirror/view": "^6.43.1",
+        "@lezer/highlight": "^1.2.3",
         "@nivo/bar": "^0.99.0",
         "@nivo/core": "^0.99.0",
         "@nivo/line": "^0.99.0",
@@ -143,6 +150,28 @@
 
     "@codecov/vite-plugin": ["@codecov/vite-plugin@2.0.1", "", { "dependencies": { "@codecov/bundler-plugin-core": "^2.0.1", "unplugin": "^1.10.1" }, "peerDependencies": { "vite": "4.x || 5.x || 6.x" } }, "sha512-w7nGA9SSc0WECzn05yRrw3uN8293I620Kd9x97I0kyyxUjtWxCMmlgmAbS364gJZYvljd0A6iQyAigVV2dOX9A=="],
 
+    "@codemirror/autocomplete": ["@codemirror/autocomplete@6.20.3", "", { "dependencies": { "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.17.0", "@lezer/common": "^1.0.0" } }, "sha512-tlosUqb+3BbxCxZdu4tKeRghPFC+QM7q4X5YhKV2eCmPG+1r2F3f4AaSz5sCrFqUtX4Jh20VFTKecl16MgiV9g=="],
+
+    "@codemirror/commands": ["@codemirror/commands@6.10.3", "", { "dependencies": { "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.6.0", "@codemirror/view": "^6.27.0", "@lezer/common": "^1.1.0" } }, "sha512-JFRiqhKu+bvSkDLI+rUhJwSxQxYb759W5GBezE8Uc8mHLqC9aV/9aTC7yJSqCtB3F00pylrLCwnyS91Ap5ej4Q=="],
+
+    "@codemirror/lang-css": ["@codemirror/lang-css@6.3.1", "", { "dependencies": { "@codemirror/autocomplete": "^6.0.0", "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.0.0", "@lezer/common": "^1.0.2", "@lezer/css": "^1.1.7" } }, "sha512-kr5fwBGiGtmz6l0LSJIbno9QrifNMUusivHbnA1H6Dmqy4HZFte3UAICix1VuKo0lMPKQr2rqB+0BkKi/S3Ejg=="],
+
+    "@codemirror/lang-html": ["@codemirror/lang-html@6.4.11", "", { "dependencies": { "@codemirror/autocomplete": "^6.0.0", "@codemirror/lang-css": "^6.0.0", "@codemirror/lang-javascript": "^6.0.0", "@codemirror/language": "^6.4.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.17.0", "@lezer/common": "^1.0.0", "@lezer/css": "^1.1.0", "@lezer/html": "^1.3.12" } }, "sha512-9NsXp7Nwp891pQchI7gPdTwBuSuT3K65NGTHWHNJ55HjYcHLllr0rbIZNdOzas9ztc1EUVBlHou85FFZS4BNnw=="],
+
+    "@codemirror/lang-javascript": ["@codemirror/lang-javascript@6.2.5", "", { "dependencies": { "@codemirror/autocomplete": "^6.0.0", "@codemirror/language": "^6.6.0", "@codemirror/lint": "^6.0.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.17.0", "@lezer/common": "^1.0.0", "@lezer/javascript": "^1.0.0" } }, "sha512-zD4e5mS+50htS7F+TYjBPsiIFGanfVqg4HyUz6WNFikgOPf2BgKlx+TQedI1w6n/IqRBVBbBWmGFdLB/7uxO4A=="],
+
+    "@codemirror/lang-markdown": ["@codemirror/lang-markdown@6.5.0", "", { "dependencies": { "@codemirror/autocomplete": "^6.7.1", "@codemirror/lang-html": "^6.0.0", "@codemirror/language": "^6.3.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.0.0", "@lezer/common": "^1.2.1", "@lezer/markdown": "^1.0.0" } }, "sha512-0K40bZ35jpHya6FriukbgaleaqzBLZfOh7HuzqbMxBXkbYMJDxfF39c23xOgxFezR+3G+tR2/Mup+Xk865OMvw=="],
+
+    "@codemirror/language": ["@codemirror/language@6.12.3", "", { "dependencies": { "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.23.0", "@lezer/common": "^1.5.0", "@lezer/highlight": "^1.0.0", "@lezer/lr": "^1.0.0", "style-mod": "^4.0.0" } }, "sha512-QwCZW6Tt1siP37Jet9Tb02Zs81TQt6qQrZR2H+eGMcFsL1zMrk2/b9CLC7/9ieP1fjIUMgviLWMmgiHoJrj+ZA=="],
+
+    "@codemirror/lint": ["@codemirror/lint@6.9.7", "", { "dependencies": { "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.42.0", "crelt": "^1.0.5" } }, "sha512-28/+iWLYxKxsvGYhSYL7zaCZqLz5+FFFDq9tVsvGv9kv8RY4fFAchJ5WX9M3YrrRlTIsECjsXPqeNgnSmNP2dg=="],
+
+    "@codemirror/state": ["@codemirror/state@6.6.0", "", { "dependencies": { "@marijn/find-cluster-break": "^1.0.0" } }, "sha512-4nbvra5R5EtiCzr9BTHiTLc+MLXK2QGiAVYMyi8PkQd3SR+6ixar/Q/01Fa21TBIDOZXgeWV4WppsQolSreAPQ=="],
+
+    "@codemirror/theme-one-dark": ["@codemirror/theme-one-dark@6.1.3", "", { "dependencies": { "@codemirror/language": "^6.0.0", "@codemirror/state": "^6.0.0", "@codemirror/view": "^6.0.0", "@lezer/highlight": "^1.0.0" } }, "sha512-NzBdIvEJmx6fjeremiGp3t/okrLPYT0d9orIc7AFun8oZcRk58aejkqhv6spnz4MLAevrKNPMQYXEWMg4s+sKA=="],
+
+    "@codemirror/view": ["@codemirror/view@6.43.1", "", { "dependencies": { "@codemirror/state": "^6.6.0", "crelt": "^1.0.6", "style-mod": "^4.1.0", "w3c-keyname": "^2.2.4" } }, "sha512-+BIjw/AG3tDQ4pJgTLPYdAW25eDE66YsvM4LKyVPgGzVgZ4a9Wj1SRX8kPVKgBDdPt8oHtZ15F0qx7p0oOHdHw=="],
+
     "@csstools/color-helpers": ["@csstools/color-helpers@6.0.2", "", {}, "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q=="],
 
     "@csstools/css-calc": ["@csstools/css-calc@3.1.1", "", { "peerDependencies": { "@csstools/css-parser-algorithms": "^4.0.0", "@csstools/css-tokenizer": "^4.0.0" } }, "sha512-HJ26Z/vmsZQqs/o3a6bgKslXGFAungXGbinULZO3eMsOyNJHeBBZfup5FiZInOghgoM4Hwnmw+OgbJCNg1wwUQ=="],
@@ -266,6 +295,22 @@
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+
+    "@lezer/common": ["@lezer/common@1.5.2", "", {}, "sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ=="],
+
+    "@lezer/css": ["@lezer/css@1.3.3", "", { "dependencies": { "@lezer/common": "^1.2.0", "@lezer/highlight": "^1.0.0", "@lezer/lr": "^1.3.0" } }, "sha512-RzBo8r+/6QJeow7aPHIpGVIH59xTcJXp399820gZoMo9noQDRVpJLheIBUicYwKcsbOYoBRoLZlf2720dG/4Tg=="],
+
+    "@lezer/highlight": ["@lezer/highlight@1.2.3", "", { "dependencies": { "@lezer/common": "^1.3.0" } }, "sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g=="],
+
+    "@lezer/html": ["@lezer/html@1.3.13", "", { "dependencies": { "@lezer/common": "^1.2.0", "@lezer/highlight": "^1.0.0", "@lezer/lr": "^1.0.0" } }, "sha512-oI7n6NJml729m7pjm9lvLvmXbdoMoi2f+1pwSDJkl9d68zGr7a9Btz8NdHTGQZtW2DA25ybeuv/SyDb9D5tseg=="],
+
+    "@lezer/javascript": ["@lezer/javascript@1.5.4", "", { "dependencies": { "@lezer/common": "^1.2.0", "@lezer/highlight": "^1.1.3", "@lezer/lr": "^1.3.0" } }, "sha512-vvYx3MhWqeZtGPwDStM2dwgljd5smolYD2lR2UyFcHfxbBQebqx8yjmFmxtJ/E6nN6u1D9srOiVWm3Rb4tmcUA=="],
+
+    "@lezer/lr": ["@lezer/lr@1.4.10", "", { "dependencies": { "@lezer/common": "^1.0.0" } }, "sha512-rnCpTIBafOx4mRp43xOxDJbFipJm/c0cia/V5TiGlhmMa+wsSdoGmUN3w5Bqrks/09Q/D4tNAmWaT8p6NRi77A=="],
+
+    "@lezer/markdown": ["@lezer/markdown@1.6.4", "", { "dependencies": { "@lezer/common": "^1.5.0", "@lezer/highlight": "^1.0.0" } }, "sha512-N0SxazMj4k65DBfaf1azqtMZd6u7MqluP84/NZnB/io8Td9aleFmAhz9hcbvSfsxT5tdYlJ5qgv5aMJGY4zEtA=="],
+
+    "@marijn/find-cluster-break": ["@marijn/find-cluster-break@1.0.2", "", {}, "sha512-l0h88YhZFyKdXIFNfSWpyjStDjGHwZ/U7iobcK1cQQD8sejsONdQtTVU+1wVN1PBw40PiiHB1vA5S7VTfQiP9g=="],
 
     "@mswjs/interceptors": ["@mswjs/interceptors@0.41.3", "", { "dependencies": { "@open-draft/deferred-promise": "^2.2.0", "@open-draft/logger": "^0.3.0", "@open-draft/until": "^2.0.0", "is-node-process": "^1.2.0", "outvariant": "^1.4.3", "strict-event-emitter": "^0.5.1" } }, "sha512-cXu86tF4VQVfwz8W1SPbhoRyHJkti6mjH/XJIxp40jhO4j2k1m4KYrEykxqWPkFF3vrK4rgQppBh//AwyGSXPA=="],
 
@@ -644,6 +689,8 @@
     "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
 
     "cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
+
+    "crelt": ["crelt@1.0.6", "", {}, "sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g=="],
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 
@@ -1125,6 +1172,8 @@
 
     "strip-json-comments": ["strip-json-comments@3.1.1", "", {}, "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig=="],
 
+    "style-mod": ["style-mod@4.1.3", "", {}, "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ=="],
+
     "style-to-js": ["style-to-js@1.1.21", "", { "dependencies": { "style-to-object": "1.0.14" } }, "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ=="],
 
     "style-to-object": ["style-to-object@1.0.14", "", { "dependencies": { "inline-style-parser": "0.2.7" } }, "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw=="],
@@ -1206,6 +1255,8 @@
     "vite": ["vite@7.3.1", "", { "dependencies": { "esbuild": "^0.27.0", "fdir": "^6.5.0", "picomatch": "^4.0.3", "postcss": "^8.5.6", "rollup": "^4.43.0", "tinyglobby": "^0.2.15" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "jiti": ">=1.21.0", "less": "^4.0.0", "lightningcss": "^1.21.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "jiti", "less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA=="],
 
     "vitest": ["vitest@4.0.18", "", { "dependencies": { "@vitest/expect": "4.0.18", "@vitest/mocker": "4.0.18", "@vitest/pretty-format": "4.0.18", "@vitest/runner": "4.0.18", "@vitest/snapshot": "4.0.18", "@vitest/spy": "4.0.18", "@vitest/utils": "4.0.18", "es-module-lexer": "^1.7.0", "expect-type": "^1.2.2", "magic-string": "^0.30.21", "obug": "^2.1.1", "pathe": "^2.0.3", "picomatch": "^4.0.3", "std-env": "^3.10.0", "tinybench": "^2.9.0", "tinyexec": "^1.0.2", "tinyglobby": "^0.2.15", "tinyrainbow": "^3.0.3", "vite": "^6.0.0 || ^7.0.0", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@opentelemetry/api": "^1.9.0", "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0", "@vitest/browser-playwright": "4.0.18", "@vitest/browser-preview": "4.0.18", "@vitest/browser-webdriverio": "4.0.18", "@vitest/ui": "4.0.18", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@opentelemetry/api", "@types/node", "@vitest/browser-playwright", "@vitest/browser-preview", "@vitest/browser-webdriverio", "@vitest/ui", "happy-dom", "jsdom"], "bin": { "vitest": "vitest.mjs" } }, "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ=="],
+
+    "w3c-keyname": ["w3c-keyname@2.2.8", "", {}, "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ=="],
 
     "w3c-xmlserializer": ["w3c-xmlserializer@5.0.0", "", { "dependencies": { "xml-name-validator": "^5.0.0" } }, "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA=="],
 

--- a/ui/package.json
+++ b/ui/package.json
@@ -16,6 +16,13 @@
 	},
 	"dependencies": {
 		"@animxyz/core": "^0.6.6",
+		"@codemirror/commands": "^6.10.3",
+		"@codemirror/lang-markdown": "^6.5.0",
+		"@codemirror/language": "^6.12.3",
+		"@codemirror/state": "^6.6.0",
+		"@codemirror/theme-one-dark": "^6.1.3",
+		"@codemirror/view": "^6.43.1",
+		"@lezer/highlight": "^1.2.3",
 		"@nivo/bar": "^0.99.0",
 		"@nivo/core": "^0.99.0",
 		"@nivo/line": "^0.99.0",

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -9,6 +9,7 @@ import {
 	CommunicatePage,
 	DashboardPage,
 	HooksPage,
+	KnowledgebasePage,
 	LoginPage,
 	MemoriesPage,
 	MonitoringPage,
@@ -63,6 +64,11 @@ function App() {
 							<Route path="/approvals" element={<ApprovalQueuePage />} />
 							<Route path="/memories" element={<MemoriesPage />} />
 							<Route path="/communicate" element={<CommunicatePage />} />
+							<Route path="/knowledge" element={<KnowledgebasePage />} />
+							<Route
+								path="/knowledge/:projectId/*"
+								element={<KnowledgebasePage />}
+							/>
 
 							{/* Product-admin section — superuser only (backend-enforced) */}
 							<Route element={<RequireSuperuser />}>

--- a/ui/src/components/knowledge/DocumentEditor.tsx
+++ b/ui/src/components/knowledge/DocumentEditor.tsx
@@ -1,0 +1,116 @@
+/**
+ * DocumentEditor — CodeMirror 6 markdown editor with debounced autosave.
+ *
+ * - Creates an EditorView imperatively in a useRef div.
+ * - Debounces changes (1 500 ms) and calls updateDocument with the optimistic-
+ *   concurrency precondition (expected_updated_at = last known updated_at).
+ * - Tears down the editor on unmount.
+ */
+
+import { defaultKeymap, history, historyKeymap } from "@codemirror/commands";
+import { markdown } from "@codemirror/lang-markdown";
+import { oneDark } from "@codemirror/theme-one-dark";
+import { EditorState } from "@codemirror/state";
+import { EditorView, keymap, lineNumbers } from "@codemirror/view";
+import { useEffect, useRef } from "react";
+import type { DocumentContent } from "@/types/knowledge";
+
+interface DocumentEditorProps {
+	docContent: DocumentContent | null;
+	/** Called whenever the editor content changes (debounced). */
+	onSave: (content: string, expectedUpdatedAt: string) => void;
+	onSavingChange: (saving: boolean) => void;
+}
+
+const DEBOUNCE_MS = 1_500;
+
+export function DocumentEditor({
+	docContent,
+	onSave,
+	onSavingChange,
+}: DocumentEditorProps) {
+	const containerRef = useRef<HTMLDivElement>(null);
+	const viewRef = useRef<EditorView | null>(null);
+	const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+	// Track the last-known updated_at for optimistic concurrency
+	const updatedAtRef = useRef<string>("");
+
+	// Recreate the editor whenever the document changes
+	useEffect(() => {
+		if (!containerRef.current) return;
+
+		// Destroy previous view
+		viewRef.current?.destroy();
+		if (debounceRef.current) clearTimeout(debounceRef.current);
+
+		if (!docContent) {
+			viewRef.current = null;
+			return;
+		}
+
+		updatedAtRef.current = docContent.document.updated_at;
+		const initialContent = docContent.content;
+
+		const updateListener = EditorView.updateListener.of((update) => {
+			if (!update.docChanged) return;
+
+			onSavingChange(true);
+
+			if (debounceRef.current) clearTimeout(debounceRef.current);
+			debounceRef.current = setTimeout(() => {
+				const content = update.state.doc.toString();
+				onSave(content, updatedAtRef.current);
+			}, DEBOUNCE_MS);
+		});
+
+		const state = EditorState.create({
+			doc: initialContent,
+			extensions: [
+				history(),
+				keymap.of([...defaultKeymap, ...historyKeymap]),
+				lineNumbers(),
+				markdown(),
+				oneDark,
+				updateListener,
+				EditorView.theme({
+					"&": { height: "100%", fontSize: "13px" },
+					".cm-scroller": { overflow: "auto", fontFamily: "monospace" },
+				}),
+			],
+		});
+
+		viewRef.current = new EditorView({
+			state,
+			parent: containerRef.current,
+		});
+
+		return () => {
+			if (debounceRef.current) clearTimeout(debounceRef.current);
+			viewRef.current?.destroy();
+			viewRef.current = null;
+		};
+	}, [docContent?.document.id]); // recreate only when the doc ID changes
+
+	// Update the updatedAt ref whenever the server confirms a save
+	useEffect(() => {
+		if (docContent) {
+			updatedAtRef.current = docContent.document.updated_at;
+		}
+	}, [docContent?.document.updated_at]);
+
+	if (!docContent) {
+		return (
+			<div className="flex h-full items-center justify-center text-sm text-th-text-muted">
+				Select a document from the tree to edit it.
+			</div>
+		);
+	}
+
+	return (
+		<div
+			ref={containerRef}
+			className="h-full w-full overflow-hidden"
+			aria-label="Markdown editor"
+		/>
+	);
+}

--- a/ui/src/components/knowledge/DocumentToolbar.tsx
+++ b/ui/src/components/knowledge/DocumentToolbar.tsx
@@ -1,0 +1,162 @@
+/**
+ * DocumentToolbar — actions above the editor: create, rename, delete.
+ */
+
+import { FilePlus, Save, Trash2 } from "lucide-react";
+import { useState } from "react";
+import type { Document } from "@/types/knowledge";
+
+interface DocumentToolbarProps {
+	document: Document | null;
+	saving: boolean;
+	projectId: string | null;
+	onCreateClick: () => void;
+	onDeleteClick: () => void;
+}
+
+export function DocumentToolbar({
+	document,
+	saving,
+	projectId,
+	onCreateClick,
+	onDeleteClick,
+}: DocumentToolbarProps) {
+	return (
+		<div className="flex items-center gap-2 border-b border-th-border bg-th-surface px-4 py-2">
+			{/* Document title / path */}
+			<div className="flex-1 min-w-0">
+				{document ? (
+					<div className="flex items-baseline gap-2">
+						<span className="text-sm font-semibold text-th-text truncate">
+							{document.title}
+						</span>
+						<span className="text-xs text-th-text-muted truncate">
+							{document.rel_path}
+						</span>
+					</div>
+				) : (
+					<span className="text-sm text-th-text-muted">
+						{projectId ? "Select a document" : "Select a project"}
+					</span>
+				)}
+			</div>
+
+			{/* Autosave indicator */}
+			{saving && (
+				<span className="flex items-center gap-1 text-xs text-th-text-muted">
+					<Save size={12} className="animate-pulse" />
+					Saving…
+				</span>
+			)}
+
+			{/* Actions */}
+			{projectId && (
+				<button
+					type="button"
+					onClick={onCreateClick}
+					title="New document"
+					className="flex items-center gap-1 rounded-md px-2 py-1 text-xs font-medium text-th-text hover:bg-th-surface-secondary"
+				>
+					<FilePlus size={14} />
+					New
+				</button>
+			)}
+			{document && (
+				<button
+					type="button"
+					onClick={onDeleteClick}
+					title="Delete document"
+					className="flex items-center gap-1 rounded-md px-2 py-1 text-xs font-medium text-th-status-error-text hover:bg-th-status-error-bg"
+				>
+					<Trash2 size={14} />
+					Delete
+				</button>
+			)}
+		</div>
+	);
+}
+
+// ---------------------------------------------------------------------------
+// Create document dialog
+// ---------------------------------------------------------------------------
+
+interface CreateDocumentDialogProps {
+	onConfirm: (relPath: string, title: string) => void;
+	onCancel: () => void;
+}
+
+export function CreateDocumentDialog({
+	onConfirm,
+	onCancel,
+}: CreateDocumentDialogProps) {
+	const [relPath, setRelPath] = useState("");
+	const [title, setTitle] = useState("");
+
+	function handleSubmit(e: React.FormEvent) {
+		e.preventDefault();
+		const path = relPath.trim();
+		if (!path) return;
+		const finalPath = path.endsWith(".md") ? path : `${path}.md`;
+		onConfirm(finalPath, title.trim());
+	}
+
+	return (
+		<div className="fixed inset-0 z-50 flex items-center justify-center bg-th-overlay">
+			<div className="w-full max-w-md rounded-lg border border-th-border bg-th-surface p-6 shadow-xl">
+				<h2 className="mb-4 text-base font-semibold text-th-text">
+					New Document
+				</h2>
+				<form onSubmit={handleSubmit} className="space-y-3">
+					<div>
+						<label
+							htmlFor="rel-path"
+							className="mb-1 block text-xs font-medium text-th-text-muted"
+						>
+							Path (relative, e.g. docs/api.md)
+						</label>
+						<input
+							id="rel-path"
+							type="text"
+							value={relPath}
+							onChange={(e) => setRelPath(e.target.value)}
+							placeholder="readme.md"
+							required
+							className="w-full rounded-md border border-th-border bg-th-background px-3 py-2 text-sm text-th-text focus:outline-none focus:ring-2 focus:ring-th-border-focus"
+						/>
+					</div>
+					<div>
+						<label
+							htmlFor="doc-title"
+							className="mb-1 block text-xs font-medium text-th-text-muted"
+						>
+							Title (optional)
+						</label>
+						<input
+							id="doc-title"
+							type="text"
+							value={title}
+							onChange={(e) => setTitle(e.target.value)}
+							placeholder="Leave blank to use filename"
+							className="w-full rounded-md border border-th-border bg-th-background px-3 py-2 text-sm text-th-text focus:outline-none focus:ring-2 focus:ring-th-border-focus"
+						/>
+					</div>
+					<div className="flex justify-end gap-2 pt-2">
+						<button
+							type="button"
+							onClick={onCancel}
+							className="rounded-md px-3 py-1.5 text-sm text-th-text hover:bg-th-surface-secondary"
+						>
+							Cancel
+						</button>
+						<button
+							type="submit"
+							className="rounded-md bg-th-button-primary px-3 py-1.5 text-sm font-medium text-th-button-primary-text hover:bg-th-button-primary-hover"
+						>
+							Create
+						</button>
+					</div>
+				</form>
+			</div>
+		</div>
+	);
+}

--- a/ui/src/components/knowledge/DocumentTree.tsx
+++ b/ui/src/components/knowledge/DocumentTree.tsx
@@ -1,0 +1,108 @@
+/**
+ * DocumentTree — renders the virtual folder/file tree for a project.
+ *
+ * Folders are expandable; clicking a file node fires onSelectDoc.
+ */
+
+import { ChevronDown, ChevronRight, File, FolderOpen } from "lucide-react";
+import { useState } from "react";
+import type { TreeNode } from "@/types/knowledge";
+
+interface DocumentTreeProps {
+	nodes: TreeNode[];
+	selectedDocId: string | null;
+	onSelectDoc: (docId: string, path: string) => void;
+}
+
+export function DocumentTree({
+	nodes,
+	selectedDocId,
+	onSelectDoc,
+}: DocumentTreeProps) {
+	if (nodes.length === 0) {
+		return (
+			<p className="px-2 py-3 text-xs text-th-text-muted">
+				No documents yet. Create one to get started.
+			</p>
+		);
+	}
+	return (
+		<ul role="tree" className="space-y-0.5">
+			{nodes.map((node) => (
+				<TreeItem
+					key={node.path}
+					node={node}
+					selectedDocId={selectedDocId}
+					onSelectDoc={onSelectDoc}
+					depth={0}
+				/>
+			))}
+		</ul>
+	);
+}
+
+interface TreeItemProps {
+	node: TreeNode;
+	selectedDocId: string | null;
+	onSelectDoc: (docId: string, path: string) => void;
+	depth: number;
+}
+
+function TreeItem({ node, selectedDocId, onSelectDoc, depth }: TreeItemProps) {
+	const [expanded, setExpanded] = useState(true);
+	const indent = depth * 12;
+
+	if (node.type === "folder") {
+		return (
+			<li role="treeitem" aria-expanded={expanded}>
+				<button
+					type="button"
+					onClick={() => setExpanded((e) => !e)}
+					className="flex w-full items-center gap-1 rounded px-2 py-1 text-xs font-medium text-th-text-muted hover:bg-th-surface-secondary"
+					style={{ paddingLeft: `${8 + indent}px` }}
+				>
+					{expanded ? (
+						<ChevronDown size={12} className="shrink-0" />
+					) : (
+						<ChevronRight size={12} className="shrink-0" />
+					)}
+					<FolderOpen size={13} className="shrink-0" />
+					<span className="truncate">{node.name}</span>
+				</button>
+				{expanded && (
+					<ul role="group">
+						{node.children.map((child) => (
+							<TreeItem
+								key={child.path}
+								node={child}
+								selectedDocId={selectedDocId}
+								onSelectDoc={onSelectDoc}
+								depth={depth + 1}
+							/>
+						))}
+					</ul>
+				)}
+			</li>
+		);
+	}
+
+	const isSelected = node.doc_id === selectedDocId;
+	return (
+		<li role="treeitem" aria-selected={isSelected}>
+			<button
+				type="button"
+				onClick={() => onSelectDoc(node.doc_id, node.path)}
+				className={[
+					"flex w-full items-center gap-1 rounded px-2 py-1 text-xs",
+					isSelected
+						? "bg-th-nav-active font-medium text-th-text-nav-active"
+						: "text-th-text hover:bg-th-surface-secondary",
+				].join(" ")}
+				style={{ paddingLeft: `${8 + indent}px` }}
+			>
+				<File size={12} className="shrink-0" />
+				<span className="truncate">{node.name}</span>
+			</button>
+		</li>
+	);
+}

--- a/ui/src/components/knowledge/ProjectPicker.tsx
+++ b/ui/src/components/knowledge/ProjectPicker.tsx
@@ -11,9 +11,14 @@ import { orchestratorClient } from "@/services/orchestrator";
 interface ProjectPickerProps {
 	selectedId: string | null;
 	onSelect: (project: Project) => void;
+	onError?: (message: string) => void;
 }
 
-export function ProjectPicker({ selectedId, onSelect }: ProjectPickerProps) {
+export function ProjectPicker({
+	selectedId,
+	onSelect,
+	onError,
+}: ProjectPickerProps) {
 	const [projects, setProjects] = useState<Project[]>([]);
 	const [loading, setLoading] = useState(true);
 	const [open, setOpen] = useState(false);
@@ -27,14 +32,16 @@ export function ProjectPicker({ selectedId, onSelect }: ProjectPickerProps) {
 			.then((page) => {
 				if (!cancelled) setProjects(page.items);
 			})
-			.catch(console.error)
+			.catch((e) => {
+				if (!cancelled) onError?.(`Failed to load projects: ${e}`);
+			})
 			.finally(() => {
 				if (!cancelled) setLoading(false);
 			});
 		return () => {
 			cancelled = true;
 		};
-	}, []);
+	}, [onError]);
 
 	// Close on outside click
 	useEffect(() => {

--- a/ui/src/components/knowledge/ProjectPicker.tsx
+++ b/ui/src/components/knowledge/ProjectPicker.tsx
@@ -1,0 +1,107 @@
+/**
+ * ProjectPicker — dropdown that lists all projects from the orchestrator and
+ * lets the user select one as the active knowledge context.
+ */
+
+import { ChevronDown, FolderOpen } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+import type { Project } from "@/types/orchestrator";
+import { orchestratorClient } from "@/services/orchestrator";
+
+interface ProjectPickerProps {
+	selectedId: string | null;
+	onSelect: (project: Project) => void;
+}
+
+export function ProjectPicker({ selectedId, onSelect }: ProjectPickerProps) {
+	const [projects, setProjects] = useState<Project[]>([]);
+	const [loading, setLoading] = useState(true);
+	const [open, setOpen] = useState(false);
+	const ref = useRef<HTMLDivElement>(null);
+
+	useEffect(() => {
+		let cancelled = false;
+		setLoading(true);
+		orchestratorClient
+			.listProjects({ limit: 200 })
+			.then((page) => {
+				if (!cancelled) setProjects(page.items);
+			})
+			.catch(console.error)
+			.finally(() => {
+				if (!cancelled) setLoading(false);
+			});
+		return () => {
+			cancelled = true;
+		};
+	}, []);
+
+	// Close on outside click
+	useEffect(() => {
+		function handle(e: MouseEvent) {
+			if (ref.current && !ref.current.contains(e.target as Node)) {
+				setOpen(false);
+			}
+		}
+		document.addEventListener("mousedown", handle);
+		return () => document.removeEventListener("mousedown", handle);
+	}, []);
+
+	const selected = projects.find((p) => p.id === selectedId);
+
+	return (
+		<div ref={ref} className="relative">
+			<button
+				type="button"
+				onClick={() => setOpen((o) => !o)}
+				className="flex w-full items-center gap-2 rounded-md border border-th-border bg-th-surface px-3 py-2 text-sm font-medium text-th-text hover:bg-th-surface-secondary"
+			>
+				<FolderOpen size={16} className="shrink-0 text-th-text-muted" />
+				<span className="flex-1 truncate text-left">
+					{loading
+						? "Loading projects…"
+						: selected
+							? selected.name
+							: "Select a project"}
+				</span>
+				<ChevronDown size={14} className="shrink-0 text-th-text-muted" />
+			</button>
+
+			{open && !loading && (
+				<ul
+					role="listbox"
+					className="absolute z-50 mt-1 max-h-64 w-full overflow-y-auto rounded-md border border-th-border bg-th-surface shadow-lg"
+				>
+					{projects.length === 0 ? (
+						<li className="px-3 py-2 text-sm text-th-text-muted">
+							No projects found
+						</li>
+					) : (
+						projects.map((p) => (
+							<li key={p.id}>
+								<button
+									type="button"
+									role="option"
+									aria-selected={p.id === selectedId}
+									onClick={() => {
+										onSelect(p);
+										setOpen(false);
+									}}
+									className={[
+										"flex w-full items-center gap-2 px-3 py-2 text-sm hover:bg-th-surface-secondary",
+										p.id === selectedId
+											? "bg-th-surface-secondary font-medium text-th-text"
+											: "text-th-text",
+									].join(" ")}
+								>
+									<FolderOpen size={14} className="shrink-0 text-th-text-muted" />
+									<span className="truncate">{p.name}</span>
+								</button>
+							</li>
+						))
+					)}
+				</ul>
+			)}
+		</div>
+	);
+}

--- a/ui/src/layouts/Sidebar.tsx
+++ b/ui/src/layouts/Sidebar.tsx
@@ -9,6 +9,7 @@
 import {
 	BarChart2,
 	Bell,
+	BookOpen,
 	Bot,
 	Brain,
 	CheckSquare,
@@ -64,6 +65,7 @@ const NAV_ITEMS: NavItem[] = [
 	{ label: "Questions", path: "/questions", icon: <HelpCircle size={20} /> },
 	{ label: "Workflows", path: "/workflows", icon: <GitBranch size={20} /> },
 	{ label: "Memories", path: "/memories", icon: <Brain size={20} /> },
+	{ label: "Knowledge", path: "/knowledge", icon: <BookOpen size={20} /> },
 	{
 		label: "Communicate",
 		path: "/communicate",

--- a/ui/src/pages/KnowledgebasePage.tsx
+++ b/ui/src/pages/KnowledgebasePage.tsx
@@ -1,0 +1,7 @@
+import { KnowledgebaseView } from "./knowledge/KnowledgebaseView";
+
+export function KnowledgebasePage() {
+	return <KnowledgebaseView />;
+}
+
+export default KnowledgebasePage;

--- a/ui/src/pages/index.ts
+++ b/ui/src/pages/index.ts
@@ -5,6 +5,7 @@ export { ApprovalQueuePage } from "./approvals/ApprovalQueue";
 export { CommunicatePage } from "./communicate/CommunicatePage";
 export { DashboardPage } from "./DashboardPage";
 export { HooksPage } from "./HooksPage";
+export { KnowledgebasePage } from "./KnowledgebasePage";
 export { MemoriesPage } from "./MemoriesPage";
 export { MonitoringPage } from "./MonitoringPage";
 export { NotFoundPage } from "./NotFoundPage";

--- a/ui/src/pages/knowledge/KnowledgebaseView.tsx
+++ b/ui/src/pages/knowledge/KnowledgebaseView.tsx
@@ -19,13 +19,9 @@ import { DocumentToolbar, CreateDocumentDialog } from "@/components/knowledge/Do
 import { ProjectPicker } from "@/components/knowledge/ProjectPicker";
 
 export function KnowledgebaseView() {
-	const { projectId, "*": splat } = useParams<{
-		projectId?: string;
-		"*": string;
-	}>();
+	const { projectId } = useParams<{ projectId?: string }>();
 	const navigate = useNavigate();
 
-	const [project, setProject] = useState<Project | null>(null);
 	const [tree, setTree] = useState<TreeNode[]>([]);
 	const [treeLoading, setTreeLoading] = useState(false);
 	const [selectedDocId, setSelectedDocId] = useState<string | null>(null);
@@ -161,7 +157,6 @@ export function KnowledgebaseView() {
 	// ------------------------------------------------------------------
 
 	function handleSelectProject(p: Project) {
-		setProject(p);
 		setSelectedDocId(null);
 		setDocContent(null);
 		navigate(`/knowledge/${p.id}`);
@@ -180,6 +175,7 @@ export function KnowledgebaseView() {
 					<ProjectPicker
 						selectedId={projectId ?? null}
 						onSelect={handleSelectProject}
+						onError={setError}
 					/>
 				</div>
 

--- a/ui/src/pages/knowledge/KnowledgebaseView.tsx
+++ b/ui/src/pages/knowledge/KnowledgebaseView.tsx
@@ -1,0 +1,242 @@
+/**
+ * KnowledgebaseView — two-panel layout: sidebar (project picker + document
+ * tree) and main area (toolbar + CodeMirror editor).
+ *
+ * State management:
+ * - selectedProjectId / selectedDocId live in URL params so deep-links work.
+ * - Document content is fetched on doc selection and kept in local state.
+ * - Autosave writes back via PUT with optimistic-concurrency token.
+ */
+
+import { useCallback, useEffect, useState } from "react";
+import { useParams, useNavigate } from "react-router-dom";
+import type { DocumentContent, TreeNode } from "@/types/knowledge";
+import type { Project } from "@/types/orchestrator";
+import { knowledgeClient } from "@/services/knowledge";
+import { DocumentEditor } from "@/components/knowledge/DocumentEditor";
+import { DocumentTree } from "@/components/knowledge/DocumentTree";
+import { DocumentToolbar, CreateDocumentDialog } from "@/components/knowledge/DocumentToolbar";
+import { ProjectPicker } from "@/components/knowledge/ProjectPicker";
+
+export function KnowledgebaseView() {
+	const { projectId, "*": splat } = useParams<{
+		projectId?: string;
+		"*": string;
+	}>();
+	const navigate = useNavigate();
+
+	const [project, setProject] = useState<Project | null>(null);
+	const [tree, setTree] = useState<TreeNode[]>([]);
+	const [treeLoading, setTreeLoading] = useState(false);
+	const [selectedDocId, setSelectedDocId] = useState<string | null>(null);
+	const [docContent, setDocContent] = useState<DocumentContent | null>(null);
+	const [saving, setSaving] = useState(false);
+	const [showCreate, setShowCreate] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+
+	// ------------------------------------------------------------------
+	// Load tree when project changes
+	// ------------------------------------------------------------------
+
+	useEffect(() => {
+		if (!projectId) {
+			setTree([]);
+			setDocContent(null);
+			setSelectedDocId(null);
+			return;
+		}
+		let cancelled = false;
+		setTreeLoading(true);
+		setError(null);
+		knowledgeClient
+			.getTree(projectId)
+			.then((nodes) => {
+				if (!cancelled) setTree(nodes);
+			})
+			.catch((e) => {
+				if (!cancelled) setError(String(e));
+			})
+			.finally(() => {
+				if (!cancelled) setTreeLoading(false);
+			});
+		return () => {
+			cancelled = true;
+		};
+	}, [projectId]);
+
+	// ------------------------------------------------------------------
+	// Load document content when selection changes
+	// ------------------------------------------------------------------
+
+	useEffect(() => {
+		if (!projectId || !selectedDocId) {
+			setDocContent(null);
+			return;
+		}
+		let cancelled = false;
+		knowledgeClient
+			.getDocumentContent(projectId, selectedDocId)
+			.then((dc) => {
+				if (!cancelled) setDocContent(dc);
+			})
+			.catch((e) => {
+				if (!cancelled) setError(String(e));
+			});
+		return () => {
+			cancelled = true;
+		};
+	}, [projectId, selectedDocId]);
+
+	// ------------------------------------------------------------------
+	// Autosave handler (called by DocumentEditor with debounced content)
+	// ------------------------------------------------------------------
+
+	const handleSave = useCallback(
+		async (content: string, expectedUpdatedAt: string) => {
+			if (!projectId || !selectedDocId) return;
+			try {
+				const updated = await knowledgeClient.updateDocument(
+					projectId,
+					selectedDocId,
+					{ content, expected_updated_at: expectedUpdatedAt },
+				);
+				// Patch the local doc so updated_at stays current for next save
+				setDocContent((prev) =>
+					prev ? { ...prev, document: updated, content } : null,
+				);
+			} catch (e) {
+				setError(`Autosave failed: ${e}`);
+			} finally {
+				setSaving(false);
+			}
+		},
+		[projectId, selectedDocId],
+	);
+
+	// ------------------------------------------------------------------
+	// Create document
+	// ------------------------------------------------------------------
+
+	const handleCreate = useCallback(
+		async (relPath: string, title: string) => {
+			if (!projectId) return;
+			setShowCreate(false);
+			try {
+				const doc = await knowledgeClient.createDocument(projectId, {
+					rel_path: relPath,
+					title: title || undefined,
+					content: `# ${title || relPath}\n`,
+				});
+				// Refresh tree and select the new doc
+				const nodes = await knowledgeClient.getTree(projectId);
+				setTree(nodes);
+				setSelectedDocId(doc.id);
+			} catch (e) {
+				setError(`Failed to create document: ${e}`);
+			}
+		},
+		[projectId],
+	);
+
+	// ------------------------------------------------------------------
+	// Delete document
+	// ------------------------------------------------------------------
+
+	const handleDelete = useCallback(async () => {
+		if (!projectId || !selectedDocId) return;
+		if (!window.confirm("Permanently delete this document?")) return;
+		try {
+			await knowledgeClient.deleteDocument(projectId, selectedDocId);
+			const nodes = await knowledgeClient.getTree(projectId);
+			setTree(nodes);
+			setSelectedDocId(null);
+			setDocContent(null);
+		} catch (e) {
+			setError(`Failed to delete document: ${e}`);
+		}
+	}, [projectId, selectedDocId]);
+
+	// ------------------------------------------------------------------
+	// Project selection
+	// ------------------------------------------------------------------
+
+	function handleSelectProject(p: Project) {
+		setProject(p);
+		setSelectedDocId(null);
+		setDocContent(null);
+		navigate(`/knowledge/${p.id}`);
+	}
+
+	// ------------------------------------------------------------------
+	// Render
+	// ------------------------------------------------------------------
+
+	return (
+		<div className="flex h-full overflow-hidden">
+			{/* Left sidebar */}
+			<aside className="flex w-56 shrink-0 flex-col border-r border-th-border bg-th-surface">
+				{/* Project picker */}
+				<div className="border-b border-th-border p-3">
+					<ProjectPicker
+						selectedId={projectId ?? null}
+						onSelect={handleSelectProject}
+					/>
+				</div>
+
+				{/* Document tree */}
+				<div className="flex-1 overflow-y-auto p-2">
+					{treeLoading ? (
+						<p className="px-2 py-3 text-xs text-th-text-muted">Loading…</p>
+					) : (
+						<DocumentTree
+							nodes={tree}
+							selectedDocId={selectedDocId}
+							onSelectDoc={(docId) => setSelectedDocId(docId)}
+						/>
+					)}
+				</div>
+			</aside>
+
+			{/* Main editor area */}
+			<div className="flex flex-1 flex-col overflow-hidden">
+				{/* Error banner */}
+				{error && (
+					<div className="flex items-center gap-2 border-b border-th-status-error-text bg-th-status-error-bg px-4 py-2 text-xs text-th-status-error-text">
+						<span className="flex-1">{error}</span>
+						<button
+							type="button"
+							onClick={() => setError(null)}
+							className="font-bold"
+						>
+							✕
+						</button>
+					</div>
+				)}
+
+				<DocumentToolbar
+					document={docContent?.document ?? null}
+					saving={saving}
+					projectId={projectId ?? null}
+					onCreateClick={() => setShowCreate(true)}
+					onDeleteClick={handleDelete}
+				/>
+
+				<div className="flex-1 overflow-hidden">
+					<DocumentEditor
+						docContent={docContent}
+						onSave={handleSave}
+						onSavingChange={setSaving}
+					/>
+				</div>
+			</div>
+
+			{/* Create dialog */}
+			{showCreate && (
+				<CreateDocumentDialog
+					onConfirm={handleCreate}
+					onCancel={() => setShowCreate(false)}
+				/>
+			)}
+		</div>
+	);
+}

--- a/ui/src/services/config.ts
+++ b/ui/src/services/config.ts
@@ -39,6 +39,10 @@ export const serviceConfig = {
 		runtimeServiceUrl("communicate") ??
 		import.meta.env.VITE_AGENTD_COMMUNICATE_SERVICE_URL ??
 		"http://localhost:17010",
+	knowledgeServiceUrl:
+		runtimeServiceUrl("knowledge") ??
+		import.meta.env.VITE_AGENTD_KNOWLEDGE_SERVICE_URL ??
+		"http://localhost:17011",
 } as const;
 
 export type ServiceConfig = typeof serviceConfig;

--- a/ui/src/services/index.ts
+++ b/ui/src/services/index.ts
@@ -7,3 +7,4 @@ export { MemoryClient, memoryClient } from "./memory";
 export { MonitorClient, monitorClient } from "./monitor";
 export { NotifyClient, notifyClient } from "./notify";
 export { OrchestratorClient, orchestratorClient } from "./orchestrator";
+export { KnowledgeClient, knowledgeClient } from "./knowledge";

--- a/ui/src/services/knowledge.ts
+++ b/ui/src/services/knowledge.ts
@@ -1,0 +1,107 @@
+/**
+ * Client for the Knowledge service (default port 17011).
+ *
+ * Provides strongly-typed methods for all document operations including
+ * creating, listing, updating, deleting, and retrieving the virtual tree.
+ */
+
+import type { HealthResponse, PaginatedResponse } from "@/types/common";
+import type {
+	CreateDocumentRequest,
+	Document,
+	DocumentContent,
+	DocumentListParams,
+	TreeNode,
+	UpdateDocumentRequest,
+} from "@/types/knowledge";
+import { ApiClient } from "./base";
+import { serviceConfig } from "./config";
+
+export class KnowledgeClient extends ApiClient {
+	// -------------------------------------------------------------------------
+	// Health
+	// -------------------------------------------------------------------------
+
+	/** `GET /health` — service health check. */
+	getHealth(): Promise<HealthResponse> {
+		return this.get<HealthResponse>("/health");
+	}
+
+	// -------------------------------------------------------------------------
+	// Documents – collection
+	// -------------------------------------------------------------------------
+
+	/** `GET /projects/:projectId/documents` — list documents with optional filters. */
+	listDocuments(
+		projectId: string,
+		params?: DocumentListParams,
+	): Promise<PaginatedResponse<Document>> {
+		return this.get<PaginatedResponse<Document>>(
+			`/projects/${projectId}/documents`,
+			params as Record<string, string | number | boolean | undefined>,
+		);
+	}
+
+	/** `POST /projects/:projectId/documents` — create a new document. */
+	createDocument(
+		projectId: string,
+		request: CreateDocumentRequest,
+	): Promise<Document> {
+		return this.post<Document>(`/projects/${projectId}/documents`, request);
+	}
+
+	/** `DELETE /projects/:projectId/documents` — bulk-delete all documents. */
+	bulkDeleteDocuments(projectId: string): Promise<void> {
+		return this.delete<void>(`/projects/${projectId}/documents`);
+	}
+
+	// -------------------------------------------------------------------------
+	// Documents – instance
+	// -------------------------------------------------------------------------
+
+	/** `GET /projects/:projectId/documents/:docId` — get document metadata. */
+	getDocument(projectId: string, docId: string): Promise<Document> {
+		return this.get<Document>(`/projects/${projectId}/documents/${docId}`);
+	}
+
+	/** `GET /projects/:projectId/documents/:docId/content` — get metadata + body. */
+	getDocumentContent(
+		projectId: string,
+		docId: string,
+	): Promise<DocumentContent> {
+		return this.get<DocumentContent>(
+			`/projects/${projectId}/documents/${docId}/content`,
+		);
+	}
+
+	/** `PUT /projects/:projectId/documents/:docId` — update a document. */
+	updateDocument(
+		projectId: string,
+		docId: string,
+		request: UpdateDocumentRequest,
+	): Promise<Document> {
+		return this.put<Document>(
+			`/projects/${projectId}/documents/${docId}`,
+			request,
+		);
+	}
+
+	/** `DELETE /projects/:projectId/documents/:docId` — delete a document. */
+	deleteDocument(projectId: string, docId: string): Promise<void> {
+		return this.delete<void>(`/projects/${projectId}/documents/${docId}`);
+	}
+
+	// -------------------------------------------------------------------------
+	// Tree
+	// -------------------------------------------------------------------------
+
+	/** `GET /projects/:projectId/tree` — get the virtual folder/file tree. */
+	getTree(projectId: string): Promise<TreeNode[]> {
+		return this.get<TreeNode[]>(`/projects/${projectId}/tree`);
+	}
+}
+
+/** Singleton client instance using the configured service URL. */
+export const knowledgeClient = new KnowledgeClient({
+	baseUrl: serviceConfig.knowledgeServiceUrl,
+});

--- a/ui/src/services/orchestrator.ts
+++ b/ui/src/services/orchestrator.ts
@@ -33,6 +33,8 @@ import type {
 	UpdatePolicyRequest,
 	UpdateWorkflowRequest,
 	Workflow,
+	Project,
+	ListProjectsParams,
 } from "@/types/orchestrator";
 import { ApiClient, withAuth } from "./base";
 import { serviceConfig } from "./config";
@@ -312,6 +314,20 @@ export class OrchestratorClient extends ApiClient {
 	 */
 	connectAgentMonitor(agentId: string): WebSocket {
 		return this.openWebSocket(`/stream/${agentId}`);
+	}
+
+	// -------------------------------------------------------------------------
+	// Projects
+	// -------------------------------------------------------------------------
+
+	/** `GET /projects` — list all projects. */
+	listProjects(
+		params?: ListProjectsParams,
+	): Promise<PaginatedResponse<Project>> {
+		return this.get<PaginatedResponse<Project>>(
+			"/projects",
+			params as Record<string, string | number | boolean | undefined>,
+		);
 	}
 }
 

--- a/ui/src/test/services/knowledge.test.ts
+++ b/ui/src/test/services/knowledge.test.ts
@@ -1,0 +1,230 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { KnowledgeClient } from "@/services/knowledge";
+import type { Document, DocumentContent, TreeNode } from "@/types/knowledge";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeJsonResponse(status: number, body: unknown) {
+	return new Response(JSON.stringify(body), {
+		status,
+		headers: new Headers({ "content-type": "application/json" }),
+	});
+}
+
+function mockFetch(status: number, body: unknown) {
+	vi.stubGlobal(
+		"fetch",
+		vi.fn().mockResolvedValue(makeJsonResponse(status, body)),
+	);
+}
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+const PROJECT_ID = "550e8400-e29b-41d4-a716-446655440000";
+const DOC_ID = "6ba7b810-9dad-11d1-80b4-00c04fd430c8";
+
+const mockDocument: Document = {
+	id: DOC_ID,
+	project_id: PROJECT_ID,
+	organization_id: null,
+	rel_path: "docs/readme.md",
+	title: "Readme",
+	size_bytes: 42,
+	created_at: "2026-01-01T00:00:00Z",
+	updated_at: "2026-01-01T00:00:00Z",
+};
+
+const mockDocumentContent: DocumentContent = {
+	document: mockDocument,
+	content: "# Readme\n\nHello world.",
+};
+
+const mockPage = { items: [mockDocument], total: 1, limit: 50, offset: 0 };
+
+const mockTree: TreeNode[] = [
+	{
+		type: "folder",
+		name: "docs",
+		path: "docs/",
+		children: [
+			{
+				type: "file",
+				name: "readme.md",
+				path: "docs/readme.md",
+				doc_id: DOC_ID,
+			},
+		],
+	},
+];
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("KnowledgeClient", () => {
+	let client: KnowledgeClient;
+
+	beforeEach(() => {
+		client = new KnowledgeClient({
+			baseUrl: "http://localhost:17011",
+			maxRetries: 1,
+		});
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	// -------------------------------------------------------------------------
+	// Health
+	// -------------------------------------------------------------------------
+
+	it("getHealth returns the health object", async () => {
+		mockFetch(200, { service: "knowledge", version: "0.4.11", status: "ok" });
+		const h = await client.getHealth();
+		expect(h.service).toBe("knowledge");
+	});
+
+	// -------------------------------------------------------------------------
+	// listDocuments
+	// -------------------------------------------------------------------------
+
+	it("listDocuments calls the correct URL", async () => {
+		const spy = vi
+			.fn()
+			.mockResolvedValue(makeJsonResponse(200, mockPage));
+		vi.stubGlobal("fetch", spy);
+
+		await client.listDocuments(PROJECT_ID);
+
+		const url: string = spy.mock.calls[0][0];
+		expect(url).toContain(`/projects/${PROJECT_ID}/documents`);
+	});
+
+	it("listDocuments forwards prefix query param", async () => {
+		const spy = vi
+			.fn()
+			.mockResolvedValue(makeJsonResponse(200, mockPage));
+		vi.stubGlobal("fetch", spy);
+
+		await client.listDocuments(PROJECT_ID, { prefix: "docs/" });
+
+		const url: string = spy.mock.calls[0][0];
+		expect(url).toContain("prefix=docs%2F");
+	});
+
+	it("listDocuments returns paginated documents", async () => {
+		mockFetch(200, mockPage);
+		const page = await client.listDocuments(PROJECT_ID);
+		expect(page.items).toHaveLength(1);
+		expect(page.items[0].id).toBe(DOC_ID);
+		expect(page.total).toBe(1);
+	});
+
+	// -------------------------------------------------------------------------
+	// createDocument
+	// -------------------------------------------------------------------------
+
+	it("createDocument posts body and returns document", async () => {
+		const spy = vi
+			.fn()
+			.mockResolvedValue(makeJsonResponse(201, mockDocument));
+		vi.stubGlobal("fetch", spy);
+
+		const doc = await client.createDocument(PROJECT_ID, {
+			rel_path: "docs/readme.md",
+			content: "# Hello",
+		});
+
+		expect(spy.mock.calls[0][1].method).toBe("POST");
+		expect(doc.id).toBe(DOC_ID);
+	});
+
+	// -------------------------------------------------------------------------
+	// getDocumentContent
+	// -------------------------------------------------------------------------
+
+	it("getDocumentContent returns content", async () => {
+		mockFetch(200, mockDocumentContent);
+		const dc = await client.getDocumentContent(PROJECT_ID, DOC_ID);
+		expect(dc.content).toBe("# Readme\n\nHello world.");
+		expect(dc.document.rel_path).toBe("docs/readme.md");
+	});
+
+	// -------------------------------------------------------------------------
+	// updateDocument
+	// -------------------------------------------------------------------------
+
+	it("updateDocument sends PUT with body", async () => {
+		const spy = vi
+			.fn()
+			.mockResolvedValue(makeJsonResponse(200, mockDocument));
+		vi.stubGlobal("fetch", spy);
+
+		await client.updateDocument(PROJECT_ID, DOC_ID, {
+			content: "# Updated",
+			expected_updated_at: "2026-01-01T00:00:00Z",
+		});
+
+		expect(spy.mock.calls[0][1].method).toBe("PUT");
+		const body = JSON.parse(spy.mock.calls[0][1].body as string);
+		expect(body.content).toBe("# Updated");
+		expect(body.expected_updated_at).toBe("2026-01-01T00:00:00Z");
+	});
+
+	// -------------------------------------------------------------------------
+	// deleteDocument
+	// -------------------------------------------------------------------------
+
+	it("deleteDocument sends DELETE to correct URL", async () => {
+		const spy = vi
+			.fn()
+			.mockResolvedValue(new Response(null, { status: 204 }));
+		vi.stubGlobal("fetch", spy);
+
+		await client.deleteDocument(PROJECT_ID, DOC_ID);
+
+		const url: string = spy.mock.calls[0][0];
+		expect(url).toContain(`/projects/${PROJECT_ID}/documents/${DOC_ID}`);
+		expect(spy.mock.calls[0][1].method).toBe("DELETE");
+	});
+
+	// -------------------------------------------------------------------------
+	// getTree
+	// -------------------------------------------------------------------------
+
+	it("getTree returns tree nodes", async () => {
+		mockFetch(200, mockTree);
+		const nodes = await client.getTree(PROJECT_ID);
+		expect(nodes).toHaveLength(1);
+		expect(nodes[0].type).toBe("folder");
+		if (nodes[0].type === "folder") {
+			expect(nodes[0].children[0].type).toBe("file");
+		}
+	});
+
+	// -------------------------------------------------------------------------
+	// Error handling
+	// -------------------------------------------------------------------------
+
+	it("throws ApiError on 404", async () => {
+		mockFetch(404, { error: "document not found" });
+		await expect(client.getDocument(PROJECT_ID, DOC_ID)).rejects.toMatchObject(
+			{ status: 404 },
+		);
+	});
+
+	it("throws ApiError on 409 conflict", async () => {
+		mockFetch(409, { error: "document already exists" });
+		await expect(
+			client.createDocument(PROJECT_ID, {
+				rel_path: "docs/readme.md",
+				content: "",
+			}),
+		).rejects.toMatchObject({ status: 409 });
+	});
+});

--- a/ui/src/types/knowledge.ts
+++ b/ui/src/types/knowledge.ts
@@ -1,0 +1,95 @@
+/**
+ * TypeScript types for the Knowledge service.
+ * Mirrors the Rust types in crates/knowledge/src/types.rs.
+ */
+
+// ---------------------------------------------------------------------------
+// Document model
+// ---------------------------------------------------------------------------
+
+/** A single document record stored in the knowledge service. */
+export interface Document {
+	/** Unique identifier (UUID). */
+	id: string;
+	/** Project this document belongs to (UUID from orchestrator). */
+	project_id: string;
+	/** Optional organization scope (null until tenant scoping lands). */
+	organization_id: string | null;
+	/** Relative filesystem path, e.g. "docs/api.md". Must end in .md. */
+	rel_path: string;
+	/** Human-readable title (defaults to filename stem). */
+	title: string;
+	/** Size of the markdown file on disk in bytes. */
+	size_bytes: number;
+	/** RFC 3339 creation timestamp. */
+	created_at: string;
+	/** RFC 3339 last-updated timestamp. */
+	updated_at: string;
+}
+
+/** Document metadata plus the raw markdown body. */
+export interface DocumentContent {
+	document: Document;
+	content: string;
+}
+
+// ---------------------------------------------------------------------------
+// Tree model
+// ---------------------------------------------------------------------------
+
+/** A node in the virtual folder/file tree for a project. */
+export type TreeNode =
+	| {
+			type: "folder";
+			name: string;
+			path: string;
+			children: TreeNode[];
+	  }
+	| {
+			type: "file";
+			name: string;
+			path: string;
+			doc_id: string;
+	  };
+
+// ---------------------------------------------------------------------------
+// Request bodies
+// ---------------------------------------------------------------------------
+
+/** Request body for `POST /projects/:id/documents`. */
+export interface CreateDocumentRequest {
+	/** Relative path (must end in .md, depth <= 8). */
+	rel_path: string;
+	/** Optional title override (defaults to filename stem). */
+	title?: string;
+	/** Markdown body. */
+	content: string;
+}
+
+/** Request body for `PUT /projects/:id/documents/:doc_id`. */
+export interface UpdateDocumentRequest {
+	/** New markdown body (omit to leave unchanged). */
+	content?: string;
+	/** New title (omit to leave unchanged). */
+	title?: string;
+	/**
+	 * Optimistic concurrency token — the `updated_at` value returned by the
+	 * last GET. The server rejects the update if the document has been modified
+	 * since this timestamp.
+	 */
+	expected_updated_at?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Query params
+// ---------------------------------------------------------------------------
+
+/** Query parameters accepted by `GET /projects/:id/documents`. */
+export interface DocumentListParams {
+	/** Filter to documents whose rel_path starts with this prefix. */
+	prefix?: string;
+	/** Maximum items to return (default 50, max 200). */
+	limit?: number;
+	/** Pagination offset (default 0). */
+	offset?: number;
+}

--- a/ui/src/types/orchestrator.ts
+++ b/ui/src/types/orchestrator.ts
@@ -643,3 +643,23 @@ export interface ListApprovalsParams {
 	limit?: number;
 	offset?: number;
 }
+
+// ---------------------------------------------------------------------------
+// Projects
+// ---------------------------------------------------------------------------
+
+/** A project as returned by the orchestrator API. */
+export interface Project {
+	id: string;
+	name: string;
+	description: string | null;
+	created_at: string;
+	updated_at: string;
+}
+
+/** Query parameters for `GET /projects`. */
+export interface ListProjectsParams {
+	limit?: number;
+	offset?: number;
+}
+


### PR DESCRIPTION
Add a **Knowledge** section to the React UI: project picker, virtual document tree, and a CodeMirror 6 markdown editor with debounced autosave and optimistic-concurrency support.

## What's included

**New types** (`ui/src/types/knowledge.ts`):
- `Document`, `DocumentContent`, `TreeNode` (folder/file discriminated union)
- `CreateDocumentRequest`, `UpdateDocumentRequest`, `DocumentListParams`

**KnowledgeClient** (`ui/src/services/knowledge.ts`):
- Extends `ApiClient` following the `MemoryClient` pattern
- 11 typed methods: `getHealth`, `listDocuments`, `createDocument`, `bulkDeleteDocuments`, `getDocument`, `getDocumentContent`, `updateDocument`, `deleteDocument`, `getTree`
- Singleton `knowledgeClient` exported from `services/index.ts`
- `knowledgeServiceUrl` added to `services/config.ts` (port 17011, runtime/env/default resolution)

**Orchestrator additions** (`types/orchestrator.ts`, `services/orchestrator.ts`):
- `Project` type + `ListProjectsParams`
- `listProjects()` method (calls `GET /projects`)

**Pages & components**:
- `KnowledgebasePage.tsx` — thin wrapper (mirrors `MemoriesPage`)
- `pages/knowledge/KnowledgebaseView.tsx` — two-panel layout: sidebar + editor
- `components/knowledge/ProjectPicker.tsx` — dropdown listing all orchestrator projects
- `components/knowledge/DocumentTree.tsx` — expandable folder/file tree with selection state
- `components/knowledge/DocumentEditor.tsx` — CodeMirror 6 editor (one-dark theme, markdown highlighting, debounced autosave at 1 500 ms, optimistic-concurrency `expected_updated_at` token)
- `components/knowledge/DocumentToolbar.tsx` — New/Delete buttons, `CreateDocumentDialog` modal

**Routing & nav** (`App.tsx`, `Sidebar.tsx`):
- Routes: `/knowledge` and `/knowledge/:projectId/*`
- Sidebar nav item: "Knowledge" with `BookOpen` icon

**Tests** (`ui/src/test/services/knowledge.test.ts`):
- 11 vitest tests covering all client methods, query-param forwarding, error handling (404, 409)

**Dependencies installed** (bun):
- `@codemirror/state`, `@codemirror/view`, `@codemirror/commands`
- `@codemirror/lang-markdown`, `@codemirror/language`, `@codemirror/theme-one-dark`
- `@lezer/highlight`

## Review feedback addressed

- Added \`"knowledge"\` to \`BROWSER_SERVICES\` in \`crates/ui/src/runtime_config.rs\` (blocking: without this, \`runtimeServiceUrl("knowledge")\` always returns \`undefined\` and the client falls back to \`localhost:17011\` on deployed instances)
- Added \`"knowledge" => s.knowledge.port\` match arm and test assertion (\`assert_eq!(runtime.services["knowledge"].port, 17011)\`)
- Removed dead \`project\` / \`setProject\` state from \`KnowledgebaseView\` (\`projectId\` from \`useParams\` is used throughout; the state was never read in render)
- Removed unused \`splat\` destructure from \`useParams\`
- Added \`onError?: (message: string) => void\` prop to \`ProjectPicker\`; \`listProjects\` failures now call \`onError\` instead of swallowing with \`console.error\`; \`KnowledgebaseView\` wires \`onError={setError}\` to surface errors in the existing error banner

Closes #1284