### PR TITLE
epic: Remove project CRUD from orchestrator, keep association endpoint

### DIFF
--- a/crates/cli/src/commands/admin.rs
+++ b/crates/cli/src/commands/admin.rs
@@ -124,7 +124,8 @@ struct ServiceTables {
 }
 
 const SCOPED_TABLES: &[ServiceTables] = &[
-    ServiceTables { service: "orchestrator", tables: &["agents", "workflows", "projects"] },
+    ServiceTables { service: "orchestrator", tables: &["agents", "workflows"] },
+    ServiceTables { service: "core", tables: &["projects"] },
     ServiceTables { service: "notify", tables: &["notifications"] },
     ServiceTables { service: "communicate", tables: &["rooms"] },
     ServiceTables { service: "memory", tables: &["memory_entries"] },

--- a/crates/orchestrator/src/api.rs
+++ b/crates/orchestrator/src/api.rs
@@ -97,9 +97,7 @@ pub fn create_router(state: ApiState) -> Router {
         .route("/approvals/{id}/deny", post(deny_tool))
         .route("/debug/agents", get(debug_agents))
         .route("/events/ask", post(ask_event_handler))
-        // Project management
-        .route("/projects", get(list_projects).post(create_project))
-        .route("/projects/{id}", get(get_project).put(update_project).delete(delete_project))
+        // Project association endpoints (CRUD lives in core service)
         .route("/projects/{id}/agents", get(list_project_agents))
         .route(
             "/projects/{id}/agents/{agent_id}",
@@ -1307,8 +1305,10 @@ async fn ask_event_handler(
 }
 
 // ---------------------------------------------------------------------------
-// Project management handlers
+// Project association handlers
 // ---------------------------------------------------------------------------
+// Project CRUD (create/read/update/delete) has been moved to the core service.
+// These handlers manage the associations between projects and agents/workflows.
 
 #[derive(Deserialize)]
 struct ProjectListQuery {
@@ -1316,131 +1316,11 @@ struct ProjectListQuery {
     offset: Option<usize>,
 }
 
-async fn list_projects(
-    OptionalTenantId(org_id): OptionalTenantId,
-    State(state): State<ApiState>,
-    Query(query): Query<ProjectListQuery>,
-) -> Result<impl IntoResponse, ApiError> {
-    let ps = state.manager.project_storage();
-    let all = ps.list_org(org_id.as_deref()).await.map_err(ApiError::Internal)?;
-    let total = all.len();
-    let limit = clamp_limit(query.limit);
-    let offset = query.offset.unwrap_or(0);
-    let items: Vec<Project> = all.into_iter().skip(offset).take(limit).collect();
-    Ok(Json(PaginatedResponse { items, total, limit, offset }))
-}
-
-async fn create_project(
-    OptionalTenantId(org_id): OptionalTenantId,
-    State(state): State<ApiState>,
-    Json(req): Json<CreateProjectRequest>,
-) -> Result<impl IntoResponse, ApiError> {
-    if req.name.trim().is_empty() {
-        return Err(ApiError::InvalidInput("project name must not be empty".to_string()));
-    }
-    let mut project = Project::new(req.name, req.description);
-    project.organization_id = org_id;
-    let ps = state.manager.project_storage();
-    let created = ps.create(&project).await.map_err(|e| {
-        if e.to_string().contains("UNIQUE") {
-            ApiError::Conflict(format!("a project named '{}' already exists", project.name))
-        } else {
-            ApiError::Internal(e)
-        }
-    })?;
-    Ok((StatusCode::CREATED, Json(created)))
-}
-
-async fn get_project(
-    State(state): State<ApiState>,
-    Path(id): Path<Uuid>,
-) -> Result<impl IntoResponse, ApiError> {
-    let ps = state.manager.project_storage();
-    let project = ps.get(&id).await.map_err(ApiError::Internal)?.ok_or(ApiError::NotFound)?;
-
-    let agent_count =
-        state.manager.agent_storage().list(None, Some(id)).await.map_err(ApiError::Internal)?.len();
-
-    let workflow_count =
-        state.scheduler.storage().list_workflows(Some(id)).await.map_err(ApiError::Internal)?.len();
-
-    Ok(Json(ProjectResponse {
-        id: project.id,
-        name: project.name,
-        description: project.description,
-        created_at: project.created_at,
-        updated_at: project.updated_at,
-        agent_count,
-        workflow_count,
-    }))
-}
-
-async fn update_project(
-    State(state): State<ApiState>,
-    Path(id): Path<Uuid>,
-    Json(req): Json<UpdateProjectRequest>,
-) -> Result<impl IntoResponse, ApiError> {
-    let ps = state.manager.project_storage();
-    let updated = ps.update(&id, &req).await.map_err(|e| {
-        let msg = e.to_string();
-        if msg.contains("not found") {
-            ApiError::NotFound
-        } else if msg.contains("UNIQUE") {
-            ApiError::Conflict("a project with that name already exists".to_string())
-        } else {
-            ApiError::Internal(e)
-        }
-    })?;
-    Ok(Json(updated))
-}
-
-async fn delete_project(
-    State(state): State<ApiState>,
-    Path(id): Path<Uuid>,
-) -> Result<impl IntoResponse, ApiError> {
-    let ps = state.manager.project_storage();
-
-    // Verify project exists.
-    ps.get(&id).await.map_err(ApiError::Internal)?.ok_or(ApiError::NotFound)?;
-
-    // Reject if any agents are still associated.
-    let associated_agents =
-        state.manager.agent_storage().list(None, Some(id)).await.map_err(ApiError::Internal)?;
-    if !associated_agents.is_empty() {
-        return Err(ApiError::InvalidInput(format!(
-            "cannot delete project: {} agent(s) still associated",
-            associated_agents.len()
-        )));
-    }
-
-    // Reject if any workflows are still associated.
-    let associated_workflows =
-        state.scheduler.storage().list_workflows(Some(id)).await.map_err(ApiError::Internal)?;
-    if !associated_workflows.is_empty() {
-        return Err(ApiError::InvalidInput(format!(
-            "cannot delete project: {} workflow(s) still associated",
-            associated_workflows.len()
-        )));
-    }
-
-    ps.delete(&id).await.map_err(|e| {
-        if e.to_string().contains("not found") {
-            ApiError::NotFound
-        } else {
-            ApiError::Internal(e)
-        }
-    })?;
-    Ok(StatusCode::NO_CONTENT)
-}
-
 async fn list_project_agents(
     State(state): State<ApiState>,
     Path(id): Path<Uuid>,
     Query(query): Query<ProjectListQuery>,
 ) -> Result<impl IntoResponse, ApiError> {
-    let ps = state.manager.project_storage();
-    ps.get(&id).await.map_err(ApiError::Internal)?.ok_or(ApiError::NotFound)?;
-
     let limit = clamp_limit(query.limit);
     let offset = query.offset.unwrap_or(0);
 
@@ -1465,9 +1345,7 @@ async fn associate_project_agent(
     State(state): State<ApiState>,
     Path((id, agent_id)): Path<(Uuid, Uuid)>,
 ) -> Result<impl IntoResponse, ApiError> {
-    // Verify project and agent exist.
-    let ps = state.manager.project_storage();
-    ps.get(&id).await.map_err(ApiError::Internal)?.ok_or(ApiError::NotFound)?;
+    // Verify agent exists.
     state
         .manager
         .get_agent(&agent_id)
@@ -1486,10 +1364,8 @@ async fn associate_project_agent(
 
 async fn dissociate_project_agent(
     State(state): State<ApiState>,
-    Path((id, agent_id)): Path<(Uuid, Uuid)>,
+    Path((_id, agent_id)): Path<(Uuid, Uuid)>,
 ) -> Result<impl IntoResponse, ApiError> {
-    let ps = state.manager.project_storage();
-    ps.get(&id).await.map_err(ApiError::Internal)?.ok_or(ApiError::NotFound)?;
     state
         .manager
         .get_agent(&agent_id)
@@ -1511,9 +1387,6 @@ async fn list_project_workflows(
     Path(id): Path<Uuid>,
     Query(query): Query<ProjectListQuery>,
 ) -> Result<impl IntoResponse, ApiError> {
-    let ps = state.manager.project_storage();
-    ps.get(&id).await.map_err(ApiError::Internal)?.ok_or(ApiError::NotFound)?;
-
     let limit = clamp_limit(query.limit);
     let offset = query.offset.unwrap_or(0);
 
@@ -1532,8 +1405,7 @@ async fn associate_project_workflow(
     State(state): State<ApiState>,
     Path((id, workflow_id)): Path<(Uuid, Uuid)>,
 ) -> Result<impl IntoResponse, ApiError> {
-    let ps = state.manager.project_storage();
-    ps.get(&id).await.map_err(ApiError::Internal)?.ok_or(ApiError::NotFound)?;
+    // Verify workflow exists.
     state
         .scheduler
         .storage()
@@ -1553,10 +1425,9 @@ async fn associate_project_workflow(
 
 async fn dissociate_project_workflow(
     State(state): State<ApiState>,
-    Path((id, workflow_id)): Path<(Uuid, Uuid)>,
+    Path((_id, workflow_id)): Path<(Uuid, Uuid)>,
 ) -> Result<impl IntoResponse, ApiError> {
-    let ps = state.manager.project_storage();
-    ps.get(&id).await.map_err(ApiError::Internal)?.ok_or(ApiError::NotFound)?;
+    // Verify workflow exists.
     state
         .scheduler
         .storage()

--- a/crates/orchestrator/src/entity/mod.rs
+++ b/crates/orchestrator/src/entity/mod.rs
@@ -3,7 +3,6 @@
 pub mod agent;
 pub mod conversation_event;
 pub mod dispatch;
-pub mod project;
 pub mod task_queue;
 pub mod usage_session;
 pub mod workflow;

--- a/crates/orchestrator/src/manager.rs
+++ b/crates/orchestrator/src/manager.rs
@@ -1,5 +1,5 @@
 use crate::scheduler::events::SystemEvent;
-use crate::storage::{AgentStorage, ProjectStorage};
+use crate::storage::AgentStorage;
 use crate::types::{
     Agent, AgentConfig, AgentStatus, AgentUsageStats, ClearContextResponse, RetentionConfig,
 };
@@ -84,11 +84,6 @@ impl AgentManager {
 
     pub fn registry(&self) -> &ConnectionRegistry {
         &self.registry
-    }
-
-    /// Returns a [`ProjectStorage`] backed by the same database connection.
-    pub fn project_storage(&self) -> ProjectStorage {
-        ProjectStorage::from_db(self.storage.db().clone())
     }
 
     /// Returns the underlying [`AgentStorage`] for direct access.

--- a/crates/orchestrator/src/storage.rs
+++ b/crates/orchestrator/src/storage.rs
@@ -6,13 +6,11 @@
 use crate::{
     entity::agent as agent_entity,
     entity::conversation_event as conv_entity,
-    entity::project as project_entity,
     entity::usage_session as session_entity,
     migration::Migrator,
     types::{
         Agent, AgentConfig, AgentStatus, AgentUsageStats, ConversationEvent, ConversationQuery,
-        ConversationSummary, Project, SessionUsage, ToolPolicy, UpdateProjectRequest,
-        UsageSnapshot,
+        ConversationSummary, SessionUsage, ToolPolicy, UsageSnapshot,
     },
 };
 use anyhow::Result;
@@ -1053,124 +1051,6 @@ impl AgentStorage {
 }
 
 // ---------------------------------------------------------------------------
-// ProjectStorage
-// ---------------------------------------------------------------------------
-
-/// Persistent storage backend for project records using SeaORM + SQLite.
-///
-/// Shares the same [`DatabaseConnection`] as [`AgentStorage`] — construct via
-/// [`ProjectStorage::from_db`] using the connection returned by
-/// [`AgentStorage::db()`].
-#[derive(Clone)]
-pub struct ProjectStorage {
-    db: DatabaseConnection,
-}
-
-impl ProjectStorage {
-    /// Wrap an existing database connection (shared with `AgentStorage`).
-    pub fn from_db(db: DatabaseConnection) -> Self {
-        Self { db }
-    }
-
-    /// Insert a new project and return it.
-    pub async fn create(&self, project: &Project) -> Result<Project> {
-        let model = project_entity::ActiveModel {
-            id: Set(project.id.to_string()),
-            name: Set(project.name.clone()),
-            description: Set(project.description.clone()),
-            created_at: Set(project.created_at.to_rfc3339()),
-            updated_at: Set(project.updated_at.to_rfc3339()),
-            organization_id: Set(project.organization_id.clone()),
-        };
-        project_entity::Entity::insert(model).exec(&self.db).await?;
-        Ok(project.clone())
-    }
-
-    /// Retrieve a project by UUID.  Returns `None` if not found.
-    pub async fn get(&self, id: &Uuid) -> Result<Option<Project>> {
-        let model = project_entity::Entity::find_by_id(id.to_string()).one(&self.db).await?;
-        model.map(model_to_project).transpose()
-    }
-
-    /// Retrieve a project by its unique name.  Returns `None` if not found.
-    #[allow(dead_code)]
-    pub async fn get_by_name(&self, name: &str) -> Result<Option<Project>> {
-        let model = project_entity::Entity::find()
-            .filter(project_entity::Column::Name.eq(name))
-            .one(&self.db)
-            .await?;
-        model.map(model_to_project).transpose()
-    }
-
-    /// List all projects ordered by creation time (newest first).
-    #[allow(dead_code)]
-    pub async fn list(&self) -> Result<Vec<Project>> {
-        self.list_org(None).await
-    }
-
-    /// Like [`list`] but also filters by `org_id` when provided.
-    pub async fn list_org(&self, org_id: Option<&str>) -> Result<Vec<Project>> {
-        let mut query =
-            project_entity::Entity::find().order_by(project_entity::Column::CreatedAt, Order::Desc);
-        if let Some(oid) = org_id {
-            // Include legacy NULL rows so pre-migration data is still visible
-            // to authenticated tenants until backfill-tenant is run.
-            query = query.filter(
-                Condition::any()
-                    .add(project_entity::Column::OrganizationId.eq(oid))
-                    .add(project_entity::Column::OrganizationId.is_null()),
-            );
-        }
-        let models = query.all(&self.db).await?;
-        models.into_iter().map(model_to_project).collect()
-    }
-
-    /// Apply an update request to the project identified by `id`.
-    ///
-    /// Only fields present in `req` are changed; `updated_at` is always
-    /// refreshed.  Returns the updated project or errors if not found.
-    pub async fn update(&self, id: &Uuid, req: &UpdateProjectRequest) -> Result<Project> {
-        use sea_orm::sea_query::Expr;
-
-        let now = Utc::now().to_rfc3339();
-
-        let mut update = project_entity::Entity::update_many()
-            .col_expr(project_entity::Column::UpdatedAt, Expr::value(&now))
-            .filter(project_entity::Column::Id.eq(id.to_string()));
-
-        if let Some(ref name) = req.name {
-            update = update.col_expr(project_entity::Column::Name, Expr::value(name.clone()));
-        }
-        if let Some(ref desc) = req.description {
-            update =
-                update.col_expr(project_entity::Column::Description, Expr::value(desc.clone()));
-        }
-
-        let result = update.exec(&self.db).await?;
-        if result.rows_affected == 0 {
-            anyhow::bail!("Project not found");
-        }
-
-        self.get(id).await?.ok_or_else(|| anyhow::anyhow!("Project not found after update"))
-    }
-
-    /// Delete a project by UUID.  Errors if not found.
-    ///
-    /// Callers should verify no agents or workflows reference this project
-    /// before calling (enforced via FK in migration #828).
-    pub async fn delete(&self, id: &Uuid) -> Result<()> {
-        let result = project_entity::Entity::delete_many()
-            .filter(project_entity::Column::Id.eq(id.to_string()))
-            .exec(&self.db)
-            .await?;
-        if result.rows_affected == 0 {
-            anyhow::bail!("Project not found");
-        }
-        Ok(())
-    }
-}
-
-// ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
@@ -1246,18 +1126,6 @@ fn model_to_session_usage(model: &session_entity::Model) -> Result<SessionUsage>
         result_count: model.result_count.max(0) as u32,
         started_at,
         ended_at,
-    })
-}
-
-/// Convert a raw [`project_entity::Model`] into the domain [`Project`] type.
-fn model_to_project(model: project_entity::Model) -> Result<Project> {
-    Ok(Project {
-        id: Uuid::parse_str(&model.id)?,
-        name: model.name,
-        description: model.description,
-        created_at: DateTime::parse_from_rfc3339(&model.created_at)?.with_timezone(&Utc),
-        updated_at: DateTime::parse_from_rfc3339(&model.updated_at)?.with_timezone(&Utc),
-        organization_id: model.organization_id,
     })
 }
 
@@ -1818,162 +1686,6 @@ mod tests {
         assert_eq!(retrieved.config.docker_image, None);
         assert_eq!(retrieved.config.resource_limits, None);
     }
-
-    // -----------------------------------------------------------------------
-    // ProjectStorage tests
-    // -----------------------------------------------------------------------
-
-    fn project_storage(agent_storage: &AgentStorage) -> ProjectStorage {
-        ProjectStorage::from_db(agent_storage.db().clone())
-    }
-
-    #[tokio::test]
-    async fn test_project_create_and_get() {
-        let (storage, _tmp) = create_test_storage().await;
-        let ps = project_storage(&storage);
-
-        let project = Project::new("alpha".to_string(), Some("first project".to_string()));
-        let id = project.id;
-
-        ps.create(&project).await.unwrap();
-
-        let retrieved = ps.get(&id).await.unwrap().unwrap();
-        assert_eq!(retrieved.id, id);
-        assert_eq!(retrieved.name, "alpha");
-        assert_eq!(retrieved.description, Some("first project".to_string()));
-    }
-
-    #[tokio::test]
-    async fn test_project_get_returns_none_for_unknown_id() {
-        let (storage, _tmp) = create_test_storage().await;
-        let ps = project_storage(&storage);
-
-        let result = ps.get(&Uuid::new_v4()).await.unwrap();
-        assert!(result.is_none());
-    }
-
-    #[tokio::test]
-    async fn test_project_get_by_name() {
-        let (storage, _tmp) = create_test_storage().await;
-        let ps = project_storage(&storage);
-
-        let project = Project::new("beta".to_string(), None);
-        ps.create(&project).await.unwrap();
-
-        let found = ps.get_by_name("beta").await.unwrap().unwrap();
-        assert_eq!(found.id, project.id);
-        assert_eq!(found.description, None);
-    }
-
-    #[tokio::test]
-    async fn test_project_get_by_name_missing() {
-        let (storage, _tmp) = create_test_storage().await;
-        let ps = project_storage(&storage);
-
-        assert!(ps.get_by_name("nonexistent").await.unwrap().is_none());
-    }
-
-    #[tokio::test]
-    async fn test_project_list() {
-        let (storage, _tmp) = create_test_storage().await;
-        let ps = project_storage(&storage);
-
-        ps.create(&Project::new("p1".to_string(), None)).await.unwrap();
-        ps.create(&Project::new("p2".to_string(), None)).await.unwrap();
-        ps.create(&Project::new("p3".to_string(), None)).await.unwrap();
-
-        let projects = ps.list().await.unwrap();
-        assert_eq!(projects.len(), 3);
-        // Newest first
-        let names: Vec<&str> = projects.iter().map(|p| p.name.as_str()).collect();
-        assert!(names.contains(&"p1"));
-        assert!(names.contains(&"p2"));
-        assert!(names.contains(&"p3"));
-    }
-
-    #[tokio::test]
-    async fn test_project_list_empty() {
-        let (storage, _tmp) = create_test_storage().await;
-        let ps = project_storage(&storage);
-        assert!(ps.list().await.unwrap().is_empty());
-    }
-
-    #[tokio::test]
-    async fn test_project_update_name() {
-        let (storage, _tmp) = create_test_storage().await;
-        let ps = project_storage(&storage);
-
-        let project = Project::new("old-name".to_string(), None);
-        ps.create(&project).await.unwrap();
-
-        let req = UpdateProjectRequest { name: Some("new-name".to_string()), description: None };
-        let updated = ps.update(&project.id, &req).await.unwrap();
-
-        assert_eq!(updated.name, "new-name");
-        assert_eq!(updated.description, None);
-        assert!(updated.updated_at >= project.updated_at);
-    }
-
-    #[tokio::test]
-    async fn test_project_update_description() {
-        let (storage, _tmp) = create_test_storage().await;
-        let ps = project_storage(&storage);
-
-        let project = Project::new("proj".to_string(), None);
-        ps.create(&project).await.unwrap();
-
-        let req =
-            UpdateProjectRequest { name: None, description: Some("added description".to_string()) };
-        let updated = ps.update(&project.id, &req).await.unwrap();
-
-        assert_eq!(updated.name, "proj");
-        assert_eq!(updated.description, Some("added description".to_string()));
-    }
-
-    #[tokio::test]
-    async fn test_project_update_not_found() {
-        let (storage, _tmp) = create_test_storage().await;
-        let ps = project_storage(&storage);
-
-        let req = UpdateProjectRequest { name: Some("x".to_string()), description: None };
-        let result = ps.update(&Uuid::new_v4(), &req).await;
-        assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("not found"));
-    }
-
-    #[tokio::test]
-    async fn test_project_delete() {
-        let (storage, _tmp) = create_test_storage().await;
-        let ps = project_storage(&storage);
-
-        let project = Project::new("to-delete".to_string(), None);
-        ps.create(&project).await.unwrap();
-        assert!(ps.get(&project.id).await.unwrap().is_some());
-
-        ps.delete(&project.id).await.unwrap();
-        assert!(ps.get(&project.id).await.unwrap().is_none());
-    }
-
-    #[tokio::test]
-    async fn test_project_delete_not_found() {
-        let (storage, _tmp) = create_test_storage().await;
-        let ps = project_storage(&storage);
-
-        let result = ps.delete(&Uuid::new_v4()).await;
-        assert!(result.is_err());
-        assert!(result.unwrap_err().to_string().contains("not found"));
-    }
-
-    #[tokio::test]
-    async fn test_project_name_unique() {
-        let (storage, _tmp) = create_test_storage().await;
-        let ps = project_storage(&storage);
-
-        ps.create(&Project::new("unique".to_string(), None)).await.unwrap();
-        let result = ps.create(&Project::new("unique".to_string(), None)).await;
-        assert!(result.is_err());
-    }
-
     // -----------------------------------------------------------------------
     // Conversation event tests
     // -----------------------------------------------------------------------

--- a/crates/orchestrator/src/types.rs
+++ b/crates/orchestrator/src/types.rs
@@ -514,9 +514,15 @@ fn default_shell() -> String {
 
 // ---------------------------------------------------------------------------
 // Project types
+//
+// NOTE: Project CRUD has moved to the core service (epic #1306). These types
+// are kept temporarily so that `client.rs` and the CLI can still compile while
+// issue #1311 (repoint CLI/client to core) is in progress. Remove them once
+// #1311 lands.
 // ---------------------------------------------------------------------------
 
 /// A project groups agents, workflows, and rooms under a named boundary.
+#[allow(dead_code)]
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 pub struct Project {
     pub id: Uuid,
@@ -529,6 +535,7 @@ pub struct Project {
     pub organization_id: Option<String>,
 }
 
+#[allow(dead_code)]
 impl Project {
     pub fn new(name: String, description: Option<String>) -> Self {
         let now = Utc::now();
@@ -544,6 +551,7 @@ impl Project {
 }
 
 /// Detailed project response including associated resource counts.
+#[allow(dead_code)]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ProjectResponse {
     pub id: Uuid,
@@ -557,6 +565,7 @@ pub struct ProjectResponse {
 }
 
 /// Request body for POST /projects.
+#[allow(dead_code)]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct CreateProjectRequest {
     pub name: String,
@@ -569,6 +578,7 @@ pub struct CreateProjectRequest {
 /// Fields that are `None` are left unchanged in the database.
 /// Pass `description: Some(None)` is not supported via this struct —
 /// to clear a description set it to `Some("")` or omit the field.
+#[allow(dead_code)]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct UpdateProjectRequest {
     #[serde(skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
epic: Remove project CRUD from orchestrator, keep association endpoints

feat(orchestrator): remove project CRUD, keep association endpoints

- Delete ProjectStorage struct and all methods from storage.rs
- Delete model_to_project helper
- Remove project_entity import from storage.rs
- Remove project_storage() accessor from manager.rs
- Remove GET/POST /projects and GET/PUT/DELETE /projects/{id} routes
- Remove list_projects, create_project, get_project, update_project, delete_project handlers
- Remove ps.get() existence checks from all association handlers
- Remove pub mod project from entity/mod.rs (unused after dropping checks)
- Add allow(dead_code) to project types in types.rs (kept for client.rs compat until #1311 lands)
- Update CLI admin SCOPED_TABLES: move projects from orchestrator to core