### PR TITLE
feat(orchestrator): remove project CRUD, keep association endpoints

### DIFF
--- a/crates/cli/src/commands/admin.rs
+++ b/crates/cli/src/commands/admin.rs
@@ -82,7 +82,8 @@ struct ServiceTables {
 }
 
 const SCOPED_TABLES: &[ServiceTables] = &[
-    ServiceTables { service: "orchestrator", tables: &["agents", "workflows", "projects"] },
+    ServiceTables { service: "orchestrator", tables: &["agents", "workflows"] },
+    ServiceTables { service: "core", tables: &["projects"] },
     ServiceTables { service: "notify", tables: &["notifications"] },
     ServiceTables { service: "communicate", tables: &["rooms"] },
     ServiceTables { service: "memory", tables: &["memory_entries"] },

--- a/crates/core/src/api.rs
+++ b/crates/core/src/api.rs
@@ -22,6 +22,11 @@
 //! - `GET  /api/v1/organizations/{id}/members`   — list members
 //! - `POST /api/v1/organizations/{id}/members`   — add member (owners only)
 //! - `DELETE /api/v1/organizations/{id}/members/{uid}` — remove member (owners only)
+//! - `POST /api/v1/projects`                     — create project
+//! - `GET  /api/v1/projects`                     — list projects (tenant-scoped via X-Tenant-ID)
+//! - `GET  /api/v1/projects/{id}`                — get project
+//! - `PUT  /api/v1/projects/{id}`                — update project
+//! - `DELETE /api/v1/projects/{id}`              — delete project
 //! - `GET  /api/v1/health`                       — aggregate downstream health check
 //! - `ANY  /api/v1/{service}/*`                  — proxy to downstream service
 
@@ -29,6 +34,7 @@ pub mod admin;
 pub mod auth;
 pub mod gateway;
 pub mod organizations;
+pub mod projects;
 pub mod users;
 
 use axum::{routing::get, Json, Router};
@@ -52,6 +58,7 @@ pub fn create_router_with_proxy(state: AppState, proxy: ProxyConfig) -> Router {
     let api_v1 = Router::new()
         .nest("/users", users::v1_router())
         .nest("/organizations", organizations::router())
+        .nest("/projects", projects::router())
         // Product-admin routes — superuser only, product-wide (not tenant-scoped)
         .nest("/admin", admin::router())
         // Gateway routes — /api/v1/health and /api/v1/{service}/* path

--- a/crates/core/src/api/projects.rs
+++ b/crates/core/src/api/projects.rs
@@ -1,0 +1,850 @@
+//! Project management endpoint handlers.
+//!
+//! # Endpoints
+//!
+//! | Method | Path                   | Auth | Description                               |
+//! |--------|------------------------|------|-------------------------------------------|
+//! | POST   | `/api/v1/projects`     | Yes  | Create a project (org from tenant header) |
+//! | GET    | `/api/v1/projects`     | Yes  | List projects, optionally scoped to org   |
+//! | GET    | `/api/v1/projects/{id}`| Yes  | Get project by UUID                       |
+//! | PUT    | `/api/v1/projects/{id}`| Yes  | Update project name and/or description    |
+//! | DELETE | `/api/v1/projects/{id}`| Yes  | Delete project                            |
+
+use axum::{
+    extract::{Path, Query, State},
+    http::StatusCode,
+    response::IntoResponse,
+    routing::{delete, get, post, put},
+    Json, Router,
+};
+use serde::{Deserialize, Serialize};
+
+use agentd_common::error::ApiError;
+use agentd_common::tenant::OptionalTenantId;
+
+use crate::middleware::auth::AuthUser;
+
+use super::AppState;
+
+// ---------------------------------------------------------------------------
+// Request / response types
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+pub struct CreateProjectRequest {
+    pub name: String,
+    pub description: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct UpdateProjectRequest {
+    pub name: Option<String>,
+    pub description: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct ProjectListQuery {
+    pub limit: Option<usize>,
+    pub offset: Option<usize>,
+}
+
+#[derive(Debug, Serialize)]
+pub struct ProjectResponse {
+    pub id: String,
+    pub name: String,
+    pub description: Option<String>,
+    pub organization_id: Option<String>,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+// ---------------------------------------------------------------------------
+// Router
+// ---------------------------------------------------------------------------
+
+pub fn router() -> Router<AppState> {
+    Router::new()
+        .route("/", post(create_project_handler))
+        .route("/", get(list_projects_handler))
+        .route("/{id}", get(get_project_handler))
+        .route("/{id}", put(update_project_handler))
+        .route("/{id}", delete(delete_project_handler))
+}
+
+// ---------------------------------------------------------------------------
+// Handlers
+// ---------------------------------------------------------------------------
+
+/// `POST /api/v1/projects`
+///
+/// Creates a new project. The `organization_id` is taken from the
+/// `X-Tenant-ID` header when present (forwarded by the core gateway).
+///
+/// Returns `201 Created` with the project payload.
+async fn create_project_handler(
+    _auth: AuthUser,
+    OptionalTenantId(org_id): OptionalTenantId,
+    State(state): State<AppState>,
+    Json(body): Json<CreateProjectRequest>,
+) -> Result<impl IntoResponse, ApiError> {
+    if body.name.trim().is_empty() {
+        return Err(ApiError::InvalidInput("project name must not be empty".to_string()));
+    }
+
+    let project = state
+        .storage
+        .projects()
+        .create(&body.name, body.description.as_deref(), org_id.as_deref())
+        .await
+        .map_err(|e| {
+            if e.to_string().contains("UNIQUE") {
+                ApiError::Conflict(format!("a project named '{}' already exists", body.name))
+            } else {
+                ApiError::Internal(e)
+            }
+        })?;
+
+    Ok((
+        StatusCode::CREATED,
+        Json(ProjectResponse {
+            id: project.id,
+            name: project.name,
+            description: project.description,
+            organization_id: project.organization_id,
+            created_at: project.created_at,
+            updated_at: project.updated_at,
+        }),
+    ))
+}
+
+/// `GET /api/v1/projects`
+///
+/// Lists projects. When an `X-Tenant-ID` header is present (forwarded by
+/// the core gateway), only projects belonging to that organization are
+/// returned (plus legacy NULL-org rows). Supports `limit` and `offset`
+/// query parameters for pagination.
+///
+/// Note: rows are fetched in full then sliced in memory. A follow-up
+/// `list_org_paginated` storage method should be added to avoid loading
+/// unbounded result sets for large deployments.
+async fn list_projects_handler(
+    _auth: AuthUser,
+    OptionalTenantId(org_id): OptionalTenantId,
+    State(state): State<AppState>,
+    Query(query): Query<ProjectListQuery>,
+) -> Result<impl IntoResponse, ApiError> {
+    let all =
+        state.storage.projects().list_org(org_id.as_deref()).await.map_err(ApiError::Internal)?;
+
+    let total = all.len();
+    let limit = query.limit.unwrap_or(50).min(200);
+    let offset = query.offset.unwrap_or(0);
+
+    let items: Vec<ProjectResponse> = all
+        .into_iter()
+        .skip(offset)
+        .take(limit)
+        .map(|p| ProjectResponse {
+            id: p.id,
+            name: p.name,
+            description: p.description,
+            organization_id: p.organization_id,
+            created_at: p.created_at,
+            updated_at: p.updated_at,
+        })
+        .collect();
+
+    Ok(Json(serde_json::json!({
+        "items": items,
+        "total": total,
+        "limit": limit,
+        "offset": offset,
+    })))
+}
+
+/// `GET /api/v1/projects/{id}`
+///
+/// Returns project details for the given UUID. Returns `404` if not found.
+async fn get_project_handler(
+    _auth: AuthUser,
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+) -> Result<impl IntoResponse, ApiError> {
+    let project = state
+        .storage
+        .projects()
+        .get_by_id(&id)
+        .await
+        .map_err(ApiError::Internal)?
+        .ok_or(ApiError::NotFound)?;
+
+    Ok(Json(ProjectResponse {
+        id: project.id,
+        name: project.name,
+        description: project.description,
+        organization_id: project.organization_id,
+        created_at: project.created_at,
+        updated_at: project.updated_at,
+    }))
+}
+
+/// `PUT /api/v1/projects/{id}`
+///
+/// Updates the project's `name` and/or `description`. Fields absent from
+/// the body are left unchanged. Returns `400` if the supplied name is
+/// whitespace-only, `404` if not found, `409` if the new name conflicts
+/// with an existing project.
+async fn update_project_handler(
+    _auth: AuthUser,
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+    Json(body): Json<UpdateProjectRequest>,
+) -> Result<impl IntoResponse, ApiError> {
+    if let Some(ref name) = body.name {
+        if name.trim().is_empty() {
+            return Err(ApiError::InvalidInput("project name must not be empty".to_string()));
+        }
+    }
+
+    let project = state
+        .storage
+        .projects()
+        .update(&id, body.name.as_deref(), body.description.as_deref())
+        .await
+        .map_err(|e| {
+            let msg = e.to_string();
+            if msg.contains("not found") {
+                ApiError::NotFound
+            } else if msg.contains("UNIQUE") {
+                ApiError::Conflict("a project with that name already exists".to_string())
+            } else {
+                ApiError::Internal(e)
+            }
+        })?;
+
+    Ok(Json(ProjectResponse {
+        id: project.id,
+        name: project.name,
+        description: project.description,
+        organization_id: project.organization_id,
+        created_at: project.created_at,
+        updated_at: project.updated_at,
+    }))
+}
+
+/// `DELETE /api/v1/projects/{id}`
+///
+/// Deletes the project. Core only checks its own constraints — there is no
+/// cross-service delete-guard at this layer. Returns `204 No Content`.
+async fn delete_project_handler(
+    _auth: AuthUser,
+    State(state): State<AppState>,
+    Path(id): Path<String>,
+) -> Result<impl IntoResponse, ApiError> {
+    let deleted = state.storage.projects().delete(&id).await.map_err(ApiError::Internal)?;
+
+    if !deleted {
+        return Err(ApiError::NotFound);
+    }
+
+    Ok(StatusCode::NO_CONTENT)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use crate::api::AppState;
+    use crate::storage::Storage;
+    use agentd_common::storage::create_test_connection;
+    use axum::{
+        body::Body,
+        http::{header, Request, StatusCode},
+        Router,
+    };
+    use http_body_util::BodyExt;
+    use tower::ServiceExt;
+
+    async fn test_app() -> (Router, tempfile::TempDir) {
+        let (conn, tmp) = create_test_connection().await;
+        let storage = Storage::new(conn).await.unwrap();
+        let state = AppState { storage };
+        let app = crate::api::create_router(state);
+        (app, tmp)
+    }
+
+    async fn body_json(response: axum::response::Response) -> serde_json::Value {
+        let bytes = response.into_body().collect().await.unwrap().to_bytes();
+        serde_json::from_slice(&bytes).unwrap()
+    }
+
+    /// Register a user and return `(token, user_id)`.
+    async fn register(app: &Router, username: &str, email: &str) -> (String, String) {
+        let payload =
+            serde_json::json!({ "username": username, "email": email, "password": "testpass" });
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/auth/register")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(payload.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let body = body_json(response).await;
+        let token = body["token"].as_str().unwrap().to_string();
+        let user_id = body["user"]["id"].as_str().unwrap().to_string();
+        (token, user_id)
+    }
+
+    // -----------------------------------------------------------------------
+    // Create project
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_create_project_returns_201() {
+        let (app, _tmp) = test_app().await;
+        let (token, _) = register(&app, "alice", "alice@example.com").await;
+
+        let payload = serde_json::json!({ "name": "Test Project" });
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/projects")
+                    .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(payload.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::CREATED);
+        let body = body_json(response).await;
+        assert_eq!(body["name"], "Test Project");
+        assert!(body["id"].as_str().is_some());
+    }
+
+    #[tokio::test]
+    async fn test_create_project_unauthenticated() {
+        let (app, _tmp) = test_app().await;
+
+        let payload = serde_json::json!({ "name": "Unauth Project" });
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/projects")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(payload.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn test_create_project_with_description() {
+        let (app, _tmp) = test_app().await;
+        let (token, _) = register(&app, "bob", "bob@example.com").await;
+
+        let payload = serde_json::json!({
+            "name": "Described Project",
+            "description": "A helpful description"
+        });
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/projects")
+                    .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(payload.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::CREATED);
+        let body = body_json(response).await;
+        assert_eq!(body["description"], "A helpful description");
+    }
+
+    #[tokio::test]
+    async fn test_create_project_empty_name_returns_400() {
+        let (app, _tmp) = test_app().await;
+        let (token, _) = register(&app, "carol", "carol@example.com").await;
+
+        let payload = serde_json::json!({ "name": "   " });
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/projects")
+                    .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(payload.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn test_create_duplicate_project_returns_409() {
+        let (app, _tmp) = test_app().await;
+        let (token, _) = register(&app, "dan", "dan@example.com").await;
+
+        let payload = serde_json::json!({ "name": "Duplicate Project" });
+        app.clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/projects")
+                    .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(payload.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/projects")
+                    .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(payload.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::CONFLICT);
+    }
+
+    #[tokio::test]
+    async fn test_create_project_sets_org_from_tenant_header() {
+        let (app, _tmp) = test_app().await;
+        let (token, _) = register(&app, "eve", "eve@example.com").await;
+
+        let payload = serde_json::json!({ "name": "Tenant Project" });
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/projects")
+                    .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .header("X-Tenant-ID", "org-abc")
+                    .body(Body::from(payload.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::CREATED);
+        let body = body_json(response).await;
+        assert_eq!(body["organization_id"], "org-abc");
+    }
+
+    // -----------------------------------------------------------------------
+    // Get project
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_get_project_returns_200() {
+        let (app, _tmp) = test_app().await;
+        let (token, _) = register(&app, "frank", "frank@example.com").await;
+
+        let payload = serde_json::json!({ "name": "Fetchable Project" });
+        let create_resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/projects")
+                    .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(payload.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let created = body_json(create_resp).await;
+        let id = created["id"].as_str().unwrap();
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri(format!("/api/v1/projects/{id}"))
+                    .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = body_json(response).await;
+        assert_eq!(body["name"], "Fetchable Project");
+    }
+
+    #[tokio::test]
+    async fn test_get_project_unauthenticated() {
+        let (app, _tmp) = test_app().await;
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/api/v1/projects/some-id")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn test_get_missing_project_returns_404() {
+        let (app, _tmp) = test_app().await;
+        let (token, _) = register(&app, "grace", "grace@example.com").await;
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/api/v1/projects/nonexistent-id")
+                    .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    // -----------------------------------------------------------------------
+    // List projects
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_list_projects_unauthenticated() {
+        let (app, _tmp) = test_app().await;
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/api/v1/projects")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn test_list_projects_returns_all() {
+        let (app, _tmp) = test_app().await;
+        let (token, _) = register(&app, "henry", "henry@example.com").await;
+
+        for name in &["Alpha", "Beta", "Gamma"] {
+            let payload = serde_json::json!({ "name": name });
+            app.clone()
+                .oneshot(
+                    Request::builder()
+                        .method("POST")
+                        .uri("/api/v1/projects")
+                        .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                        .header(header::CONTENT_TYPE, "application/json")
+                        .body(Body::from(payload.to_string()))
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+        }
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/api/v1/projects")
+                    .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = body_json(response).await;
+        assert_eq!(body["total"], 3);
+        assert_eq!(body["items"].as_array().unwrap().len(), 3);
+    }
+
+    #[tokio::test]
+    async fn test_list_projects_with_pagination() {
+        let (app, _tmp) = test_app().await;
+        let (token, _) = register(&app, "ida", "ida@example.com").await;
+
+        for i in 0..5u32 {
+            let payload = serde_json::json!({ "name": format!("Proj {i}") });
+            app.clone()
+                .oneshot(
+                    Request::builder()
+                        .method("POST")
+                        .uri("/api/v1/projects")
+                        .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                        .header(header::CONTENT_TYPE, "application/json")
+                        .body(Body::from(payload.to_string()))
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+        }
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("GET")
+                    .uri("/api/v1/projects?limit=2&offset=1")
+                    .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = body_json(response).await;
+        assert_eq!(body["total"], 5);
+        assert_eq!(body["items"].as_array().unwrap().len(), 2);
+        assert_eq!(body["limit"], 2);
+        assert_eq!(body["offset"], 1);
+    }
+
+    // -----------------------------------------------------------------------
+    // Update project
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_update_project_unauthenticated() {
+        let (app, _tmp) = test_app().await;
+
+        let payload = serde_json::json!({ "name": "New Name" });
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("PUT")
+                    .uri("/api/v1/projects/some-id")
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(payload.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn test_update_project_returns_200() {
+        let (app, _tmp) = test_app().await;
+        let (token, _) = register(&app, "jack", "jack@example.com").await;
+
+        let payload = serde_json::json!({ "name": "Original Name" });
+        let create_resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/projects")
+                    .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(payload.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let created = body_json(create_resp).await;
+        let id = created["id"].as_str().unwrap();
+
+        let update_payload = serde_json::json!({ "name": "Updated Name" });
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("PUT")
+                    .uri(format!("/api/v1/projects/{id}"))
+                    .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(update_payload.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = body_json(response).await;
+        assert_eq!(body["name"], "Updated Name");
+    }
+
+    #[tokio::test]
+    async fn test_update_project_empty_name_returns_400() {
+        let (app, _tmp) = test_app().await;
+        let (token, _) = register(&app, "kate", "kate@example.com").await;
+
+        let payload = serde_json::json!({ "name": "Valid Name" });
+        let create_resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/projects")
+                    .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(payload.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let created = body_json(create_resp).await;
+        let id = created["id"].as_str().unwrap();
+
+        let update_payload = serde_json::json!({ "name": "   " });
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("PUT")
+                    .uri(format!("/api/v1/projects/{id}"))
+                    .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(update_payload.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+    }
+
+    #[tokio::test]
+    async fn test_update_missing_project_returns_404() {
+        let (app, _tmp) = test_app().await;
+        let (token, _) = register(&app, "liam", "liam@example.com").await;
+
+        let payload = serde_json::json!({ "name": "New Name" });
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("PUT")
+                    .uri("/api/v1/projects/nonexistent-id")
+                    .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(payload.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+
+    // -----------------------------------------------------------------------
+    // Delete project
+    // -----------------------------------------------------------------------
+
+    #[tokio::test]
+    async fn test_delete_project_unauthenticated() {
+        let (app, _tmp) = test_app().await;
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("DELETE")
+                    .uri("/api/v1/projects/some-id")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn test_delete_project_returns_204() {
+        let (app, _tmp) = test_app().await;
+        let (token, _) = register(&app, "mia", "mia@example.com").await;
+
+        let payload = serde_json::json!({ "name": "To Delete" });
+        let create_resp = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/api/v1/projects")
+                    .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                    .header(header::CONTENT_TYPE, "application/json")
+                    .body(Body::from(payload.to_string()))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let created = body_json(create_resp).await;
+        let id = created["id"].as_str().unwrap();
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("DELETE")
+                    .uri(format!("/api/v1/projects/{id}"))
+                    .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::NO_CONTENT);
+    }
+
+    #[tokio::test]
+    async fn test_delete_missing_project_returns_404() {
+        let (app, _tmp) = test_app().await;
+        let (token, _) = register(&app, "noah", "noah@example.com").await;
+
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("DELETE")
+                    .uri("/api/v1/projects/nonexistent-id")
+                    .header(header::AUTHORIZATION, format!("Bearer {token}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::NOT_FOUND);
+    }
+}

--- a/crates/core/src/entity/mod.rs
+++ b/crates/core/src/entity/mod.rs
@@ -1,13 +1,15 @@
 //! SeaORM entity definitions for the core crate.
 //!
-//! Four entities map to the core service tables:
+//! Five entities map to the core service tables:
 //!
 //! - [`user`] → `users` table
 //! - [`organization`] → `organizations` table
 //! - [`membership`] → `memberships` table
 //! - [`session`] → `sessions` table
+//! - [`project`] → `projects` table
 
 pub mod membership;
 pub mod organization;
+pub mod project;
 pub mod session;
 pub mod user;

--- a/crates/core/src/entity/project.rs
+++ b/crates/core/src/entity/project.rs
@@ -1,0 +1,29 @@
+//! SeaORM entity for the `projects` table.
+//!
+//! Projects provide a logical grouping layer below organizations:
+//! `org > project > {agents, workflows, rooms, docs}`.
+
+use sea_orm::entity::prelude::*;
+
+/// SeaORM model for the `projects` table.
+///
+/// The `name` column carries a unique index enforced by the migration.
+/// `organization_id` is optional — rows with `NULL` represent legacy data
+/// created before multi-tenancy was introduced.
+#[derive(Clone, Debug, PartialEq, DeriveEntityModel)]
+#[sea_orm(table_name = "projects")]
+pub struct Model {
+    #[sea_orm(primary_key, auto_increment = false)]
+    pub id: String,
+    #[sea_orm(unique)]
+    pub name: String,
+    pub description: Option<String>,
+    pub organization_id: Option<String>,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+#[derive(Copy, Clone, Debug, EnumIter, DeriveRelation)]
+pub enum Relation {}
+
+impl ActiveModelBehavior for ActiveModel {}

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -11,6 +11,7 @@ pub mod membership_storage;
 pub mod middleware;
 pub mod migration;
 pub mod organization_storage;
+pub mod project_storage;
 pub mod proxy;
 pub mod session_storage;
 pub mod storage;

--- a/crates/core/src/migration/m20260616_000004_create_projects_table.rs
+++ b/crates/core/src/migration/m20260616_000004_create_projects_table.rs
@@ -1,0 +1,72 @@
+//! Migration 4: create the `projects` table in the core service.
+//!
+//! Projects sit below organizations in the tenant hierarchy:
+//! `org > project > {agents, workflows, rooms, docs}`.
+
+use sea_orm_migration::prelude::*;
+
+#[derive(DeriveMigrationName)]
+pub struct Migration;
+
+#[async_trait::async_trait]
+impl MigrationTrait for Migration {
+    async fn up(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager
+            .create_table(
+                Table::create()
+                    .table(Projects::Table)
+                    .if_not_exists()
+                    .col(ColumnDef::new(Projects::Id).string().not_null().primary_key())
+                    .col(ColumnDef::new(Projects::Name).string().not_null())
+                    .col(ColumnDef::new(Projects::Description).string().null())
+                    .col(ColumnDef::new(Projects::OrganizationId).string().null())
+                    .col(ColumnDef::new(Projects::CreatedAt).string().not_null())
+                    .col(ColumnDef::new(Projects::UpdatedAt).string().not_null())
+                    .to_owned(),
+            )
+            .await?;
+
+        // Unique index on name — project names must be globally unique.
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx_projects_name")
+                    .table(Projects::Table)
+                    .col(Projects::Name)
+                    .unique()
+                    .if_not_exists()
+                    .to_owned(),
+            )
+            .await?;
+
+        // Non-unique index on organization_id for tenant-scoped listing.
+        manager
+            .create_index(
+                Index::create()
+                    .name("idx_projects_organization_id")
+                    .table(Projects::Table)
+                    .col(Projects::OrganizationId)
+                    .if_not_exists()
+                    .to_owned(),
+            )
+            .await?;
+
+        Ok(())
+    }
+
+    async fn down(&self, manager: &SchemaManager) -> Result<(), DbErr> {
+        manager.drop_table(Table::drop().table(Projects::Table).to_owned()).await
+    }
+}
+
+/// Iden enum for the `projects` table columns.
+#[derive(DeriveIden)]
+enum Projects {
+    Table,
+    Id,
+    Name,
+    Description,
+    OrganizationId,
+    CreatedAt,
+    UpdatedAt,
+}

--- a/crates/core/src/migration/mod.rs
+++ b/crates/core/src/migration/mod.rs
@@ -14,6 +14,7 @@ pub use sea_orm_migration::prelude::*;
 mod m20260305_000001_create_core_tables;
 mod m20260408_000002_add_username_to_users;
 mod m20260614_000003_add_is_superuser_to_users;
+mod m20260616_000004_create_projects_table;
 
 /// The migration runner — applies all known migrations in order.
 pub struct Migrator;
@@ -25,6 +26,7 @@ impl MigratorTrait for Migrator {
             Box::new(m20260305_000001_create_core_tables::Migration),
             Box::new(m20260408_000002_add_username_to_users::Migration),
             Box::new(m20260614_000003_add_is_superuser_to_users::Migration),
+            Box::new(m20260616_000004_create_projects_table::Migration),
         ]
     }
 }

--- a/crates/core/src/project_storage.rs
+++ b/crates/core/src/project_storage.rs
@@ -1,0 +1,296 @@
+//! SeaORM-based storage for project records.
+//!
+//! [`ProjectStorage`] provides CRUD operations for the `projects` table.
+//! It holds a [`DatabaseConnection`] shared with the parent
+//! [`crate::storage::Storage`].
+//!
+//! ## Tenant-scoped listing
+//!
+//! [`ProjectStorage::list_org`] includes rows with a `NULL` `organization_id`
+//! alongside rows that match the requested org.  This preserves visibility of
+//! legacy data created before multi-tenancy was introduced; those rows should
+//! be backfilled by the `backfill-projects` admin command before NULL inclusion
+//! is removed.
+
+use anyhow::{anyhow, Result};
+use sea_orm::{
+    ActiveModelTrait, ColumnTrait, Condition, DatabaseConnection, EntityTrait, PaginatorTrait,
+    QueryFilter, QueryOrder, Set,
+};
+use uuid::Uuid;
+
+use crate::entity::project::{self, Column};
+
+/// Storage operations for the `projects` table.
+#[derive(Clone)]
+pub struct ProjectStorage {
+    db: DatabaseConnection,
+}
+
+impl ProjectStorage {
+    pub fn new(db: DatabaseConnection) -> Self {
+        Self { db }
+    }
+
+    /// Insert a new project and return the created record.
+    pub async fn create(
+        &self,
+        name: &str,
+        description: Option<&str>,
+        organization_id: Option<&str>,
+    ) -> Result<project::Model> {
+        let now = chrono::Utc::now().to_rfc3339();
+        let model = project::ActiveModel {
+            id: Set(Uuid::new_v4().to_string()),
+            name: Set(name.to_string()),
+            description: Set(description.map(|s| s.to_string())),
+            organization_id: Set(organization_id.map(|s| s.to_string())),
+            created_at: Set(now.clone()),
+            updated_at: Set(now),
+        }
+        .insert(&self.db)
+        .await?;
+        Ok(model)
+    }
+
+    /// Return the project with the given id, or `None` if not found.
+    pub async fn get_by_id(&self, id: &str) -> Result<Option<project::Model>> {
+        Ok(project::Entity::find_by_id(id).one(&self.db).await?)
+    }
+
+    /// Return the project with the given name, or `None` if not found.
+    pub async fn get_by_name(&self, name: &str) -> Result<Option<project::Model>> {
+        Ok(project::Entity::find().filter(Column::Name.eq(name)).one(&self.db).await?)
+    }
+
+    /// Return all projects ordered by `created_at` descending.
+    pub async fn list(&self) -> Result<Vec<project::Model>> {
+        Ok(project::Entity::find().order_by_desc(Column::CreatedAt).all(&self.db).await?)
+    }
+
+    /// Return projects filtered by organization, or all projects when `org_id` is `None`.
+    ///
+    /// When `org_id` is provided, rows with a matching `organization_id` **or**
+    /// a `NULL` `organization_id` are included.  The NULL-row inclusion is a
+    /// deliberate tenant-transition aid: pre-migration data remains visible to
+    /// authenticated tenants until the `backfill-projects` admin command is run.
+    pub async fn list_org(&self, org_id: Option<&str>) -> Result<Vec<project::Model>> {
+        let query = project::Entity::find().order_by_desc(Column::CreatedAt);
+        let query = if let Some(oid) = org_id {
+            // Include legacy NULL rows so pre-migration data is still visible
+            // to authenticated tenants until backfill-tenant is run.
+            query.filter(
+                Condition::any()
+                    .add(Column::OrganizationId.eq(oid))
+                    .add(Column::OrganizationId.is_null()),
+            )
+        } else {
+            query
+        };
+        Ok(query.all(&self.db).await?)
+    }
+
+    /// Return a paginated list of all projects ordered by `created_at` descending.
+    ///
+    /// Intended for product-admin use — not tenant-scoped.
+    pub async fn list_paginated(
+        &self,
+        limit: u64,
+        offset: u64,
+    ) -> Result<agentd_common::types::PaginatedResponse<project::Model>> {
+        let paginator =
+            project::Entity::find().order_by_desc(Column::CreatedAt).paginate(&self.db, limit);
+        let total = paginator.num_items().await?;
+        let page = offset.checked_div(limit).unwrap_or(0);
+        let items = paginator.fetch_page(page).await?;
+        Ok(agentd_common::types::PaginatedResponse {
+            items,
+            total: total as usize,
+            limit: limit as usize,
+            offset: offset as usize,
+        })
+    }
+
+    /// Update name and/or description for the given project.
+    ///
+    /// Returns an error if the project does not exist.
+    pub async fn update(
+        &self,
+        id: &str,
+        name: Option<&str>,
+        description: Option<&str>,
+    ) -> Result<project::Model> {
+        let proj = project::Entity::find_by_id(id)
+            .one(&self.db)
+            .await?
+            .ok_or_else(|| anyhow!("project not found: {}", id))?;
+
+        let mut active: project::ActiveModel = proj.into();
+        if let Some(name) = name {
+            active.name = Set(name.to_string());
+        }
+        if let Some(description) = description {
+            active.description = Set(Some(description.to_string()));
+        }
+        active.updated_at = Set(chrono::Utc::now().to_rfc3339());
+        Ok(active.update(&self.db).await?)
+    }
+
+    /// Delete the project with the given id.
+    ///
+    /// Returns `true` if a row was deleted, `false` if not found.
+    pub async fn delete(&self, id: &str) -> Result<bool> {
+        let result = project::Entity::delete_by_id(id).exec(&self.db).await?;
+        Ok(result.rows_affected > 0)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::migration::Migrator;
+    use agentd_common::storage::create_test_connection;
+    use sea_orm_migration::MigratorTrait;
+
+    async fn setup() -> (ProjectStorage, tempfile::TempDir) {
+        let (conn, tmp) = create_test_connection().await;
+        Migrator::up(&conn, None).await.unwrap();
+        (ProjectStorage::new(conn), tmp)
+    }
+
+    #[tokio::test]
+    async fn test_create_and_get_by_id() {
+        let (storage, _tmp) = setup().await;
+        let proj = storage.create("My Project", Some("A test project"), None).await.unwrap();
+        assert_eq!(proj.name, "My Project");
+        assert_eq!(proj.description.as_deref(), Some("A test project"));
+        assert!(proj.organization_id.is_none());
+
+        let found = storage.get_by_id(&proj.id).await.unwrap().unwrap();
+        assert_eq!(found.id, proj.id);
+        assert_eq!(found.name, "My Project");
+    }
+
+    #[tokio::test]
+    async fn test_get_by_name() {
+        let (storage, _tmp) = setup().await;
+        storage.create("Named Project", None, None).await.unwrap();
+
+        let found = storage.get_by_name("Named Project").await.unwrap().unwrap();
+        assert_eq!(found.name, "Named Project");
+
+        let missing = storage.get_by_name("nope").await.unwrap();
+        assert!(missing.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_get_by_id_not_found() {
+        let (storage, _tmp) = setup().await;
+        let missing = storage.get_by_id("nonexistent-id").await.unwrap();
+        assert!(missing.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_list_ordered_by_created_at_desc() {
+        let (storage, _tmp) = setup().await;
+        storage.create("Alpha", None, None).await.unwrap();
+        storage.create("Beta", None, None).await.unwrap();
+
+        let projects = storage.list().await.unwrap();
+        assert_eq!(projects.len(), 2);
+        // Beta was created after Alpha so it should come first (desc order)
+        assert_eq!(projects[0].name, "Beta");
+        assert_eq!(projects[1].name, "Alpha");
+    }
+
+    #[tokio::test]
+    async fn test_list_org_filters_by_org_id() {
+        let (storage, _tmp) = setup().await;
+        let org_a = "org-a";
+        let org_b = "org-b";
+        storage.create("Proj A", None, Some(org_a)).await.unwrap();
+        storage.create("Proj B", None, Some(org_b)).await.unwrap();
+        // Legacy row with no org
+        storage.create("Legacy", None, None).await.unwrap();
+
+        // list_org(Some(org_a)) should return Proj A and Legacy (NULL)
+        let for_a = storage.list_org(Some(org_a)).await.unwrap();
+        let names_a: Vec<&str> = for_a.iter().map(|p| p.name.as_str()).collect();
+        assert!(names_a.contains(&"Proj A"), "expected Proj A in {:?}", names_a);
+        assert!(names_a.contains(&"Legacy"), "expected Legacy (NULL row) in {:?}", names_a);
+        assert!(!names_a.contains(&"Proj B"), "did not expect Proj B in {:?}", names_a);
+    }
+
+    #[tokio::test]
+    async fn test_list_org_none_returns_all() {
+        let (storage, _tmp) = setup().await;
+        storage.create("P1", None, Some("org-x")).await.unwrap();
+        storage.create("P2", None, None).await.unwrap();
+
+        let all = storage.list_org(None).await.unwrap();
+        assert_eq!(all.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_list_paginated() {
+        let (storage, _tmp) = setup().await;
+        for i in 0..5u32 {
+            storage.create(&format!("Project {i}"), None, None).await.unwrap();
+        }
+
+        let page = storage.list_paginated(2, 0).await.unwrap();
+        assert_eq!(page.items.len(), 2);
+        assert_eq!(page.total, 5);
+        assert_eq!(page.limit, 2);
+        assert_eq!(page.offset, 0);
+
+        let page2 = storage.list_paginated(2, 2).await.unwrap();
+        assert_eq!(page2.items.len(), 2);
+        assert_eq!(page2.offset, 2);
+    }
+
+    #[tokio::test]
+    async fn test_update() {
+        let (storage, _tmp) = setup().await;
+        let proj = storage.create("Old Name", Some("old desc"), None).await.unwrap();
+
+        let updated = storage.update(&proj.id, Some("New Name"), Some("new desc")).await.unwrap();
+        assert_eq!(updated.name, "New Name");
+        assert_eq!(updated.description.as_deref(), Some("new desc"));
+        assert!(updated.updated_at >= proj.updated_at);
+    }
+
+    #[tokio::test]
+    async fn test_update_not_found() {
+        let (storage, _tmp) = setup().await;
+        let result = storage.update("nonexistent-id", Some("x"), None).await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_delete() {
+        let (storage, _tmp) = setup().await;
+        let proj = storage.create("To Delete", None, None).await.unwrap();
+
+        let deleted = storage.delete(&proj.id).await.unwrap();
+        assert!(deleted);
+
+        let found = storage.get_by_id(&proj.id).await.unwrap();
+        assert!(found.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_delete_not_found() {
+        let (storage, _tmp) = setup().await;
+        let result = storage.delete("nonexistent-id").await.unwrap();
+        assert!(!result);
+    }
+
+    #[tokio::test]
+    async fn test_unique_name_constraint() {
+        let (storage, _tmp) = setup().await;
+        storage.create("Duplicate", None, None).await.unwrap();
+        let result = storage.create("Duplicate", None, None).await;
+        assert!(result.is_err(), "duplicate name should be rejected");
+    }
+}

--- a/crates/core/src/storage.rs
+++ b/crates/core/src/storage.rs
@@ -22,6 +22,7 @@ use sea_orm_migration::MigratorTrait;
 use crate::membership_storage::MembershipStorage;
 use crate::migration::Migrator;
 use crate::organization_storage::OrganizationStorage;
+use crate::project_storage::ProjectStorage;
 use crate::session_storage::SessionStorage;
 use crate::user_storage::UserStorage;
 
@@ -52,6 +53,11 @@ impl Storage {
     /// Returns an [`OrganizationStorage`] instance sharing this connection.
     pub fn organizations(&self) -> OrganizationStorage {
         OrganizationStorage::new(self.db.clone())
+    }
+
+    /// Returns a [`ProjectStorage`] instance sharing this connection.
+    pub fn projects(&self) -> ProjectStorage {
+        ProjectStorage::new(self.db.clone())
     }
 
     /// Returns a [`MembershipStorage`] instance sharing this connection.

--- a/crates/orchestrator/src/api.rs
+++ b/crates/orchestrator/src/api.rs
@@ -97,9 +97,7 @@ pub fn create_router(state: ApiState) -> Router {
         .route("/approvals/{id}/deny", post(deny_tool))
         .route("/debug/agents", get(debug_agents))
         .route("/events/ask", post(ask_event_handler))
-        // Project management
-        .route("/projects", get(list_projects).post(create_project))
-        .route("/projects/{id}", get(get_project).put(update_project).delete(delete_project))
+        // Project association endpoints (CRUD lives in core service)
         .route("/projects/{id}/agents", get(list_project_agents))
         .route(
             "/projects/{id}/agents/{agent_id}",
@@ -1307,8 +1305,10 @@ async fn ask_event_handler(
 }
 
 // ---------------------------------------------------------------------------
-// Project management handlers
+// Project association handlers
 // ---------------------------------------------------------------------------
+// Project CRUD (create/read/update/delete) has been moved to the core service.
+// These handlers manage the associations between projects and agents/workflows.
 
 #[derive(Deserialize)]
 struct ProjectListQuery {
@@ -1316,131 +1316,11 @@ struct ProjectListQuery {
     offset: Option<usize>,
 }
 
-async fn list_projects(
-    OptionalTenantId(org_id): OptionalTenantId,
-    State(state): State<ApiState>,
-    Query(query): Query<ProjectListQuery>,
-) -> Result<impl IntoResponse, ApiError> {
-    let ps = state.manager.project_storage();
-    let all = ps.list_org(org_id.as_deref()).await.map_err(ApiError::Internal)?;
-    let total = all.len();
-    let limit = clamp_limit(query.limit);
-    let offset = query.offset.unwrap_or(0);
-    let items: Vec<Project> = all.into_iter().skip(offset).take(limit).collect();
-    Ok(Json(PaginatedResponse { items, total, limit, offset }))
-}
-
-async fn create_project(
-    OptionalTenantId(org_id): OptionalTenantId,
-    State(state): State<ApiState>,
-    Json(req): Json<CreateProjectRequest>,
-) -> Result<impl IntoResponse, ApiError> {
-    if req.name.trim().is_empty() {
-        return Err(ApiError::InvalidInput("project name must not be empty".to_string()));
-    }
-    let mut project = Project::new(req.name, req.description);
-    project.organization_id = org_id;
-    let ps = state.manager.project_storage();
-    let created = ps.create(&project).await.map_err(|e| {
-        if e.to_string().contains("UNIQUE") {
-            ApiError::Conflict(format!("a project named '{}' already exists", project.name))
-        } else {
-            ApiError::Internal(e)
-        }
-    })?;
-    Ok((StatusCode::CREATED, Json(created)))
-}
-
-async fn get_project(
-    State(state): State<ApiState>,
-    Path(id): Path<Uuid>,
-) -> Result<impl IntoResponse, ApiError> {
-    let ps = state.manager.project_storage();
-    let project = ps.get(&id).await.map_err(ApiError::Internal)?.ok_or(ApiError::NotFound)?;
-
-    let agent_count =
-        state.manager.agent_storage().list(None, Some(id)).await.map_err(ApiError::Internal)?.len();
-
-    let workflow_count =
-        state.scheduler.storage().list_workflows(Some(id)).await.map_err(ApiError::Internal)?.len();
-
-    Ok(Json(ProjectResponse {
-        id: project.id,
-        name: project.name,
-        description: project.description,
-        created_at: project.created_at,
-        updated_at: project.updated_at,
-        agent_count,
-        workflow_count,
-    }))
-}
-
-async fn update_project(
-    State(state): State<ApiState>,
-    Path(id): Path<Uuid>,
-    Json(req): Json<UpdateProjectRequest>,
-) -> Result<impl IntoResponse, ApiError> {
-    let ps = state.manager.project_storage();
-    let updated = ps.update(&id, &req).await.map_err(|e| {
-        let msg = e.to_string();
-        if msg.contains("not found") {
-            ApiError::NotFound
-        } else if msg.contains("UNIQUE") {
-            ApiError::Conflict("a project with that name already exists".to_string())
-        } else {
-            ApiError::Internal(e)
-        }
-    })?;
-    Ok(Json(updated))
-}
-
-async fn delete_project(
-    State(state): State<ApiState>,
-    Path(id): Path<Uuid>,
-) -> Result<impl IntoResponse, ApiError> {
-    let ps = state.manager.project_storage();
-
-    // Verify project exists.
-    ps.get(&id).await.map_err(ApiError::Internal)?.ok_or(ApiError::NotFound)?;
-
-    // Reject if any agents are still associated.
-    let associated_agents =
-        state.manager.agent_storage().list(None, Some(id)).await.map_err(ApiError::Internal)?;
-    if !associated_agents.is_empty() {
-        return Err(ApiError::InvalidInput(format!(
-            "cannot delete project: {} agent(s) still associated",
-            associated_agents.len()
-        )));
-    }
-
-    // Reject if any workflows are still associated.
-    let associated_workflows =
-        state.scheduler.storage().list_workflows(Some(id)).await.map_err(ApiError::Internal)?;
-    if !associated_workflows.is_empty() {
-        return Err(ApiError::InvalidInput(format!(
-            "cannot delete project: {} workflow(s) still associated",
-            associated_workflows.len()
-        )));
-    }
-
-    ps.delete(&id).await.map_err(|e| {
-        if e.to_string().contains("not found") {
-            ApiError::NotFound
-        } else {
-            ApiError::Internal(e)
-        }
-    })?;
-    Ok(StatusCode::NO_CONTENT)
-}
-
 async fn list_project_agents(
     State(state): State<ApiState>,
     Path(id): Path<Uuid>,
     Query(query): Query<ProjectListQuery>,
 ) -> Result<impl IntoResponse, ApiError> {
-    let ps = state.manager.project_storage();
-    ps.get(&id).await.map_err(ApiError::Internal)?.ok_or(ApiError::NotFound)?;
-
     let limit = clamp_limit(query.limit);
     let offset = query.offset.unwrap_or(0);
 
@@ -1465,9 +1345,7 @@ async fn associate_project_agent(
     State(state): State<ApiState>,
     Path((id, agent_id)): Path<(Uuid, Uuid)>,
 ) -> Result<impl IntoResponse, ApiError> {
-    // Verify project and agent exist.
-    let ps = state.manager.project_storage();
-    ps.get(&id).await.map_err(ApiError::Internal)?.ok_or(ApiError::NotFound)?;
+    // Verify agent exists.
     state
         .manager
         .get_agent(&agent_id)
@@ -1486,10 +1364,8 @@ async fn associate_project_agent(
 
 async fn dissociate_project_agent(
     State(state): State<ApiState>,
-    Path((id, agent_id)): Path<(Uuid, Uuid)>,
+    Path((_id, agent_id)): Path<(Uuid, Uuid)>,
 ) -> Result<impl IntoResponse, ApiError> {
-    let ps = state.manager.project_storage();
-    ps.get(&id).await.map_err(ApiError::Internal)?.ok_or(ApiError::NotFound)?;
     state
         .manager
         .get_agent(&agent_id)
@@ -1511,9 +1387,6 @@ async fn list_project_workflows(
     Path(id): Path<Uuid>,
     Query(query): Query<ProjectListQuery>,
 ) -> Result<impl IntoResponse, ApiError> {
-    let ps = state.manager.project_storage();
-    ps.get(&id).await.map_err(ApiError::Internal)?.ok_or(ApiError::NotFound)?;
-
     let limit = clamp_limit(query.limit);
     let offset = query.offset.unwrap_or(0);
 
@@ -1532,8 +1405,7 @@ async fn associate_project_workflow(
     State(state): State<ApiState>,
     Path((id, workflow_id)): Path<(Uuid, Uuid)>,
 ) -> Result<impl IntoResponse, ApiError> {
-    let ps = state.manager.project_storage();
-    ps.get(&id).await.map_err(ApiError::Internal)?.ok_or(ApiError::NotFound)?;
+    // Verify workflow exists.
     state
         .scheduler
         .storage()
@@ -1553,10 +1425,9 @@ async fn associate_project_workflow(
 
 async fn dissociate_project_workflow(
     State(state): State<ApiState>,
-    Path((id, workflow_id)): Path<(Uuid, Uuid)>,
+    Path((_id, workflow_id)): Path<(Uuid, Uuid)>,
 ) -> Result<impl IntoResponse, ApiError> {
-    let ps = state.manager.project_storage();
-    ps.get(&id).await.map_err(ApiError::Internal)?.ok_or(ApiError::NotFound)?;
+    // Verify workflow exists.
     state
         .scheduler
         .storage()

--- a/crates/orchestrator/src/entity/mod.rs
+++ b/crates/orchestrator/src/entity/mod.rs
@@ -3,7 +3,6 @@
 pub mod agent;
 pub mod conversation_event;
 pub mod dispatch;
-pub mod project;
 pub mod task_queue;
 pub mod usage_session;
 pub mod workflow;

--- a/crates/orchestrator/src/manager.rs
+++ b/crates/orchestrator/src/manager.rs
@@ -1,5 +1,5 @@
 use crate::scheduler::events::SystemEvent;
-use crate::storage::{AgentStorage, ProjectStorage};
+use crate::storage::AgentStorage;
 use crate::types::{
     Agent, AgentConfig, AgentStatus, AgentUsageStats, ClearContextResponse, RetentionConfig,
 };
@@ -84,11 +84,6 @@ impl AgentManager {
 
     pub fn registry(&self) -> &ConnectionRegistry {
         &self.registry
-    }
-
-    /// Returns a [`ProjectStorage`] backed by the same database connection.
-    pub fn project_storage(&self) -> ProjectStorage {
-        ProjectStorage::from_db(self.storage.db().clone())
     }
 
     /// Returns the underlying [`AgentStorage`] for direct access.

--- a/crates/orchestrator/src/storage.rs
+++ b/crates/orchestrator/src/storage.rs
@@ -6,13 +6,11 @@
 use crate::{
     entity::agent as agent_entity,
     entity::conversation_event as conv_entity,
-    entity::project as project_entity,
     entity::usage_session as session_entity,
     migration::Migrator,
     types::{
         Agent, AgentConfig, AgentStatus, AgentUsageStats, ConversationEvent, ConversationQuery,
-        ConversationSummary, Project, SessionUsage, ToolPolicy, UpdateProjectRequest,
-        UsageSnapshot,
+        ConversationSummary, SessionUsage, ToolPolicy, UsageSnapshot,
     },
 };
 use anyhow::Result;
@@ -1053,124 +1051,6 @@ impl AgentStorage {
 }
 
 // ---------------------------------------------------------------------------
-// ProjectStorage
-// ---------------------------------------------------------------------------
-
-/// Persistent storage backend for project records using SeaORM + SQLite.
-///
-/// Shares the same [`DatabaseConnection`] as [`AgentStorage`] — construct via
-/// [`ProjectStorage::from_db`] using the connection returned by
-/// [`AgentStorage::db()`].
-#[derive(Clone)]
-pub struct ProjectStorage {
-    db: DatabaseConnection,
-}
-
-impl ProjectStorage {
-    /// Wrap an existing database connection (shared with `AgentStorage`).
-    pub fn from_db(db: DatabaseConnection) -> Self {
-        Self { db }
-    }
-
-    /// Insert a new project and return it.
-    pub async fn create(&self, project: &Project) -> Result<Project> {
-        let model = project_entity::ActiveModel {
-            id: Set(project.id.to_string()),
-            name: Set(project.name.clone()),
-            description: Set(project.description.clone()),
-            created_at: Set(project.created_at.to_rfc3339()),
-            updated_at: Set(project.updated_at.to_rfc3339()),
-            organization_id: Set(project.organization_id.clone()),
-        };
-        project_entity::Entity::insert(model).exec(&self.db).await?;
-        Ok(project.clone())
-    }
-
-    /// Retrieve a project by UUID.  Returns `None` if not found.
-    pub async fn get(&self, id: &Uuid) -> Result<Option<Project>> {
-        let model = project_entity::Entity::find_by_id(id.to_string()).one(&self.db).await?;
-        model.map(model_to_project).transpose()
-    }
-
-    /// Retrieve a project by its unique name.  Returns `None` if not found.
-    #[allow(dead_code)]
-    pub async fn get_by_name(&self, name: &str) -> Result<Option<Project>> {
-        let model = project_entity::Entity::find()
-            .filter(project_entity::Column::Name.eq(name))
-            .one(&self.db)
-            .await?;
-        model.map(model_to_project).transpose()
-    }
-
-    /// List all projects ordered by creation time (newest first).
-    #[allow(dead_code)]
-    pub async fn list(&self) -> Result<Vec<Project>> {
-        self.list_org(None).await
-    }
-
-    /// Like [`list`] but also filters by `org_id` when provided.
-    pub async fn list_org(&self, org_id: Option<&str>) -> Result<Vec<Project>> {
-        let mut query =
-            project_entity::Entity::find().order_by(project_entity::Column::CreatedAt, Order::Desc);
-        if let Some(oid) = org_id {
-            // Include legacy NULL rows so pre-migration data is still visible
-            // to authenticated tenants until backfill-tenant is run.
-            query = query.filter(
-                Condition::any()
-                    .add(project_entity::Column::OrganizationId.eq(oid))
-                    .add(project_entity::Column::OrganizationId.is_null()),
-            );
-        }
-        let models = query.all(&self.db).await?;
-        models.into_iter().map(model_to_project).collect()
-    }
-
-    /// Apply an update request to the project identified by `id`.
-    ///
-    /// Only fields present in `req` are changed; `updated_at` is always
-    /// refreshed.  Returns the updated project or errors if not found.
-    pub async fn update(&self, id: &Uuid, req: &UpdateProjectRequest) -> Result<Project> {
-        use sea_orm::sea_query::Expr;
-
-        let now = Utc::now().to_rfc3339();
-
-        let mut update = project_entity::Entity::update_many()
-            .col_expr(project_entity::Column::UpdatedAt, Expr::value(&now))
-            .filter(project_entity::Column::Id.eq(id.to_string()));
-
-        if let Some(ref name) = req.name {
-            update = update.col_expr(project_entity::Column::Name, Expr::value(name.clone()));
-        }
-        if let Some(ref desc) = req.description {
-            update =
-                update.col_expr(project_entity::Column::Description, Expr::value(desc.clone()));
-        }
-
-        let result = update.exec(&self.db).await?;
-        if result.rows_affected == 0 {
-            anyhow::bail!("Project not found");
-        }
-
-        self.get(id).await?.ok_or_else(|| anyhow::anyhow!("Project not found after update"))
-    }
-
-    /// Delete a project by UUID.  Errors if not found.
-    ///
-    /// Callers should verify no agents or workflows reference this project
-    /// before calling (enforced via FK in migration #828).
-    pub async fn delete(&self, id: &Uuid) -> Result<()> {
-        let result = project_entity::Entity::delete_many()
-            .filter(project_entity::Column::Id.eq(id.to_string()))
-            .exec(&self.db)
-            .await?;
-        if result.rows_affected == 0 {
-            anyhow::bail!("Project not found");
-        }
-        Ok(())
-    }
-}
-
-// ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
@@ -1246,18 +1126,6 @@ fn model_to_session_usage(model: &session_entity::Model) -> Result<SessionUsage>
         result_count: model.result_count.max(0) as u32,
         started_at,
         ended_at,
-    })
-}
-
-/// Convert a raw [`project_entity::Model`] into the domain [`Project`] type.
-fn model_to_project(model: project_entity::Model) -> Result<Project> {
-    Ok(Project {
-        id: Uuid::parse_str(&model.id)?,
-        name: model.name,
-        description: model.description,
-        created_at: DateTime::parse_from_rfc3339(&model.created_at)?.with_timezone(&Utc),
-        updated_at: DateTime::parse_from_rfc3339(&model.updated_at)?.with_timezone(&Utc),
-        organization_id: model.organization_id,
     })
 }
 
@@ -1818,162 +1686,6 @@ mod tests {
         assert_eq!(retrieved.config.docker_image, None);
         assert_eq!(retrieved.config.resource_limits, None);
     }
-
-    // -----------------------------------------------------------------------
-    // ProjectStorage tests
-    // -----------------------------------------------------------------------
-
-    fn project_storage(agent_storage: &AgentStorage) -> ProjectStorage {
-        ProjectStorage::from_db(agent_storage.db().clone())
-    }
-
-    #[tokio::test]
-    async fn test_project_create_and_get() {
-        let (storage, _tmp) = create_test_storage().await;
-        let ps = project_storage(&storage);
-
-        let project = Project::new("alpha".to_string(), Some("first project".to_string()));
-        let id = project.id;
-
-        ps.create(&project).await.unwrap();
-
-        let retrieved = ps.get(&id).await.unwrap().unwrap();
-        assert_eq!(retrieved.id, id);
-        assert_eq!(retrieved.name, "alpha");
-        assert_eq!(retrieved.description, Some("first project".to_string()));
-    }
-
-    #[tokio::test]
-    async fn test_project_get_returns_none_for_unknown_id() {
-        let (storage, _tmp) = create_test_storage().await;
-        let ps = project_storage(&storage);
-
-        let result = ps.get(&Uuid::new_v4()).await.unwrap();
-        assert!(result.is_none());
-    }
-
-    #[tokio::test]
-    async fn test_project_get_by_name() {
-        let (storage, _tmp) = create_test_storage().await;
-        let ps = project_storage(&storage);
-
-        let project = Project::new("beta".to_string(), None);
-        ps.create(&project).await.unwrap();
-
-        let found = ps.get_by_name("beta").await.unwrap().unwrap();
-        assert_eq!(found.id, project.id);
-        assert_eq!(found.description, None);
-    }
-
-    #[tokio::test]
-    async fn test_project_get_by_name_missing() {
-        let (storage, _tmp) = create_test_storage().await;
-        let ps = project_storage(&storage);
-
-        assert!(ps.get_by_name("nonexistent").await.unwrap().is_none());
-    }
-
-    #[tokio::test]
-    async fn test_project_list() {
-        let (storage, _tmp) = create_test_storage().await;
-        let ps = project_storage(&storage);
-
-        ps.create(&Project::new("p1".to_string(), None)).await.unwrap();
-        ps.create(&Project::new("p2".to_string(), None)).await.unwrap();
-        ps.create(&Project::new("p3".to_string(), None)).await.unwrap();
-
-        let projects = ps.list().await.unwrap();
-        assert_eq!(projects.len(), 3);
-        // Newest first
-        let names: Vec<&str> = projects.iter().map(|p| p.name.as_str()).collect();
-        assert!(names.contains(&"p1"));
-        assert!(names.contains(&"p2"));
-        assert!(names.contains(&"p3"));
-    }
-
-    #[tokio::test]
-    async fn test_project_list_empty() {
-        let (storage, _tmp) = create_test_storage().await;
-        let ps = project_storage(&storage);
-        assert!(ps.list().await.unwrap().is_empty());
-    }
-
-    #[tokio::test]
-    async fn test_project_update_name() {
-        let (storage, _tmp) = create_test_storage().await;
-        let ps = project_storage(&storage);
-
-        let project = Project::new("old-name".to_string(), None);
-        ps.create(&project).await.unwrap();
-
-        let req = UpdateProjectRequest { name: Some("new-name".to_string()), description: None };
-        let updated = ps.update(&project.id, &req).await.unwrap();
-
-        assert_eq!(updated.name, "new-name");
-        assert_eq!(updated.description, None);
-        assert!(updated.updated_at >= project.updated_at);
-    }
-
-    #[tokio::test]
-    async fn test_project_update_description() {
-        let (storage, _tmp) = create_test_storage().await;
-        let ps = project_storage(&storage);
-
-        let project = Project::new("proj".to_string(), None);
-        ps.create(&project).await.unwrap();
-
-        let req =
-            UpdateProjectRequest { name: None, description: Some("added description".to_string()) };
-        let updated = ps.update(&project.id, &req).await.unwrap();
-
-        assert_eq!(updated.name, "proj");
-        assert_eq!(updated.description, Some("added description".to_string()));
-    }
-
-    #[tokio::test]
-    async fn test_project_update_not_found() {
-        let (storage, _tmp) = create_test_storage().await;
-        let ps = project_storage(&storage);
-
-        let req = UpdateProjectRequest { name: Some("x".to_string()), description: None };
-        let result = ps.update(&Uuid::new_v4(), &req).await;
-        assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("not found"));
-    }
-
-    #[tokio::test]
-    async fn test_project_delete() {
-        let (storage, _tmp) = create_test_storage().await;
-        let ps = project_storage(&storage);
-
-        let project = Project::new("to-delete".to_string(), None);
-        ps.create(&project).await.unwrap();
-        assert!(ps.get(&project.id).await.unwrap().is_some());
-
-        ps.delete(&project.id).await.unwrap();
-        assert!(ps.get(&project.id).await.unwrap().is_none());
-    }
-
-    #[tokio::test]
-    async fn test_project_delete_not_found() {
-        let (storage, _tmp) = create_test_storage().await;
-        let ps = project_storage(&storage);
-
-        let result = ps.delete(&Uuid::new_v4()).await;
-        assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("not found"));
-    }
-
-    #[tokio::test]
-    async fn test_project_name_unique() {
-        let (storage, _tmp) = create_test_storage().await;
-        let ps = project_storage(&storage);
-
-        ps.create(&Project::new("unique".to_string(), None)).await.unwrap();
-        let result = ps.create(&Project::new("unique".to_string(), None)).await;
-        assert!(result.is_err());
-    }
-
     // -----------------------------------------------------------------------
     // Conversation event tests
     // -----------------------------------------------------------------------

--- a/crates/orchestrator/src/types.rs
+++ b/crates/orchestrator/src/types.rs
@@ -514,9 +514,15 @@ fn default_shell() -> String {
 
 // ---------------------------------------------------------------------------
 // Project types
+//
+// NOTE: Project CRUD has moved to the core service (epic #1306). These types
+// are kept temporarily so that `client.rs` and the CLI can still compile while
+// issue #1311 (repoint CLI/client to core) is in progress. Remove them once
+// #1311 lands.
 // ---------------------------------------------------------------------------
 
 /// A project groups agents, workflows, and rooms under a named boundary.
+#[allow(dead_code)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct Project {
     pub id: Uuid,
@@ -529,6 +535,7 @@ pub struct Project {
     pub organization_id: Option<String>,
 }
 
+#[allow(dead_code)]
 impl Project {
     pub fn new(name: String, description: Option<String>) -> Self {
         let now = Utc::now();
@@ -544,6 +551,7 @@ impl Project {
 }
 
 /// Detailed project response including associated resource counts.
+#[allow(dead_code)]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ProjectResponse {
     pub id: Uuid,
@@ -557,6 +565,7 @@ pub struct ProjectResponse {
 }
 
 /// Request body for POST /projects.
+#[allow(dead_code)]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CreateProjectRequest {
     pub name: String,
@@ -569,6 +578,7 @@ pub struct CreateProjectRequest {
 /// Fields that are `None` are left unchanged in the database.
 /// Pass `description: Some(None)` is not supported via this struct —
 /// to clear a description set it to `Some("")` or omit the field.
+#[allow(dead_code)]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct UpdateProjectRequest {
     #[serde(skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
Remove canonical project CRUD from the orchestrator now that core owns the entity. Project association endpoints (agents/workflows) are preserved and continue to work as before.

## Changes

### `crates/orchestrator/src/storage.rs`
- Deleted `ProjectStorage` struct and all its methods
- Deleted `model_to_project` helper function
- Removed `entity::project as project_entity` import and `Project`/`UpdateProjectRequest` from types import
- Removed all ProjectStorage unit tests

### `crates/orchestrator/src/manager.rs`
- Deleted `project_storage()` accessor
- Removed `ProjectStorage` import

### `crates/orchestrator/src/api.rs`
- Removed CRUD routes: `GET/POST /projects`, `GET/PUT/DELETE /projects/{id}`
- Removed CRUD handlers: `list_projects`, `create_project`, `get_project`, `update_project`, `delete_project`
- Removed `ps.get()` project-existence checks from all association handlers (dropped since ProjectStorage is gone)
- Kept `ProjectListQuery` (still used by `list_project_agents` and `list_project_workflows`)
- Kept all association routes/handlers intact

### `crates/orchestrator/src/entity/mod.rs`
- Removed `pub mod project;` (entity unused once existence checks were dropped)

### `crates/orchestrator/src/types.rs`
- Added `#[allow(dead_code)]` to `Project`, `ProjectResponse`, `CreateProjectRequest`, `UpdateProjectRequest` with a migration note
- Types are kept temporarily so `client.rs` and the CLI compile until issue #1311 (repoint CLI to core) lands

### `crates/cli/src/commands/admin.rs`
- Removed `"projects"` from orchestrator `SCOPED_TABLES` entry
- Added `ServiceTables { service: "core", tables: &["projects"] }` entry

## Notes
- This PR is intentionally stacked on `issue-1309` rather than `#1310` since #1310 (CLI repoint) is not yet implemented
- The project types in `types.rs` are preserved with `#[allow(dead_code)]` until #1311 completes the CLI migration
- 503 lib tests pass; the 5 `conversation_stream_v2` integration test failures are pre-existing sandbox permission issues unrelated to this change

Closes #1313