### PR TITLE
feat: repoint MCP tools and UI project calls to core

### DIFF
--- a/crates/common/src/config.rs
+++ b/crates/common/src/config.rs
@@ -455,6 +455,8 @@ impl Default for CorePamConfig {
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
 #[serde(default)]
 pub struct McpConfig {
+    /// Core service URL (API gateway). Defaults to `"http://localhost:17000"`.
+    pub core_url: String,
     /// Orchestrator service URL. Defaults to `"http://localhost:17006"`.
     pub orchestrator_url: String,
     /// Notify service URL. Defaults to `"http://localhost:17004"`.
@@ -478,6 +480,7 @@ pub struct McpConfig {
 impl Default for McpConfig {
     fn default() -> Self {
         Self {
+            core_url: "http://localhost:17000".to_string(),
             orchestrator_url: "http://localhost:17006".to_string(),
             notify_url: "http://localhost:17004".to_string(),
             ask_url: "http://localhost:17001".to_string(),
@@ -731,6 +734,7 @@ impl ValidateConfig for MonitorConfig {
 impl ValidateConfig for McpConfig {
     fn validate(&self) -> Result<()> {
         for (name, url) in [
+            ("mcp.core_url", self.core_url.as_str()),
             ("mcp.orchestrator_url", self.orchestrator_url.as_str()),
             ("mcp.notify_url", self.notify_url.as_str()),
             ("mcp.ask_url", self.ask_url.as_str()),
@@ -1164,6 +1168,11 @@ fn merge(base: AgentdConfig, file: AgentdConfig) -> AgentdConfig {
                 },
             },
             mcp: McpConfig {
+                core_url: pick(
+                    &base.services.mcp.core_url,
+                    &file.services.mcp.core_url,
+                    &d.services.mcp.core_url,
+                ),
                 orchestrator_url: pick(
                     &base.services.mcp.orchestrator_url,
                     &file.services.mcp.orchestrator_url,
@@ -1368,6 +1377,9 @@ fn apply_env_overrides(cfg: &mut AgentdConfig) {
     }
 
     // ── MCP ───────────────────────────────────────────────────────────────
+    if let Ok(v) = env::var("AGENTD_MCP_CORE_URL") {
+        cfg.services.mcp.core_url = v;
+    }
     if let Ok(v) = env::var("AGENTD_MCP_ORCHESTRATOR_URL") {
         cfg.services.mcp.orchestrator_url = v;
     }

--- a/crates/mcp/src/client.rs
+++ b/crates/mcp/src/client.rs
@@ -22,6 +22,11 @@ impl AgentdClient {
         Self { inner: Client::new(), config }
     }
 
+    /// Returns the base URL for the core service (API gateway).
+    pub fn core_url(&self) -> &str {
+        &self.config.core_url
+    }
+
     /// Returns the base URL for the orchestrator service.
     pub fn orchestrator_url(&self) -> &str {
         &self.config.orchestrator_url

--- a/crates/mcp/src/config.rs
+++ b/crates/mcp/src/config.rs
@@ -11,6 +11,8 @@ use std::env;
 /// Configuration for connecting to agentd services.
 #[derive(Debug, Clone)]
 pub struct AgentdMcpConfig {
+    /// Core service URL (API gateway, default: `http://127.0.0.1:17000`)
+    pub core_url: String,
     /// Orchestrator service URL (default: `http://127.0.0.1:17006`)
     pub orchestrator_url: String,
     /// Communicate service URL (default: `http://127.0.0.1:17010`)
@@ -41,6 +43,7 @@ impl AgentdMcpConfig {
     ///
     /// | Variable                        | Default                     |
     /// |---------------------------------|-----------------------------|
+    /// | `AGENTD_CORE_URL`               | `http://127.0.0.1:17000`   |
     /// | `AGENTD_ORCHESTRATOR_URL`       | `http://127.0.0.1:17006`   |
     /// | `AGENTD_COMMUNICATE_URL`        | `http://127.0.0.1:17010`   |
     /// | `AGENTD_MEMORY_URL`             | `http://127.0.0.1:17008`   |
@@ -58,6 +61,7 @@ impl AgentdMcpConfig {
         let base = shared.services.mcp;
 
         Self {
+            core_url: env::var("AGENTD_CORE_URL").unwrap_or(base.core_url),
             orchestrator_url: env::var("AGENTD_ORCHESTRATOR_URL").unwrap_or(base.orchestrator_url),
             communicate_url: env::var("AGENTD_COMMUNICATE_URL").unwrap_or(base.communicate_url),
             memory_url: env::var("AGENTD_MEMORY_URL").unwrap_or(base.memory_url),
@@ -80,6 +84,7 @@ impl AgentdMcpConfig {
 impl ValidateConfig for AgentdMcpConfig {
     fn validate(&self) -> Result<()> {
         let urls = [
+            ("mcp.core_url", self.core_url.as_str()),
             ("mcp.orchestrator_url", self.orchestrator_url.as_str()),
             ("mcp.communicate_url", self.communicate_url.as_str()),
             ("mcp.memory_url", self.memory_url.as_str()),
@@ -111,6 +116,7 @@ mod tests {
     fn test_defaults() {
         let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let vars = [
+            "AGENTD_CORE_URL",
             "AGENTD_ORCHESTRATOR_URL",
             "AGENTD_COMMUNICATE_URL",
             "AGENTD_MEMORY_URL",
@@ -133,6 +139,7 @@ mod tests {
         env::set_var("AGENTD_CONFIG", "/nonexistent/agentd-mcp-test-config.toml");
 
         let config = AgentdMcpConfig::from_env();
+        assert_eq!(config.core_url, "http://localhost:17000");
         assert_eq!(config.orchestrator_url, "http://localhost:17006");
         assert_eq!(config.communicate_url, "http://localhost:17010");
         assert_eq!(config.memory_url, "http://localhost:17008");
@@ -168,6 +175,7 @@ mod tests {
     fn test_validate_default_passes() {
         let _g = ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         let vars = [
+            "AGENTD_CORE_URL",
             "AGENTD_ORCHESTRATOR_URL",
             "AGENTD_COMMUNICATE_URL",
             "AGENTD_MEMORY_URL",
@@ -195,6 +203,7 @@ mod tests {
     #[test]
     fn test_validate_bad_url_fails() {
         let config = AgentdMcpConfig {
+            core_url: "http://127.0.0.1:17000".to_string(),
             orchestrator_url: "not-a-url".to_string(),
             communicate_url: "http://127.0.0.1:17010".to_string(),
             memory_url: "http://127.0.0.1:17008".to_string(),

--- a/crates/mcp/src/tools/orchestrator_debug.rs
+++ b/crates/mcp/src/tools/orchestrator_debug.rs
@@ -90,8 +90,6 @@ struct ProjectDetail {
     description: Option<String>,
     created_at: String,
     updated_at: String,
-    agent_count: u64,
-    workflow_count: u64,
 }
 
 #[derive(Debug, Deserialize)]
@@ -302,13 +300,13 @@ pub async fn run_get_conversation_summary(client: &AgentdClient, agent_id: &str)
 }
 
 pub async fn run_list_projects(client: &AgentdClient, limit: Option<u32>) -> String {
-    let base = client.orchestrator_url();
+    let base = client.core_url();
     let limit_val = limit.unwrap_or(50).clamp(1, 200);
-    let url = format!("{base}/projects?limit={limit_val}");
+    let url = format!("{base}/api/v1/projects?limit={limit_val}");
 
     let resp = match client.inner.get(&url).send().await {
         Ok(r) => r,
-        Err(e) => return format!("Error: orchestrator unreachable at {base}: {e}"),
+        Err(e) => return format!("Error: core unreachable at {base}: {e}"),
     };
     if !resp.status().is_success() {
         return format!("Error: HTTP {} listing projects", resp.status());
@@ -338,12 +336,12 @@ pub async fn run_list_projects(client: &AgentdClient, limit: Option<u32>) -> Str
 }
 
 pub async fn run_get_project(client: &AgentdClient, project_id: &str) -> String {
-    let base = client.orchestrator_url();
-    let url = format!("{base}/projects/{project_id}");
+    let base = client.core_url();
+    let url = format!("{base}/api/v1/projects/{project_id}");
 
     let resp = match client.inner.get(&url).send().await {
         Ok(r) => r,
-        Err(e) => return format!("Error: orchestrator unreachable at {base}: {e}"),
+        Err(e) => return format!("Error: core unreachable at {base}: {e}"),
     };
     if resp.status() == reqwest::StatusCode::NOT_FOUND {
         return format!("Project `{project_id}` not found.");
@@ -361,8 +359,6 @@ pub async fn run_get_project(client: &AgentdClient, project_id: &str) -> String 
     if let Some(ref d) = p.description {
         out.push_str(&format!("- **Description**: {d}\n"));
     }
-    out.push_str(&format!("- **Agents**: {}\n", p.agent_count));
-    out.push_str(&format!("- **Workflows**: {}\n", p.workflow_count));
     out.push_str(&format!("- **Created**: {}\n", p.created_at));
     out.push_str(&format!("- **Updated**: {}\n", p.updated_at));
     out

--- a/crates/mcp/tests/common/mod.rs
+++ b/crates/mcp/tests/common/mod.rs
@@ -418,6 +418,7 @@ pub async fn mock_monitor_server() -> MockServer {
 /// Build an `AgentdClient` pointed at the given mock servers.
 pub fn test_client(orch_addr: &str, notify_addr: &str, monitor_addr: &str) -> AgentdClient {
     let config = Arc::new(AgentdMcpConfig {
+        core_url: "http://127.0.0.1:1".to_string(), // unused
         orchestrator_url: orch_addr.to_string(),
         communicate_url: "http://127.0.0.1:1".to_string(), // unused
         memory_url: "http://127.0.0.1:1".to_string(),

--- a/ui/src/components/knowledge/ProjectPicker.tsx
+++ b/ui/src/components/knowledge/ProjectPicker.tsx
@@ -6,7 +6,7 @@
 import { ChevronDown, FolderOpen } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 import type { Project } from "@/types/orchestrator";
-import { orchestratorClient } from "@/services/orchestrator";
+import { coreClient } from "@/services/core";
 
 interface ProjectPickerProps {
 	selectedId: string | null;
@@ -27,7 +27,7 @@ export function ProjectPicker({
 	useEffect(() => {
 		let cancelled = false;
 		setLoading(true);
-		orchestratorClient
+		coreClient
 			.listProjects({ limit: 200 })
 			.then((page) => {
 				if (!cancelled) setProjects(page.items);

--- a/ui/src/services/core.ts
+++ b/ui/src/services/core.ts
@@ -1,0 +1,32 @@
+/**
+ * Client for the Core service (default port 17000).
+ *
+ * The core service is the API gateway and owns the canonical project entity.
+ * Project CRUD operations are served from `/api/v1/projects`.
+ */
+
+import type { PaginatedResponse } from "@/types/common";
+import type { ListProjectsParams, Project } from "@/types/orchestrator";
+import { ApiClient, withAuth } from "./base";
+import { serviceConfig } from "./config";
+
+export class CoreClient extends ApiClient {
+	// -------------------------------------------------------------------------
+	// Projects
+	// -------------------------------------------------------------------------
+
+	/** `GET /api/v1/projects` — list all projects. */
+	listProjects(
+		params?: ListProjectsParams,
+	): Promise<PaginatedResponse<Project>> {
+		return this.get<PaginatedResponse<Project>>(
+			"/api/v1/projects",
+			params as Record<string, string | number | boolean | undefined>,
+		);
+	}
+}
+
+/** Singleton client instance using the configured core service URL */
+export const coreClient = new CoreClient(
+	withAuth({ baseUrl: serviceConfig.coreServiceUrl }),
+);


### PR DESCRIPTION
Update MCP `run_list_projects` and `run_get_project` tools to target the core service URL (`/api/v1/projects`). Add `core_url` to `AgentdMcpConfig` (env: `AGENTD_CORE_URL`) and `AgentdClient`. Create `ui/src/services/core.ts` with a `CoreClient` and update `ProjectPicker` to use it. Remove `agent_count`/`workflow_count` from `ProjectDetail` since core does not compute them.

Closes #1312